### PR TITLE
Update language reference to match implementation

### DIFF
--- a/docs/reference/11-Control-Flow.md
+++ b/docs/reference/11-Control-Flow.md
@@ -1,56 +1,47 @@
 # 11. Control Flow
 
-## 11.1 The Aristotelian Approach
+## 11.1 Design Philosophy
 
-ΓΛΩΣΣΑ follows Aristotle's logical syntax from the *Organon* rather than modern imperative control flow. In Aristotle's syllogistic logic, consequences are introduced with **ἀνάγκη** (necessity):
+ΓΛΩΣΣΑ uses Greek grammatical mood to delimit control flow:
 
-```
-εἰ τὸ Α κατὰ παντὸς τοῦ Β, ἀνάγκη τὸ Α κατὰ παντὸς τοῦ Γ
-"If A of all B, necessarily A of all C"
-```
+- The **subjunctive mood** (ᾖ) marks hypothetical/conditional boundaries
+- **Commas** separate condition clauses from consequence clauses
+- **Imperative verbs** (λέγε, παῦε) express commands in consequence clauses
+- **εἰ δὲ μή** ("if but not") introduces else branches
 
-This is **declarative**: we state logical truths, not imperative commands.
+This allows natural Greek sentence structure to encode if/else, loops, and pattern matching without braces or special delimiters.
 
 ## 11.2 Conditionals
 
-### Simple Conditional (εἰ... ἀνάγκη)
+### Simple Conditional (εἰ... ᾖ)
 
 ```glossa
-εἰ ξ πέντε μεῖζον ᾖ, ἀνάγκη «μέγα» λέγειν.
-"If x than-five greater be-[subj], necessarily 'large' to-say."
-// → if x > 5 { println!("large") }
+εἰ ξ πέντε μεῖζον ᾖ, «ναί» λέγε.
+"If x than-five greater be-[subj], 'yes' say."
+// → if x > 5 { println!("yes") }
 
 // The subjunctive ᾖ marks the condition boundary
-// ἀνάγκη introduces the necessary consequence
+// The comma separates condition from consequence
 ```
 
-### Alternative: δεῖ (must/ought)
-
-For less absolute necessity, use **δεῖ** (it is necessary, one must):
+### Conditional with Else (εἰ... εἰ δὲ μή...)
 
 ```glossa
-εἰ ξ πέντε μεῖζον ᾖ, δεῖ «μέγα» λέγειν.
-"If x than-five greater be, one-must 'large' to-say."
-```
-
-### Conditional with Else (εἰ... ἀνάγκη... εἰ δὲ μή...)
-
-```glossa
-εἰ ξ πέντε μεῖζον ᾖ, ἀνάγκη «ναί» λέγειν · εἰ δὲ μή, «οὔ» λέγειν.
-"If x than-five greater be, necessarily 'yes' to-say; if but not, 'no' to-say."
+εἰ ξ πέντε μεῖζον ᾖ, «ναί» λέγε · εἰ δὲ μή, «οὔ» λέγε.
+"If x than-five greater be, 'yes' say; if but not, 'no' say."
 // → if x > 5 { println!("yes") } else { println!("no") }
 ```
 
 ### Chained Conditionals
 
 ```glossa
-εἰ ξ μηδὲν ᾖ, ἀνάγκη «μηδέν» λέγειν ·
-εἰ ξ ἓν ᾖ, ἀνάγκη «ἕν» λέγειν ·
-εἰ δὲ μή, «ἄλλο» λέγειν.
+εἰ ξ μηδὲν ᾖ, «μηδέν» λέγε ·
+εἰ ξ ἓν ᾖ, «ἕν» λέγε ·
+εἰ δὲ μή, «ἄλλο» λέγε.
 
-"If x zero be, necessarily 'zero' to-say;
- if x one be, necessarily 'one' to-say;
- if but not, 'other' to-say."
+"If x zero be, 'zero' say;
+ if x one be, 'one' say;
+ if but not, 'other' say."
 // → if x == 0 { "zero" } else if x == 1 { "one" } else { "other" }
 ```
 
@@ -60,62 +51,61 @@ For less absolute necessity, use **δεῖ** (it is necessary, one must):
 |-------|---------|-------|
 | εἰ | if | General conditional |
 | ἐάν / ἤν | if (uncertain) | With subjunctive, future-leaning |
-| ἀνάγκη | necessarily | Introduces logical consequence |
-| δεῖ | must, ought | Introduces practical consequence |
 | εἰ δὲ μή | if but not | Else clause |
-| ἄλλως | otherwise | Alternative else |
 
 ## 11.3 Pattern Matching (κατά)
 
 Pattern matching uses **κατά** (according to) with cases:
 
 ```glossa
-κατὰ τιμήν·
-    μηδὲν ᾖ, ἀνάγκη «μηδέν»·
-    ἓν ᾖ, ἀνάγκη «ἕν»·
-    ἄλλο ᾖ, ἀνάγκη «ἄλλο».
+κατὰ ξ·
+    μηδὲν ᾖ, «μηδέν» λέγε·
+    ἓν ᾖ, «ἕν» λέγε·
+    ἄλλο ᾖ, «ἄλλο» λέγε.
 
-"According-to value:
-    zero be, necessarily 'zero';
-    one be, necessarily 'one';
-    other be, necessarily 'other'."
+"According-to x:
+    zero be, 'zero' say;
+    one be, 'one' say;
+    other be, 'other' say."
 
-// → match value { 0 => "zero", 1 => "one", _ => "other" }
+// → match x { 0 => println!("zero"), 1 => println!("one"), _ => println!("other") }
 ```
+
+The wildcard pattern uses **ἄλλο** ("other") which maps to Rust's `_`.
 
 ## 11.4 Loops
 
-### While Loop (ἕως... ἀνάγκη)
-
-The pattern follows Aristotle: "while condition holds, necessarily action":
+### While Loop (ἕως)
 
 ```glossa
-ἕως ξ μηδενὸς μεῖζον ᾖ, ἀνάγκη ξ μειοῦσθαι.
-"While x than-zero greater be-[subj], necessarily x to-decrease."
-// → while x > 0 { x -= 1 }
+ἕως ξ μηδενὸς μεῖζον ᾖ, ξ λέγε.
+"While x than-zero greater be-[subj], x say."
+// → while x > 0 { println!("{}", x) }
 ```
 
-### Iteration (διά + Genitive)
+### Collection Iteration (διά)
 
-Iteration uses **διά** (through) with the genitive:
+Iteration uses **διά** (through):
 
 ```glossa
-διὰ στοιχείων λίστης, ἀνάγκη στοιχεῖον λέγειν.
-"Through elements of-list, necessarily element to-say."
-// → for elem in list { println!("{}", elem) }
+διὰ στοιχείων, στοιχεῖον λέγε.
+"Through elements, element say."
+// → for elem in elements { println!("{}", elem) }
 ```
 
 ### Range Iteration (ἀπό... μέχρι/ἕως)
 
 ```glossa
-ἀπὸ μηδενὸς μέχρι δέκα, ἀνάγκη ι λέγειν.
-"From zero until ten, necessarily i to-say."
-// → for i in 0..10 { println!("{}", i) }
+ἀπὸ μηδενὸς μέχρι πέντε, ι λέγε.
+"From zero until five, i say."
+// → for i in 0..5 { println!("{}", i) }
 
-ἀπὸ μηδενὸς ἕως δέκα, ἀνάγκη ι λέγειν.
-"From zero to ten [inclusive], necessarily i to-say."
-// → for i in 0..=10 { println!("{}", i) }
+ἀπὸ μηδενὸς ἕως πέντε, ι λέγε.
+"From zero to five [inclusive], i say."
+// → for i in 0..=5 { println!("{}", i) }
 ```
+
+Note: **μέχρι** (until) produces an exclusive range (`..`), while **ἕως** (to) produces an inclusive range (`..=`).
 
 ## 11.5 Loop Control
 
@@ -124,29 +114,35 @@ Iteration uses **διά** (through) with the genitive:
 συνέχιζε.       // continue - "carry on!" (imperative of συνεχίζω)
 ```
 
+These can be used inside conditional clauses within loops:
+
+```glossa
+ἀπὸ μηδενὸς μέχρι δέκα, εἰ ι πέντε μεῖζον ᾖ, παῦε.
+// → for i in 0..10 { if i > 5 { break } }
+```
+
 ## 11.6 Early Return
 
 ```glossa
-δίδου τιμήν.    // return value - "give value!" (imperative active)
-διδόσθω τιμή.   // return value - "let value be given" (imperative passive)
+δός τιμήν.      // return value - "give!" (aorist imperative of δίδωμι)
+// → return value;
 ```
 
 ## 11.7 Design Rationale
 
-### Why ἀνάγκη?
+### Why Subjunctive + Comma?
 
-1. **Philosophical consistency**: Follows Aristotle's actual logical notation
-2. **Declarative semantics**: States what must be true, not what to do
-3. **Clear boundaries**: ἀνάγκη explicitly marks the consequence
-4. **No braces needed**: Greek syntax naturally delimits clauses
+1. **Grammatical naturalism**: The subjunctive mood (ᾖ) naturally marks hypothetical conditions in Greek
+2. **Minimal syntax**: Commas separate clauses just as in Greek prose
+3. **No braces needed**: Greek clause structure naturally delimits scope
+4. **Morphological consistency**: Mood encodes semantics, not keywords
 
 ### Comparison with Traditional Languages
 
 | Traditional | ΓΛΩΣΣΑ |
 |-------------|--------|
-| `if (x > 5) { ... }` | `εἰ ξ πέντε μεῖζον ᾖ, ἀνάγκη ...` |
-| `while (x > 0) { ... }` | `ἕως ξ μηδενὸς μεῖζον ᾖ, ἀνάγκη ...` |
-| `for x in list { ... }` | `διὰ στοιχείων, ἀνάγκη ...` |
-
-The subjunctive mood (ᾖ) naturally marks hypothetical/conditional boundaries,
-and ἀνάγκη introduces what necessarily follows—exactly as Aristotle wrote.
+| `if (x > 5) { ... }` | `εἰ ξ πέντε μεῖζον ᾖ, ...` |
+| `while (x > 0) { ... }` | `ἕως ξ μηδενὸς μεῖζον ᾖ, ...` |
+| `for i in 0..10 { ... }` | `ἀπὸ μηδενὸς μέχρι δέκα, ...` |
+| `for x in list { ... }` | `διὰ στοιχείων, ...` |
+| `match x { ... }` | `κατὰ ξ· ...` |

--- a/docs/reference/12-Collections.md
+++ b/docs/reference/12-Collections.md
@@ -1,132 +1,59 @@
 # 12. Collections
 
-## 12.1 Arrays (Πίναξ)
+## 12.1 Arrays
 
 ### Literals
 
 ```glossa
-// Array literal
-[εἷς, δύο, τρεῖς] ἔστω ἀριθμοί.
-// → let numbers = [1, 2, 3];
-
-// Empty array with type
-πίναξ ἀριθμῶν κενός ἔστω.
-"array of-numbers empty let-be"
-// → let arr: Vec<i64> = vec![];
+ξ [1, 2, 3] ἔστω.
+"x [1, 2, 3] let-be."
+// → let mut xi = vec![1, 2, 3];
 ```
 
-### Indexing
+Array bindings are automatically mutable in generated Rust.
+
+### Indexing with Ordinals
+
+Ordinal adjectives map to array indices:
 
 ```glossa
-// Access by index (genitive of position)
-πίνακος τρίτου στοιχεῖον
-"of-array of-third element"
-// → array[2]
-
-// Or with ἐν (in/at)
-στοιχεῖον ἐν πίνακι τρίτον
-"element in array third"
-// → array[2]
+ξ [10, 20, 30] ἔστω.
+ψ ξ πρῶτον ἔστω.           // y = x[0]  (first → index 0)
+χ ξ δεύτερον ἔστω.          // z = x[1]  (second → index 1)
+ξ τρίτον λέγε.              // print(x[2]) (third → index 2)
 ```
 
-### Methods
+| Ordinal | Meaning | Index |
+|---------|---------|-------|
+| πρῶτον | first | 0 |
+| δεύτερον | second | 1 |
+| τρίτον | third | 2 |
+
+### Direct Indexing
+
+Square bracket indexing is also supported:
 
 ```glossa
-// Push (dative recipient + accusative item)
-πίνακι στοιχεῖον ὠθεῖ.
-"to-array element pushes"
-// → array.push(element)
-
-// Pop (middle voice - array acts on itself)
-πίναξ ἕλκεται.
-"array pulls-itself"
-// → array.pop()
-
-// Length
-πίνακος μῆκος
-"of-array length"
-// → array.len()
-
-// Is empty
-πίναξ κενός;
-"array empty?"
-// → array.is_empty()
+ξ[0] λέγε.
+// → println!("{}", xi[0]);
 ```
 
-## 12.2 HashMap (Χάρτης)
-
-### Creation
+### Length
 
 ```glossa
-χάρτης κενὸς ἔστω.
-"map empty let-be"
-// → let map = HashMap::new();
+ξ μῆκος λέγε.
+"x length say."
+// → println!("{}", xi.len());
 ```
 
-### Set
+## 12.2 Iterator Operations
+
+See [Chapter 17 — Participles as Lambdas](17-Lambdas.md) for map, filter, fold, find, any, and all operations on collections.
 
 ```glossa
-χάρτῃ κλειδὶ τιμὴν τίθησι.
-"to-map with-key value places"
-// → map.insert(key, value)
+[1, 2, 3] διπλασιαζόμενα λέγε.         // map: double each
+[1, 10, 3, 8] πέντε μείζονα λέγε.       // filter: > 5
+[1, 5, 3, 8] πέντε μείζονα διπλασιαζόμενα λέγε.  // filter then map
 ```
 
-### Get
-
-```glossa
-χάρτου κλειδὸς τιμή
-"of-map of-key value"
-// → map.get(&key)
-
-// Returns Option, so often with optative:
-χάρτου κλειδὸς τιμὴ εὑρεθείη.
-"of-map of-key value might-be-found"
-// → map.get(&key)  // Option<V>
-```
-
-### Contains
-
-```glossa
-κλεὶς ἐν χάρτῃ;
-"key in map?"
-// → map.contains_key(&key)
-```
-
-## 12.3 Set (Σύνολον)
-
-```glossa
-// Create
-σύνολον κενὸν ἔστω.
-
-// Add
-συνόλῳ στοιχεῖον τίθησι.
-"to-set element places"
-// → set.insert(element)
-
-// Contains
-στοιχεῖον ἐν συνόλῳ;
-"element in set?"
-// → set.contains(&element)
-```
-
-## 12.4 String (Λόγος)
-
-```glossa
-// Length
-λόγου μῆκος
-// → string.len()
-
-// Contains
-«κόσμε» ἐν λόγῳ;
-// → string.contains("κόσμε")
-
-// Split
-λόγος κατὰ « » σχίζεται.
-"string according-to ' ' splits-itself"
-// → string.split(' ')
-
-// Join
-λόγοι κατὰ «, » ἑνοῦνται.
-"strings according-to ', ' unite-themselves"
-// → strings.join(", ")
-```
+> **Not yet implemented:** HashMap, Set, and String-specific operations (insert, get, contains, split, join). The lexicon recognizes the Greek vocabulary for these types (χάρτης, σύνολον, λόγος) but semantic support for their operations is pending.

--- a/docs/reference/13-Functions.md
+++ b/docs/reference/13-Functions.md
@@ -2,66 +2,82 @@
 
 ## 13.1 Function Definition
 
-Functions use the infinitive or are introduced with ἔργον:
+Functions are defined with **ὁρίζειν** ("to define/delimit"). Parameters use the **dative case** marker **τῷ** ("to/for"):
 
 ```glossa
-// Simple function
-διπλασιασμὸς ἔργον ἀριθμῷ·
-    ἀριθμὸς δύο πολλαπλασιασθείς.
+// Simple function — no parameters
+χαιρετισμος ὁρίζειν· «χαῖρε» λέγε.
+"greeting to-define: 'hello' say."
+// → fn chairetismos() { println!("hello"); }
 
-"doubling [is] a work for-number:
-    number two multiplied"
-
-// → fn double(n: i64) -> i64 { n * 2 }
+// Function with one parameter
+διπλασιασμος ὁρίζειν τῷ ξ· δός ξ δύο γινόμενον.
+"doubling to-define for x: give x two product."
+// → fn diplasiasmos(xi: i64) -> i64 { return xi * 2; }
 ```
 
-### With Explicit Types
+### With Type Annotations
+
+Type annotations use the **genitive** (type "of" the parameter):
 
 ```glossa
-διπλασιασμὸς ἔργον· ἀριθμῷ ἀριθμὸν δίδωσι·
-    ἀριθμὸς δύο γινόμενον.
-
-"doubling [is] a work: for-number gives number:
-    number two product"
-
-// → fn double(n: i64) -> i64 { n * 2 }
+προσθεσις ὁρίζειν τῷ ξ ἀριθμοῦ τῷ ψ ἀριθμοῦ· δός ξ ψ ἄθροισμα.
+"addition to-define for x of-number for y of-number: give x y sum."
+// → fn prosthesis(xi: i64, psi: i64) -> i64 { return xi + psi; }
 ```
 
-## 13.2 Function Call
+## 13.2 Return Statements
+
+The imperative **δός** ("give!") serves as `return`:
 
 ```glossa
-πέντε διπλασιάζεται.
-"five is-doubled"
-// → double(5)
-
-// Or with explicit object
-πέντε διπλασιασμός.
-"five doubling"
-// → double(5)
+διπλασιασμος ὁρίζειν τῷ ξ· δός ξ δύο γινόμενον.
+// → fn diplasiasmos(xi: i64) -> i64 { return xi * 2; }
 ```
 
-## 13.3 Multiple Parameters
+Return types are inferred from the expression given to δός. When parameters have type annotations, the return type is explicit in generated code.
 
-Parameters in dative case:
+## 13.3 Function Calls
+
+Functions are called by name with arguments. Bind the result with **ἔστω**:
 
 ```glossa
-πρόσθεσις ἔργον· αῳ βῳ ἀριθμὸν δίδωσι·
-    α β ἄθροισμα.
-
-"addition [is] a work: for-a for-b gives number:
-    of-a of-b sum"
-
-// → fn add(a: i64, b: i64) -> i64 { a + b }
+ἀποτελεσμα προσθεσις πέντε τρία ἔστω.
+"result addition five three let-be."
+// → let apotelasma = prosthesis(5, 3);
 ```
 
-## 13.4 No Return Value
+### Nested Calls
+
+Parentheses group nested function calls:
 
 ```glossa
-ἐκτύπωσις ἔργον· λόγῳ·
-    λόγον λέγε.
+ψ διπλασιασμος (διπλασιασμος πέντε) ἔστω.
+"y doubling (doubling five) let-be."
+// → let psi = diplasiasmos(diplasiasmos(5));
+```
 
-"printing [is] a work: for-string:
-    string say"
+## 13.4 Multiple Parameters
 
-// → fn print(s: &str) { println!("{}", s); }
+Parameters are introduced with repeated **τῷ** markers:
+
+```glossa
+προσθεσις ὁρίζειν τῷ ξ τῷ ψ· δός ξ ψ ἄθροισμα.
+"addition to-define for x for y: give x y sum."
+// → fn prosthesis(xi: i64, psi: i64) -> i64 { return xi + psi; }
+```
+
+## 13.5 Local Variables
+
+Functions can define local bindings with **ἔστω**:
+
+```glossa
+αυξησις ὁρίζειν τῷ ξ·
+    τοπικον ξ ἓν ἄθροισμα ἔστω·
+    δός τοπικον.
+
+"increment to-define for x:
+    local x one sum let-be;
+    give local."
+// → fn auxesis(xi: i64) -> i64 { let topikon = xi + 1; return topikon; }
 ```

--- a/docs/reference/14-Types.md
+++ b/docs/reference/14-Types.md
@@ -2,62 +2,65 @@
 
 ## 14.1 Struct Definition
 
-The genitive + εἶδος pattern:
+Types are defined with **εἶδος** ("form/type") + name + **ὁρίζειν** ("to define") + braced fields:
 
 ```glossa
-Χρήστου εἶδος·
-    ὄνομα λόγος·
-    ἡλικία ἀριθμός.
-
-"Of-User form:
-    name [is] string;
-    age [is] number."
+εἶδος σημεῖον ὁρίζειν { ξ ἀριθμοῦ. }.
+"form point to-define { x of-number. }."
 ```
 
 →
 
 ```rust
-struct Chrestes {
-    onoma: String,
-    helikia: i64,
+struct Semeion {
+    xi: i64,
 }
 ```
 
-## 14.2 Field Modifiers
+Fields are declared as `name type_genitive`, where the type is in the genitive case ("of number" = `ἀριθμοῦ`). Multiple fields are separated by middle dots or periods:
 
 ```glossa
-Ἀποτελέσματος εἶδος·
-    τιμὴ ἀριθμὸς ἴσως·      // Option<i64>
-    σφάλματα λόγοι πολλά·   // Vec<String>
-    μετρητὴς ἀριθμὸς μετά.  // mut i64
-
-// ἴσως = maybe → Option<T>
-// πολλά = many → Vec<T>
-// μετά = mutable → mut
+εἶδος σημεῖον ὁρίζειν { ξ ἀριθμοῦ· ψ ἀριθμοῦ. }.
+"form point to-define { x of-number; y of-number. }."
 ```
 
-## 14.3 Instantiation
+→
+
+```rust
+struct Semeion {
+    xi: i64,
+    psi: i64,
+}
+```
+
+## 14.2 Instantiation
+
+Struct instances are created with **νέον** ("new") + type name + field values:
 
 ```glossa
-// Constructor call
-χρήστης Χρήστης.νέος «Σωκράτης» ἑβδομήκοντα.
-// → let user = User::new("Socrates", 70);
+π νέον σημεῖον πέντε ἔστω.
+"p new point five let-be."
+// → let pi = Semeion { xi: 5 };
 
-// Literal syntax
-χρήστης Χρήστης· ὄνομα «Σωκράτης» · ἡλικία ἑβδομήκοντα.
-// → let user = User { name: "Socrates", age: 70 };
+π νέον σημεῖον πέντε τρία ἔστω.
+"p new point five three let-be."
+// → let pi = Semeion { xi: 5, psi: 3 };
 ```
 
-## 14.4 Field Access
+Field values are positional, matching the order of field declarations.
 
-Genitive chain:
+## 14.3 Field Access
+
+Field access uses the **genitive** (possessive "of") pattern. The variable name takes a genitive suffix (commonly `-ου`):
 
 ```glossa
-χρήστου ὄνομα
-"of-user name"
-// → user.name
+που ξ λέγε.
+"of-p x say."
+// → println!("{}", pi.xi);
 
-χρήστου ἡλικίας διπλάσιον
-"of-user of-age double"
-// → user.age * 2
+αου ψ λέγε.
+"of-a y say."
+// → println!("{}", alpha.psi);
 ```
+
+The genitive suffix varies by variable name — single Greek letters typically add `-ου` (e.g., `π` → `που`, `α` → `αου`).

--- a/docs/reference/15-Traits.md
+++ b/docs/reference/15-Traits.md
@@ -1,50 +1,66 @@
-# 15. Traits (Ἀρετή)
+# 15. Traits (Χαρακτήρ)
 
 ## 15.1 Trait Definition
 
-Nominative + ἀρετή pattern:
+Traits are defined with **χαρακτήρ** ("characteristic/trait") + name + **ὁρίζειν** + braced methods:
 
 ```glossa
-Ἐμφανίσιμον ἀρετή·
-    ἐμφάνισις λόγον δίδωσι.
-
-"Displayable [is] a virtue:
-    display gives string."
+χαρακτήρ Showable ὁρίζειν {
+    δεῖ show τῷ self.
+}.
+"characteristic Showable to-define {
+    must show for self.
+}."
 ```
 
 →
 
 ```rust
-trait Emphanisimon {
-    fn emphanisis(&self) -> String;
+trait Showable {
+    fn show(&self);
 }
 ```
 
-## 15.2 Method Signatures
+## 15.2 Required Methods (δεῖ)
+
+**δεῖ** ("it is necessary / must") marks a method that implementors are required to provide:
 
 ```glossa
-// fn method(&self) -> T
-μέθοδος τύπον δίδωσι.
+δεῖ show τῷ self.
+// → fn show(&self);
 
-// fn method(&self, param: P) -> T
-μέθοδος παραμέτρῳ τύπον δίδωσι.
-
-// fn method(&mut self)
-μέθοδος ἑαυτὸν μεταβάλλει.
-
-// fn method(&mut self, param: P)
-μέθοδος παραμέτρῳ ἑαυτὸν μεταβάλλει.
+δεῖ add τῷ self τῷ other.
+// → fn add(&self, other: &Self);
 ```
 
-## 15.3 Trait Bounds
+Parameters use the **dative marker** τῷ. The first parameter is typically `self`.
+
+## 15.3 Default Methods (ἤδη)
+
+**ἤδη** ("already") marks a method with a default body. The body follows a middle dot (`·`):
 
 ```glossa
-// Generic with trait bound
-μέγιστον ἔργον· αῳ βῳ Συγκρισίμοις·
-    ...
+ἤδη double τῷ self· δός selfου value selfου value ἄθροισμα.
+"already double for self: give self's-value self's-value sum."
+// → fn double(&self) -> i64 { return self.value() + self.value(); }
+```
 
-"maximum [is] a work: for-a for-b [which are] Comparable:
-    ..."
+Default methods need not be implemented by types — they inherit the default body.
 
-// → fn max<T: Ord>(a: T, b: T) -> T
+## 15.4 Multiple Methods
+
+```glossa
+χαρακτήρ Math ὁρίζειν {
+    δεῖ add τῷ self τῷ other.
+    ἤδη double τῷ self· δός selfου value selfου value ἄθροισμα.
+}.
+```
+
+→
+
+```rust
+trait Math {
+    fn add(&self, other: &Self);
+    fn double(&self) -> i64 { return self.value() + self.value(); }
+}
 ```

--- a/docs/reference/16-Implementation.md
+++ b/docs/reference/16-Implementation.md
@@ -2,70 +2,75 @@
 
 ## 16.1 Trait Implementation
 
-Dative (for type) + nominative (trait):
+Trait implementations use **εἶδος** + type name + **τῷ** (dative marker) + trait name + **ἐμπίπτειν** ("to fall into / to implement"):
 
 ```glossa
-Χρήστῃ Ἐμφανίσιμον·
-    ἐμφάνισις·
-        τούτου ὄνομα δίδωσι.
-
-"For-User Displayable:
-    display:
-        of-this name gives."
+εἶδος Point τῷ Showable ἐμπίπτειν {
+    show τῷ self· selfου ξ λέγε.
+}.
+"form Point for Showable to-implement {
+    show for self: self's x say.
+}."
 ```
 
 →
 
 ```rust
-impl Emphanisimon for Chrestes {
-    fn emphanisis(&self) -> String {
-        self.onoma.clone()
+impl Showable for Point {
+    fn show(&self) {
+        println!("{}", self.xi);
     }
 }
 ```
 
-## 16.2 Inherent Implementation
+Each method starts with its name, parameters (using **τῷ** for each), then a middle dot (`·`) followed by the method body.
 
-Dative + ἔργα (works):
+## 16.2 Self References
+
+Inside method bodies, **selfου** (genitive of self, "of self") accesses fields:
 
 ```glossa
-Χρήστῃ ἔργα·
-    
-    νέος ἐξ ὀνόματος καὶ ἡλικίας ποιεῖται·
-        Χρήστης· ὄνομα τὸ ὄνομα· ἡλικία ἡ ἡλικία.
-    
-    γενέθλια τούτῳ·
-        τούτου ἡλικία αὐξάνεται.
+selfου ξ λέγε.
+"of-self x say."
+// → println!("{}", self.xi);
 
-"For-User works:
-    
-    new from name and age makes-itself:
-        User: name the name; age the age.
-    
-    birthday for-this:
-        of-this age increases."
+selfου v otherou v ἄθροισμα
+"of-self v of-other v sum"
+// → self.v + other.v
 ```
 
-→
+| Pattern | Meaning | Rust |
+|---------|---------|------|
+| `τῷ self` | self parameter | `&self` |
+| `selfου field` | field of self | `self.field` |
+| `τῷ other` | additional parameter | `other: &Self` |
+| `otherou field` | field of other | `other.field` |
 
-```rust
-impl Chrestes {
-    fn neos(onoma: String, helikia: i64) -> Self {
-        Chrestes { onoma, helikia }
-    }
-    
-    fn genethlia(&mut self) {
-        self.helikia += 1;
-    }
-}
+## 16.3 Complete Example
+
+```glossa
+// Define trait
+χαρακτήρ Math ὁρίζειν {
+    δεῖ add τῷ self τῷ other.
+    ἤδη double τῷ self· δός selfου value selfου value ἄθροισμα.
+}.
+
+// Define type
+εἶδος Number ὁρίζειν { v ἀριθμοῦ. }.
+
+// Implement trait for type
+εἶδος Number τῷ Math ἐμπίπτειν {
+    add τῷ self τῷ other· δός νέον Number (selfου v otherou v ἄθροισμα).
+}.
 ```
 
-## 16.3 Self References
+## 16.4 Validation Rules
 
-| Greek | Case | Meaning | Rust |
-|-------|------|---------|------|
-| τοῦτο | Nom | this (subject) | `self` |
-| τούτου | Gen | of this | `self.` |
-| τούτῳ | Dat | for/to this | `&mut self` |
-| τοῦτον | Acc | this (object) | `self` |
-| ἑαυτόν | Acc | oneself (reflexive) | `self` |
+The compiler enforces:
+
+1. **Trait must be defined** before implementing it
+2. **Type must be defined** before implementing a trait for it
+3. **All required methods** (δεῖ) must be provided in the implementation
+4. **Default methods** (ἤδη) may be omitted (the default body is inherited) or overridden
+5. A type may implement **multiple traits**
+6. Multiple types may implement the **same trait**

--- a/docs/reference/18-Option-And-Result.md
+++ b/docs/reference/18-Option-And-Result.md
@@ -1,53 +1,82 @@
 # 18. Option and Result
 
-## 18.1 Option Type (Optative Mood)
+## 18.1 Option Type
 
-The optative mood ("might be") naturally expresses `Option<T>`:
+Options represent values that may or may not exist. They use the Greek vocabulary of "something" and "nothing":
 
-```glossa
-// Declaration
-τιμὴ εὑρεθείη.
-"value might-be-found-[optative]"
-// → let value: Option<T> = find();
-
-// Check and unwrap
-τιμὴ εὑρεθείη·
-    ὑπάρχουσα, τιμὴν χρῶ·
-    οὐδὲν οὖσα, σφάλμα.
-
-"value might-be-found:
-    existing, value use;
-    nothing being, error."
-
-// → match value { Some(v) => use(v), None => error() }
-```
-
-## 18.2 Some and None
+### Some — τί ("something")
 
 ```glossa
-τί τιμή         // Some(value)  — τί = "something"
-οὐδέν           // None         — "nothing"
+ξ τι πέντε ἔστω.
+"x something five let-be."
+// → let x = Some(5);
+
+ψ τι «χαῖρε» ἔστω.
+"y something 'hello' let-be."
+// → let y = Some("hello");
 ```
 
-## 18.3 Result Type
+### None — οὐδέν ("nothing")
 
 ```glossa
-// Result declaration
-ἀποτέλεσμα ἢ ἐπιτυχία ἢ σφάλμα.
-"result either success or error"
-
-// Pattern match
-κατὰ ἀποτέλεσμα·
-    ἐπιτυχία ᾖ, τιμὴν χρῶ·
-    σφάλμα ᾖ, σφάλμα λέγε.
+ξ ουδεν ἔστω.
+"x nothing let-be."
+// → let x: Option<i64> = None;
 ```
 
-## 18.4 Error Handling
+## 18.2 Result Type
+
+Results represent computations that may succeed or fail:
+
+### Ok — ἐπιτυχία ("success")
 
 ```glossa
-// Propagate with ?
-τιμὴ εὑρεθείη;    // The ; propagates None/Err
-
-// Unwrap (panics)
-τιμὴ εὑρέθη!      // Indicative + ! = unwrap
+ξ επιτυχια δέκα ἔστω.
+"x success ten let-be."
+// → let x = Ok(10);
 ```
+
+### Err — σφάλμα ("error/mistake")
+
+```glossa
+ξ σφαλμα «πρόβλημα» ἔστω.
+"x error 'problem' let-be."
+// → let x = Err("problem");
+```
+
+## 18.3 Unwrap — `!` operator
+
+The **`!`** suffix performs confident extraction (panics if None/Err):
+
+```glossa
+ξ τι πέντε ἔστω.
+ψ ξ! ἔστω.
+"y x! let-be."
+// → let y = x.unwrap();
+
+ξ! λέγε.
+"x! say."
+// → println!("{}", x.unwrap());
+```
+
+## 18.4 Propagation — `;` operator
+
+Ending a statement with **`;`** (ASCII semicolon) instead of **`.`** propagates None/Err upward (equivalent to Rust's `?` operator):
+
+```glossa
+τιμη τι πεντε εστω;
+"value something five let-be;"
+// → let timee = Some(5)?;
+// If None, returns early from the enclosing function
+```
+
+## 18.5 Summary
+
+| ΓΛΩΣΣΑ | Meaning | Rust |
+|---------|---------|------|
+| `τι value` | something | `Some(value)` |
+| `ουδεν` | nothing | `None` |
+| `επιτυχια value` | success | `Ok(value)` |
+| `σφαλμα value` | error | `Err(value)` |
+| `expr!` | confident extract | `expr.unwrap()` |
+| `stmt;` | propagate | `stmt?` |

--- a/docs/reference/2-Lexical-Structure.md
+++ b/docs/reference/2-Lexical-Structure.md
@@ -51,26 +51,27 @@ Diacritics (breathings, accents, iota subscript) are normalized during lexing bu
 | Symbol | Unicode | Name | Meaning |
 |--------|---------|------|---------|
 | `.` | U+002E | τελεία | Statement terminator |
-| `·` | U+00B7 | ἄνω τελεία | Expression chain (semicolon) |
-| `;` | U+037E | ἐρωτηματικό | Question / query |
+| `·` | U+00B7 | ἄνω τελεία | Expression chain (chains clauses) |
+| `;` | U+037E | ἐρωτηματικό | Query (also accepts `?`) |
+| `;` | U+003B | (ASCII semicolon) | Propagation operator (Rust's `?`) |
+| `,` | U+002C | (comma) | Clause separator (control flow) |
 | `«»` | U+00AB/BB | εἰσαγωγικά | String delimiters |
 
 ## 2.3 Literals
 
 ### Strings
 ```glossa
-«χαῖρε κόσμε»           // Greek guillemets (preferred)
-"hello world"           // ASCII quotes (allowed)
+«χαῖρε κόσμε»           // Greek guillemets
 ```
+
+String literals use Greek guillemets (`« »`). ASCII double quotes are not supported.
 
 ### Numbers
 ```glossa
-42                      // Arabic numerals
-0x2A                    // Hexadecimal
-0b101010                // Binary
-3.14159                 // Float
-μβʹ                     // Greek numerals (42)
+42                      // Arabic numerals (integer only)
 ```
+
+> **Not yet implemented:** Hexadecimal (`0x2A`), binary (`0b101010`), floating-point (`3.14`), and Greek numeral (`μβʹ`) literals.
 
 ### Booleans
 ```glossa
@@ -87,12 +88,9 @@ Diacritics (breathings, accents, iota subscript) are normalized during lexing bu
 
 ```glossa
 // Single line comment (like Rust)
-
-/* 
-   Block comment
-   (like C)
-*/
 ```
+
+> **Not yet implemented:** Block comments (`/* ... */`).
 
 ## 2.5 Whitespace
 

--- a/docs/reference/20-Complete-Grammar.md
+++ b/docs/reference/20-Complete-Grammar.md
@@ -1,41 +1,116 @@
 # 20. Complete Grammar
 
+This EBNF reflects the actual PEG grammar (`glossa.pest`).
+
 ```ebnf
-(* Top Level *)
-program        = { statement }
-statement      = expression_list "."
-               | expression_list ";"
+(* ============ Top Level ============ *)
+program           = { statement }
 
-expression_list = expression { "·" expression }
+statement         = ( type_definition
+                    | trait_definition
+                    | trait_impl
+                    | clause_list )
+                    statement_end
 
-(* Expressions *)
-expression     = term+
+statement_end     = period | query | propagate
 
-term           = literal
-               | greek_word
-               | "[" [expression {"," expression}] "]"
-               | "(" expression ")"
+(* ============ Definitions ============ *)
 
-literal        = string_literal
-               | number_literal
-               | boolean_literal
+(* εἶδος typename ὁρίζειν { fields } *)
+type_definition   = eidos_keyword greek_word orizontin_keyword
+                    "{" [ field_list ] "}"
 
-string_literal = "«" {character} "»"
-               | '"' {character} '"'
+(* χαρακτήρ traitname ὁρίζειν { methods } *)
+trait_definition   = character_keyword greek_word orizontin_keyword
+                    "{" [ trait_method_list ] "}"
 
-number_literal = digit+
-               | digit+ "." digit+
-               | "0x" hex_digit+
-               | "0b" binary_digit+
-               | greek_numeral
+(* εἶδος typename τῷ traitname ἐμπίπτειν { methods } *)
+trait_impl         = eidos_keyword greek_word dative_marker greek_word
+                    empiptein_keyword "{" [ impl_method_list ] "}"
 
-boolean_literal = "ἀληθές" | "ψεῦδος"
+(* ============ Keywords ============ *)
+eidos_keyword      = "εἶδος" | "ειδος"
+character_keyword  = "χαρακτήρ" | "χαρακτηρ"
+orizontin_keyword  = "ὁρίζειν" | "οριζειν"
+dative_marker      = "τῷ" | "τω"
+empiptein_keyword  = "ἐμπίπτειν" | "εμπιπτειν"
+dei_keyword        = "δεῖ" | "δει"
+ede_keyword        = "ἤδη" | "ηδη"
 
-greek_word     = greek_char+
+(* ============ Fields & Methods ============ *)
+field_list         = field_declaration { (chain | period) field_declaration }
+                    [ chain | period ]
 
-greek_char     = greek_letter | combining_mark
+field_declaration  = greek_word greek_word
 
-(* Comments *)
-comment        = "//" {any} newline
-               | "/*" {any} "*/"
+trait_method_list  = trait_method { period trait_method } [ period ]
+
+(* δεῖ/ἤδη method params [· body] *)
+trait_method       = (dei_keyword | ede_keyword) greek_word+
+                    [ chain statement+ ]
+
+impl_method_list   = impl_method+
+
+(* method params · body_statement *)
+impl_method        = greek_word+ chain statement
+
+(* ============ Clauses ============ *)
+clause_list       = clause { comma clause }
+
+clause            = expression { chain expression }
+
+(* ============ Expressions ============ *)
+expression        = term+
+
+term              = block
+                  | array_literal
+                  | string_literal
+                  | number_literal
+                  | boolean_literal
+                  | unwrap_expr
+                  | indexed_word
+                  | parenthesized_expr
+                  | greek_word
+
+unwrap_expr       = greek_word "!"
+
+parenthesized_expr = "(" expression ")"
+
+indexed_word      = greek_word "[" index_expr "]"
+index_expr        = number_literal | greek_word
+
+array_literal     = "[" [ array_elements ] "]"
+array_elements    = array_element { "," array_element }
+array_element     = string_literal | number_literal
+                  | boolean_literal | greek_word
+
+block             = "{" statement* "}"
+
+(* ============ Literals ============ *)
+string_literal    = "«" { character } "»"
+
+number_literal    = digit+
+
+boolean_literal   = "ἀληθές" | "ψεῦδος" | "αληθες" | "ψευδος"
+
+(* ============ Words ============ *)
+greek_word        = greek_char+
+                  | ascii_alpha { ascii_alphanumeric | "_" }
+
+greek_char        = greek_letter | greek_combining
+
+greek_letter      = U+0370..U+037D | U+037F..U+0386
+                  | U+0388..U+03FF | U+1F00..U+1FFF
+
+greek_combining   = U+0300..U+036F
+
+(* ============ Punctuation ============ *)
+period            = "."                  (* τελεία — statement end *)
+chain             = U+00B7              (* ἄνω τελεία — expression chain *)
+query             = U+037E | "?"        (* ἐρωτηματικό — query *)
+propagate         = ";"                  (* propagation — converts to ? *)
+comma             = ","                  (* clause separator *)
+
+(* ============ Comments ============ *)
+comment           = "//" { any } newline
 ```

--- a/docs/reference/22-Appendix.md
+++ b/docs/reference/22-Appendix.md
@@ -1,38 +1,60 @@
 # Appendix A: ASCII Transliteration
 
-For environments without Greek input:
+For environments without Greek input, keywords accept non-accented forms:
 
-| Greek | ASCII |
-|-------|-------|
-| εἶδος | eidos |
-| ἀρετή | arete |
-| ἔστω | esto |
-| λέγε | lege |
-| γράφει | graphei |
-| ἀληθές | alethes |
-| ψεῦδος | pseudos |
-| οὐδέν | ouden |
+| Greek | ASCII/Normalized | Meaning |
+|-------|------------------|---------|
+| εἶδος | ειδος | type/struct keyword |
+| χαρακτήρ | χαρακτηρ | trait keyword |
+| ὁρίζειν | οριζειν | to define |
+| ἐμπίπτειν | εμπιπτειν | to implement |
+| ἔστω | εστω | let it be (binding) |
+| λέγε | λεγε | say (print) |
+| ἀληθές | αληθες | true |
+| ψεῦδος | ψευδος | false |
+| οὐδέν | ουδεν | nothing (None) |
+| δεῖ | δει | must (required method) |
+| ἤδη | ηδη | already (default method) |
+| τῷ | τω | dative marker (parameter) |
 
 ---
 
 # Appendix B: Quick Reference Card
 
 ```
-BINDING:        ξ πέντε ἔστω.           → let x = 5;
-MUTABLE:        μετὰ ξ πέντε ἔστω.      → let mut x = 5;
-PRINT:          «hello» λέγε.           → println!("hello");
-PROPERTY:       χρήστου ὄνομα           → user.name
-METHOD:         λίστῃ στοιχεῖον ὠθεῖ.   → list.push(elem);
-IF:             εἰ ξ πέντε μεῖζον ᾖ,... → if x > 5 { ... }
-ELSE:           εἰ δὲ μή, ...           → else { ... }
-WHILE:          ἕως ξ μηδενὸς μεῖζον ᾖ  → while x > 0
-FOR:            διὰ στοιχείων λίστης    → for elem in list
-MATCH:          κατὰ τιμήν·             → match value {
-RETURN:         τιμὴν δίδου.            → return value;
-STRUCT:         Χρήστου εἶδος·          → struct User {
-TRAIT:          Ἐμφανίσιμον ἀρετή·      → trait Displayable {
-IMPL:           Χρήστῃ Ἐμφανίσιμον·     → impl Displayable for User {
-SELF:           τούτου                  → self.
-OPTION:         τιμὴ εὑρεθείη           → Option<T>
-SOME:           τί τιμή                 → Some(value)
-NONE:           οὐδέν                   → None
+BINDING:        ξ πέντε ἔστω.                              → let x = 5;
+PRINT:          «χαῖρε» λέγε.                              → println!("hello");
+STRUCT:         εἶδος Point ὁρίζειν { ξ ἀριθμοῦ. }.        → struct Point { xi: i64 }
+NEW:            π νέον Point πέντε ἔστω.                    → let pi = Point { xi: 5 };
+FIELD:          που ξ λέγε.                                 → println!("{}", pi.xi);
+TRAIT:          χαρακτήρ Show ὁρίζειν { δεῖ show τῷ self. }.→ trait Show { fn show(&self); }
+IMPL:           εἶδος P τῷ Show ἐμπίπτειν { ... }.         → impl Show for P { ... }
+SELF:           selfου ξ                                    → self.xi
+FUNCTION:       add ὁρίζειν τῷ ξ τῷ ψ· δός ξ ψ ἄθροισμα.  → fn add(x, y) { return x + y; }
+CALL:           ρ add πέντε τρία ἔστω.                      → let r = add(5, 3);
+RETURN:         δός τιμήν.                                  → return value;
+IF:             εἰ ξ πέντε μεῖζον ᾖ, «ναί» λέγε.          → if x > 5 { println!("yes"); }
+ELSE:           εἰ δὲ μή, «οὔ» λέγε.                       → else { println!("no"); }
+WHILE:          ἕως ξ μηδενὸς μεῖζον ᾖ, ξ λέγε.            → while x > 0 { println!("{}", x); }
+FOR:            ἀπὸ μηδενὸς μέχρι πέντε, ι λέγε.           → for i in 0..5 { println!("{}", i); }
+FOREACH:        διὰ στοιχείων, στοιχεῖον λέγε.             → for elem in items { ... }
+MATCH:          κατὰ ξ· μηδὲν ᾖ, ... · ἄλλο ᾖ, ...        → match x { 0 => ..., _ => ... }
+BREAK:          παῦε.                                       → break;
+CONTINUE:       συνέχιζε.                                   → continue;
+SOME:           τι πέντε                                    → Some(5)
+NONE:           ουδεν                                       → None
+OK:             επιτυχια δέκα                               → Ok(10)
+ERR:            σφαλμα «λάθος»                              → Err("error")
+UNWRAP:         ξ!                                          → x.unwrap()
+PROPAGATE:      stmt;                                       → stmt?
+ARRAY:          [1, 2, 3]                                   → vec![1, 2, 3]
+INDEX:          ξ πρῶτον                                    → x[0]
+MAP:            [1, 2, 3] διπλασιαζόμενα                    → .map(|x| x * 2)
+FILTER:         [1, 5, 3] πέντε μείζονα                     → .filter(|x| x > 5)
+GREATER:        ξ πέντε μεῖζον                              → x > 5
+LESS:           ξ πέντε ἔλαττον                             → x < 5
+EQUAL:          ξ πέντε ἴσον                                → x == 5
+ADD:            ξ ψ ἄθροισμα                                → x + y
+AND:            α καί β                                     → a && b
+OR:             α ἤ β                                       → a || b
+```

--- a/docs/reference/9-Variables-And-Binding.md
+++ b/docs/reference/9-Variables-And-Binding.md
@@ -1,49 +1,51 @@
 # 9. Variables and Binding
 
-## 9.1 Immutable Binding
+## 9.1 Binding with ἔστω
 
-The imperative of εἰμί ("to be") creates bindings:
+The imperative of εἰμί ("to be") creates bindings. Variable names are Greek letters or words:
 
 ```glossa
 ξ πέντε ἔστω.
 "x five let-it-be"
-// → let x = 5;
+// → let xi = 5;
 
 ὄνομα «Σωκράτης» ἔστω.
 "name 'Socrates' let-it-be"
-// → let name = "Socrates";
+// → let onoma = "Socrates";
+
+θ [1, 2, 3] ἔστω.
+"theta [1, 2, 3] let-it-be"
+// → let mut theta = vec![1, 2, 3];
 ```
 
-## 9.2 Mutable Binding
+Array bindings are automatically made mutable to support push/pop operations.
 
-Use μεταβάλλεται ("changes") or μετά prefix:
+## 9.2 Greek Letter Variables
 
-```glossa
-ξ πέντε μεταβάλλεται.
-"x five changes"
-// → let mut x = 5;
+Single Greek letters serve as variable names and are transliterated in generated Rust:
 
-// Or with explicit mutability marker
-μετὰ ξ πέντε ἔστω.
-"mutable x five let-be"
-// → let mut x = 5;
-```
+| Greek | Rust | Greek | Rust |
+|-------|------|-------|------|
+| α | alpha | ν | nu |
+| β | beta | ξ | xi |
+| γ | gamma | ο | omicron |
+| δ | delta | π | pi |
+| ε | epsilon | ρ | rho |
+| ζ | zeta | σ | sigma |
+| η | eta | τ | tau |
+| θ | theta | υ | upsilon |
+| ι | iota | φ | phi |
+| κ | kappa | χ | chi |
+| λ | lambda | ψ | psi |
+| μ | mu | ω | omega |
 
-## 9.3 Assignment
+Multi-letter Greek words are also valid identifiers and are transliterated to Latin characters.
 
-Middle voice indicates self-change:
+## 9.3 Shadowing
 
-```glossa
-ξ δέκα γίγνεται.
-"x ten becomes"
-// → x = 10;
-```
-
-## 9.4 Shadowing
-
-New binding with same name shadows:
+New binding with the same name shadows the previous one:
 
 ```glossa
 ξ πέντε ἔστω.
-ξ «hello» ἔστω.    // Shadows with new type
+ξ «χαῖρε» ἔστω.    // Shadows with new type
 ```


### PR DESCRIPTION
## Overview

Comprehensive audit and update of all language reference documentation to align with the actual assembler-first + semantic analysis architecture.

## What Changed

### Major Rewrites (matching actual implementation)

1. **11-Control-Flow.md** — Removed unimplemented Aristotelian ἀνάγκη pattern, documented actual subjunctive+comma syntax
2. **13-Functions.md** — Changed from ἔργον to actual ὁρίζειν syntax with τῷ parameters and δός returns
3. **14-Types.md** — Changed from genitive+εἶδος to actual `εἶδος name ὁρίζειν { fields }` with νέον instantiation
4. **15-Traits.md** — Changed from ἀρετή to actual χαρακτήρ with δεῖ/ἤδη method markers
5. **16-Implementation.md** — Updated to actual `εἶδος Type τῷ Trait ἐμπίπτειν` with selfου pattern
6. **18-Option-And-Result.md** — Changed from optative mood to actual τι/ουδεν/επιτυχια/σφαλμα keywords
7. **20-Complete-Grammar.md** — Completely rewrote EBNF to match actual glossa.pest PEG grammar
8. **22-Appendix.md** — Rewrote Quick Reference Card with accurate syntax examples

### Minor Updates (accuracy notes)

9. **2-Lexical-Structure.md** — Added notes about unimplemented features (hex/binary/float literals, block comments)
10. **9-Variables-And-Binding.md** — Removed unimplemented mutable binding/assignment syntax
11. **12-Collections.md** — Documented what's implemented (Vec, indexing, length) vs. aspirational (HashMap, Set, String ops)

## GitHub Issues Created

Created 11 actionable issues for unimplemented features:

### Lexical & Literals
- #67 — Hex, binary, and float literals
- #68 — Block comments (`/* */`)
- #69 — Greek numeral literals (μβʹ = 42)

### Morphological Semantics
- #70 — Dual number support (two-element operations)
- #71 — Article semantics (bare vs. definite for allocation/reference)
- #72 — Mutable bindings and assignment
- #73 — Aspect-as-ownership codegen (Present=borrow, Aorist=move)
- #74 — Voice-based method semantics (middle voice for mutation)

### Type System Features
- #75 — Trait bounds and generics
- #76 — Inherent implementations (methods without traits)
- #77 — Field modifiers (ἴσως→Option, πολλά→Vec, μετά→mut)
- #78 — HashMap, Set, and String operations

## Result

All reference docs now accurately reflect the **assembler-first + semantic analysis** architecture, with clear notes on what's implemented vs. aspirational.