### PR TITLE
🗺️ Atlas: Break circular dependency between semantic and ir modules

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,0 +1,8 @@
+## 2024-05-22 - [Breaking The Knot: Semantic-IR Cycle]
+**Tangle:** The `semantic` module imports `ir` to use `IteratorOp` and `lower_expr` for detecting iterator patterns. The `ir` module imports `semantic` to consume `AnalyzedProgram` for lowering. This creates a circular dependency `semantic <-> ir`.
+**Blueprint:**
+1. Define `AnalyzedIteratorOp` in `semantic` to mirror `IteratorOp` but with `AnalyzedExpr`.
+2. Update `AnalyzedExpr` to use `AnalyzedIteratorOp`.
+3. Stop calling `ir::lower_expr` inside `semantic`.
+4. Update `ir` to map `AnalyzedIteratorOp` to `ir::IteratorOp` during lowering.
+**Stability:** Decouples semantic analysis from IR generation details. `semantic` becomes strictly upstream of `ir`.

--- a/src/ir/hir.rs
+++ b/src/ir/hir.rs
@@ -3,7 +3,8 @@
 //! A simplified IR that maps closely to Rust constructs.
 
 use crate::semantic::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, StatementKind,
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedIteratorOp, AnalyzedProgram, AnalyzedStatement,
+    StatementKind,
 };
 
 /// A HIR program ready for code generation
@@ -576,7 +577,24 @@ pub fn lower_expr(expr: &AnalyzedExpr) -> HirExpr {
         }
         AnalyzedExprKind::IteratorChain { collection, ops } => HirExpr::IteratorChain {
             collection: Box::new(lower_expr(collection)),
-            ops: ops.clone(),
+            ops: ops
+                .iter()
+                .map(|op| match op {
+                    AnalyzedIteratorOp::Iter => IteratorOp::Iter,
+                    AnalyzedIteratorOp::Map(expr) => IteratorOp::Map(Box::new(lower_expr(expr))),
+                    AnalyzedIteratorOp::Filter(expr) => {
+                        IteratorOp::Filter(Box::new(lower_expr(expr)))
+                    }
+                    AnalyzedIteratorOp::Find(expr) => IteratorOp::Find(Box::new(lower_expr(expr))),
+                    AnalyzedIteratorOp::Fold { init, closure } => IteratorOp::Fold {
+                        init: Box::new(lower_expr(init)),
+                        closure: Box::new(lower_expr(closure)),
+                    },
+                    AnalyzedIteratorOp::Any(expr) => IteratorOp::Any(Box::new(lower_expr(expr))),
+                    AnalyzedIteratorOp::All(expr) => IteratorOp::All(Box::new(lower_expr(expr))),
+                    AnalyzedIteratorOp::Collect => IteratorOp::Collect,
+                })
+                .collect(),
         },
         AnalyzedExprKind::Literal(n) => HirExpr::IntLit(*n),
     }

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -2028,7 +2028,7 @@ fn detect_iterator_pattern(
     };
 
     // Start with the collection variable
-    let mut iterator_ops = vec![crate::ir::IteratorOp::Iter];
+    let mut iterator_ops = vec![AnalyzedIteratorOp::Iter];
 
     // Check for any/all quantifiers
     let mut is_any = false;
@@ -2141,17 +2141,11 @@ fn detect_iterator_pattern(
 
                 // Determine which operation to use based on quantifier
                 if is_any {
-                    iterator_ops.push(crate::ir::IteratorOp::Any(Box::new(crate::ir::lower_expr(
-                        &filter_closure,
-                    ))));
+                    iterator_ops.push(AnalyzedIteratorOp::Any(Box::new(filter_closure.clone())));
                 } else if is_all {
-                    iterator_ops.push(crate::ir::IteratorOp::All(Box::new(crate::ir::lower_expr(
-                        &filter_closure,
-                    ))));
+                    iterator_ops.push(AnalyzedIteratorOp::All(Box::new(filter_closure.clone())));
                 } else {
-                    iterator_ops.push(crate::ir::IteratorOp::Filter(Box::new(
-                        crate::ir::lower_expr(&filter_closure),
-                    )));
+                    iterator_ops.push(AnalyzedIteratorOp::Filter(Box::new(filter_closure.clone())));
                 }
             }
         }
@@ -2220,9 +2214,9 @@ fn detect_iterator_pattern(
                         glossa_type: GlossaType::Number,
                     };
 
-                    iterator_ops.push(crate::ir::IteratorOp::Fold {
-                        init: Box::new(crate::ir::lower_expr(&init_expr)),
-                        closure: Box::new(crate::ir::lower_expr(&fold_closure)),
+                    iterator_ops.push(AnalyzedIteratorOp::Fold {
+                        init: Box::new(init_expr.clone()),
+                        closure: Box::new(fold_closure.clone()),
                     });
 
                     is_fold = true;
@@ -2294,9 +2288,7 @@ fn detect_iterator_pattern(
             };
 
             // Lower the closure to HIR and wrap in iterator op
-            iterator_ops.push(crate::ir::IteratorOp::Map(Box::new(crate::ir::lower_expr(
-                &closure,
-            ))));
+            iterator_ops.push(AnalyzedIteratorOp::Map(Box::new(closure.clone())));
         }
     }
 
@@ -2377,13 +2369,9 @@ fn detect_iterator_pattern(
                 };
 
                 if is_any {
-                    iterator_ops.push(crate::ir::IteratorOp::Any(Box::new(crate::ir::lower_expr(
-                        &any_all_closure,
-                    ))));
+                    iterator_ops.push(AnalyzedIteratorOp::Any(Box::new(any_all_closure.clone())));
                 } else {
-                    iterator_ops.push(crate::ir::IteratorOp::All(Box::new(crate::ir::lower_expr(
-                        &any_all_closure,
-                    ))));
+                    iterator_ops.push(AnalyzedIteratorOp::All(Box::new(any_all_closure.clone())));
                 }
 
                 // Build the iterator chain for any/all (returns boolean)
@@ -2480,9 +2468,7 @@ fn detect_iterator_pattern(
                         },
                     };
 
-                    iterator_ops.push(crate::ir::IteratorOp::Find(Box::new(
-                        crate::ir::lower_expr(&find_closure),
-                    )));
+                    iterator_ops.push(AnalyzedIteratorOp::Find(Box::new(find_closure.clone())));
                     break;
                 }
             }
@@ -2510,8 +2496,8 @@ fn detect_iterator_pattern(
                 },
             };
 
-            iterator_ops.push(crate::ir::IteratorOp::Find(Box::new(
-                crate::ir::lower_expr(&find_first_closure),
+            iterator_ops.push(AnalyzedIteratorOp::Find(Box::new(
+                find_first_closure.clone(),
             )));
         }
 
@@ -2536,13 +2522,13 @@ fn detect_iterator_pattern(
     // Check if this is a fold/any/all operation (returns single value, not a collection)
     let has_fold = iterator_ops
         .iter()
-        .any(|op| matches!(op, crate::ir::IteratorOp::Fold { .. }));
+        .any(|op| matches!(op, AnalyzedIteratorOp::Fold { .. }));
     let has_any = iterator_ops
         .iter()
-        .any(|op| matches!(op, crate::ir::IteratorOp::Any(_)));
+        .any(|op| matches!(op, AnalyzedIteratorOp::Any(_)));
     let has_all = iterator_ops
         .iter()
-        .any(|op| matches!(op, crate::ir::IteratorOp::All(_)));
+        .any(|op| matches!(op, AnalyzedIteratorOp::All(_)));
 
     if has_fold {
         // Fold returns a single value, no .collect() needed
@@ -2569,7 +2555,7 @@ fn detect_iterator_pattern(
     }
 
     // Add .collect() at the end for map/filter operations
-    iterator_ops.push(crate::ir::IteratorOp::Collect);
+    iterator_ops.push(AnalyzedIteratorOp::Collect);
 
     // Build the iterator chain expression
     let iterator_chain = AnalyzedExpr {
@@ -3757,6 +3743,30 @@ pub struct AnalyzedImplMethod {
     pub body: Vec<AnalyzedStatement>,
 }
 
+/// Iterator operation for AnalyzedExpr
+#[derive(Debug, Clone)]
+pub enum AnalyzedIteratorOp {
+    /// .iter() - create iterator
+    Iter,
+    /// .map(closure) - transform elements
+    Map(Box<AnalyzedExpr>),
+    /// .filter(closure) - select elements
+    Filter(Box<AnalyzedExpr>),
+    /// .find(closure) - find first matching element
+    Find(Box<AnalyzedExpr>),
+    /// .fold(init, closure) - reduce to single value
+    Fold {
+        init: Box<AnalyzedExpr>,
+        closure: Box<AnalyzedExpr>,
+    },
+    /// .any(closure) - test if any element matches
+    Any(Box<AnalyzedExpr>),
+    /// .all(closure) - test if all elements match
+    All(Box<AnalyzedExpr>),
+    /// .collect() - collect into collection
+    Collect,
+}
+
 /// Analyzed expression with type information
 #[derive(Debug, Clone)]
 pub struct AnalyzedExpr {
@@ -3848,7 +3858,7 @@ pub enum AnalyzedExprKind {
     /// Iterator chain collection.iter().map(...).filter(...)
     IteratorChain {
         collection: Box<AnalyzedExpr>,
-        ops: Vec<crate::ir::IteratorOp>,
+        ops: Vec<AnalyzedIteratorOp>,
     },
     /// Literal value (used in iterator ops, different from specific literals above)
     Literal(i64),


### PR DESCRIPTION
🕸️ Tangle: The `semantic` module imported `ir` to use `IteratorOp` and `lower_expr` for detecting iterator patterns, while `ir` imported `semantic` to consume `AnalyzedProgram`, creating a cycle.
📐 Blueprint: Introduced `AnalyzedIteratorOp` in `semantic` to represent iterator operations with `AnalyzedExpr`. Removed `semantic`'s dependency on `ir` by deferring lowering to the `ir` module.
🧱 Stability: Decoupled architecture, ensures `semantic` is strictly upstream of `ir`.
🔬 Verification: `cargo check` and `cargo test` passed.

---
*PR created automatically by Jules for task [7584529087202439347](https://jules.google.com/task/7584529087202439347) started by @madmax983*