### PR TITLE
Add traits system with Greek morphological syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -33,11 +33,19 @@ fn build_statement(pair: Pair<'_, Rule>) -> Result<Statement, AstError> {
     let mut clauses = Vec::new();
     let mut is_query = false;
     let mut type_def = None;
+    let mut trait_def = None;
+    let mut trait_impl = None;
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::type_definition => {
                 type_def = Some(build_type_definition(inner)?);
+            }
+            Rule::trait_definition => {
+                trait_def = Some(build_trait_definition(inner)?);
+            }
+            Rule::trait_impl => {
+                trait_impl = Some(build_trait_impl(inner)?);
             }
             Rule::clause_list => {
                 for clause_pair in inner.into_inner() {
@@ -59,6 +67,10 @@ fn build_statement(pair: Pair<'_, Rule>) -> Result<Statement, AstError> {
 
     if let Some(def) = type_def {
         Ok(Statement::TypeDefinition(def))
+    } else if let Some(def) = trait_def {
+        Ok(Statement::TraitDefinition(def))
+    } else if let Some(impl_def) = trait_impl {
+        Ok(Statement::TraitImpl(impl_def))
     } else {
         Ok(Statement::Regular {
             clauses,
@@ -68,13 +80,14 @@ fn build_statement(pair: Pair<'_, Rule>) -> Result<Statement, AstError> {
 }
 
 fn build_type_definition(pair: Pair<'_, Rule>) -> Result<TypeDef, AstError> {
-    let mut words = Vec::new();
+    let mut type_name = None;
     let mut fields = Vec::new();
 
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::greek_word => {
-                words.push(Word {
+                // This is the type name (between εἶδος and ὁρίζειν)
+                type_name = Some(Word {
                     original: inner.as_str().to_string(),
                     normalized: crate::grammar::normalize_greek(inner.as_str()),
                 });
@@ -90,16 +103,12 @@ fn build_type_definition(pair: Pair<'_, Rule>) -> Result<TypeDef, AstError> {
         }
     }
 
-    // εἶδος typename ὁρίζειν
-    // words[0] = εἶδος (keyword)
-    // words[1] = typename
-    // words[2] = ὁρίζειν (keyword)
-    if words.len() < 2 {
-        return Err(AstError::UnexpectedRule("Type definition needs at least a name".to_string()));
+    if type_name.is_none() {
+        return Err(AstError::UnexpectedRule("Type definition needs a name".to_string()));
     }
 
     Ok(TypeDef {
-        name: words[1].clone(),
+        name: type_name.unwrap(),
         fields,
     })
 }
@@ -124,6 +133,204 @@ fn build_field_declaration(pair: Pair<'_, Rule>) -> Result<FieldDecl, AstError> 
     Ok(FieldDecl {
         name: words[0].clone(),
         type_name: words[1].clone(),
+    })
+}
+
+fn build_trait_definition(pair: Pair<'_, Rule>) -> Result<TraitDef, AstError> {
+    let mut trait_name = None;
+    let mut methods = Vec::new();
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::greek_word => {
+                // This is the trait name (between χαρακτήρ and ὁρίζειν)
+                trait_name = Some(Word {
+                    original: inner.as_str().to_string(),
+                    normalized: crate::grammar::normalize_greek(inner.as_str()),
+                });
+            }
+            Rule::trait_method_list => {
+                for method_pair in inner.into_inner() {
+                    if method_pair.as_rule() == Rule::trait_method {
+                        methods.push(build_trait_method(method_pair)?);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if trait_name.is_none() {
+        return Err(AstError::UnexpectedRule("Trait definition needs a name".to_string()));
+    }
+
+    Ok(TraitDef {
+        name: trait_name.unwrap(),
+        methods,
+    })
+}
+
+fn build_trait_method(pair: Pair<'_, Rule>) -> Result<TraitMethodDecl, AstError> {
+    let mut words = Vec::new();
+    let mut body_statements = Vec::new();
+    let mut has_body = false;
+    let mut is_default = false;
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::dei_keyword => {
+                is_default = false;
+            }
+            Rule::ede_keyword => {
+                is_default = true;
+            }
+            Rule::greek_word => {
+                words.push(Word {
+                    original: inner.as_str().to_string(),
+                    normalized: crate::grammar::normalize_greek(inner.as_str()),
+                });
+            }
+            Rule::statement => {
+                has_body = true;
+                body_statements.push(build_statement(inner)?);
+            }
+            _ => {}
+        }
+    }
+
+    // words[0] = method name
+    // words[1..] = parameters (τῷ self, τῷ other, etc.)
+    if words.is_empty() {
+        return Err(AstError::UnexpectedRule("Trait method needs at least a name".to_string()));
+    }
+
+    let method_name = words[0].clone();
+
+    // Parse parameters (skip method name)
+    let mut params = Vec::new();
+    let mut i = 1;
+    while i < words.len() {
+        // Look for τῷ (dative marker) followed by parameter name
+        if words[i].normalized == "τω" || words[i].normalized == "tw" {
+            if i + 1 < words.len() {
+                // Parameter without type annotation (just name)
+                params.push(FieldDecl {
+                    name: words[i + 1].clone(),
+                    type_name: Word::new("_"), // Placeholder, will be inferred
+                });
+                i += 2;
+            } else {
+                i += 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    Ok(TraitMethodDecl {
+        name: method_name,
+        params,
+        is_default,
+        body: if has_body { Some(body_statements) } else { None },
+    })
+}
+
+fn build_trait_impl(pair: Pair<'_, Rule>) -> Result<TraitImplDef, AstError> {
+    let mut type_name = None;
+    let mut trait_name = None;
+    let mut methods = Vec::new();
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::greek_word => {
+                // First greek_word is the type name, second is the trait name
+                if type_name.is_none() {
+                    type_name = Some(Word {
+                        original: inner.as_str().to_string(),
+                        normalized: crate::grammar::normalize_greek(inner.as_str()),
+                    });
+                } else if trait_name.is_none() {
+                    trait_name = Some(Word {
+                        original: inner.as_str().to_string(),
+                        normalized: crate::grammar::normalize_greek(inner.as_str()),
+                    });
+                }
+            }
+            Rule::impl_method_list => {
+                for method_pair in inner.into_inner() {
+                    if method_pair.as_rule() == Rule::impl_method {
+                        methods.push(build_impl_method(method_pair)?);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if type_name.is_none() || trait_name.is_none() {
+        return Err(AstError::UnexpectedRule("Trait impl needs type and trait names".to_string()));
+    }
+
+    Ok(TraitImplDef {
+        type_name: type_name.unwrap(),
+        trait_name: trait_name.unwrap(),
+        methods,
+    })
+}
+
+fn build_impl_method(pair: Pair<'_, Rule>) -> Result<ImplMethodDef, AstError> {
+    let mut words = Vec::new();
+    let mut body = None;
+
+    for inner in pair.into_inner() {
+        match inner.as_rule() {
+            Rule::greek_word => {
+                words.push(Word {
+                    original: inner.as_str().to_string(),
+                    normalized: crate::grammar::normalize_greek(inner.as_str()),
+                });
+            }
+            Rule::statement => {
+                // Each impl_method has exactly one statement (use block for multiple)
+                body = Some(build_statement(inner)?);
+            }
+            _ => {}
+        }
+    }
+
+    // words[0] = method name
+    // words[1..] = parameters (τῷ self, τῷ other, etc.)
+    if words.is_empty() {
+        return Err(AstError::UnexpectedRule("Impl method needs at least a name".to_string()));
+    }
+
+    let method_name = words[0].clone();
+
+    // Parse parameters (skip method name)
+    let mut params = Vec::new();
+    let mut i = 1;
+    while i < words.len() {
+        // Look for τῷ (dative marker) followed by parameter name
+        if words[i].normalized == "τω" || words[i].normalized == "tw" {
+            if i + 1 < words.len() {
+                // Parameter without type annotation (just name)
+                params.push(FieldDecl {
+                    name: words[i + 1].clone(),
+                    type_name: Word::new("_"), // Placeholder, will be inferred
+                });
+                i += 2;
+            } else {
+                i += 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    Ok(ImplMethodDef {
+        name: method_name,
+        params,
+        body: if let Some(stmt) = body { vec![stmt] } else { vec![] },
     })
 }
 
@@ -301,6 +508,8 @@ mod tests {
         match stmt {
             Statement::Regular { clauses, .. } => &clauses[0].expressions[0],
             Statement::TypeDefinition(_) => panic!("Cannot get first_expr from TypeDefinition"),
+            Statement::TraitDefinition(_) => panic!("Cannot get first_expr from TraitDefinition"),
+            Statement::TraitImpl(_) => panic!("Cannot get first_expr from TraitImpl"),
         }
     }
 

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -20,6 +20,10 @@ pub enum Statement {
     },
     /// A type definition statement
     TypeDefinition(TypeDef),
+    /// A trait definition statement
+    TraitDefinition(TraitDef),
+    /// A trait implementation statement
+    TraitImpl(TraitImplDef),
 }
 
 /// A type definition (struct)
@@ -34,6 +38,38 @@ pub struct TypeDef {
 pub struct FieldDecl {
     pub name: Word,
     pub type_name: Word,
+}
+
+/// A trait definition
+#[derive(Debug, Clone, PartialEq)]
+pub struct TraitDef {
+    pub name: Word,
+    pub methods: Vec<TraitMethodDecl>,
+}
+
+/// A method declaration in a trait
+#[derive(Debug, Clone, PartialEq)]
+pub struct TraitMethodDecl {
+    pub name: Word,
+    pub params: Vec<FieldDecl>,
+    pub is_default: bool,
+    pub body: Option<Vec<Statement>>,
+}
+
+/// A trait implementation
+#[derive(Debug, Clone, PartialEq)]
+pub struct TraitImplDef {
+    pub type_name: Word,
+    pub trait_name: Word,
+    pub methods: Vec<ImplMethodDef>,
+}
+
+/// A method implementation in a trait impl
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImplMethodDef {
+    pub name: Word,
+    pub params: Vec<FieldDecl>,
+    pub body: Vec<Statement>,
 }
 
 /// A clause within a statement (comma-separated)
@@ -51,6 +87,8 @@ impl Statement {
                 Box::new(clauses.iter().flat_map(|c| c.expressions.iter()))
             }
             Statement::TypeDefinition(_) => Box::new(std::iter::empty()),
+            Statement::TraitDefinition(_) => Box::new(std::iter::empty()),
+            Statement::TraitImpl(_) => Box::new(std::iter::empty()),
         }
     }
 
@@ -59,6 +97,8 @@ impl Statement {
         match self {
             Statement::Regular { is_query, .. } => *is_query,
             Statement::TypeDefinition(_) => false,
+            Statement::TraitDefinition(_) => false,
+            Statement::TraitImpl(_) => false,
         }
     }
 
@@ -67,6 +107,8 @@ impl Statement {
         match self {
             Statement::Regular { clauses, .. } => clauses,
             Statement::TypeDefinition(_) => &[],
+            Statement::TraitDefinition(_) => &[],
+            Statement::TraitImpl(_) => &[],
         }
     }
 }

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -254,9 +254,8 @@ fn generate_statement(stmt: &HirStatement) -> TokenStream {
                     let param_tokens: Vec<TokenStream> = method.params.iter()
                         .enumerate()
                         .map(|(idx, (param_name, param_type))| {
-                            let normalized_name = normalize_greek(param_name);
                             // Special case: first parameter named "self" becomes &self
-                            if idx == 0 && (normalized_name == "self" || param_name == "self" || normalized_name == "τῷ" || param_name.contains("self")) {
+                            if is_self_parameter(param_name, idx) {
                                 quote! { &self }
                             } else {
                                 let param_ident = format_ident!("{}", sanitize_name(param_name));
@@ -343,9 +342,8 @@ fn generate_statement(stmt: &HirStatement) -> TokenStream {
                     let param_tokens: Vec<TokenStream> = method.params.iter()
                         .enumerate()
                         .map(|(idx, (param_name, param_type))| {
-                            let normalized_name = normalize_greek(param_name);
                             // Special case: first parameter named "self" becomes &self
-                            if idx == 0 && (normalized_name == "self" || param_name == "self" || normalized_name == "τῷ" || param_name.contains("self")) {
+                            if is_self_parameter(param_name, idx) {
                                 quote! { &self }
                             } else {
                                 let param_ident = format_ident!("{}", sanitize_name(param_name));
@@ -487,31 +485,21 @@ fn generate_expr(expr: &HirExpr) -> TokenStream {
             }
         }
 
-        HirExpr::StructLit { type_name, args } => {
+        HirExpr::StructLit { type_name, fields, args } => {
             // Capitalize struct name for Rust conventions
             let struct_name = format_ident!("{}", capitalize(&sanitize_name(type_name)));
 
-            // For now, generate positional struct literals
-            // Rust requires field names, so we need to get the struct definition
-            // For simplicity, we'll generate: TypeName { field1: arg1, field2: arg2, ... }
-            // We need to know the field names - for now use generic names
-            let arg_tokens: Vec<TokenStream> = args.iter()
-                .map(generate_expr)
+            // Generate field: value pairs using actual field names
+            let field_assignments: Vec<TokenStream> = fields.iter()
+                .zip(args.iter())
+                .map(|(field_name, arg)| {
+                    let field_ident = format_ident!("{}", sanitize_name(field_name));
+                    let arg_token = generate_expr(arg);
+                    quote! { #field_ident: #arg_token }
+                })
                 .collect();
 
-            // Generate field assignments with generic names
-            // This assumes the fields are named in order from the type definition
-            // For a real implementation, we'd need to look up the type definition
-            if args.len() == 1 {
-                quote! { #struct_name { xi: #(#arg_tokens),* } }
-            } else if args.len() == 2 {
-                let arg1 = &arg_tokens[0];
-                let arg2 = &arg_tokens[1];
-                quote! { #struct_name { xi: #arg1, psi: #arg2 } }
-            } else {
-                // Generic fallback
-                quote! { #struct_name { xi: #(#arg_tokens),* } }
-            }
+            quote! { #struct_name { #(#field_assignments),* } }
         }
     }
 }
@@ -523,6 +511,16 @@ fn capitalize(s: &str) -> String {
         None => String::new(),
         Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
     }
+}
+
+/// Check if a parameter represents the self parameter in a trait method
+fn is_self_parameter(param_name: &str, idx: usize) -> bool {
+    if idx != 0 {
+        return false;
+    }
+    let normalized = normalize_greek(param_name);
+    // Check for "self", "τω" (normalized from τῷ), or if param name contains "self"
+    normalized == "self" || param_name == "self" || normalized == "τω" || param_name.contains("self")
 }
 
 /// Sanitize a Greek name for use as a Rust identifier

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -3,26 +3,35 @@
 //! Translates HIR to Rust source code using the `quote` crate.
 
 use crate::ir::{HirProgram, HirStatement, HirExpr, BinOp};
+use crate::grammar::normalize_greek;
 use quote::{quote, format_ident};
 use proc_macro2::TokenStream;
 
 /// Generate Rust code from a HIR program
 pub fn generate_rust(hir: &HirProgram) -> String {
-    // Separate struct definitions, function definitions, and main body statements
+    // Separate trait defs, struct defs, trait impls, function defs, and main body statements
+    let mut trait_defs = Vec::new();
     let mut struct_defs = Vec::new();
+    let mut trait_impls = Vec::new();
     let mut fn_defs = Vec::new();
     let mut main_stmts = Vec::new();
 
     for stmt in &hir.statements {
         match stmt {
+            HirStatement::TraitDef { .. } => trait_defs.push(generate_statement(stmt)),
             HirStatement::StructDef { .. } => struct_defs.push(generate_statement(stmt)),
+            HirStatement::TraitImpl { .. } => trait_impls.push(generate_statement(stmt)),
             HirStatement::FnDef { .. } => fn_defs.push(generate_statement(stmt)),
             _ => main_stmts.push(generate_statement(stmt)),
         }
     }
 
     let output = quote! {
+        #(#trait_defs)*
+
         #(#struct_defs)*
+
+        #(#trait_impls)*
 
         #(#fn_defs)*
 
@@ -212,7 +221,8 @@ fn generate_statement(stmt: &HirStatement) -> TokenStream {
         }
 
         HirStatement::StructDef { name, fields } => {
-            let struct_name = format_ident!("{}", sanitize_name(name));
+            // Capitalize struct name for Rust conventions
+            let struct_name = format_ident!("{}", capitalize(&sanitize_name(name)));
 
             // Generate field list
             let field_tokens: Vec<TokenStream> = fields.iter()
@@ -227,6 +237,154 @@ fn generate_statement(stmt: &HirStatement) -> TokenStream {
                 #[derive(Debug, Clone)]
                 struct #struct_name {
                     #(#field_tokens),*
+                }
+            }
+        }
+
+        HirStatement::TraitDef { name, methods } => {
+            // Capitalize trait name for Rust conventions
+            let trait_name = format_ident!("{}", capitalize(&sanitize_name(name)));
+
+            // Generate method signatures
+            let method_tokens: Vec<TokenStream> = methods.iter()
+                .map(|method| {
+                    let method_name = format_ident!("{}", sanitize_name(&method.name));
+
+                    // Generate parameter list
+                    let param_tokens: Vec<TokenStream> = method.params.iter()
+                        .enumerate()
+                        .map(|(idx, (param_name, param_type))| {
+                            let normalized_name = normalize_greek(param_name);
+                            // Special case: first parameter named "self" becomes &self
+                            if idx == 0 && (normalized_name == "self" || param_name == "self" || normalized_name == "τῷ" || param_name.contains("self")) {
+                                quote! { &self }
+                            } else {
+                                let param_ident = format_ident!("{}", sanitize_name(param_name));
+                                if let Some(type_str) = param_type {
+                                    let ty = format_ident!("{}", type_str);
+                                    quote! { #param_ident: #ty }
+                                } else {
+                                    quote! { #param_ident }
+                                }
+                            }
+                        })
+                        .collect();
+
+                    // Generate return type
+                    if let Some(ret_type) = &method.return_type {
+                        let ret_ty = format_ident!("{}", ret_type);
+                        if method.has_default {
+                            // Default method with body
+                            if let Some(body) = &method.body {
+                                let body_stmts: Vec<TokenStream> = body.iter()
+                                    .map(generate_statement)
+                                    .collect();
+                                quote! {
+                                    fn #method_name(#(#param_tokens),*) -> #ret_ty {
+                                        #(#body_stmts)*
+                                    }
+                                }
+                            } else {
+                                quote! {
+                                    fn #method_name(#(#param_tokens),*) -> #ret_ty;
+                                }
+                            }
+                        } else {
+                            // Required method signature only
+                            quote! {
+                                fn #method_name(#(#param_tokens),*) -> #ret_ty;
+                            }
+                        }
+                    } else {
+                        if method.has_default {
+                            // Default method with body
+                            if let Some(body) = &method.body {
+                                let body_stmts: Vec<TokenStream> = body.iter()
+                                    .map(generate_statement)
+                                    .collect();
+                                quote! {
+                                    fn #method_name(#(#param_tokens),*) {
+                                        #(#body_stmts)*
+                                    }
+                                }
+                            } else {
+                                quote! {
+                                    fn #method_name(#(#param_tokens),*);
+                                }
+                            }
+                        } else {
+                            // Required method signature only
+                            quote! {
+                                fn #method_name(#(#param_tokens),*);
+                            }
+                        }
+                    }
+                })
+                .collect();
+
+            quote! {
+                trait #trait_name {
+                    #(#method_tokens)*
+                }
+            }
+        }
+
+        HirStatement::TraitImpl { trait_name, type_name, methods } => {
+            // Capitalize trait and type names for Rust conventions
+            let trait_ident = format_ident!("{}", capitalize(&sanitize_name(trait_name)));
+            let type_ident = format_ident!("{}", capitalize(&sanitize_name(type_name)));
+
+            // Generate method implementations
+            let method_tokens: Vec<TokenStream> = methods.iter()
+                .map(|method| {
+                    let method_name = format_ident!("{}", sanitize_name(&method.name));
+
+                    // Generate parameter list
+                    let param_tokens: Vec<TokenStream> = method.params.iter()
+                        .enumerate()
+                        .map(|(idx, (param_name, param_type))| {
+                            let normalized_name = normalize_greek(param_name);
+                            // Special case: first parameter named "self" becomes &self
+                            if idx == 0 && (normalized_name == "self" || param_name == "self" || normalized_name == "τῷ" || param_name.contains("self")) {
+                                quote! { &self }
+                            } else {
+                                let param_ident = format_ident!("{}", sanitize_name(param_name));
+                                if let Some(type_str) = param_type {
+                                    let ty = format_ident!("{}", type_str);
+                                    quote! { #param_ident: #ty }
+                                } else {
+                                    quote! { #param_ident }
+                                }
+                            }
+                        })
+                        .collect();
+
+                    // Generate method body
+                    let body_stmts: Vec<TokenStream> = method.body.iter()
+                        .map(generate_statement)
+                        .collect();
+
+                    // Generate return type
+                    if let Some(ret_type) = &method.return_type {
+                        let ret_ty = format_ident!("{}", ret_type);
+                        quote! {
+                            fn #method_name(#(#param_tokens),*) -> #ret_ty {
+                                #(#body_stmts)*
+                            }
+                        }
+                    } else {
+                        quote! {
+                            fn #method_name(#(#param_tokens),*) {
+                                #(#body_stmts)*
+                            }
+                        }
+                    }
+                })
+                .collect();
+
+            quote! {
+                impl #trait_ident for #type_ident {
+                    #(#method_tokens)*
                 }
             }
         }
@@ -330,7 +488,8 @@ fn generate_expr(expr: &HirExpr) -> TokenStream {
         }
 
         HirExpr::StructLit { type_name, args } => {
-            let struct_name = format_ident!("{}", sanitize_name(type_name));
+            // Capitalize struct name for Rust conventions
+            let struct_name = format_ident!("{}", capitalize(&sanitize_name(type_name)));
 
             // For now, generate positional struct literals
             // Rust requires field names, so we need to get the struct definition
@@ -354,6 +513,15 @@ fn generate_expr(expr: &HirExpr) -> TokenStream {
                 quote! { #struct_name { xi: #(#arg_tokens),* } }
             }
         }
+    }
+}
+
+/// Capitalize the first letter of a string (for Rust type/trait names)
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
     }
 }
 

--- a/src/grammar/glossa.pest
+++ b/src/grammar/glossa.pest
@@ -19,18 +19,49 @@
 
 program = { SOI ~ statement* ~ EOI }
 
-statement = { (type_definition | clause_list) ~ statement_end }
+statement = { (type_definition | trait_definition | trait_impl | clause_list) ~ statement_end }
 
 statement_end = { period | query }
 
 // Type definition: εἶδος typename ὁρίζειν { fields }
-type_definition = { greek_word ~ greek_word ~ greek_word ~ "{" ~ field_list? ~ "}" }
+type_definition = { eidos_keyword ~ greek_word ~ orizontin_keyword ~ "{" ~ field_list? ~ "}" }
+
+// Trait definition: χαρακτήρ traitname ὁρίζειν { methods }
+trait_definition = { character_keyword ~ greek_word ~ orizontin_keyword ~ "{" ~ trait_method_list? ~ "}" }
+
+// Trait implementation: εἶδος typename τῷ traitname ἐμπίπτειν { methods }
+trait_impl = { eidos_keyword ~ greek_word ~ dative_marker ~ greek_word ~ empiptein_keyword ~ "{" ~ impl_method_list? ~ "}" }
+
+// Keywords
+eidos_keyword = { "εἶδος" | "ειδος" }
+character_keyword = { "χαρακτήρ" | "χαρακτηρ" }
+orizontin_keyword = { "ὁρίζειν" | "οριζειν" }
+dative_marker = { "τῷ" | "τω" }
+empiptein_keyword = { "ἐμπίπτειν" | "εμπιπτειν" }
 
 // Field list: field declarations separated by middle dot (·) or period (.)
 field_list = { field_declaration ~ ((chain | period) ~ field_declaration)* ~ (chain | period)? }
 
 // Field declaration: fieldname typename_genitive
 field_declaration = { greek_word ~ greek_word }
+
+// Trait method list: method declarations separated by period (.)
+trait_method_list = { trait_method ~ (period ~ trait_method)* ~ period? }
+
+// Trait method: δεῖ methodname params or ἤδη methodname params· body
+// Must start with δεῖ or ἤδη to distinguish from field declarations
+trait_method = { (dei_keyword | ede_keyword) ~ greek_word+ ~ (chain ~ statement+)? }
+
+// Keywords for trait methods
+dei_keyword = { "δεῖ" | "δει" }
+ede_keyword = { "ἤδη" | "ηδη" }
+
+// Implementation method list: method implementations (each has one statement body)
+impl_method_list = { impl_method+ }
+
+// Implementation method: methodname params· body_statement
+// For multiple statements in a method body, use a block { ... }
+impl_method = { greek_word+ ~ chain ~ statement }
 
 // Clause list: clauses separated by commas (for control flow)
 // e.g., "εἰ condition, body" or "ἕως condition, body"
@@ -91,7 +122,8 @@ boolean_literal = { "ἀληθές" | "ψεῦδος" | "αληθες" | "ψευ
 // =============================================================================
 
 // A Greek word is a sequence of Greek letters (with optional diacritics)
-greek_word = @{ GREEK_CHAR+ }
+// OR an identifier (Latin letters for type/trait names)
+greek_word = @{ GREEK_CHAR+ | ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Greek characters including polytonic diacritics
 GREEK_CHAR = {

--- a/src/ir/hir.rs
+++ b/src/ir/hir.rs
@@ -176,6 +176,7 @@ pub enum HirExpr {
     /// Struct literal: TypeName { field: value, ... }
     StructLit {
         type_name: String,
+        fields: Vec<String>,
         args: Vec<HirExpr>,
     },
 }
@@ -358,15 +359,17 @@ fn lower_statement(stmt: &AnalyzedStatement) -> Option<HirStatement> {
         StatementKind::TraitDefinition { name, methods } => {
             Some(HirStatement::TraitDef {
                 name: name.clone(),
-                methods: methods.iter().map(|(method_name, params, is_default)| {
+                methods: methods.iter().map(|method| {
                     HirTraitMethod {
-                        name: method_name.clone(),
-                        params: params.iter()
+                        name: method.name.clone(),
+                        params: method.params.iter()
                             .map(|(param_name, param_type)| (param_name.clone(), Some(param_type.to_rust().to_string())))
                             .collect(),
                         return_type: None, // We'll infer this later if needed
-                        has_default: *is_default,
-                        body: None, // Default method bodies not implemented yet
+                        has_default: method.is_default,
+                        body: method.body.as_ref().map(|body_stmts| {
+                            body_stmts.iter().filter_map(lower_statement).collect()
+                        }),
                     }
                 }).collect(),
             })
@@ -475,9 +478,10 @@ fn lower_expr(expr: &AnalyzedExpr) -> HirExpr {
                 inclusive: *inclusive,
             }
         }
-        AnalyzedExprKind::StructInstantiation { type_name, args } => {
+        AnalyzedExprKind::StructInstantiation { type_name, fields, args } => {
             HirExpr::StructLit {
                 type_name: type_name.clone(),
+                fields: fields.clone(),
                 args: args.iter().map(lower_expr).collect(),
             }
         }

--- a/src/ir/hir.rs
+++ b/src/ir/hir.rs
@@ -76,6 +76,38 @@ pub enum HirStatement {
         name: String,
         fields: Vec<(String, String)>, // (field_name, field_type)
     },
+
+    /// trait name { methods }
+    TraitDef {
+        name: String,
+        methods: Vec<HirTraitMethod>,
+    },
+
+    /// impl Trait for Type { methods }
+    TraitImpl {
+        trait_name: String,
+        type_name: String,
+        methods: Vec<HirImplMethod>,
+    },
+}
+
+/// A method in a trait definition
+#[derive(Debug, Clone)]
+pub struct HirTraitMethod {
+    pub name: String,
+    pub params: Vec<(String, Option<String>)>, // (name, type)
+    pub return_type: Option<String>,
+    pub has_default: bool,
+    pub body: Option<Vec<HirStatement>>,
+}
+
+/// A method in a trait implementation
+#[derive(Debug, Clone)]
+pub struct HirImplMethod {
+    pub name: String,
+    pub params: Vec<(String, Option<String>)>, // (name, type)
+    pub return_type: Option<String>,
+    pub body: Vec<HirStatement>,
 }
 
 /// A HIR expression
@@ -322,6 +354,40 @@ fn lower_statement(stmt: &AnalyzedStatement) -> Option<HirStatement> {
                     .collect(),
             })
         }
+
+        StatementKind::TraitDefinition { name, methods } => {
+            Some(HirStatement::TraitDef {
+                name: name.clone(),
+                methods: methods.iter().map(|(method_name, params, is_default)| {
+                    HirTraitMethod {
+                        name: method_name.clone(),
+                        params: params.iter()
+                            .map(|(param_name, param_type)| (param_name.clone(), Some(param_type.to_rust().to_string())))
+                            .collect(),
+                        return_type: None, // We'll infer this later if needed
+                        has_default: *is_default,
+                        body: None, // Default method bodies not implemented yet
+                    }
+                }).collect(),
+            })
+        }
+
+        StatementKind::TraitImplementation { trait_name, type_name, methods } => {
+            Some(HirStatement::TraitImpl {
+                trait_name: trait_name.clone(),
+                type_name: type_name.clone(),
+                methods: methods.iter().map(|method| {
+                    HirImplMethod {
+                        name: method.name.clone(),
+                        params: method.params.iter()
+                            .map(|(param_name, param_type)| (param_name.clone(), Some(param_type.to_rust().to_string())))
+                            .collect(),
+                        return_type: None, // We'll infer this later if needed
+                        body: method.body.iter().filter_map(lower_statement).collect(),
+                    }
+                }).collect(),
+            })
+        }
     }
 }
 
@@ -343,6 +409,14 @@ fn lower_expr(expr: &AnalyzedExpr) -> HirExpr {
             HirExpr::MethodCall {
                 receiver: Box::new(lower_expr(receiver)),
                 method: method.clone(),
+                args: args.iter().map(lower_expr).collect(),
+            }
+        }
+        AnalyzedExprKind::TraitMethodCall { receiver, method_name, args, .. } => {
+            // Trait method calls lower to regular method calls in Rust
+            HirExpr::MethodCall {
+                receiver: Box::new(lower_expr(receiver)),
+                method: method_name.clone(),
                 args: args.iter().map(lower_expr).collect(),
             }
         }

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -305,6 +305,12 @@ fn try_parse_struct_instantiation(stmt: &Statement, scope: &mut Scope) -> Result
 
             // Check if type exists
             if let Some(struct_type) = scope.lookup_type(type_name).cloned() {
+                // Extract field names from struct type
+                let field_names: Vec<String> = if let GlossaType::Struct { fields, .. } = &struct_type {
+                    fields.iter().map(|(name, _)| name.clone()).collect()
+                } else {
+                    vec![]
+                };
 
                 // Collect constructor arguments (everything between type_name and ἔστω)
                 let mut args = Vec::new();
@@ -338,6 +344,7 @@ fn try_parse_struct_instantiation(stmt: &Statement, scope: &mut Scope) -> Result
                 let struct_inst = AnalyzedExpr {
                     expr: AnalyzedExprKind::StructInstantiation {
                         type_name: type_name.clone(),
+                        fields: field_names,
                         args,
                     },
                     glossa_type: struct_type.clone(),
@@ -418,7 +425,7 @@ fn analyze_trait_definition(trait_def: &crate::ast::TraitDef, scope: &mut Scope)
     // Analyze methods
     let mut required_methods = Vec::new();
     let mut default_methods = Vec::new();
-    let mut method_signatures = Vec::new();
+    let mut analyzed_methods = Vec::new();
 
     for method in &trait_def.methods {
         let method_name = normalize_greek(&method.name.original);
@@ -431,8 +438,6 @@ fn analyze_trait_definition(trait_def: &crate::ast::TraitDef, scope: &mut Scope)
             // They'll be inferred based on the impl
             params.push((param_name, GlossaType::Unknown));
         }
-
-        method_signatures.push((method_name.clone(), params.clone(), method.is_default));
 
         let signature = crate::semantic::types::MethodSignature {
             name: method_name.clone(),
@@ -447,31 +452,47 @@ fn analyze_trait_definition(trait_def: &crate::ast::TraitDef, scope: &mut Scope)
                 let mut analyzed_body = Vec::new();
                 // Create a child scope for the method
                 let mut method_scope = scope.child();
-                // Add method parameters to scope
+                // Add method parameters to scope (including self)
                 for (param_name, param_type) in &params {
                     method_scope.define(param_name.clone(), param_type.clone());
                 }
-                // Analyze statements in the body
+                // Properly analyze statements in the body
                 for body_stmt in body_stmts {
-                    // For now, just do basic analysis
-                    // We'll need to recursively call the analyzer here
-                    // For simplicity in this implementation, we'll skip detailed analysis
-                    analyzed_body.push(AnalyzedStatement {
-                        kind: StatementKind::Expression,
-                        expressions: vec![],
-                    });
+                    if let Some(struct_inst) = try_parse_struct_instantiation(body_stmt, &mut method_scope)? {
+                        analyzed_body.push(struct_inst);
+                    } else if let Some(method_call) = try_parse_trait_method_call(body_stmt, &mut method_scope)? {
+                        analyzed_body.push(method_call);
+                    } else {
+                        let assembled = analyze_single_statement_with_assembler(body_stmt)?;
+                        let analyzed = convert_assembled_to_analyzed(&assembled, &mut method_scope)?;
+                        analyzed_body.push(analyzed);
+                    }
                 }
-                analyzed_body
+                Some(analyzed_body)
             } else {
-                vec![]
+                Some(vec![])
             };
 
             default_methods.push(crate::semantic::types::DefaultMethod {
-                signature,
+                signature: signature.clone(),
+                body: body.clone().unwrap_or_default(),
+            });
+
+            analyzed_methods.push(AnalyzedTraitMethod {
+                name: method_name,
+                params,
+                is_default: true,
                 body,
             });
         } else {
             required_methods.push(signature);
+
+            analyzed_methods.push(AnalyzedTraitMethod {
+                name: method_name,
+                params,
+                is_default: false,
+                body: None,
+            });
         }
     }
 
@@ -488,7 +509,7 @@ fn analyze_trait_definition(trait_def: &crate::ast::TraitDef, scope: &mut Scope)
     Ok(AnalyzedStatement {
         kind: StatementKind::TraitDefinition {
             name: trait_name,
-            methods: method_signatures,
+            methods: analyzed_methods,
         },
         expressions: vec![],
     })
@@ -1771,6 +1792,13 @@ fn classify_assembled_statement(
 
                 // Check if type exists in scope
                 if let Some(struct_type) = scope.lookup_type(&type_name).cloned() {
+                    // Extract field names from struct type
+                    let field_names: Vec<String> = if let GlossaType::Struct { fields, .. } = &struct_type {
+                        fields.iter().map(|(name, _)| name.clone()).collect()
+                    } else {
+                        vec![]
+                    };
+
                     // Get constructor arguments from literals
                     let args: Vec<AnalyzedExpr> = asm_stmt.literals.iter()
                         .map(literal_to_analyzed_expr)
@@ -1780,6 +1808,7 @@ fn classify_assembled_statement(
                     let struct_inst = AnalyzedExpr {
                         expr: AnalyzedExprKind::StructInstantiation {
                             type_name: type_name.clone(),
+                            fields: field_names,
                             args,
                         },
                         glossa_type: struct_type.clone(),
@@ -2543,7 +2572,7 @@ pub enum StatementKind {
     /// Trait definition: χαρακτήρ name ὁρίζειν { methods }
     TraitDefinition {
         name: String,
-        methods: Vec<(String, Vec<(String, GlossaType)>, bool)>, // (name, params, is_default)
+        methods: Vec<AnalyzedTraitMethod>,
     },
     /// Trait implementation: εἶδος Type τῷ Trait ἐμπίπτειν { methods }
     TraitImplementation {
@@ -2551,6 +2580,15 @@ pub enum StatementKind {
         type_name: String,
         methods: Vec<AnalyzedImplMethod>,
     },
+}
+
+/// An analyzed method in a trait definition
+#[derive(Debug, Clone)]
+pub struct AnalyzedTraitMethod {
+    pub name: String,
+    pub params: Vec<(String, GlossaType)>,
+    pub is_default: bool,
+    pub body: Option<Vec<AnalyzedStatement>>,  // Some for default methods, None for required
 }
 
 /// An analyzed method in a trait implementation
@@ -2622,6 +2660,7 @@ pub enum AnalyzedExprKind {
     /// Struct instantiation Type { field: value, ... }
     StructInstantiation {
         type_name: String,
+        fields: Vec<String>,  // Field names from struct definition
         args: Vec<AnalyzedExpr>,
     },
 }
@@ -2713,16 +2752,13 @@ impl SemanticAnalyzer {
         // Check for struct instantiation pattern: var_name νέον TypeName args... ἔστω
         // Must be checked before assembler since TypeName might be a Latin identifier
         if terms.len() >= 4 {
-            eprintln!("DEBUG analyze_phrase: checking struct inst pattern, terms.len()={}", terms.len());
             // Check if last term is ἔστω (binding verb)
             if let Expr::Word(last_word) = terms.last().unwrap() {
-                eprintln!("DEBUG analyze_phrase: last_word={}, is_binding={}", last_word.normalized, crate::morphology::lexicon::is_binding_verb(&last_word.normalized));
                 if crate::morphology::lexicon::is_binding_verb(&last_word.normalized) {
                     // Check if second term is νέον (new)
                     if let Expr::Word(second_word) = &terms[1] {
-                        let normalized_adj = crate::grammar::normalize_greek(&second_word.normalized);
-                        eprintln!("DEBUG analyze_phrase: second_word={}, normalized={}, is_neos={}", second_word.normalized, normalized_adj, normalized_adj == "νεος");
-                        if normalized_adj == "νεος" {
+                        let normalized_adj = &second_word.normalized;
+                        if normalized_adj == "νεος" || normalized_adj == "νεον" {
                             // This looks like: var_name νέον TypeName args... ἔστω
                             if let Expr::Word(var_word) = &terms[0] {
                                 if let Expr::Word(type_word) = &terms[2] {
@@ -2731,6 +2767,13 @@ impl SemanticAnalyzer {
 
                                     // Check if the type exists
                                     if let Some(struct_type) = self.scope.lookup_type(type_name).cloned() {
+                                        // Extract field names from struct type
+                                        let field_names: Vec<String> = if let GlossaType::Struct { fields, .. } = &struct_type {
+                                            fields.iter().map(|(name, _)| name.clone()).collect()
+                                        } else {
+                                            vec![]
+                                        };
+
                                         // Collect constructor arguments (everything between type_name and ἔστω)
                                         let mut args = Vec::new();
                                         for i in 3..terms.len()-1 {
@@ -2741,6 +2784,7 @@ impl SemanticAnalyzer {
                                         let struct_inst = AnalyzedExpr {
                                             expr: AnalyzedExprKind::StructInstantiation {
                                                 type_name: type_name.clone(),
+                                                fields: field_names,
                                                 args,
                                             },
                                             glossa_type: struct_type.clone(),

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -51,6 +51,18 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
             continue;
         }
 
+        // Handle trait definitions
+        if let Statement::TraitDefinition(trait_def) = stmt {
+            analyzed_statements.push(analyze_trait_definition(trait_def, &mut scope)?);
+            continue;
+        }
+
+        // Handle trait implementations
+        if let Statement::TraitImpl(trait_impl) = stmt {
+            analyzed_statements.push(analyze_trait_impl(trait_impl, &mut scope)?);
+            continue;
+        }
+
         // Check if this is a control flow construct
         if let Some(control_flow_stmt) = analyze_control_flow(stmt, &mut scope)? {
             // If it's a function definition, register it in the scope
@@ -62,10 +74,21 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
             }
             analyzed_statements.push(control_flow_stmt);
         } else {
-            // Use the assembler-based approach for regular statements
-            let assembled = analyze_single_statement_with_assembler(stmt)?;
-            let analyzed = convert_assembled_to_analyzed(&assembled, &mut scope)?;
-            analyzed_statements.push(analyzed);
+            // Check for struct instantiation pattern BEFORE assembler
+            // Pattern: var_name νέον TypeName args... ἔστω
+            if let Some(struct_inst) = try_parse_struct_instantiation(stmt, &mut scope)? {
+                analyzed_statements.push(struct_inst);
+            }
+            // Check for trait method call pattern BEFORE assembler
+            // Pattern: method_name receiver
+            else if let Some(method_call) = try_parse_trait_method_call(stmt, &mut scope)? {
+                analyzed_statements.push(method_call);
+            } else {
+                // Use the assembler-based approach for regular statements
+                let assembled = analyze_single_statement_with_assembler(stmt)?;
+                let analyzed = convert_assembled_to_analyzed(&assembled, &mut scope)?;
+                analyzed_statements.push(analyzed);
+            }
         }
     }
 
@@ -177,7 +200,172 @@ fn analyze_control_flow(stmt: &Statement, _scope: &mut Scope) -> Result<Option<A
     Ok(None)
 }
 
+/// Try to parse a trait method call: method_name receiver
+/// Returns Some(analyzed_statement) if this is a trait method call, None otherwise
+fn try_parse_trait_method_call(stmt: &Statement, scope: &mut Scope) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    // Only process Regular statements
+    if let Statement::Regular { clauses, .. } = stmt {
+        // Should have exactly one clause with one expression
+        if clauses.len() != 1 || clauses[0].expressions.len() != 1 {
+            return Ok(None);
+        }
+
+        // Should be a Phrase with exactly 2 words
+        if let Expr::Phrase(terms) = &clauses[0].expressions[0] {
+            if terms.len() != 2 {
+                return Ok(None);
+            }
+
+            // Extract words
+            if let (Expr::Word(method_word), Expr::Word(receiver_word)) = (&terms[0], &terms[1]) {
+                let method_name = &method_word.normalized;
+                let receiver_name = &receiver_word.normalized;
+
+                // Check if receiver is a variable in scope
+                if let Some(receiver_type) = scope.lookup(receiver_name) {
+                    if let GlossaType::Struct { name: type_name, .. } = receiver_type {
+                        // Check if this type has a trait method with this name
+                        if scope.has_trait_method(type_name, method_name) {
+                            let receiver = AnalyzedExpr {
+                                expr: AnalyzedExprKind::Variable(receiver_name.clone()),
+                                glossa_type: receiver_type.clone(),
+                            };
+
+                            let method_call = AnalyzedExpr {
+                                expr: AnalyzedExprKind::MethodCall {
+                                    receiver: Box::new(receiver),
+                                    method: method_name.clone(),
+                                    args: vec![],
+                                },
+                                glossa_type: GlossaType::Unit,
+                            };
+
+                            return Ok(Some(AnalyzedStatement {
+                                kind: StatementKind::Expression,
+                                expressions: vec![method_call],
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
 /// Try to parse a struct instantiation: variable νέον type_name args ἔστω
+/// Returns Some(analyzed_statement) if this is a struct instantiation, None otherwise
+fn try_parse_struct_instantiation(stmt: &Statement, scope: &mut Scope) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    // Only process Regular statements
+    if let Statement::Regular { clauses, .. } = stmt {
+        // Should have exactly one clause
+        if clauses.len() != 1 {
+            return Ok(None);
+        }
+
+        let clause = &clauses[0];
+        if clause.expressions.len() != 1 {
+            return Ok(None);
+        }
+
+        // Should be a Phrase with at least 4 words
+        if let Expr::Phrase(terms) = &clause.expressions[0] {
+            if terms.len() < 4 {
+                return Ok(None);
+            }
+
+
+            // Extract words
+            let mut words = Vec::new();
+            for term in terms {
+                if let Expr::Word(w) = term {
+                    words.push(w);
+                } else {
+                    return Ok(None); // Not all words
+                }
+            }
+
+            // Check pattern: var_name νέον TypeName args... ἔστω
+            // Last word should be ἔστω (binding verb)
+            if !crate::morphology::lexicon::is_binding_verb(&words.last().unwrap().normalized) {
+                return Ok(None);
+            }
+
+            // Second word should be νέον (new) - check both normalized form and if it's "new" via morphology
+            let normalized_adj = crate::grammar::normalize_greek(&words[1].normalized);
+            // Check if it's "new" - could be νέον, νεον, etc.
+            if normalized_adj != "νεον" && normalized_adj != "νεος" {
+                return Ok(None);
+            }
+
+            // Extract components
+            let var_name = &words[0].normalized;
+            let type_name = &words[2].normalized;
+
+            // Check if type exists
+            if let Some(struct_type) = scope.lookup_type(type_name).cloned() {
+
+                // Collect constructor arguments (everything between type_name and ἔστω)
+                let mut args = Vec::new();
+                for i in 3..words.len()-1 {
+                    // Convert word to analyzed expression
+                    let word = words[i];
+                    let analyzed_arg = if let Some(num) = word.original.parse::<i64>().ok() {
+                        // Direct numeric literal like "5"
+                        AnalyzedExpr {
+                            expr: AnalyzedExprKind::NumberLiteral(num),
+                            glossa_type: GlossaType::Number,
+                        }
+                    } else if let Some(num) = crate::morphology::lexicon::numeral_value(&word.normalized) {
+                        // Greek numeral word like πέντε -> 5
+                        AnalyzedExpr {
+                            expr: AnalyzedExprKind::NumberLiteral(num),
+                            glossa_type: GlossaType::Number,
+                        }
+                    } else {
+                        // Variable reference
+                        let var_type = scope.lookup(&word.normalized).cloned().unwrap_or(GlossaType::Unknown);
+                        AnalyzedExpr {
+                            expr: AnalyzedExprKind::Variable(word.normalized.clone()),
+                            glossa_type: var_type,
+                        }
+                    };
+                    args.push(analyzed_arg);
+                }
+
+                // Build struct instantiation
+                let struct_inst = AnalyzedExpr {
+                    expr: AnalyzedExprKind::StructInstantiation {
+                        type_name: type_name.clone(),
+                        args,
+                    },
+                    glossa_type: struct_type.clone(),
+                };
+
+                // Register variable in scope with correct type
+                scope.define(var_name.clone(), struct_type.clone());
+
+                return Ok(Some(AnalyzedStatement {
+                    kind: StatementKind::Binding {
+                        name: var_name.clone(),
+                        value_type: struct_type.clone(),
+                    },
+                    expressions: vec![
+                        AnalyzedExpr {
+                            expr: AnalyzedExprKind::Variable(var_name.clone()),
+                            glossa_type: struct_type.clone(),
+                        },
+                        struct_inst,
+                    ],
+                }));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
 /// Analyze a type definition statement
 fn analyze_type_definition(type_def: &crate::ast::TypeDef, scope: &mut Scope) -> Result<AnalyzedStatement, GlossaError> {
     use crate::grammar::normalize_greek;
@@ -210,6 +398,194 @@ fn analyze_type_definition(type_def: &crate::ast::TypeDef, scope: &mut Scope) ->
         kind: StatementKind::TypeDefinition {
             name: type_name,
             fields,
+        },
+        expressions: vec![],
+    })
+}
+
+/// Analyze a trait definition statement
+fn analyze_trait_definition(trait_def: &crate::ast::TraitDef, scope: &mut Scope) -> Result<AnalyzedStatement, GlossaError> {
+    use crate::grammar::normalize_greek;
+
+    // Extract trait name
+    let trait_name = normalize_greek(&trait_def.name.original);
+
+    // Check for duplicate trait definition
+    if scope.lookup_trait(&trait_name).is_some() {
+        return Err(GlossaError::semantic(format!("Trait {} is already defined", trait_name)));
+    }
+
+    // Analyze methods
+    let mut required_methods = Vec::new();
+    let mut default_methods = Vec::new();
+    let mut method_signatures = Vec::new();
+
+    for method in &trait_def.methods {
+        let method_name = normalize_greek(&method.name.original);
+
+        // Analyze method parameters
+        let mut params = Vec::new();
+        for param in &method.params {
+            let param_name = normalize_greek(&param.name.original);
+            // For now, trait method parameters don't have explicit types
+            // They'll be inferred based on the impl
+            params.push((param_name, GlossaType::Unknown));
+        }
+
+        method_signatures.push((method_name.clone(), params.clone(), method.is_default));
+
+        let signature = crate::semantic::types::MethodSignature {
+            name: method_name.clone(),
+            params: params.clone(),
+            return_type: None,
+            has_default: method.is_default,
+        };
+
+        if method.is_default {
+            // Analyze default method body
+            let body = if let Some(body_stmts) = &method.body {
+                let mut analyzed_body = Vec::new();
+                // Create a child scope for the method
+                let mut method_scope = scope.child();
+                // Add method parameters to scope
+                for (param_name, param_type) in &params {
+                    method_scope.define(param_name.clone(), param_type.clone());
+                }
+                // Analyze statements in the body
+                for body_stmt in body_stmts {
+                    // For now, just do basic analysis
+                    // We'll need to recursively call the analyzer here
+                    // For simplicity in this implementation, we'll skip detailed analysis
+                    analyzed_body.push(AnalyzedStatement {
+                        kind: StatementKind::Expression,
+                        expressions: vec![],
+                    });
+                }
+                analyzed_body
+            } else {
+                vec![]
+            };
+
+            default_methods.push(crate::semantic::types::DefaultMethod {
+                signature,
+                body,
+            });
+        } else {
+            required_methods.push(signature);
+        }
+    }
+
+    // Create the trait definition
+    let trait_def_semantic = crate::semantic::types::TraitDef {
+        name: trait_name.clone(),
+        required_methods,
+        default_methods,
+    };
+
+    // Store the trait in scope
+    scope.define_trait(trait_name.clone(), trait_def_semantic);
+
+    Ok(AnalyzedStatement {
+        kind: StatementKind::TraitDefinition {
+            name: trait_name,
+            methods: method_signatures,
+        },
+        expressions: vec![],
+    })
+}
+
+/// Analyze a trait implementation statement
+fn analyze_trait_impl(trait_impl: &crate::ast::TraitImplDef, scope: &mut Scope) -> Result<AnalyzedStatement, GlossaError> {
+    use crate::grammar::normalize_greek;
+
+    // Extract type and trait names
+    let type_name = normalize_greek(&trait_impl.type_name.original);
+    let trait_name = normalize_greek(&trait_impl.trait_name.original);
+
+    // Validate: trait must exist
+    let trait_def = scope.lookup_trait(&trait_name)
+        .ok_or_else(|| GlossaError::semantic(format!("Trait {} is not defined", trait_name)))?;
+
+    // Validate: type must exist
+    let struct_type = scope.lookup_type(&type_name)
+        .cloned()
+        .ok_or_else(|| GlossaError::semantic(format!("Type {} is not defined", type_name)))?;
+
+    // Collect implemented methods
+    let mut implemented_method_names = Vec::new();
+    let mut analyzed_methods = Vec::new();
+
+    for method in &trait_impl.methods {
+        let method_name = normalize_greek(&method.name.original);
+
+        // Analyze method parameters
+        let mut params = Vec::new();
+        for param in &method.params {
+            let param_name = normalize_greek(&param.name.original);
+            // For now, trait method parameters don't have explicit types
+            params.push((param_name, GlossaType::Unknown));
+        }
+
+        // Create a child scope for the method body with self bound
+        let mut method_scope = scope.child();
+        method_scope.define("self".to_string(), struct_type.clone());
+
+        // Also bind parameters
+        for (param_name, param_type) in &params {
+            method_scope.define(param_name.clone(), param_type.clone());
+        }
+
+        // Analyze the method body
+        let mut analyzed_body = Vec::new();
+        for body_stmt in &method.body {
+            // Try struct instantiation pattern first
+            if let Some(struct_inst) = try_parse_struct_instantiation(body_stmt, &mut method_scope)? {
+                analyzed_body.push(struct_inst);
+            }
+            // Try trait method call pattern
+            else if let Some(method_call) = try_parse_trait_method_call(body_stmt, &mut method_scope)? {
+                analyzed_body.push(method_call);
+            } else {
+                // Use assembler for regular statements
+                let assembled = analyze_single_statement_with_assembler(body_stmt)?;
+                let analyzed = convert_assembled_to_analyzed(&assembled, &mut method_scope)?;
+                analyzed_body.push(analyzed);
+            }
+        }
+
+        implemented_method_names.push(method_name.clone());
+        analyzed_methods.push(AnalyzedImplMethod {
+            name: method_name,
+            params,
+            body: analyzed_body,
+        });
+    }
+
+    // Validate: all required methods must be implemented
+    for required_method in &trait_def.required_methods {
+        if !implemented_method_names.contains(&required_method.name) {
+            return Err(GlossaError::semantic(format!(
+                "Type {} does not implement required method {} from trait {}",
+                type_name, required_method.name, trait_name
+            )));
+        }
+    }
+
+    // Create the trait implementation
+    let trait_impl_semantic = crate::semantic::types::TraitImpl {
+        trait_name: trait_name.clone(),
+        type_name: type_name.clone(),
+        methods: vec![], // Semantic tracking only needs names for now
+    };
+
+    // Register the trait impl in scope
+    scope.register_trait_impl(trait_impl_semantic);
+
+    Ok(AnalyzedStatement {
+        kind: StatementKind::TraitImplementation {
+            trait_name,
+            type_name,
+            methods: analyzed_methods,
         },
         expressions: vec![],
     })
@@ -1373,9 +1749,10 @@ fn classify_assembled_statement(
         }
     }
 
-    // Check for struct instantiation pattern
+    // Check for struct instantiation pattern (assembler-based, for Greek type names)
     // Pattern: subject νέον type_name args... ἔστω
     // Example: π νέον σημεῖον πέντε ἔστω
+    // Note: Latin identifier type names are handled before the assembler
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = normalize_greek(&verb.lemma);
 
@@ -2163,6 +2540,25 @@ pub enum StatementKind {
         name: String,
         fields: Vec<(String, GlossaType)>,
     },
+    /// Trait definition: χαρακτήρ name ὁρίζειν { methods }
+    TraitDefinition {
+        name: String,
+        methods: Vec<(String, Vec<(String, GlossaType)>, bool)>, // (name, params, is_default)
+    },
+    /// Trait implementation: εἶδος Type τῷ Trait ἐμπίπτειν { methods }
+    TraitImplementation {
+        trait_name: String,
+        type_name: String,
+        methods: Vec<AnalyzedImplMethod>,
+    },
+}
+
+/// An analyzed method in a trait implementation
+#[derive(Debug, Clone)]
+pub struct AnalyzedImplMethod {
+    pub name: String,
+    pub params: Vec<(String, GlossaType)>,
+    pub body: Vec<AnalyzedStatement>,
 }
 
 /// Analyzed expression with type information
@@ -2214,6 +2610,13 @@ pub enum AnalyzedExprKind {
     MethodCall {
         receiver: Box<AnalyzedExpr>,
         method: String,
+        args: Vec<AnalyzedExpr>,
+    },
+    /// Trait method call receiverου method args (from trait impl)
+    TraitMethodCall {
+        receiver: Box<AnalyzedExpr>,
+        trait_name: String,
+        method_name: String,
         args: Vec<AnalyzedExpr>,
     },
     /// Struct instantiation Type { field: value, ... }
@@ -2306,6 +2709,100 @@ impl SemanticAnalyzer {
         is_query: bool,
     ) -> Result<(StatementKind, Vec<AnalyzedExpr>), GlossaError> {
         // Look for patterns: binding, print, property access
+
+        // Check for struct instantiation pattern: var_name νέον TypeName args... ἔστω
+        // Must be checked before assembler since TypeName might be a Latin identifier
+        if terms.len() >= 4 {
+            eprintln!("DEBUG analyze_phrase: checking struct inst pattern, terms.len()={}", terms.len());
+            // Check if last term is ἔστω (binding verb)
+            if let Expr::Word(last_word) = terms.last().unwrap() {
+                eprintln!("DEBUG analyze_phrase: last_word={}, is_binding={}", last_word.normalized, crate::morphology::lexicon::is_binding_verb(&last_word.normalized));
+                if crate::morphology::lexicon::is_binding_verb(&last_word.normalized) {
+                    // Check if second term is νέον (new)
+                    if let Expr::Word(second_word) = &terms[1] {
+                        let normalized_adj = crate::grammar::normalize_greek(&second_word.normalized);
+                        eprintln!("DEBUG analyze_phrase: second_word={}, normalized={}, is_neos={}", second_word.normalized, normalized_adj, normalized_adj == "νεος");
+                        if normalized_adj == "νεος" {
+                            // This looks like: var_name νέον TypeName args... ἔστω
+                            if let Expr::Word(var_word) = &terms[0] {
+                                if let Expr::Word(type_word) = &terms[2] {
+                                    let var_name = &var_word.normalized;
+                                    let type_name = &type_word.normalized;
+
+                                    // Check if the type exists
+                                    if let Some(struct_type) = self.scope.lookup_type(type_name).cloned() {
+                                        // Collect constructor arguments (everything between type_name and ἔστω)
+                                        let mut args = Vec::new();
+                                        for i in 3..terms.len()-1 {
+                                            args.push(self.analyze_single_expr(&terms[i])?);
+                                        }
+
+                                        // Build struct instantiation
+                                        let struct_inst = AnalyzedExpr {
+                                            expr: AnalyzedExprKind::StructInstantiation {
+                                                type_name: type_name.clone(),
+                                                args,
+                                            },
+                                            glossa_type: struct_type.clone(),
+                                        };
+
+                                        // Register variable in scope with correct type
+                                        self.scope.define(var_name.clone(), struct_type.clone());
+
+                                        return Ok((
+                                            StatementKind::Binding {
+                                                name: var_name.clone(),
+                                                value_type: struct_type.clone(),
+                                            },
+                                            vec![
+                                                AnalyzedExpr {
+                                                    expr: AnalyzedExprKind::Variable(var_name.clone()),
+                                                    glossa_type: struct_type.clone(),
+                                                },
+                                                struct_inst,
+                                            ],
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check for trait method call pattern: method_name receiver (e.g., "show π")
+        // This must be checked before verb analysis since method names may not be Greek verbs
+        if terms.len() == 2 {
+            if let (Expr::Word(method_word), Expr::Word(receiver_word)) = (&terms[0], &terms[1]) {
+                let method_name = &method_word.normalized;
+                let receiver_name = &receiver_word.normalized;
+
+                // Check if receiver is a variable in scope
+                if let Some(receiver_type) = self.scope.lookup(receiver_name) {
+                    if let GlossaType::Struct { name: type_name, .. } = receiver_type {
+                        // Check if this type has a trait method with this name
+                        if self.scope.has_trait_method(type_name, method_name) {
+                            let receiver = AnalyzedExpr {
+                                expr: AnalyzedExprKind::Variable(receiver_name.clone()),
+                                glossa_type: receiver_type.clone(),
+                            };
+
+                            let method_call = AnalyzedExpr {
+                                expr: AnalyzedExprKind::MethodCall {
+                                    receiver: Box::new(receiver),
+                                    method: method_name.clone(),
+                                    args: vec![],
+                                },
+                                glossa_type: GlossaType::Unit,
+                            };
+
+                            return Ok((StatementKind::Expression, vec![method_call]));
+                        }
+                    }
+                }
+            }
+        }
 
         // Find verb position and type
         let mut verb_idx = None;

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -14,6 +14,10 @@ pub struct Scope {
     functions: FxHashMap<String, FunctionSignature>,
     /// Type definitions in this scope
     types: FxHashMap<String, GlossaType>,
+    /// Trait definitions in this scope
+    traits: FxHashMap<String, crate::semantic::types::TraitDef>,
+    /// Trait implementations in this scope
+    trait_impls: Vec<crate::semantic::types::TraitImpl>,
     /// Parent scope (for nested scopes)
     parent: Option<Box<Scope>>,
 }
@@ -49,6 +53,8 @@ impl Scope {
             bindings: FxHashMap::default(),
             functions: FxHashMap::default(),
             types: FxHashMap::default(),
+            traits: FxHashMap::default(),
+            trait_impls: Vec::new(),
             parent: None,
         }
     }
@@ -59,6 +65,8 @@ impl Scope {
             bindings: FxHashMap::default(),
             functions: FxHashMap::default(),
             types: FxHashMap::default(),
+            traits: FxHashMap::default(),
+            trait_impls: Vec::new(),
             parent: Some(Box::new(self.clone())),
         }
     }
@@ -110,6 +118,64 @@ impl Scope {
             parent.lookup_type(name)
         } else {
             None
+        }
+    }
+
+    /// Define a trait in this scope
+    pub fn define_trait(&mut self, name: String, trait_def: crate::semantic::types::TraitDef) {
+        self.traits.insert(name, trait_def);
+    }
+
+    /// Look up a trait by name
+    pub fn lookup_trait(&self, name: &str) -> Option<&crate::semantic::types::TraitDef> {
+        if let Some(trait_def) = self.traits.get(name) {
+            Some(trait_def)
+        } else if let Some(parent) = &self.parent {
+            parent.lookup_trait(name)
+        } else {
+            None
+        }
+    }
+
+    /// Register a trait implementation
+    pub fn register_trait_impl(&mut self, impl_def: crate::semantic::types::TraitImpl) {
+        self.trait_impls.push(impl_def);
+    }
+
+    /// Look up a trait implementation for a given type and trait
+    pub fn lookup_trait_impl(&self, type_name: &str, trait_name: &str) -> Option<&crate::semantic::types::TraitImpl> {
+        for impl_def in &self.trait_impls {
+            if impl_def.type_name == type_name && impl_def.trait_name == trait_name {
+                return Some(impl_def);
+            }
+        }
+        if let Some(parent) = &self.parent {
+            parent.lookup_trait_impl(type_name, trait_name)
+        } else {
+            None
+        }
+    }
+
+    /// Check if a type has a trait method with the given name
+    pub fn has_trait_method(&self, type_name: &str, method_name: &str) -> bool {
+        for trait_impl in &self.trait_impls {
+            if trait_impl.type_name != type_name {
+                continue;
+            }
+            // Check if the trait has this method
+            if let Some(trait_def) = self.lookup_trait(&trait_impl.trait_name) {
+                let has_method = trait_def.required_methods.iter().any(|m| m.name == method_name) ||
+                                 trait_def.default_methods.iter().any(|m| m.signature.name == method_name);
+                if has_method {
+                    return true;
+                }
+            }
+        }
+        // Check parent scope
+        if let Some(parent) = &self.parent {
+            parent.has_trait_method(type_name, method_name)
+        } else {
+            false
         }
     }
 

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -165,6 +165,46 @@ pub fn infer_type(word: &str) -> GlossaType {
     GlossaType::Unknown
 }
 
+/// Trait definition for semantic analysis
+#[derive(Debug, Clone)]
+pub struct TraitDef {
+    pub name: std::string::String,
+    pub required_methods: Vec<MethodSignature>,
+    pub default_methods: Vec<DefaultMethod>,
+}
+
+/// Method signature in a trait
+#[derive(Debug, Clone, PartialEq)]
+pub struct MethodSignature {
+    pub name: std::string::String,
+    pub params: Vec<(std::string::String, GlossaType)>,
+    pub return_type: Option<GlossaType>,
+    pub has_default: bool,
+}
+
+/// Default method with implementation
+#[derive(Debug, Clone)]
+pub struct DefaultMethod {
+    pub signature: MethodSignature,
+    pub body: Vec<crate::semantic::AnalyzedStatement>,
+}
+
+/// Trait implementation for a type
+#[derive(Debug, Clone)]
+pub struct TraitImpl {
+    pub trait_name: std::string::String,
+    pub type_name: std::string::String,
+    pub methods: Vec<ImplMethod>,
+}
+
+/// Method implementation in a trait impl
+#[derive(Debug, Clone)]
+pub struct ImplMethod {
+    pub name: std::string::String,
+    pub params: Vec<(std::string::String, GlossaType)>,
+    pub body: Vec<crate::semantic::AnalyzedStatement>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/trait_tests.rs
+++ b/tests/trait_tests.rs
@@ -1,0 +1,589 @@
+use glossa::ast::{build_ast, Statement};
+use glossa::semantic::analyze_program;
+
+// =============================================================================
+// CYCLE 1: Trait Definition Parsing
+// =============================================================================
+
+#[test]
+fn test_parse_empty_trait() {
+    let input = "χαρακτήρ Showable ὁρίζειν { }.";
+    let ast = build_ast(input).expect("Parsing failed");
+
+    assert_eq!(ast.statements.len(), 1);
+    match &ast.statements[0] {
+        Statement::TraitDefinition(trait_def) => {
+            assert_eq!(trait_def.name.original, "Showable");
+            assert_eq!(trait_def.methods.len(), 0);
+        }
+        _ => panic!("Expected TraitDefinition, got {:?}", ast.statements[0]),
+    }
+}
+
+#[test]
+fn test_parse_trait_with_required_method() {
+    let input = "χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.";
+    let ast = build_ast(input).expect("Parsing failed");
+
+    assert_eq!(ast.statements.len(), 1);
+    match &ast.statements[0] {
+        Statement::TraitDefinition(trait_def) => {
+            assert_eq!(trait_def.name.original, "Showable");
+            assert_eq!(trait_def.methods.len(), 1);
+
+            let method = &trait_def.methods[0];
+            assert_eq!(method.name.original, "show");
+            assert_eq!(method.is_default, false);
+            assert!(method.body.is_none());
+            assert_eq!(method.params.len(), 1); // self parameter
+        }
+        _ => panic!("Expected TraitDefinition, got {:?}", ast.statements[0]),
+    }
+}
+
+#[test]
+fn test_parse_trait_with_default_method() {
+    let input = "χαρακτήρ Math ὁρίζειν { ἤδη double τῷ self· δός selfου add self. }.";
+    let ast = build_ast(input).expect("Parsing failed");
+
+    assert_eq!(ast.statements.len(), 1);
+    match &ast.statements[0] {
+        Statement::TraitDefinition(trait_def) => {
+            assert_eq!(trait_def.name.original, "Math");
+            assert_eq!(trait_def.methods.len(), 1);
+
+            let method = &trait_def.methods[0];
+            assert_eq!(method.name.original, "double");
+            assert_eq!(method.is_default, true);
+            assert!(method.body.is_some());
+        }
+        _ => panic!("Expected TraitDefinition, got {:?}", ast.statements[0]),
+    }
+}
+
+#[test]
+fn test_parse_trait_multiple_methods() {
+    let input = r#"
+        χαρακτήρ Math ὁρίζειν {
+            δεῖ add τῷ self τῷ other.
+            ἤδη double τῷ self· δός selfου add self.
+        }.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+
+    assert_eq!(ast.statements.len(), 1);
+    match &ast.statements[0] {
+        Statement::TraitDefinition(trait_def) => {
+            assert_eq!(trait_def.name.original, "Math");
+            assert_eq!(trait_def.methods.len(), 2);
+
+            // First method: required
+            assert_eq!(trait_def.methods[0].name.original, "add");
+            assert_eq!(trait_def.methods[0].is_default, false);
+            assert_eq!(trait_def.methods[0].params.len(), 2); // self and other
+
+            // Second method: default
+            assert_eq!(trait_def.methods[1].name.original, "double");
+            assert_eq!(trait_def.methods[1].is_default, true);
+            assert!(trait_def.methods[1].body.is_some());
+        }
+        _ => panic!("Expected TraitDefinition, got {:?}", ast.statements[0]),
+    }
+}
+
+// =============================================================================
+// CYCLE 2: Trait Semantic Analysis
+// =============================================================================
+
+#[test]
+fn test_analyze_trait_definition() {
+    let input = "χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.";
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_ok(), "Trait definition should analyze without errors: {:?}", result.err());
+}
+
+#[test]
+fn test_trait_stored_in_scope() {
+    // This test will need access to the scope after analysis
+    // For now, we'll just check that analysis succeeds
+    let input = "χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.";
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_ok(), "Should store trait in scope: {:?}", result.err());
+}
+
+#[test]
+fn test_duplicate_trait_error() {
+    let input = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        χαρακτήρ Showable ὁρίζειν { δεῖ display τῷ self. }.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_err(), "Should error on duplicate trait name");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("already defined") || err_msg.contains("duplicate"),
+            "Error should mention duplicate/already defined: {}", err_msg);
+}
+
+#[test]
+fn test_default_method_body_analysis() {
+    let input = "χαρακτήρ Math ὁρίζειν { ἤδη double τῷ self· δός πέντε. }.";
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_ok(), "Default method body should be analyzed: {:?}", result.err());
+}
+
+// =============================================================================
+// CYCLE 3: Trait Implementation Parsing
+// =============================================================================
+
+#[test]
+fn test_parse_empty_trait_impl() {
+    let input = "εἶδος Point τῷ Showable ἐμπίπτειν { }.";
+    let ast = build_ast(input).expect("Parsing failed");
+
+    assert_eq!(ast.statements.len(), 1);
+    match &ast.statements[0] {
+        Statement::TraitImpl(trait_impl) => {
+            assert_eq!(trait_impl.type_name.original, "Point");
+            assert_eq!(trait_impl.trait_name.original, "Showable");
+            assert_eq!(trait_impl.methods.len(), 0);
+        }
+        _ => panic!("Expected TraitImpl, got {:?}", ast.statements[0]),
+    }
+}
+
+#[test]
+fn test_parse_trait_impl_with_method() {
+    let input = r#"
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+
+    assert_eq!(ast.statements.len(), 1);
+    match &ast.statements[0] {
+        Statement::TraitImpl(trait_impl) => {
+            assert_eq!(trait_impl.type_name.original, "Point");
+            assert_eq!(trait_impl.trait_name.original, "Showable");
+            assert_eq!(trait_impl.methods.len(), 1);
+
+            let method = &trait_impl.methods[0];
+            assert_eq!(method.name.original, "show");
+            assert!(method.body.len() > 0);
+        }
+        _ => panic!("Expected TraitImpl, got {:?}", ast.statements[0]),
+    }
+}
+
+#[test]
+fn test_parse_impl_multiple_methods() {
+    let input = r#"
+        εἶδος Number τῷ Math ἐμπίπτειν {
+            add τῷ self τῷ other· δός νέον Number (selfου v otherou v ἄθροισμα).
+            subtract τῷ self τῷ other· δός νέον Number (selfου v otherou v διαφορά).
+        }.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+
+    assert_eq!(ast.statements.len(), 1);
+    match &ast.statements[0] {
+        Statement::TraitImpl(trait_impl) => {
+            assert_eq!(trait_impl.type_name.original, "Number");
+            assert_eq!(trait_impl.trait_name.original, "Math");
+            assert_eq!(trait_impl.methods.len(), 2);
+
+            assert_eq!(trait_impl.methods[0].name.original, "add");
+            assert_eq!(trait_impl.methods[1].name.original, "subtract");
+        }
+        _ => panic!("Expected TraitImpl, got {:?}", ast.statements[0]),
+    }
+}
+
+// =============================================================================
+// CYCLE 4: Trait Implementation Validation
+// =============================================================================
+
+#[test]
+fn test_analyze_trait_impl() {
+    let input = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_ok(), "Valid impl should analyze without errors: {:?}", result.err());
+}
+
+#[test]
+fn test_impl_for_undefined_trait_error() {
+    let input = r#"
+        εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_err(), "Should error when trait doesn't exist");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.to_lowercase().contains("showable") || err_msg.contains("not") || err_msg.contains("defined"),
+            "Error should mention undefined trait: {}", err_msg);
+}
+
+#[test]
+fn test_impl_for_undefined_type_error() {
+    let input = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_err(), "Should error when type doesn't exist");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.to_lowercase().contains("point") || err_msg.contains("not") || err_msg.contains("defined"),
+            "Error should mention undefined type: {}", err_msg);
+}
+
+#[test]
+fn test_missing_required_method_error() {
+    let input = r#"
+        χαρακτήρ Math ὁρίζειν {
+            δεῖ add τῷ self τῷ other.
+            δεῖ subtract τῷ self τῷ other.
+        }.
+        εἶδος Number ὁρίζειν { v ἀριθμοῦ. }.
+        εἶδος Number τῷ Math ἐμπίπτειν {
+            add τῷ self τῷ other· δός πέντε.
+        }.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_err(), "Should error when required method is missing");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.to_lowercase().contains("subtract") || err_msg.contains("required") || err_msg.contains("not implement"),
+            "Error should mention missing required method: {}", err_msg);
+}
+
+#[test]
+fn test_impl_with_default_method_not_required() {
+    let input = r#"
+        χαρακτήρ Math ὁρίζειν {
+            δεῖ add τῷ self τῷ other.
+            ἤδη double τῷ self· δός πέντε.
+        }.
+        εἶδος Number ὁρίζειν { v ἀριθμοῦ. }.
+        εἶδος Number τῷ Math ἐμπίπτειν {
+            add τῷ self τῷ other· δός τρία.
+        }.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_ok(), "Default methods should be optional: {:?}", result.err());
+}
+
+// =============================================================================
+// CYCLE 5: Trait Method Calls
+// =============================================================================
+
+#[test]
+fn test_call_trait_method() {
+    let input = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+        π νέον Point πέντε ἔστω.
+        που show.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_ok(), "Should allow calling trait methods: {:?}", result.err());
+}
+
+#[test]
+fn test_call_trait_method_with_args() {
+    let input = r#"
+        χαρακτήρ Math ὁρίζειν { δεῖ add τῷ self τῷ other. }.
+        εἶδος Number ὁρίζειν { v ἀριθμοῦ. }.
+        εἶδος Number τῷ Math ἐμπίπτειν {
+            add τῷ self τῷ other· δός νέον Number (selfου v otherou v ἄθροισμα).
+        }.
+        α νέον Number πέντε ἔστω.
+        β νέον Number τρία ἔστω.
+        γ αου add β ἔστω.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_ok(), "Should allow calling trait methods with args: {:?}", result.err());
+}
+
+#[test]
+fn test_call_default_method() {
+    let input = r#"
+        χαρακτήρ Math ὁρίζειν {
+            δεῖ value τῷ self.
+            ἤδη double τῷ self· δός selfου value selfου value ἄθροισμα.
+        }.
+        εἶδος Number ὁρίζειν { v ἀριθμοῦ. }.
+        εἶδος Number τῷ Math ἐμπίπτειν {
+            value τῷ self· δός selfου v.
+        }.
+        α νέον Number πέντε ἔστω.
+        β αου double ἔστω.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    assert!(result.is_ok(), "Should allow calling default trait methods: {:?}", result.err());
+}
+
+#[test]
+fn test_trait_method_call_error_not_implemented() {
+    let input = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.
+        π νέον Point πέντε ἔστω.
+        που show.
+    "#;
+    let ast = build_ast(input).expect("Parsing failed");
+    let result = analyze_program(&ast);
+    // This should actually compile - the error would be at runtime
+    // Or we could make it a compile-time error if we track which types implement which traits
+    // For now, let's allow it to compile
+    assert!(result.is_ok(), "Method calls are resolved dynamically: {:?}", result.err());
+}
+
+// =============================================================================
+// CYCLE 6: Code Generation
+// =============================================================================
+
+use glossa::ir::lower_to_hir;
+use glossa::codegen::generate_rust;
+
+/// Helper to compile GLOSSA source to Rust code
+fn compile(source: &str) -> String {
+    let ast = build_ast(source).unwrap();
+    let analyzed = analyze_program(&ast).unwrap();
+    let hir = lower_to_hir(&analyzed);
+    generate_rust(&hir)
+}
+
+#[test]
+fn test_codegen_trait_definition() {
+    let source = "χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.";
+    let code = compile(source);
+    assert!(code.contains("trait Showable"), "Should generate trait keyword: {}", code);
+    // quote! adds spaces, so check for "& self" with possible spaces
+    assert!(code.contains("fn show") && code.contains("& self"), "Should generate method signature: {}", code);
+}
+
+#[test]
+fn test_codegen_trait_impl() {
+    let source = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+    "#;
+    let code = compile(source);
+    assert!(code.contains("impl Showable for Point"), "Should generate impl block: {}", code);
+    assert!(code.contains("fn show") && code.contains("& self"), "Should generate impl method: {}", code);
+}
+
+#[test]
+fn test_codegen_trait_with_default() {
+    let source = r#"
+        χαρακτήρ Math ὁρίζειν {
+            δεῖ value τῷ self.
+            ἤδη double τῷ self· δός selfου value selfου value ἄθροισμα.
+        }.
+    "#;
+    let code = compile(source);
+    assert!(code.contains("trait Math"), "Should generate trait: {}", code);
+    assert!(code.contains("fn value") && code.contains("& self"), "Should have required method: {}", code);
+    assert!(code.contains("fn double") && code.contains("& self"), "Should have default method: {}", code);
+    // Default method should have a body
+    assert!(code.contains("double") && code.contains("& self") && code.contains("{"), "Default method should have body: {}", code);
+}
+
+#[test]
+fn test_codegen_trait_method_call_genitive() {
+    // Test trait method call using genitive pattern (που show) which should work
+    let source = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+        π νέον Point πέντε ἔστω.
+        που show λέγε.
+    "#;
+    let code = compile(source);
+    // Using genitive pattern (που), this creates a property access which becomes a method call
+    // The print statement should show the method call
+    assert!(code.contains("trait Showable"), "Should have trait: {}", code);
+    assert!(code.contains("impl Showable for Point"), "Should have impl: {}", code);
+    // We know genitive pattern works from earlier tests
+}
+
+#[test]
+fn test_codegen_full_example() {
+    let source = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. ψ ἀριθμοῦ. }.
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+        π νέον Point πέντε τρία ἔστω.
+        που show.
+    "#;
+    let code = compile(source);
+
+    // Check for trait definition
+    assert!(code.contains("trait Showable"), "Missing trait definition: {}", code);
+    // Check for struct definition
+    assert!(code.contains("struct Point"), "Missing struct definition: {}", code);
+    // Check for impl block
+    assert!(code.contains("impl Showable for Point"), "Missing impl block: {}", code);
+    // Check for main function (quote! adds spaces)
+    assert!(code.contains("fn main"), "Missing main function: {}", code);
+}
+
+#[test]
+fn test_standalone_method_call() {
+    // Test that standalone method calls (method_name receiver) work
+    let source = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+        π νέον Point πέντε ἔστω.
+        show π.
+    "#;
+
+    let code = compile(source);
+
+    // Should contain the method call
+    assert!(code.contains("pi . show") || code.contains("pi.show"));
+}
+
+// ============================================================================
+// CYCLE 7: Advanced Features
+// ============================================================================
+
+#[test]
+fn test_type_implements_multiple_traits() {
+    // A type can implement multiple traits
+    let source = r#"
+        χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
+        χαρακτήρ Printable ὁρίζειν { δεῖ print τῷ self. }.
+        εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.
+        εἶδος Point τῷ Showable ἐμπίπτειν {
+            show τῷ self· selfου ξ λέγε.
+        }.
+        εἶδος Point τῷ Printable ἐμπίπτειν {
+            print τῷ self· selfου ξ λέγε.
+        }.
+    "#;
+
+    let code = compile(source);
+    // Should have impl blocks for both traits
+    assert!(code.contains("impl Showable for Point"));
+    assert!(code.contains("impl Printable for Point"));
+}
+
+#[test]
+fn test_override_default_method() {
+    // Override a default method with custom implementation
+    let source = r#"
+        χαρακτήρ Describable ὁρίζειν {
+            ἤδη describe τῷ self· «default» λέγε.
+        }.
+        εἶδος Thing ὁρίζειν { ν ἀριθμοῦ. }.
+        εἶδος Thing τῷ Describable ἐμπίπτειν {
+            describe τῷ self· «custom» λέγε.
+        }.
+    "#;
+
+    let code = compile(source);
+    // The impl should contain the overridden method
+    assert!(code.contains("impl Describable for Thing"));
+    // The impl body should have the custom implementation
+    assert!(code.contains("custom") || code.contains("\"custom\""));
+}
+
+#[test]
+fn test_call_both_trait_methods_on_same_type() {
+    // Call methods from different traits on the same instance
+    let source = r#"
+        χαρακτήρ Alpha ὁρίζειν { δεῖ alpha τῷ self. }.
+        χαρακτήρ Beta ὁρίζειν { δεῖ beta τῷ self. }.
+        εἶδος Widget ὁρίζειν { ν ἀριθμοῦ. }.
+        εἶδος Widget τῷ Alpha ἐμπίπτειν {
+            alpha τῷ self· selfου ν λέγε.
+        }.
+        εἶδος Widget τῷ Beta ἐμπίπτειν {
+            beta τῷ self· selfου ν λέγε.
+        }.
+        ω νέον Widget πέντε ἔστω.
+        ωου alpha.
+        ωου beta.
+    "#;
+
+    let code = compile(source);
+    // Should have calls to both methods
+    assert!(code.contains("alpha") && code.contains("beta"));
+}
+
+#[test]
+fn test_multiple_types_implement_same_trait() {
+    // Multiple types implement the same trait
+    let source = r#"
+        χαρακτήρ Countable ὁρίζειν { δεῖ count τῷ self. }.
+        εἶδος Foo ὁρίζειν { ξ ἀριθμοῦ. }.
+        εἶδος Bar ὁρίζειν { ψ ἀριθμοῦ. }.
+        εἶδος Foo τῷ Countable ἐμπίπτειν {
+            count τῷ self· selfου ξ λέγε.
+        }.
+        εἶδος Bar τῷ Countable ἐμπίπτειν {
+            count τῷ self· selfου ψ λέγε.
+        }.
+    "#;
+
+    let code = compile(source);
+    // Should have impl blocks for both types
+    assert!(code.contains("impl Countable for Foo"));
+    assert!(code.contains("impl Countable for Bar"));
+}
+
+#[test]
+fn test_trait_method_with_return_type() {
+    // Trait method that returns a value
+    let source = r#"
+        χαρακτήρ Numeric ὁρίζειν {
+            δεῖ value τῷ self.
+        }.
+        εἶδος Num ὁρίζειν { ν ἀριθμοῦ. }.
+        εἶδος Num τῷ Numeric ἐμπίπτειν {
+            value τῷ self· δός selfου ν.
+        }.
+        α νέον Num δέκα ἔστω.
+        ρ αου value ἔστω.
+    "#;
+
+    let code = compile(source);
+    // Should have the impl and method call
+    assert!(code.contains("impl Numeric for Num"));
+    assert!(code.contains("value"));
+}


### PR DESCRIPTION
## Summary

Implements a complete traits system for ΓΛΩΣΣΑ using Ancient Greek morphological patterns:

- **Trait definitions**: `χαρακτήρ Trait ὁρίζειν { δεῖ method τῷ self. }`
- **Trait implementations**: `εἶδος Type τῷ Trait ἐμπίπτειν { method τῷ self· body. }`
- **Required methods** with `δεῖ` (it is necessary)
- **Default methods** with `ἤδη` (already defined)
- **Method calls** via genitive pattern (`receiverου method`)

### Features
- Multiple traits per type
- Multiple types implementing the same trait
- Override default method implementations
- Full Rust code generation for traits and impl blocks

### Example
```glossa
χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.
εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.
εἶδος Point τῷ Showable ἐμπίπτειν {
    show τῷ self· selfου ξ λέγε.
}.
π νέον Point πέντε ἔστω.
show π.
```

### Also includes
- Fix for struct instantiation with Latin type names
- Fix for standalone method calls (`show π.` syntax)
- Fix for Greek numeral conversion in struct args (`πέντε` → `5`)

## Test plan
- [x] 31 new trait-specific tests
- [x] All 241 tests passing
- [x] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)