### PR TITLE
Add Option and Result types with Greek morphological semantics

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -32,6 +32,7 @@ pub fn build_ast(source: &str) -> Result<Program, AstError> {
 fn build_statement(pair: Pair<'_, Rule>) -> Result<Statement, AstError> {
     let mut clauses = Vec::new();
     let mut is_query = false;
+    let mut is_propagate = false;
     let mut type_def = None;
     let mut trait_def = None;
     let mut trait_impl = None;
@@ -56,8 +57,10 @@ fn build_statement(pair: Pair<'_, Rule>) -> Result<Statement, AstError> {
             }
             Rule::statement_end => {
                 for end_inner in inner.into_inner() {
-                    if end_inner.as_rule() == Rule::query {
-                        is_query = true;
+                    match end_inner.as_rule() {
+                        Rule::query => is_query = true,
+                        Rule::propagate => is_propagate = true,
+                        _ => {}
                     }
                 }
             }
@@ -72,7 +75,11 @@ fn build_statement(pair: Pair<'_, Rule>) -> Result<Statement, AstError> {
     } else if let Some(impl_def) = trait_impl {
         Ok(Statement::TraitImpl(impl_def))
     } else {
-        Ok(Statement::Regular { clauses, is_query })
+        Ok(Statement::Regular {
+            clauses,
+            is_query,
+            is_propagate,
+        })
     }
 }
 
@@ -471,6 +478,18 @@ fn build_term(pair: Pair<'_, Rule>) -> Result<Expr, AstError> {
             // Unwrap the parentheses and build the inner expression
             let expr_pair = inner.into_inner().next().ok_or(AstError::EmptyTerm)?;
             build_expression(expr_pair)
+        }
+        Rule::unwrap_expr => {
+            // Extract the word from "word!"
+            let word_pair = inner.into_inner().next().ok_or(AstError::EmptyTerm)?;
+            let word = Expr::Word(Word {
+                original: word_pair.as_str().to_string(),
+                normalized: crate::grammar::normalize_greek(word_pair.as_str()),
+            });
+            Ok(Expr::UnaryOp {
+                op: UnaryOperator::Unwrap,
+                operand: Box::new(word),
+            })
         }
         _ => Err(AstError::UnexpectedRule(format!("{:?}", inner.as_rule()))),
     }

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -9,13 +9,14 @@ pub struct Program {
     pub statements: Vec<Statement>,
 }
 
-/// A single statement, ending with . (statement) or ? (query)
+/// A single statement, ending with . (statement), ? (query), or ; (propagate)
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
     /// A regular statement with clauses
     Regular {
         clauses: Vec<Clause>,
         is_query: bool,
+        is_propagate: bool,
     },
     /// A type definition statement
     TypeDefinition(TypeDef),
@@ -95,6 +96,16 @@ impl Statement {
     pub fn is_query(&self) -> bool {
         match self {
             Statement::Regular { is_query, .. } => *is_query,
+            Statement::TypeDefinition(_) => false,
+            Statement::TraitDefinition(_) => false,
+            Statement::TraitImpl(_) => false,
+        }
+    }
+
+    /// Check if this is a propagate statement (ends with `;`)
+    pub fn is_propagate(&self) -> bool {
+        match self {
+            Statement::Regular { is_propagate, .. } => *is_propagate,
             Statement::TypeDefinition(_) => false,
             Statement::TraitDefinition(_) => false,
             Statement::TraitImpl(_) => false,
@@ -231,8 +242,9 @@ pub enum BinOperator {
 /// Unary operators in GLOSSA
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnaryOperator {
-    Not, // οὐ/οὐκ/οὐχ
-    Neg, // arithmetic negation
+    Not,    // οὐ/οὐκ/οὐχ - logical negation
+    Neg,    // arithmetic negation
+    Unwrap, // ! - confident extraction from Option/Result
 }
 
 /// A Greek word with original and normalized forms

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -419,6 +419,35 @@ fn generate_expr(expr: &HirExpr) -> TokenStream {
             quote! { vec![#(#elem_tokens),*] }
         }
 
+        HirExpr::Some(inner) => {
+            let inner_tokens = generate_expr(inner);
+            quote! { Some(#inner_tokens) }
+        }
+
+        HirExpr::None => {
+            quote! { None }
+        }
+
+        HirExpr::Ok(inner) => {
+            let inner_tokens = generate_expr(inner);
+            quote! { Ok(#inner_tokens) }
+        }
+
+        HirExpr::Err(inner) => {
+            let inner_tokens = generate_expr(inner);
+            quote! { Err(#inner_tokens) }
+        }
+
+        HirExpr::Try(inner) => {
+            let inner_tokens = generate_expr(inner);
+            quote! { #inner_tokens? }
+        }
+
+        HirExpr::Unwrap(inner) => {
+            let inner_tokens = generate_expr(inner);
+            quote! { #inner_tokens.unwrap() }
+        }
+
         HirExpr::Index { array, index } => {
             let array_tokens = generate_expr(array);
             let index_tokens = generate_expr(index);

--- a/src/grammar/glossa.pest
+++ b/src/grammar/glossa.pest
@@ -21,7 +21,7 @@ program = { SOI ~ statement* ~ EOI }
 
 statement = { (type_definition | trait_definition | trait_impl | clause_list) ~ statement_end }
 
-statement_end = { period | query }
+statement_end = { period | query | propagate }
 
 // Type definition: εἶδος typename ὁρίζειν { fields }
 type_definition = { eidos_keyword ~ greek_word ~ orizontin_keyword ~ "{" ~ field_list? ~ "}" }
@@ -82,10 +82,14 @@ term = {
     | string_literal
     | number_literal
     | boolean_literal
+    | unwrap_expr
     | indexed_word
     | parenthesized_expr
     | greek_word
 }
+
+// Unwrap expression: word! (confident extraction from Option/Result)
+unwrap_expr = { greek_word ~ "!" }
 
 // Parenthesized expression for grouping (e.g., nested function calls)
 parenthesized_expr = { "(" ~ expression ~ ")" }
@@ -157,6 +161,10 @@ chain = { "\u{00B7}" }
 // Greek question mark (U+037E) - looks like semicolon but is the question mark
 // Also accept ASCII ? for convenience
 query = { "\u{037E}" | "?" }
+
+// ASCII semicolon - propagation operator (converts statement value to `?` in Rust)
+// Used with Option/Result to propagate None/Err upward
+propagate = { ";" }
 
 // Comma - separates clauses (condition from body in control flow)
 comma = { "," }

--- a/src/ir/hir.rs
+++ b/src/ir/hir.rs
@@ -125,6 +125,24 @@ pub enum HirExpr {
     /// Array literal vec![...]
     ArrayLit(Vec<HirExpr>),
 
+    /// Some(value) - Option<T> constructor
+    Some(Box<HirExpr>),
+
+    /// None - Option<T> empty value
+    None,
+
+    /// Ok(value) - Result<T,E> success constructor
+    Ok(Box<HirExpr>),
+
+    /// Err(error) - Result<T,E> error constructor
+    Err(Box<HirExpr>),
+
+    /// Try operator (?) - propagates None/Err
+    Try(Box<HirExpr>),
+
+    /// Unwrap operator (!) - confident extraction
+    Unwrap(Box<HirExpr>),
+
     /// Index access array[index]
     Index {
         array: Box<HirExpr>,
@@ -446,6 +464,12 @@ pub fn lower_expr(expr: &AnalyzedExpr) -> HirExpr {
         AnalyzedExprKind::ArrayLiteral(elements) => {
             HirExpr::ArrayLit(elements.iter().map(lower_expr).collect())
         }
+        AnalyzedExprKind::Some(inner) => HirExpr::Some(Box::new(lower_expr(inner))),
+        AnalyzedExprKind::None => HirExpr::None,
+        AnalyzedExprKind::Ok(inner) => HirExpr::Ok(Box::new(lower_expr(inner))),
+        AnalyzedExprKind::Err(inner) => HirExpr::Err(Box::new(lower_expr(inner))),
+        AnalyzedExprKind::Unwrap(inner) => HirExpr::Unwrap(Box::new(lower_expr(inner))),
+        AnalyzedExprKind::Try(inner) => HirExpr::Try(Box::new(lower_expr(inner))),
         AnalyzedExprKind::IndexAccess { array, index } => HirExpr::Index {
             array: Box::new(lower_expr(array)),
             index: Box::new(lower_expr(index)),

--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -72,6 +72,30 @@ const AORIST_ACTIVE_SUBJ: &[(&str, Person, Number)] = &[
     ("σωσιν", Person::Third, Number::Plural),
 ];
 
+/// Present Active Optative endings
+/// Pattern: γράφοιμι "I might write"
+/// The optative mood expresses possibility, wish, or potential - natural for Option<T>
+const PRESENT_ACTIVE_OPT: &[(&str, Person, Number)] = &[
+    ("οιμι", Person::First, Number::Singular),
+    ("οις", Person::Second, Number::Singular),
+    ("οι", Person::Third, Number::Singular),
+    ("οιμεν", Person::First, Number::Plural),
+    ("οιτε", Person::Second, Number::Plural),
+    ("οιεν", Person::Third, Number::Plural),
+];
+
+/// Aorist Passive Optative endings
+/// Pattern: εὑρεθείη "might be found"
+/// Used for values that "might exist" (Option<T> semantics)
+const AORIST_PASSIVE_OPT: &[(&str, Person, Number)] = &[
+    ("θειην", Person::First, Number::Singular),
+    ("θειης", Person::Second, Number::Singular),
+    ("θειη", Person::Third, Number::Singular),
+    ("θειημεν", Person::First, Number::Plural),
+    ("θειητε", Person::Second, Number::Plural),
+    ("θειησαν", Person::Third, Number::Plural),
+];
+
 /// Present Active Infinitive ending
 const PRESENT_INFINITIVE: &str = "ειν";
 
@@ -332,6 +356,48 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
         });
     }
 
+    // Try present active optative (for Option<T> semantics)
+    if let Some((stem, person, number)) = match_verb_endings(word, PRESENT_ACTIVE_OPT) {
+        return Some(MorphAnalysis {
+            lemma: format!("{}ω", stem),
+            part_of_speech: PartOfSpeech::Verb,
+            case: None,
+            number: Some(number),
+            gender: None,
+            person: Some(person),
+            tense: Some(Tense::Present),
+            mood: Some(Mood::Optative),
+            voice: Some(Voice::Active),
+            confidence: 0.75,
+        });
+    }
+
+    // Try aorist passive optative (εὑρεθείη "might be found")
+    if let Some((stem, person, number)) = match_verb_endings(word, AORIST_PASSIVE_OPT) {
+        // Aorist passive stem typically ends in θ (from -θη-)
+        // For θειη ending, the stem before θ is what we want
+        let lemma = if stem.ends_with('θ') {
+            // Strip the θη passive marker to get base stem, then add -ω for lemma
+            let base_stem = stem.trim_end_matches('θ');
+            format!("{}ω", base_stem)
+        } else {
+            format!("{}ω", stem)
+        };
+
+        return Some(MorphAnalysis {
+            lemma,
+            part_of_speech: PartOfSpeech::Verb,
+            case: None,
+            number: Some(number),
+            gender: None,
+            person: Some(person),
+            tense: Some(Tense::Aorist),
+            mood: Some(Mood::Optative),
+            voice: Some(Voice::Passive),
+            confidence: 0.75,
+        });
+    }
+
     None
 }
 
@@ -440,6 +506,22 @@ pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
             tense: Tense::Aorist,
             mood: Mood::Imperative,
             voice: Voice::Active,
+            has_augment: false,
+            base_confidence: 0.75,
+        },
+        ConjPattern {
+            endings: PRESENT_ACTIVE_OPT,
+            tense: Tense::Present,
+            mood: Mood::Optative,
+            voice: Voice::Active,
+            has_augment: false,
+            base_confidence: 0.75,
+        },
+        ConjPattern {
+            endings: AORIST_PASSIVE_OPT,
+            tense: Tense::Aorist,
+            mood: Mood::Optative,
+            voice: Voice::Passive,
             has_augment: false,
             base_confidence: 0.75,
         },

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -1247,6 +1247,86 @@ static LEXICON: LazyLock<FxHashMap<&'static str, LexiconEntry>> = LazyLock::new(
     );
 
     // =========================================================================
+    // Option<T> and Result<T,E> vocabulary
+    // =========================================================================
+
+    // οὐδέν - nothing (None)
+    // From οὐδείς (no one, nothing) in neuter form
+    m.insert(
+        "ουδεν",
+        LexiconEntry {
+            lemma: "ουδεις".to_string(),
+            pos: PartOfSpeech::Pronoun,
+            gender: Some(Gender::Neuter),
+            meaning: "nothing, none",
+            rust_equiv: Some("None"),
+            case: Some(Case::Nominative),
+            number: Some(Number::Singular),
+            person: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        },
+    );
+
+    // τί - something (Some)
+    // Interrogative/indefinite pronoun "what/something"
+    m.insert(
+        "τι",
+        LexiconEntry {
+            lemma: "τις".to_string(),
+            pos: PartOfSpeech::Pronoun,
+            gender: Some(Gender::Neuter),
+            meaning: "something, some",
+            rust_equiv: Some("Some"),
+            case: Some(Case::Nominative),
+            number: Some(Number::Singular),
+            person: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        },
+    );
+
+    // ἐπιτυχία - success (Ok)
+    // From ἐπιτυγχάνω "to succeed, achieve"
+    m.insert(
+        "επιτυχια",
+        LexiconEntry {
+            lemma: "επιτυχια".to_string(),
+            pos: PartOfSpeech::Noun,
+            gender: Some(Gender::Feminine),
+            meaning: "success, achievement",
+            rust_equiv: Some("Ok"),
+            case: Some(Case::Nominative),
+            number: Some(Number::Singular),
+            person: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        },
+    );
+
+    // σφάλμα - error (Err)
+    // From σφάλλω "to cause to fall, err"
+    m.insert(
+        "σφαλμα",
+        LexiconEntry {
+            lemma: "σφαλμα".to_string(),
+            pos: PartOfSpeech::Noun,
+            gender: Some(Gender::Neuter),
+            meaning: "error, mistake, failure",
+            rust_equiv: Some("Err"),
+            case: Some(Case::Nominative),
+            number: Some(Number::Singular),
+            person: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        },
+    );
+
+    // =========================================================================
     // Common words
     // =========================================================================
 
@@ -1878,6 +1958,26 @@ pub fn is_obligation_particle(normalized_word: &str) -> bool {
 /// Check if a word introduces a consequence (ἀνάγκη or δεῖ)
 pub fn is_consequence_marker(normalized_word: &str) -> bool {
     is_necessity_particle(normalized_word) || is_obligation_particle(normalized_word)
+}
+
+/// Check if a word represents None (οὐδέν)
+pub fn is_none_word(normalized_word: &str) -> bool {
+    matches!(normalized_word, "ουδεν")
+}
+
+/// Check if a word represents Some (τί)
+pub fn is_some_word(normalized_word: &str) -> bool {
+    matches!(normalized_word, "τι")
+}
+
+/// Check if a word represents Ok (ἐπιτυχία)
+pub fn is_ok_word(normalized_word: &str) -> bool {
+    matches!(normalized_word, "επιτυχια")
+}
+
+/// Check if a word represents Err (σφάλμα)
+pub fn is_err_word(normalized_word: &str) -> bool {
+    matches!(normalized_word, "σφαλμα")
 }
 
 #[cfg(test)]

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -48,8 +48,12 @@ pub struct AssembledStatement {
     pub nested_phrases: Vec<Vec<Expr>>,
     /// Participles (used for lambdas/closures)
     pub participles: Vec<ParticipleConstituent>,
-    /// Whether this is a query (ends with ;)
+    /// Unwrap expressions (expr!)
+    pub unwraps: Vec<Expr>,
+    /// Whether this is a query (ends with ?)
     pub is_query: bool,
+    /// Whether this statement propagates (ends with ;) - converts to `?` in Rust
+    pub is_propagate: bool,
 }
 
 /// A noun/pronoun constituent with its grammatical info
@@ -132,7 +136,9 @@ pub struct Assembler {
     pending_blocks: Vec<Vec<crate::ast::Statement>>,
     pending_nested_phrases: Vec<Vec<Expr>>,
     pending_participles: Vec<ParticipleConstituent>,
+    pending_unwraps: Vec<Expr>,
     is_query: bool,
+    is_propagate: bool,
 }
 
 /// Errors that can occur during assembly
@@ -184,7 +190,9 @@ impl Assembler {
             pending_blocks: Vec::new(),
             pending_nested_phrases: Vec::new(),
             pending_participles: Vec::new(),
+            pending_unwraps: Vec::new(),
             is_query: false,
+            is_propagate: false,
         }
     }
 
@@ -205,12 +213,19 @@ impl Assembler {
         self.pending_blocks.clear();
         self.pending_nested_phrases.clear();
         self.pending_participles.clear();
+        self.pending_unwraps.clear();
         self.is_query = false;
+        self.is_propagate = false;
     }
 
     /// Mark this statement as a query
     pub fn set_query(&mut self, is_query: bool) {
         self.is_query = is_query;
+    }
+
+    /// Mark this statement as propagation (ends with `;` → converts to `?`)
+    pub fn set_propagate(&mut self, is_propagate: bool) {
+        self.is_propagate = is_propagate;
     }
 
     /// Feed a morphologically-analyzed token into the assembler
@@ -331,6 +346,11 @@ impl Assembler {
     /// Feed an index access (array[index])
     pub fn feed_index_access(&mut self, array: Expr, index: Expr) {
         self.pending_index_accesses.push((array, index));
+    }
+
+    /// Feed an unwrap expression (expr!)
+    pub fn feed_unwrap(&mut self, expr: Expr) {
+        self.pending_unwraps.push(expr);
     }
 
     /// Feed a participle (for lambda construction)
@@ -495,7 +515,9 @@ impl Assembler {
             blocks: std::mem::take(&mut self.pending_blocks),
             nested_phrases: std::mem::take(&mut self.pending_nested_phrases),
             participles: std::mem::take(&mut self.pending_participles),
+            unwraps: std::mem::take(&mut self.pending_unwraps),
             is_query: self.is_query,
+            is_propagate: self.is_propagate,
         };
 
         self.reset();

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -120,6 +120,7 @@ fn analyze_single_statement_with_assembler(
 ) -> Result<AssembledStatement, GlossaError> {
     let mut asm = Assembler::new();
     asm.set_query(stmt.is_query());
+    asm.set_propagate(stmt.is_propagate());
 
     // Disambiguation context accumulator - articles set context for following words
     let mut current_context = DisambiguationContext::new();
@@ -868,6 +869,7 @@ fn parse_function_definition(
         let clause_stmt = Statement::Regular {
             clauses: vec![body_clause],
             is_query: false,
+            is_propagate: false,
         };
 
         // Analyze each body expression as a statement with the function scope
@@ -1047,6 +1049,7 @@ fn parse_while_loop(
     let body_stmt = Statement::Regular {
         clauses: body_clauses.to_vec(),
         is_query: false,
+        is_propagate: false,
     };
 
     let body_analyzed = if let Some(cf) = analyze_control_flow(&body_stmt, scope)? {
@@ -1190,6 +1193,7 @@ fn parse_for_range_loop(
     let body_stmt = Statement::Regular {
         clauses: body_clauses.to_vec(),
         is_query: false,
+        is_propagate: false,
     };
 
     // Add loop variable to scope temporarily while parsing body
@@ -1286,6 +1290,7 @@ fn parse_for_iteration_loop(
     let body_stmt = Statement::Regular {
         clauses: body_clauses.to_vec(),
         is_query: false,
+        is_propagate: false,
     };
 
     // Add loop variable to scope temporarily
@@ -1584,6 +1589,7 @@ fn parse_conditional(
             let elif_stmt = Statement::Regular {
                 clauses: elif_clauses,
                 is_query: false,
+                is_propagate: false,
             };
 
             // Recursively parse as a new conditional (which becomes the else body)
@@ -1659,6 +1665,7 @@ fn parse_clause_as_mini_statement(clause: &crate::ast::Clause) -> Result<Stateme
     Ok(Statement::Regular {
         clauses: vec![clause.clone()],
         is_query: false,
+        is_propagate: false,
     })
 }
 
@@ -1820,9 +1827,15 @@ fn feed_expr_to_assembler_with_context(
             feed_expr_to_assembler_with_context(asm, left, context)?;
             feed_expr_to_assembler_with_context(asm, right, context)?;
         }
-        Expr::UnaryOp { op: _, operand } => {
-            // TODO: Implement unary operation handling
-            feed_expr_to_assembler_with_context(asm, operand, context)?;
+        Expr::UnaryOp { op, operand } => {
+            // Handle unwrap operator specially - it's a postfix operator that doesn't need word-order handling
+            if matches!(op, crate::ast::UnaryOperator::Unwrap) {
+                // Store the unwrap expression for special handling
+                asm.feed_unwrap(operand.as_ref().clone());
+            } else {
+                // TODO: Implement other unary operations (Not, Neg)
+                feed_expr_to_assembler_with_context(asm, operand, context)?;
+            }
         }
         Expr::Block(statements) => {
             // Parenthesized expressions are stored as blocks for later analysis
@@ -2871,7 +2884,33 @@ fn classify_assembled_statement(
             };
 
             // Get value from literals or object
-            let (value_expr, value_type) = extract_value(&actual_asm);
+            // Special handling for Option/Result standalone words (None, Some without value, etc.)
+            let (value_expr, value_type) = if let Some(ref obj) = actual_asm.object {
+                let obj_normalized = normalize_greek(&obj.lemma);
+                if crate::morphology::lexicon::is_none_word(&obj_normalized) {
+                    (
+                        AnalyzedExpr {
+                            expr: AnalyzedExprKind::None,
+                            glossa_type: GlossaType::Option(Box::new(GlossaType::Unknown)),
+                        },
+                        GlossaType::Option(Box::new(GlossaType::Unknown)),
+                    )
+                } else {
+                    extract_value(&actual_asm)
+                }
+            } else {
+                extract_value(&actual_asm)
+            };
+
+            // Wrap in Try if this is a propagation statement (ends with `;`)
+            let final_value_expr = if asm_stmt.is_propagate {
+                AnalyzedExpr {
+                    glossa_type: value_type.clone(),
+                    expr: AnalyzedExprKind::Try(Box::new(value_expr)),
+                }
+            } else {
+                value_expr
+            };
 
             // Register binding in scope
             scope.define(var_name.clone(), value_type.clone());
@@ -2886,7 +2925,7 @@ fn classify_assembled_statement(
                         expr: AnalyzedExprKind::Variable(var_name),
                         glossa_type: value_type.clone(),
                     },
-                    value_expr,
+                    final_value_expr,
                 ],
             ));
         }
@@ -3023,6 +3062,19 @@ fn classify_assembled_statement(
                 return Ok((StatementKind::Print, args));
             }
 
+            // Check if we have unwrap expressions to print
+            if !asm_stmt.unwraps.is_empty() {
+                let mut args = Vec::new();
+                for unwrap_expr in &asm_stmt.unwraps {
+                    let inner_analyzed = convert_expr_to_analyzed(unwrap_expr);
+                    args.push(AnalyzedExpr {
+                        expr: AnalyzedExprKind::Unwrap(Box::new(inner_analyzed)),
+                        glossa_type: GlossaType::Unknown, // Type will be inferred
+                    });
+                }
+                return Ok((StatementKind::Print, args));
+            }
+
             // Build binary expressions from literals and operators if available
             // This handles cases like: true || false
             let mut args =
@@ -3074,13 +3126,147 @@ fn classify_assembled_statement(
     }
 
     // Default: expression statement
-    let exprs = build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators);
+    let mut exprs =
+        build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators);
+
+    // Propagation pattern: wrap the last expression in Try (converts to `?` in Rust)
+    if asm_stmt.is_propagate && !exprs.is_empty() {
+        let last_expr = exprs.pop().unwrap();
+        let try_expr = AnalyzedExpr {
+            glossa_type: last_expr.glossa_type.clone(),
+            expr: AnalyzedExprKind::Try(Box::new(last_expr)),
+        };
+        exprs.push(try_expr);
+    }
 
     Ok((StatementKind::Expression, exprs))
 }
 
 /// Extract value from assembled statement (literals or constituents)
 fn extract_value(asm_stmt: &AssembledStatement) -> (AnalyzedExpr, GlossaType) {
+    // Check for unwrap expressions first
+    if !asm_stmt.unwraps.is_empty() {
+        let inner_analyzed = convert_expr_to_analyzed(&asm_stmt.unwraps[0]);
+        return (
+            AnalyzedExpr {
+                expr: AnalyzedExprKind::Unwrap(Box::new(inner_analyzed)),
+                glossa_type: GlossaType::Unknown, // Type will be inferred
+            },
+            GlossaType::Unknown,
+        );
+    }
+
+    // Check subject for Option/Result words (pronouns often land here)
+    if let Some(ref subj) = asm_stmt.subject {
+        let subj_normalized = normalize_greek(&subj.lemma);
+
+        // Check for None (οὐδέν)
+        if crate::morphology::lexicon::is_none_word(&subj_normalized) {
+            return (
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::None,
+                    glossa_type: GlossaType::Option(Box::new(GlossaType::Unknown)),
+                },
+                GlossaType::Option(Box::new(GlossaType::Unknown)),
+            );
+        }
+
+        // Check for Some (τί) with a value
+        if crate::morphology::lexicon::is_some_word(&subj_normalized) {
+            // Get the inner value from literals
+            if let Some(lit) = asm_stmt.literals.first() {
+                let inner_expr = literal_to_analyzed_expr(lit);
+                let inner_type = inner_expr.glossa_type.clone();
+                return (
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::Some(Box::new(inner_expr)),
+                        glossa_type: GlossaType::Option(Box::new(inner_type.clone())),
+                    },
+                    GlossaType::Option(Box::new(inner_type)),
+                );
+            }
+        }
+    }
+
+    // Check nominatives for Option/Result words first (they might land here due to case)
+    for nom in &asm_stmt.nominatives {
+        let nom_lemma = normalize_greek(&nom.lemma);
+        let nom_original = normalize_greek(&nom.original);
+
+        // Check for None (οὐδέν)
+        if crate::morphology::lexicon::is_none_word(&nom_lemma)
+            || crate::morphology::lexicon::is_none_word(&nom_original)
+        {
+            return (
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::None,
+                    glossa_type: GlossaType::Option(Box::new(GlossaType::Unknown)),
+                },
+                GlossaType::Option(Box::new(GlossaType::Unknown)),
+            );
+        }
+
+        // Check for Some (τί) with a value
+        if crate::morphology::lexicon::is_some_word(&nom_lemma)
+            || crate::morphology::lexicon::is_some_word(&nom_original)
+        {
+            // Get the inner value from literals
+            if let Some(lit) = asm_stmt.literals.first() {
+                let inner_expr = literal_to_analyzed_expr(lit);
+                let inner_type = inner_expr.glossa_type.clone();
+                return (
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::Some(Box::new(inner_expr)),
+                        glossa_type: GlossaType::Option(Box::new(inner_type.clone())),
+                    },
+                    GlossaType::Option(Box::new(inner_type)),
+                );
+            }
+        }
+
+        // Check for Ok (ἐπιτυχία) with a value
+        if crate::morphology::lexicon::is_ok_word(&nom_lemma)
+            || crate::morphology::lexicon::is_ok_word(&nom_original)
+        {
+            // Get the inner value from literals
+            if let Some(lit) = asm_stmt.literals.first() {
+                let inner_expr = literal_to_analyzed_expr(lit);
+                let inner_type = inner_expr.glossa_type.clone();
+                return (
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::Ok(Box::new(inner_expr)),
+                        glossa_type: GlossaType::Result(
+                            Box::new(inner_type.clone()),
+                            Box::new(GlossaType::String),
+                        ),
+                    },
+                    GlossaType::Result(Box::new(inner_type), Box::new(GlossaType::String)),
+                );
+            }
+        }
+
+        // Check for Err (σφάλμα) with a value
+        if crate::morphology::lexicon::is_err_word(&nom_lemma)
+            || crate::morphology::lexicon::is_err_word(&nom_original)
+        {
+            // Get the error value from literals
+            if let Some(lit) = asm_stmt.literals.first() {
+                let inner_expr = literal_to_analyzed_expr(lit);
+                let inner_type = inner_expr.glossa_type.clone();
+                return (
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::Err(Box::new(inner_expr)),
+                        glossa_type: GlossaType::Result(
+                            Box::new(GlossaType::Unknown),
+                            Box::new(inner_type.clone()),
+                        ),
+                    },
+                    GlossaType::Result(Box::new(GlossaType::Unknown), Box::new(inner_type)),
+                );
+            }
+        }
+    }
+
     // If we have property accesses, use the first one
     if let Some((owner, method)) = asm_stmt.property_accesses.first() {
         let receiver = AnalyzedExpr {
@@ -3168,9 +3354,85 @@ fn extract_value(asm_stmt: &AssembledStatement) -> (AnalyzedExpr, GlossaType) {
 
     // Otherwise use object
     if let Some(ref obj) = asm_stmt.object {
-        // Check if it's a numeral word
-        if let Some(value) = crate::morphology::lexicon::numeral_value(&normalize_greek(&obj.lemma))
+        // Check both lemma and original form
+        let obj_lemma = normalize_greek(&obj.lemma);
+        let obj_original = normalize_greek(&obj.original);
+
+        // Check for None (οὐδέν)
+        if crate::morphology::lexicon::is_none_word(&obj_lemma)
+            || crate::morphology::lexicon::is_none_word(&obj_original)
         {
+            return (
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::None,
+                    glossa_type: GlossaType::Option(Box::new(GlossaType::Unknown)),
+                },
+                GlossaType::Option(Box::new(GlossaType::Unknown)),
+            );
+        }
+
+        // Check for Some (τί) with a value
+        if crate::morphology::lexicon::is_some_word(&obj_lemma)
+            || crate::morphology::lexicon::is_some_word(&obj_original)
+        {
+            // Get the inner value from literals
+            if let Some(lit) = asm_stmt.literals.first() {
+                let inner_expr = literal_to_analyzed_expr(lit);
+                let inner_type = inner_expr.glossa_type.clone();
+                return (
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::Some(Box::new(inner_expr)),
+                        glossa_type: GlossaType::Option(Box::new(inner_type.clone())),
+                    },
+                    GlossaType::Option(Box::new(inner_type)),
+                );
+            }
+        }
+
+        // Check for Ok (ἐπιτυχία) with a value
+        if crate::morphology::lexicon::is_ok_word(&obj_lemma)
+            || crate::morphology::lexicon::is_ok_word(&obj_original)
+        {
+            // Get the inner value from literals
+            if let Some(lit) = asm_stmt.literals.first() {
+                let inner_expr = literal_to_analyzed_expr(lit);
+                let inner_type = inner_expr.glossa_type.clone();
+                return (
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::Ok(Box::new(inner_expr)),
+                        glossa_type: GlossaType::Result(
+                            Box::new(inner_type.clone()),
+                            Box::new(GlossaType::String),
+                        ),
+                    },
+                    GlossaType::Result(Box::new(inner_type), Box::new(GlossaType::String)),
+                );
+            }
+        }
+
+        // Check for Err (σφάλμα) with a value
+        if crate::morphology::lexicon::is_err_word(&obj_lemma)
+            || crate::morphology::lexicon::is_err_word(&obj_original)
+        {
+            // Get the error value from literals
+            if let Some(lit) = asm_stmt.literals.first() {
+                let inner_expr = literal_to_analyzed_expr(lit);
+                let inner_type = inner_expr.glossa_type.clone();
+                return (
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::Err(Box::new(inner_expr)),
+                        glossa_type: GlossaType::Result(
+                            Box::new(GlossaType::Unknown),
+                            Box::new(inner_type.clone()),
+                        ),
+                    },
+                    GlossaType::Result(Box::new(GlossaType::Unknown), Box::new(inner_type)),
+                );
+            }
+        }
+
+        // Check if it's a numeral word
+        if let Some(value) = crate::morphology::lexicon::numeral_value(&obj_lemma) {
             return (
                 AnalyzedExpr {
                     expr: AnalyzedExprKind::NumberLiteral(value),
@@ -3538,6 +3800,18 @@ pub enum AnalyzedExprKind {
     },
     /// Array literal [1, 2, 3]
     ArrayLiteral(Vec<AnalyzedExpr>),
+    /// Some(value) - Option<T> constructor
+    Some(Box<AnalyzedExpr>),
+    /// None - Option<T> empty value
+    None,
+    /// Ok(value) - Result<T,E> success constructor
+    Ok(Box<AnalyzedExpr>),
+    /// Err(error) - Result<T,E> error constructor
+    Err(Box<AnalyzedExpr>),
+    /// Unwrap operator (!) - confident extraction from Option/Result
+    Unwrap(Box<AnalyzedExpr>),
+    /// Try operator (`;` after Option/Result) - propagates None/Err upward
+    Try(Box<AnalyzedExpr>),
     /// Index access array[index]
     IndexAccess {
         array: Box<AnalyzedExpr>,
@@ -3815,6 +4089,7 @@ impl SemanticAnalyzer {
                             expressions: vec![phrase_expr],
                         }],
                         is_query: false,
+                        is_propagate: false,
                     };
 
                     // Analyze through assembler

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -2884,23 +2884,8 @@ fn classify_assembled_statement(
             };
 
             // Get value from literals or object
-            // Special handling for Option/Result standalone words (None, Some without value, etc.)
-            let (value_expr, value_type) = if let Some(ref obj) = actual_asm.object {
-                let obj_normalized = normalize_greek(&obj.lemma);
-                if crate::morphology::lexicon::is_none_word(&obj_normalized) {
-                    (
-                        AnalyzedExpr {
-                            expr: AnalyzedExprKind::None,
-                            glossa_type: GlossaType::Option(Box::new(GlossaType::Unknown)),
-                        },
-                        GlossaType::Option(Box::new(GlossaType::Unknown)),
-                    )
-                } else {
-                    extract_value(&actual_asm)
-                }
-            } else {
-                extract_value(&actual_asm)
-            };
+            // Delegate Option/Result constructor detection to extract_value
+            let (value_expr, value_type) = extract_value(&actual_asm);
 
             // Wrap in Try if this is a propagation statement (ends with `;`)
             let final_value_expr = if asm_stmt.is_propagate {
@@ -3158,10 +3143,13 @@ fn extract_value(asm_stmt: &AssembledStatement) -> (AnalyzedExpr, GlossaType) {
 
     // Check subject for Option/Result words (pronouns often land here)
     if let Some(ref subj) = asm_stmt.subject {
-        let subj_normalized = normalize_greek(&subj.lemma);
+        let subj_lemma = normalize_greek(&subj.lemma);
+        let subj_original = normalize_greek(&subj.original);
 
-        // Check for None (οὐδέν)
-        if crate::morphology::lexicon::is_none_word(&subj_normalized) {
+        // Check for None (οὐδέν) - check both lemma and original form
+        if crate::morphology::lexicon::is_none_word(&subj_lemma)
+            || crate::morphology::lexicon::is_none_word(&subj_original)
+        {
             return (
                 AnalyzedExpr {
                     expr: AnalyzedExprKind::None,
@@ -3171,8 +3159,10 @@ fn extract_value(asm_stmt: &AssembledStatement) -> (AnalyzedExpr, GlossaType) {
             );
         }
 
-        // Check for Some (τί) with a value
-        if crate::morphology::lexicon::is_some_word(&subj_normalized) {
+        // Check for Some (τί) with a value - check both lemma and original form
+        if crate::morphology::lexicon::is_some_word(&subj_lemma)
+            || crate::morphology::lexicon::is_some_word(&subj_original)
+        {
             // Get the inner value from literals
             if let Some(lit) = asm_stmt.literals.first() {
                 let inner_expr = literal_to_analyzed_expr(lit);
@@ -3232,6 +3222,9 @@ fn extract_value(asm_stmt: &AssembledStatement) -> (AnalyzedExpr, GlossaType) {
             if let Some(lit) = asm_stmt.literals.first() {
                 let inner_expr = literal_to_analyzed_expr(lit);
                 let inner_type = inner_expr.glossa_type.clone();
+                // LIMITATION: Error type defaults to String when only Ok variant is provided.
+                // Full Result<T,E> inference would require type context from function signatures.
+                // Future enhancement: infer E from usage or allow explicit type annotations.
                 return (
                     AnalyzedExpr {
                         expr: AnalyzedExprKind::Ok(Box::new(inner_expr)),
@@ -3253,6 +3246,9 @@ fn extract_value(asm_stmt: &AssembledStatement) -> (AnalyzedExpr, GlossaType) {
             if let Some(lit) = asm_stmt.literals.first() {
                 let inner_expr = literal_to_analyzed_expr(lit);
                 let inner_type = inner_expr.glossa_type.clone();
+                // LIMITATION: Success type defaults to Unknown when only Err variant is provided.
+                // Full Result<T,E> inference would require type context from function signatures.
+                // Future enhancement: infer T from usage or allow explicit type annotations.
                 return (
                     AnalyzedExpr {
                         expr: AnalyzedExprKind::Err(Box::new(inner_expr)),
@@ -3397,6 +3393,7 @@ fn extract_value(asm_stmt: &AssembledStatement) -> (AnalyzedExpr, GlossaType) {
             if let Some(lit) = asm_stmt.literals.first() {
                 let inner_expr = literal_to_analyzed_expr(lit);
                 let inner_type = inner_expr.glossa_type.clone();
+                // LIMITATION: Error type defaults to String. See nominatives section for explanation.
                 return (
                     AnalyzedExpr {
                         expr: AnalyzedExprKind::Ok(Box::new(inner_expr)),
@@ -3418,6 +3415,7 @@ fn extract_value(asm_stmt: &AssembledStatement) -> (AnalyzedExpr, GlossaType) {
             if let Some(lit) = asm_stmt.literals.first() {
                 let inner_expr = literal_to_analyzed_expr(lit);
                 let inner_type = inner_expr.glossa_type.clone();
+                // LIMITATION: Success type defaults to Unknown. See nominatives section for explanation.
                 return (
                     AnalyzedExpr {
                         expr: AnalyzedExprKind::Err(Box::new(inner_expr)),

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -5,6 +5,10 @@
 //! - ὄνομα (onoma) → String
 //! - ἀληθές/ψεῦδος → Boolean
 //! - λίστη (liste) → List/Vec
+//!
+//! Special types from Greek morphology:
+//! - Optative mood → Option<T> (value that "might be")
+//! - ἀποτέλεσμα (apotelasma) → Result<T,E> (outcome/result)
 
 use crate::morphology::{Case, Gender, Tense};
 
@@ -22,6 +26,30 @@ pub enum GlossaType {
 
     /// λίστη - list of T
     List(Box<GlossaType>),
+
+    /// Option<T> - value that might not exist
+    ///
+    /// Expressed in ΓΛΩΣΣΑ via the **optative mood** (εὑρεθείη "might be found").
+    /// The optative mood in Ancient Greek expresses wish, possibility, or potential,
+    /// making it a natural fit for optional values.
+    ///
+    /// # Examples
+    /// - τί (ti) → Some(value) ("something")
+    /// - οὐδέν (ouden) → None ("nothing")
+    /// - `;` after optative verb → propagates None (like Rust's `?`)
+    /// - `!` suffix → unwrap (confident extraction)
+    Option(Box<GlossaType>),
+
+    /// Result<T, E> - value or error
+    ///
+    /// Expressed in ΓΛΩΣΣΑ via ἀποτέλεσμα (apotelasma) "result/outcome".
+    /// Uses disjunctive patterns to distinguish success from failure.
+    ///
+    /// # Examples
+    /// - ἐπιτυχία (epitychia) → Ok(value) ("success")
+    /// - σφάλμα (sphalma) → Err(error) ("error/mistake")
+    /// - `;` after Result expression → propagates Err (like Rust's `?`)
+    Result(Box<GlossaType>, Box<GlossaType>),
 
     /// Custom struct type (from noun)
     Struct {
@@ -45,16 +73,18 @@ pub enum GlossaType {
 
 impl GlossaType {
     /// Get the Rust equivalent type
-    pub fn to_rust(&self) -> &'static str {
+    pub fn to_rust(&self) -> String {
         match self {
-            GlossaType::Number => "i64",
-            GlossaType::String => "String",
-            GlossaType::Boolean => "bool",
-            GlossaType::List(_) => "Vec",
-            GlossaType::Unit => "()",
-            GlossaType::Struct { .. } => "struct",
-            GlossaType::Function { .. } => "fn",
-            GlossaType::Unknown => "_",
+            GlossaType::Number => "i64".to_string(),
+            GlossaType::String => "String".to_string(),
+            GlossaType::Boolean => "bool".to_string(),
+            GlossaType::List(inner) => format!("Vec<{}>", inner.to_rust()),
+            GlossaType::Option(inner) => format!("Option<{}>", inner.to_rust()),
+            GlossaType::Result(ok, err) => format!("Result<{}, {}>", ok.to_rust(), err.to_rust()),
+            GlossaType::Unit => "()".to_string(),
+            GlossaType::Struct { .. } => "struct".to_string(),
+            GlossaType::Function { .. } => "fn".to_string(),
+            GlossaType::Unknown => "_".to_string(),
         }
     }
 
@@ -65,6 +95,8 @@ impl GlossaType {
             GlossaType::String => "ὄνομα",
             GlossaType::Boolean => "ἀληθές",
             GlossaType::List(_) => "λίστη",
+            GlossaType::Option(_) => "εὑρεθείη", // "might be found" (optative)
+            GlossaType::Result(_, _) => "ἀποτέλεσμα", // "result/outcome"
             GlossaType::Unit => "οὐδέν",
             GlossaType::Struct { .. } => "εἶδος",
             GlossaType::Function { .. } => "ἔργον",
@@ -77,6 +109,10 @@ impl GlossaType {
         match (self, other) {
             (GlossaType::Unknown, _) | (_, GlossaType::Unknown) => true,
             (GlossaType::List(a), GlossaType::List(b)) => a.is_compatible(b),
+            (GlossaType::Option(a), GlossaType::Option(b)) => a.is_compatible(b),
+            (GlossaType::Result(ok1, err1), GlossaType::Result(ok2, err2)) => {
+                ok1.is_compatible(ok2) && err1.is_compatible(err2)
+            }
             _ => self == other,
         }
     }
@@ -211,9 +247,9 @@ mod tests {
 
     #[test]
     fn test_type_to_rust() {
-        assert_eq!(GlossaType::Number.to_rust(), "i64");
-        assert_eq!(GlossaType::String.to_rust(), "String");
-        assert_eq!(GlossaType::Boolean.to_rust(), "bool");
+        assert_eq!(GlossaType::Number.to_rust(), "i64".to_string());
+        assert_eq!(GlossaType::String.to_rust(), "String".to_string());
+        assert_eq!(GlossaType::Boolean.to_rust(), "bool".to_string());
     }
 
     #[test]

--- a/tests/option_result_tests.rs
+++ b/tests/option_result_tests.rs
@@ -1,0 +1,922 @@
+/// Integration tests for Option<T> and Result<T,E> types in GLOSSA
+///
+/// Tests the Ancient Greek morphology mapping:
+/// - Optative mood → Option<T>
+/// - οὐδέν (ouden) → None
+/// - τί (ti) → Some
+/// - ἐπιτυχία (epitychia) → Ok
+/// - σφάλμα (sphalma) → Err
+use glossa::semantic::GlossaType;
+
+/// Helper to compile GLOSSA source to Rust code
+fn compile(source: &str) -> Result<String, String> {
+    use glossa::ast::build_ast;
+    use glossa::codegen::generate_rust;
+    use glossa::ir::lower_to_hir;
+    use glossa::semantic::analyze_program;
+
+    let ast = build_ast(source).map_err(|e| e.to_string())?;
+    let analyzed = analyze_program(&ast).map_err(|e| e.to_string())?;
+    let hir = lower_to_hir(&analyzed);
+    Ok(generate_rust(&hir))
+}
+
+// ============================================================================
+// Phase 1: Type System Foundation Tests
+// ============================================================================
+
+#[test]
+fn test_option_type_exists() {
+    let opt = GlossaType::Option(Box::new(GlossaType::Number));
+    assert!(matches!(opt, GlossaType::Option(_)));
+}
+
+#[test]
+fn test_result_type_exists() {
+    let result = GlossaType::Result(Box::new(GlossaType::Number), Box::new(GlossaType::String));
+    assert!(matches!(result, GlossaType::Result(_, _)));
+}
+
+#[test]
+fn test_option_to_rust() {
+    let opt = GlossaType::Option(Box::new(GlossaType::Number));
+    assert_eq!(opt.to_rust(), "Option<i64>");
+}
+
+#[test]
+fn test_result_to_rust() {
+    let result = GlossaType::Result(Box::new(GlossaType::Number), Box::new(GlossaType::String));
+    assert_eq!(result.to_rust(), "Result<i64, String>");
+}
+
+#[test]
+fn test_option_type_compatibility() {
+    let opt_num = GlossaType::Option(Box::new(GlossaType::Number));
+    let opt_unknown = GlossaType::Option(Box::new(GlossaType::Unknown));
+    assert!(opt_num.is_compatible(&opt_unknown));
+}
+
+#[test]
+fn test_result_type_compatibility() {
+    let res1 = GlossaType::Result(Box::new(GlossaType::Number), Box::new(GlossaType::String));
+    let res2 = GlossaType::Result(Box::new(GlossaType::Unknown), Box::new(GlossaType::Unknown));
+    assert!(res1.is_compatible(&res2));
+}
+
+#[test]
+fn test_nested_option() {
+    let nested = GlossaType::Option(Box::new(GlossaType::Option(Box::new(GlossaType::Number))));
+    assert_eq!(nested.to_rust(), "Option<Option<i64>>");
+}
+
+// ============================================================================
+// Phase 2: Optative Mood Analysis Tests
+// ============================================================================
+
+#[test]
+fn test_optative_present_active() {
+    use glossa::morphology::{Mood, Person, analyze};
+
+    // γράφοιμι - "I might write" (present active optative)
+    let analysis = analyze("γραφοιμι");
+    assert_eq!(analysis.mood, Some(Mood::Optative));
+    assert_eq!(analysis.person, Some(Person::First));
+}
+
+#[test]
+fn test_optative_aorist_passive() {
+    use glossa::morphology::{Mood, Person, analyze};
+
+    // εὑρεθείη - "might be found" (aorist passive optative)
+    let analysis = analyze("ευρεθειη");
+    assert_eq!(analysis.mood, Some(Mood::Optative));
+    assert_eq!(analysis.person, Some(Person::Third));
+}
+
+// ============================================================================
+// Phase 3: Lexicon Vocabulary Tests
+// ============================================================================
+
+#[test]
+fn test_ouden_is_none() {
+    use glossa::morphology::lexicon;
+
+    let entry = lexicon::lookup("ουδεν");
+    assert!(entry.is_some());
+    assert_eq!(entry.unwrap().rust_equiv, Some("None"));
+}
+
+#[test]
+fn test_ti_is_some() {
+    use glossa::morphology::lexicon;
+
+    let entry = lexicon::lookup("τι");
+    assert!(entry.is_some());
+    assert_eq!(entry.unwrap().rust_equiv, Some("Some"));
+}
+
+#[test]
+fn test_epitychia_is_ok() {
+    use glossa::morphology::lexicon;
+
+    let entry = lexicon::lookup("επιτυχια");
+    assert!(entry.is_some());
+    assert_eq!(entry.unwrap().rust_equiv, Some("Ok"));
+}
+
+#[test]
+fn test_sphalma_is_err() {
+    use glossa::morphology::lexicon;
+
+    let entry = lexicon::lookup("σφαλμα");
+    assert!(entry.is_some());
+    assert_eq!(entry.unwrap().rust_equiv, Some("Err"));
+}
+
+#[test]
+fn test_is_none_word_helper() {
+    use glossa::morphology::lexicon::is_none_word;
+
+    assert!(is_none_word("ουδεν"));
+    assert!(!is_none_word("τι"));
+}
+
+#[test]
+fn test_is_some_word_helper() {
+    use glossa::morphology::lexicon::is_some_word;
+
+    assert!(is_some_word("τι"));
+    assert!(!is_some_word("ουδεν"));
+}
+
+#[test]
+fn test_is_ok_word_helper() {
+    use glossa::morphology::lexicon::is_ok_word;
+
+    assert!(is_ok_word("επιτυχια"));
+    assert!(!is_ok_word("σφαλμα"));
+}
+
+#[test]
+fn test_is_err_word_helper() {
+    use glossa::morphology::lexicon::is_err_word;
+
+    assert!(is_err_word("σφαλμα"));
+    assert!(!is_err_word("επιτυχια"));
+}
+
+// ============================================================================
+// Phase 4: HIR Extensions Tests
+// ============================================================================
+
+#[test]
+fn test_hir_some_variant() {
+    use glossa::ir::HirExpr;
+
+    let some_expr = HirExpr::Some(Box::new(HirExpr::IntLit(42)));
+    assert!(matches!(some_expr, HirExpr::Some(_)));
+}
+
+#[test]
+fn test_hir_none_variant() {
+    use glossa::ir::HirExpr;
+
+    let none_expr = HirExpr::None;
+    assert!(matches!(none_expr, HirExpr::None));
+}
+
+#[test]
+fn test_hir_ok_variant() {
+    use glossa::ir::HirExpr;
+
+    let ok_expr = HirExpr::Ok(Box::new(HirExpr::IntLit(42)));
+    assert!(matches!(ok_expr, HirExpr::Ok(_)));
+}
+
+#[test]
+fn test_hir_err_variant() {
+    use glossa::ir::HirExpr;
+
+    let err_expr = HirExpr::Err(Box::new(HirExpr::StringLit("error".to_string())));
+    assert!(matches!(err_expr, HirExpr::Err(_)));
+}
+
+#[test]
+fn test_hir_try_variant() {
+    use glossa::ir::HirExpr;
+
+    let try_expr = HirExpr::Try(Box::new(HirExpr::Var("x".to_string())));
+    assert!(matches!(try_expr, HirExpr::Try(_)));
+}
+
+#[test]
+fn test_hir_unwrap_variant() {
+    use glossa::ir::HirExpr;
+
+    let unwrap_expr = HirExpr::Unwrap(Box::new(HirExpr::Var("x".to_string())));
+    assert!(matches!(unwrap_expr, HirExpr::Unwrap(_)));
+}
+
+// ============================================================================
+// Phase 5: Semantic Analysis Tests
+// ============================================================================
+
+#[test]
+fn test_none_expression_analyzed() {
+    use glossa::ast::build_ast;
+    use glossa::semantic::analyze_program;
+
+    // ξ οὐδέν ἔστω. → let x = None;
+    let source = "ξ ουδεν εστω.";
+    let ast = build_ast(source).unwrap();
+    let analyzed = analyze_program(&ast).unwrap();
+
+    // Should have one binding statement
+    assert_eq!(analyzed.statements.len(), 1);
+}
+
+#[test]
+fn test_some_expression_analyzed() {
+    use glossa::ast::build_ast;
+    use glossa::semantic::analyze_program;
+
+    // ξ τί πέντε ἔστω. → let x = Some(5);
+    let source = "ξ τι πεντε εστω.";
+    let ast = build_ast(source).unwrap();
+    let analyzed = analyze_program(&ast).unwrap();
+
+    // Should have one binding statement
+    assert_eq!(analyzed.statements.len(), 1);
+}
+
+#[test]
+fn test_ok_expression_analyzed() {
+    use glossa::ast::build_ast;
+    use glossa::semantic::analyze_program;
+
+    // ξ ἐπιτυχία πέντε ἔστω. → let x = Ok(5);
+    let source = "ξ επιτυχια πεντε εστω.";
+    let ast = build_ast(source).unwrap();
+    let analyzed = analyze_program(&ast).unwrap();
+
+    // Should have one binding statement
+    assert_eq!(analyzed.statements.len(), 1);
+}
+
+#[test]
+fn test_err_expression_analyzed() {
+    use glossa::ast::build_ast;
+    use glossa::semantic::analyze_program;
+
+    // ξ σφάλμα «πρόβλημα» ἔστω. → let x = Err("problem");
+    let source = "ξ σφαλμα «προβλημα» εστω.";
+    let ast = build_ast(source).unwrap();
+    let analyzed = analyze_program(&ast).unwrap();
+
+    // Should have one binding statement
+    assert_eq!(analyzed.statements.len(), 1);
+}
+
+#[test]
+fn test_none_codegen() {
+    // ξ οὐδέν ἔστω. → let x = None;
+    let source = "ξ ουδεν εστω.";
+    let output = compile(source).unwrap();
+
+    // Should contain None
+    assert!(
+        output.contains("None"),
+        "Expected 'None' in output: {}",
+        output
+    );
+}
+
+#[test]
+fn test_some_codegen() {
+    //ξ τί πέντε ἔστω. → let x = Some(5);
+    let source = "ξ τι πεντε εστω.";
+    let output = compile(source).unwrap();
+
+    // Should contain Some(5)
+    assert!(
+        output.contains("Some"),
+        "Expected 'Some' in output: {}",
+        output
+    );
+    assert!(output.contains("5"), "Expected '5' in output: {}", output);
+}
+
+#[test]
+fn test_ok_codegen() {
+    //ξ ἐπιτυχία πέντε ἔστω. → let x = Ok(5);
+    let source = "ξ επιτυχια πεντε εστω.";
+    let output = compile(source).unwrap();
+
+    // Should contain Ok(5)
+    assert!(output.contains("Ok"), "Expected 'Ok' in output: {}", output);
+    assert!(output.contains("5"), "Expected '5' in output: {}", output);
+}
+
+#[test]
+fn test_err_codegen() {
+    //ξ σφάλμα «πρόβλημα» ἔστω. → let x = Err("problem");
+    let source = "ξ σφαλμα «προβλημα» εστω.";
+    let output = compile(source).unwrap();
+
+    // Should contain Err
+    assert!(
+        output.contains("Err"),
+        "Expected 'Err' in output: {}",
+        output
+    );
+}
+
+// ============================================================================
+// Phase 6: Propagation & Unwrap Operators Tests
+// ============================================================================
+
+#[test]
+fn test_unwrap_operator_codegen() {
+    use glossa::ast::build_ast;
+    use glossa::semantic::analyze_program;
+
+    // ξ τί πέντε ἔστω. ξ! λέγε. → let x = Some(5); println!("{}", x.unwrap());
+    let source = "ξ τι πεντε εστω. ξ! λεγε.";
+    let ast = build_ast(source).unwrap();
+    let analyzed = analyze_program(&ast);
+
+    // Should analyze without errors
+    assert!(analyzed.is_ok(), "Analysis failed: {:?}", analyzed.err());
+}
+
+#[test]
+fn test_unwrap_in_expression() {
+    // Test that ! suffix generates .unwrap()
+    let source = "ξ τι πεντε εστω. ψ ξ! εστω.";
+    let output = compile(source).unwrap();
+
+    // Should contain unwrap
+    assert!(
+        output.contains("unwrap"),
+        "Expected 'unwrap' in output: {}",
+        output
+    );
+}
+
+// ============================================================================
+// Phase 7: Result Type - Comprehensive Tests
+// ============================================================================
+
+#[test]
+fn test_ok_expression_exact_output() {
+    // ξ ἐπιτυχία πέντε ἔστω. → let x = Ok(5);
+    let source = "ξ επιτυχια πεντε εστω.";
+    let output = compile(source).unwrap();
+
+    // Check for Ok with 5 (allowing for spaces from quote! macro)
+    assert!(
+        output.contains("Ok") && output.contains("5i64"),
+        "Expected 'Ok' with '5i64' in output: {}",
+        output
+    );
+}
+
+#[test]
+fn test_err_expression_exact_output() {
+    // ξ σφάλμα «πρόβλημα» ἔστω. → let x = Err("problem");
+    let source = "ξ σφαλμα «προβλημα» εστω.";
+    let output = compile(source).unwrap();
+
+    assert!(
+        output.contains("Err") && output.contains("προβλημα"),
+        "Expected 'Err(\"προβλημα\")' in output: {}",
+        output
+    );
+}
+
+#[test]
+fn test_result_with_number_value() {
+    // Multiple Result values
+    let source = r#"
+        ξ επιτυχια δεκα εστω.
+        ψ σφαλμα «λαθος» εστω.
+    "#;
+    let output = compile(source).unwrap();
+
+    assert!(
+        output.contains("Ok") && output.contains("10"),
+        "Expected 'Ok' with '10' in output: {}",
+        output
+    );
+    assert!(
+        output.contains("Err"),
+        "Expected 'Err' in output: {}",
+        output
+    );
+}
+
+#[test]
+fn test_result_unwrap() {
+    // ξ ἐπιτυχία πέντε ἔστω. ξ! λέγε. → let x = Ok(5); println!("{}", x.unwrap());
+    let source = "ξ επιτυχια πεντε εστω. ξ! λεγε.";
+    let output = compile(source).unwrap();
+
+    assert!(
+        output.contains("Ok") && output.contains("5"),
+        "Expected 'Ok' with '5' in output: {}",
+        output
+    );
+    assert!(
+        output.contains("unwrap"),
+        "Expected 'unwrap()' in output: {}",
+        output
+    );
+}
+
+#[test]
+fn test_result_print_directly() {
+    // Print Result directly (not unwrapped)
+    let source = "ξ επιτυχια πεντε εστω. ξ λεγε.";
+    let output = compile(source).unwrap();
+
+    assert!(
+        output.contains("Ok") && output.contains("5"),
+        "Expected 'Ok' with '5' in output: {}",
+        output
+    );
+    // Should print the Result value itself, not unwrapped (allowing for space in "println !")
+    assert!(
+        output.contains("println"),
+        "Expected println in output: {}",
+        output
+    );
+}
+
+#[test]
+fn test_err_with_string_literal() {
+    // Err with explicit string message
+    let source = "αποτελεσμα σφαλμα «Αποτυχια» εστω.";
+    let output = compile(source).unwrap();
+
+    assert!(
+        output.contains("Err") && output.contains("Αποτυχια"),
+        "Expected 'Err(\"Αποτυχια\")' in output: {}",
+        output
+    );
+}
+
+#[test]
+fn test_multiple_results_in_sequence() {
+    // Multiple Result bindings
+    let source = r#"
+        α επιτυχια πεντε εστω.
+        β σφαλμα «κακος» εστω.
+        γ επιτυχια δεκα εστω.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have multiple Result expressions (checking for "Ok " with space)
+    let ok_count = output.matches("Ok ").count();
+    let err_count = output.matches("Err ").count();
+
+    assert!(
+        ok_count >= 2,
+        "Expected at least 2 Ok calls, got {}: {}",
+        ok_count,
+        output
+    );
+    assert!(
+        err_count >= 1,
+        "Expected at least 1 Err call, got {}: {}",
+        err_count,
+        output
+    );
+}
+
+#[test]
+fn test_result_parallels_option() {
+    // Verify Result behaves like Option
+    let option_source = "ξ τι πεντε εστω.";
+    let result_source = "ξ επιτυχια πεντε εστω.";
+
+    let option_output = compile(option_source).unwrap();
+    let result_output = compile(result_source).unwrap();
+
+    // Both should compile successfully (allowing for spaces in output)
+    assert!(
+        option_output.contains("Some") && option_output.contains("5"),
+        "Expected 'Some' with '5' in: {}",
+        option_output
+    );
+    assert!(
+        result_output.contains("Ok") && result_output.contains("5"),
+        "Expected 'Ok' with '5' in: {}",
+        result_output
+    );
+}
+
+// ============================================================================
+// Phase 8: Code Generation Refinements
+// ============================================================================
+
+// NOTE: Nested Option/Result constructions (e.g., Ok(Some(5))) are not yet supported
+// The current implementation treats each constructor independently
+// These are documented as future enhancements
+
+#[test]
+fn test_option_none_generates_correctly() {
+    // None is standalone, not wrapped in Ok/Err
+    let source = "ξ ουδεν εστω.";
+    let output = compile(source).unwrap();
+
+    assert!(output.contains("None"), "Expected 'None' in: {}", output);
+    // Should NOT be wrapped in Ok or Err
+    assert!(
+        !output.contains("Ok"),
+        "Should not contain 'Ok': {}",
+        output
+    );
+    assert!(
+        !output.contains("Err"),
+        "Should not contain 'Err': {}",
+        output
+    );
+}
+
+#[test]
+fn test_result_ok_generates_correctly() {
+    // Ok wraps the value
+    let source = "ξ επιτυχια πεντε εστω.";
+    let output = compile(source).unwrap();
+
+    assert!(output.contains("Ok"), "Expected 'Ok' in: {}", output);
+    assert!(output.contains("5"), "Expected '5' in: {}", output);
+}
+
+#[test]
+fn test_result_err_generates_correctly() {
+    // Err wraps the value
+    let source = "ξ σφαλμα πεντε εστω.";
+    let output = compile(source).unwrap();
+
+    assert!(output.contains("Err"), "Expected 'Err' in: {}", output);
+    assert!(output.contains("5"), "Expected '5' in: {}", output);
+}
+
+#[test]
+fn test_option_with_string() {
+    // Some with string literal
+    let source = "μηνυμα τι «χαιρε» εστω.";
+    let output = compile(source).unwrap();
+
+    assert!(output.contains("Some"), "Expected 'Some' in: {}", output);
+    assert!(output.contains("χαιρε"), "Expected 'χαιρε' in: {}", output);
+}
+
+#[test]
+fn test_result_with_number_error() {
+    // Err with number (unusual but valid)
+    let source = "ξ σφαλμα δεκα εστω.";
+    let output = compile(source).unwrap();
+
+    assert!(output.contains("Err"), "Expected 'Err' in: {}", output);
+    assert!(output.contains("10"), "Expected '10' in: {}", output);
+}
+
+#[test]
+fn test_unwrap_preserves_value() {
+    // Unwrap should generate .unwrap() call
+    let source = "ξ τι πεντε εστω. ψ ξ! εστω.";
+    let output = compile(source).unwrap();
+
+    assert!(
+        output.contains("unwrap"),
+        "Expected 'unwrap' in: {}",
+        output
+    );
+}
+
+#[test]
+fn test_option_in_print() {
+    // Printing Option directly (not unwrapped)
+    let source = "ξ τι πεντε εστω. ξ λεγε.";
+    let output = compile(source).unwrap();
+
+    assert!(output.contains("Some"), "Expected 'Some' in: {}", output);
+    assert!(
+        output.contains("println"),
+        "Expected 'println' in: {}",
+        output
+    );
+}
+
+#[test]
+fn test_separate_option_and_variable() {
+    // Variables and Options are currently separate concepts
+    // Wrapping variables in Option/Result requires explicit construction syntax (future feature)
+    let source = r#"
+        α πεντε εστω.
+        β τι δεκα εστω.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have both a plain variable and an Option
+    assert!(output.contains("5"), "Expected '5' in: {}", output);
+    assert!(output.contains("Some"), "Expected 'Some' in: {}", output);
+    assert!(output.contains("10"), "Expected '10' in: {}", output);
+}
+
+// ============================================================================
+// Phase 9: Integration Tests - End-to-End Scenarios
+// ============================================================================
+
+#[test]
+fn test_option_workflow() {
+    // Complete Option workflow: create, check, unwrap
+    let source = r#"
+        α τι πεντε εστω.
+        α λεγε.
+        β α! εστω.
+        β λεγε.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have Some(5)
+    assert!(
+        output.contains("Some") && output.contains("5"),
+        "Expected Some(5) in: {}",
+        output
+    );
+    // Should have two println calls
+    let println_count = output.matches("println").count();
+    assert!(
+        println_count >= 2,
+        "Expected at least 2 println calls, got {}",
+        println_count
+    );
+    // Should have unwrap call
+    assert!(output.contains("unwrap"), "Expected unwrap in: {}", output);
+}
+
+#[test]
+fn test_result_workflow() {
+    // Complete Result workflow: Ok and Err cases
+    let source = r#"
+        επιτυχη επιτυχια δεκα εστω.
+        λαθος σφαλμα «προβλημα» εστω.
+        επιτυχη λεγε.
+        λαθος λεγε.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have Ok(10)
+    assert!(
+        output.contains("Ok") && output.contains("10"),
+        "Expected Ok(10) in: {}",
+        output
+    );
+    // Should have Err("problem")
+    assert!(
+        output.contains("Err") && output.contains("προβλημα"),
+        "Expected Err with error message in: {}",
+        output
+    );
+}
+
+#[test]
+fn test_mixed_option_result() {
+    // Using both Option and Result in same program
+    let source = r#"
+        επιλογη τι πεντε εστω.
+        αποτελεσμα επιτυχια δεκα εστω.
+        επιλογη λεγε.
+        αποτελεσμα λεγε.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have both Some and Ok
+    assert!(output.contains("Some"), "Expected 'Some' in: {}", output);
+    assert!(output.contains("Ok"), "Expected 'Ok' in: {}", output);
+}
+
+#[test]
+fn test_none_handling() {
+    // Working with None values
+    let source = r#"
+        κενον ουδεν εστω.
+        κενον λεγε.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have None
+    assert!(output.contains("None"), "Expected 'None' in: {}", output);
+    assert!(
+        output.contains("println"),
+        "Expected println in: {}",
+        output
+    );
+}
+
+#[test]
+fn test_multiple_unwraps_sequence() {
+    // Multiple unwrap operations in sequence
+    let source = r#"
+        α τι πεντε εστω.
+        β τι δεκα εστω.
+        γ α! εστω.
+        δ β! εστω.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have at least 2 unwrap calls
+    let unwrap_count = output.matches("unwrap").count();
+    assert!(
+        unwrap_count >= 2,
+        "Expected at least 2 unwrap calls, got {}: {}",
+        unwrap_count,
+        output
+    );
+}
+
+#[test]
+fn test_err_with_different_types() {
+    // Err can wrap different value types
+    let source = r#"
+        α σφαλμα «μηνυμα» εστω.
+        β σφαλμα πεντε εστω.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have two Err expressions
+    let err_count = output.matches("Err").count();
+    assert!(
+        err_count >= 2,
+        "Expected at least 2 Err calls, got {}: {}",
+        err_count,
+        output
+    );
+}
+
+#[test]
+fn test_some_with_different_types() {
+    // Some can wrap different value types
+    let source = r#"
+        α τι «κειμενον» εστω.
+        β τι πεντε εστω.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have two Some expressions
+    let some_count = output.matches("Some").count();
+    assert!(
+        some_count >= 2,
+        "Expected at least 2 Some calls, got {}: {}",
+        some_count,
+        output
+    );
+}
+
+#[test]
+fn test_realistic_error_handling() {
+    // Realistic error handling pattern
+    let source = r#"
+        τιμη τι δεκα εστω.
+        λαθος σφαλμα «ουκ ευρεθη» εστω.
+        τιμη λεγε.
+        λαθος λεγε.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should compile successfully with both Some and Err
+    assert!(output.contains("Some"), "Expected Some in: {}", output);
+    assert!(output.contains("Err"), "Expected Err in: {}", output);
+    // Should have Greek error message preserved
+    assert!(
+        output.contains("ευρεθη"),
+        "Expected Greek error message in: {}",
+        output
+    );
+}
+
+// ============================================================================
+// Phase 10: Propagation Operator (`;` after optative → `?`)
+// ============================================================================
+
+#[test]
+fn test_propagation_operator_detection() {
+    // RED: Test that `;` after an optative/Option expression generates `?`
+    let source = "τιμη τι πεντε εστω; τιμη λεγε.";
+    let output = compile(source);
+
+    // Should compile successfully
+    assert!(output.is_ok(), "Compilation failed: {:?}", output.err());
+}
+
+#[test]
+fn test_propagation_generates_question_mark() {
+    // RED: Verify `;` generates `?` operator in Rust
+    let source = "τιμη τι πεντε εστω; τιμη λεγε.";
+    let output = compile(source).unwrap();
+
+    // Should contain the ? operator
+    assert!(output.contains("?"), "Expected '?' operator in: {}", output);
+}
+
+#[test]
+fn test_propagation_vs_unwrap() {
+    // Propagation (`;`) should be different from unwrap (`!`)
+    let unwrap_source = "α τι πεντε εστω. β α! εστω.";
+    let propagate_source = "α τι πεντε εστω; β α εστω.";
+
+    let unwrap_output = compile(unwrap_source).unwrap();
+    let propagate_output = compile(propagate_source).unwrap();
+
+    // Unwrap should have .unwrap()
+    assert!(
+        unwrap_output.contains("unwrap"),
+        "Expected unwrap in: {}",
+        unwrap_output
+    );
+
+    // Propagation should have ?
+    assert!(
+        propagate_output.contains("?"),
+        "Expected ? in: {}",
+        propagate_output
+    );
+}
+
+#[test]
+fn test_propagation_with_result() {
+    // RED: Propagation works with Result types
+    let source = "αποτελεσμα επιτυχια δεκα εστω; αποτελεσμα λεγε.";
+    let output = compile(source).unwrap();
+
+    assert!(output.contains("Ok"), "Expected Ok in: {}", output);
+    assert!(output.contains("?"), "Expected ? in: {}", output);
+}
+
+#[test]
+fn test_chained_propagation() {
+    // RED: Multiple propagation operators in sequence
+    let source = r#"
+        α τι πεντε εστω;
+        β τι δεκα εστω;
+        α λεγε.
+        β λεγε.
+    "#;
+    let output = compile(source).unwrap();
+
+    // Should have at least 2 ? operators
+    let question_count = output.matches('?').count();
+    assert!(
+        question_count >= 2,
+        "Expected at least 2 '?' operators, got {}: {}",
+        question_count,
+        output
+    );
+}
+
+#[test]
+fn test_propagation_early_return() {
+    // Propagation should enable early return pattern
+    let source = r#"
+        α τι πεντε εστω;
+        β α εστω.
+    "#;
+    let output = compile(source).unwrap();
+
+    // The pattern should propagate None/Err upward
+    assert!(output.contains("?"), "Expected ? operator in: {}", output);
+}
+
+#[test]
+fn test_statement_end_with_semicolon() {
+    // Regular statement end (.) vs propagation (;)
+    let regular = "α τι πεντε εστω. α λεγε.";
+    let propagate = "α τι πεντε εστω; α λεγε.";
+
+    let regular_output = compile(regular).unwrap();
+    let propagate_output = compile(propagate).unwrap();
+
+    // Regular should NOT have ?
+    assert!(
+        !regular_output.contains("?"),
+        "Should not have ? in regular statement"
+    );
+
+    // Propagate should have ?
+    assert!(propagate_output.contains("?"), "Expected ? in propagation");
+}
+
+#[test]
+fn test_propagation_in_workflow() {
+    // Realistic workflow with propagation
+    let source = r#"
+        τιμη τι πεντε εστω;
+        αποτελεσμα επιτυχια τιμη εστω.
+    "#;
+    let output = compile(source);
+
+    assert!(output.is_ok(), "Compilation failed: {:?}", output.err());
+}


### PR DESCRIPTION
## Summary
Implements `Option<T>` and `Result<T,E>` types using Ancient Greek morphology, bringing idiomatic Rust error handling to GLOSSA.

## Greek Morphology Mappings

| Rust | Greek | GLOSSA Syntax |
|------|-------|---------------|
| `Option<T>` | Optative mood | Verb in -οιμι/-θείη |
| `Some(5)` | τί (something) | `τι πεντε` |
| `None` | οὐδέν (nothing) | `ουδεν` |
| `Result<T,E>` | ἀποτέλεσμα | result/outcome |
| `Ok(5)` | ἐπιτυχία (success) | `επιτυχια πεντε` |
| `Err("msg")` | σφάλμα (mistake) | `σφαλμα «μηνυμα»` |
| `.unwrap()` | ! suffix | `ξ!` |
| `?` operator | ; statement end | `ξ εστω;` |

## Example Code

\`\`\`glossa
// Option workflow
α τι πεντε εστω.     // let alpha = Some(5);
α λεγε.               // println!("{}", alpha);
β α! εστω.            // let beta = alpha.unwrap();

// Result workflow with propagation
επιτυχη επιτυχια δεκα εστω;        // let success = Ok(10)?;
λαθος σφαλμα «προβλημα» εστω.      // let error = Err("problem");

// None handling
κενον ουδεν εστω.    // let empty = None;
\`\`\`

## Implementation Details

### Type System (`src/semantic/types.rs`)
- Added `Option(Box<GlossaType>)` and `Result(Box<GlossaType>, Box<GlossaType>)` variants
- Full generic support with `to_rust()` → `"Option<i64>"`, `"Result<i64, String>"`
- Type compatibility checking for nested types

### Morphology (`src/morphology/`)
- **Conjugation**: Present active optative (γράφοιμι) and aorist passive optative (εὑρεθείη) verb endings
- **Lexicon**: οὐδέν (None), τί (Some), ἐπιτυχία (Ok), σφάλμα (Err) with `rust_equiv` field
- Helper functions: `is_none_word()`, `is_some_word()`, `is_ok_word()`, `is_err_word()`

### Grammar (`src/grammar/glossa.pest`)
- Added `unwrap_expr = { greek_word ~ "!" }` for confident extraction
- Added `propagate = { ";" }` for error propagation
- Updated `statement_end` to include propagation

### Semantic Analysis (`src/semantic/`)
- Word-order independent detection in assembler (checks nominatives, object, subject slots)
- Checks both lemma and original forms for proper Greek word matching
- `AnalyzedExprKind`: `Some`, `None`, `Ok`, `Err`, `Try`, `Unwrap` variants
- Propagation wraps binding values in `Try` when statement ends with `;`

### HIR & Code Generation
- Full HIR node support for all Option/Result operations
- `quote!` macro generates proper Rust: `Some(#inner)`, `None`, `Ok(#inner)`, `Err(#inner)`, `#inner?`, `#inner.unwrap()`

## Test Coverage
- **65 tests** in `tests/option_result_tests.rs`
- **10 implementation phases** fully tested with TDD (RED-GREEN-REFACTOR)
- **354 total tests** pass across entire codebase
- Integration tests cover realistic error handling workflows

## Testing
\`\`\`bash
cargo test --test option_result_tests  # Run Option/Result tests
cargo test                              # All 354 tests pass
\`\`\`

🏛️ Generated with [Claude Code](https://claude.com/claude-code)