### PR TITLE
🎻 Bard: Document AST, IR, and Codegen modules

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - The Slot-Based Assembler
+**Confusion:** Users might assume GLOSSA parses strictly left-to-right like C or Rust.
+**Clarification:** The `src/semantic/assembler.rs` module implements a "Slot-Based Assembler" that mimics Ancient Greek grammar. Words are routed to grammatical slots (Subject, Object, Verb, etc.) based on their case endings, not their position. This allows for word-order independence (SOV, VSO, OVS support).

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -124,12 +124,21 @@ impl Statement {
 }
 
 /// An expression in GLOSSA
+///
+/// Expressions represent values that can be evaluated.
+/// They include literals, variable references, operations, and function calls.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
     /// A string literal: «text»
+    ///
+    /// # Example
+    /// `«χαῖρε κόσμε»`
     StringLiteral(String),
 
     /// A number literal
+    ///
+    /// # Example
+    /// `42` or `πέντε`
     NumberLiteral(i64),
 
     /// A boolean literal: ἀληθές or ψεῦδος
@@ -145,6 +154,9 @@ pub enum Expr {
     Word(Word),
 
     /// Multiple terms forming a phrase
+    ///
+    /// Phrases are sequences of words that haven't been fully parsed into
+    /// specific grammatical structures yet.
     Phrase(Vec<Expr>),
 
     /// A property access (genitive construction)
@@ -248,6 +260,19 @@ pub enum UnaryOperator {
 }
 
 /// A Greek word with original and normalized forms
+///
+/// This struct preserves the original polytonic Greek text (for display)
+/// while providing a normalized version for compiler analysis.
+///
+/// # Examples
+///
+/// ```
+/// use glossa::ast::Word;
+///
+/// let word = Word::new("Ἀθῆναι");
+/// assert_eq!(word.original, "Ἀθῆναι");
+/// assert_eq!(word.normalized, "αθηναι");
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Word {
     /// Original text with diacritics
@@ -257,6 +282,7 @@ pub struct Word {
 }
 
 impl Word {
+    /// Create a new word, automatically generating the normalized form
     pub fn new(original: impl Into<String>) -> Self {
         let original = original.into();
         let normalized = crate::grammar::normalize_greek(&original);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,6 +1,27 @@
 //! Code generation for ΓΛΩΣΣΑ
 //!
-//! Generates Rust code from the HIR.
+//! This module handles the translation of the High-Level Intermediate Representation (HIR)
+//! into executable Rust code.
+//!
+//! # Architecture
+//!
+//! The codegen process uses the `quote` crate to construct a Rust AST (TokenStream)
+//! from the HIR. This ensures that the generated code is syntactically valid Rust.
+//!
+//! 1. **Lowering**: The semantic analyzer produces an `AnalyzedProgram`.
+//! 2. **HIR Conversion**: `ir::lower_to_hir` converts this to `HirProgram`.
+//! 3. **Code Generation**: `codegen::generate_rust` takes the `HirProgram` and
+//!    produces a Rust source string.
+//!
+//! # Example
+//!
+//! ```ignore
+//! // HIR
+//! let stmt = HirStatement::Print { args: vec![HirExpr::StringLit("Hello".into())] };
+//!
+//! // Generated Rust
+//! println!("{}", "Hello");
+//! ```
 
 mod rust;
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,7 +1,23 @@
 //! Intermediate Representation for ΓΛΩΣΣΑ
 //!
-//! The HIR (High-level IR) is a simplified representation
-//! that's easier to translate to Rust code.
+//! This module defines the High-Level Intermediate Representation (HIR),
+//! which serves as the bridge between the semantic analysis phase and the
+//! code generation phase.
+//!
+//! # Why HIR?
+//!
+//! The semantic analysis produces an `AnalyzedProgram` which is rich in
+//! linguistic information (Greek-specific constructs, case usage, etc.).
+//! However, for code generation, we need something closer to the target
+//! language (Rust).
+//!
+//! The HIR strips away the Greek-specific details (like case endings and
+//! word order) and presents a clean, imperative structure that maps
+//! 1-to-1 with Rust constructs.
+//!
+//! # Pipeline
+//!
+//! `AnalyzedProgram` → `lower_to_hir()` → `HirProgram` → `generate_rust()`
 
 mod hir;
 


### PR DESCRIPTION
This PR improves the documentation for the core compiler modules (AST, IR, Codegen) and adds a journal entry explaining the Slot-Based Assembler.

Changes:
- Added doc comments and examples to `src/ast/nodes.rs`.
- Added module-level documentation to `src/codegen/mod.rs`.
- Added module-level documentation to `src/ir/mod.rs`.
- Created `.jules/bard.md` with a journal entry.

---
*PR created automatically by Jules for task [1048312950867698711](https://jules.google.com/task/1048312950867698711) started by @madmax983*