### PR TITLE
Add mutable bindings and assignment (#72)

### DIFF
--- a/docs/reference/9-Variables-And-Binding.md
+++ b/docs/reference/9-Variables-And-Binding.md
@@ -49,3 +49,59 @@ New binding with the same name shadows the previous one:
 ξ πέντε ἔστω.
 ξ «χαῖρε» ἔστω.    // Shadows with new type
 ```
+
+## 9.4 Mutable Bindings with μετά
+
+By default, bindings are immutable. Use the prefix μετά ("changeable") to create a mutable binding:
+
+```glossa
+μετά ξ πέντε ἔστω.
+"mutable xi five let-it-be"
+// → let mut xi = 5;
+
+μετά ὄνομα «Σωκράτης» ἔστω.
+"mutable name 'Socrates' let-it-be"
+// → let mut onoma = "Socrates";
+```
+
+The word μετά comes from the Greek preposition meaning "after" or "changing," reflecting that the variable's value can change after its initial binding.
+
+Note: Array bindings (`[1, 2, 3] ἔστω`) are automatically mutable to support push/pop operations, even without the μετά prefix.
+
+## 9.5 Assignment with γίγνεται
+
+To reassign a mutable variable, use the middle voice verb γίγνεται ("becomes"):
+
+```glossa
+μετά ξ πέντε ἔστω.     // let mut xi = 5;
+ξ δέκα γίγνεται.       // xi = 10;
+"xi ten becomes"
+```
+
+The middle voice γίγνεται (from γίγνομαι, "to become") indicates that the subject undergoes a change—the variable "becomes" its new value. This mirrors how Ancient Greek uses voice to express the relationship between subject and action.
+
+### Error Handling
+
+Attempting to assign to an immutable variable produces an error:
+
+```glossa
+ξ πέντε ἔστω.          // let xi = 5; (immutable)
+ξ δέκα γίγνεται.       // ERROR: Τὸ «ξ» ἀμετάβλητόν ἐστιν
+                       // "xi is unchangeable—use μετά before the definition"
+```
+
+Attempting to assign to an undefined variable also produces an error:
+
+```glossa
+ξ δέκα γίγνεται.       // ERROR: Τὸ «ξ» οὐχ ὡρίσθη
+                       // "xi was not defined—first define it"
+```
+
+### Complete Example
+
+```glossa
+μετά μετρητής μηδέν ἔστω.    // let mut metritis = 0;
+μετρητής λέγε.               // println!("{}", metritis);  → 0
+μετρητής ἓν γίγνεται.        // metritis = 1;
+μετρητής λέγε.               // println!("{}", metritis);  → 1
+```

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -62,6 +62,12 @@ fn generate_statement(stmt: &HirStatement) -> TokenStream {
             mutable,
         } => generate_let(name, value, *mutable),
 
+        HirStatement::Assign { name, value } => {
+            let name_ident = format_ident!("{}", sanitize_name(name));
+            let value_tokens = generate_expr(value);
+            quote! { #name_ident = #value_tokens; }
+        }
+
         HirStatement::Print { args } => generate_print(args),
 
         HirStatement::Expr(expr) => {

--- a/src/errors/messages.rs
+++ b/src/errors/messages.rs
@@ -14,6 +14,14 @@ pub fn undefined_variable(name: &str) -> String {
     format!("Οὐκ οἶδα τὸ ὄνομα «{}»", name)
 }
 
+/// Get a Greek message for assignment to immutable variable
+pub fn immutable_assignment(name: &str) -> String {
+    format!(
+        "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
+        name
+    )
+}
+
 /// Get a Greek message for gender mismatch
 pub fn gender_mismatch(word1: &str, gender1: Gender, word2: &str, gender2: Gender) -> String {
     format!(

--- a/src/ir/hir.rs
+++ b/src/ir/hir.rs
@@ -316,11 +316,13 @@ fn lower_statement(stmt: &AnalyzedStatement) -> Option<HirStatement> {
 
         StatementKind::Assignment { name, .. } => {
             // Get the value expression (second expression in the list)
-            let value = if stmt.expressions.len() > 1 {
-                lower_expr(&stmt.expressions[1])
-            } else {
-                HirExpr::IntLit(0) // Default
-            };
+            // Assignment must have a value - panic if missing (indicates semantic analysis bug)
+            assert!(
+                stmt.expressions.len() > 1,
+                "Assignment statement missing value expression during HIR lowering. \
+                 This indicates a bug in the semantic analysis phase."
+            );
+            let value = lower_expr(&stmt.expressions[1]);
 
             Some(HirStatement::Assign {
                 name: name.clone(),

--- a/src/ir/hir.rs
+++ b/src/ir/hir.rs
@@ -23,6 +23,9 @@ pub enum HirStatement {
         mutable: bool,
     },
 
+    /// name = value;
+    Assign { name: String, value: HirExpr },
+
     /// println!(...);
     Print { args: Vec<HirExpr> },
 
@@ -293,7 +296,7 @@ pub fn lower_to_hir(analyzed: &AnalyzedProgram) -> HirProgram {
 
 fn lower_statement(stmt: &AnalyzedStatement) -> Option<HirStatement> {
     match &stmt.kind {
-        StatementKind::Binding { name, .. } => {
+        StatementKind::Binding { name, mutable, .. } => {
             // Get the value expression (second expression in the list)
             let value = if stmt.expressions.len() > 1 {
                 lower_expr(&stmt.expressions[1])
@@ -307,7 +310,21 @@ fn lower_statement(stmt: &AnalyzedStatement) -> Option<HirStatement> {
             Some(HirStatement::Let {
                 name: name.clone(),
                 value,
-                mutable: is_array,
+                mutable: *mutable || is_array,
+            })
+        }
+
+        StatementKind::Assignment { name, .. } => {
+            // Get the value expression (second expression in the list)
+            let value = if stmt.expressions.len() > 1 {
+                lower_expr(&stmt.expressions[1])
+            } else {
+                HirExpr::IntLit(0) // Default
+            };
+
+            Some(HirStatement::Assign {
+                name: name.clone(),
+                value,
             })
         }
 
@@ -617,7 +634,7 @@ mod tests {
 
         assert!(matches!(
             &hir.statements[0],
-            HirStatement::Let { name, .. } if name == "ξ"
+            HirStatement::Let { name, mutable, .. } if name == "ξ" && !mutable
         ));
     }
 
@@ -632,5 +649,24 @@ mod tests {
         } else {
             panic!("Expected Print statement");
         }
+    }
+
+    #[test]
+    fn test_lower_assignment() {
+        let ast = build_ast("μετά ξ πέντε ἔστω. ξ δέκα γίγνεται.").unwrap();
+        let analyzed = analyze_program(&ast).unwrap();
+        let hir = lower_to_hir(&analyzed);
+
+        // First statement should be Let with mutable
+        assert!(matches!(
+            &hir.statements[0],
+            HirStatement::Let { name, mutable, .. } if name == "ξ" && *mutable
+        ));
+
+        // Second statement should be Assign
+        assert!(matches!(
+            &hir.statements[1],
+            HirStatement::Assign { name, .. } if name == "ξ"
+        ));
     }
 }

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -145,6 +145,42 @@ static LEXICON: LazyLock<FxHashMap<&'static str, LexiconEntry>> = LazyLock::new(
         },
     );
 
+    // γίγνεται - it becomes (assignment)
+    m.insert(
+        "γιγνεται",
+        LexiconEntry {
+            lemma: "γιγνομαι",
+            pos: PartOfSpeech::Verb,
+            gender: None,
+            meaning: "becomes, is assigned",
+            rust_equiv: Some("="),
+            case: None,
+            number: Some(Number::Singular),
+            person: Some(Person::Third),
+            tense: Some(Tense::Present),
+            mood: Some(Mood::Indicative),
+            voice: Some(Voice::Middle),
+        },
+    );
+
+    // γίγνομαι - to become (assignment lemma)
+    m.insert(
+        "γιγνομαι",
+        LexiconEntry {
+            lemma: "γιγνομαι",
+            pos: PartOfSpeech::Verb,
+            gender: None,
+            meaning: "to become, to be assigned",
+            rust_equiv: Some("="),
+            case: None,
+            number: Some(Number::Singular),
+            person: Some(Person::First),
+            tense: Some(Tense::Present),
+            mood: Some(Mood::Indicative),
+            voice: Some(Voice::Middle),
+        },
+    );
+
     // γράφω - to write
     m.insert(
         "γραφω",
@@ -1016,6 +1052,24 @@ static LEXICON: LazyLock<FxHashMap<&'static str, LexiconEntry>> = LazyLock::new(
         },
     );
 
+    // μετά - mutable marker
+    m.insert(
+        "μετα",
+        LexiconEntry {
+            lemma: "μετα",
+            pos: PartOfSpeech::Preposition,
+            gender: None,
+            meaning: "mutable marker",
+            rust_equiv: Some("mut"),
+            case: None,
+            number: None,
+            person: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        },
+    );
+
     // καί - and
     m.insert(
         "και",
@@ -1711,6 +1765,16 @@ pub fn is_all_quantifier(normalized_word: &str) -> bool {
     matches!(normalized_word, "παντα" | "πας") // πάντα is the form, πας is the lemma
 }
 
+/// Check if a word is a mutable marker (μετά)
+pub fn is_mutable_marker(normalized_word: &str) -> bool {
+    normalized_word == "μετα"
+}
+
+/// Check if a word is an assignment verb (γίγνεται / γίγνομαι)
+pub fn is_assignment_verb(normalized_word: &str) -> bool {
+    matches!(normalized_word, "γιγνεται" | "γιγνομαι")
+}
+
 /// Get the numeric value of a Greek numeral word
 /// Includes all case forms (nominative, genitive, dative, accusative)
 pub fn numeral_value(normalized_word: &str) -> Option<i64> {
@@ -2081,5 +2145,43 @@ mod tests {
         let entry = lookup("αθροισμα").unwrap();
         assert_eq!(entry.rust_equiv, Some("+"));
         assert_eq!(entry.pos, PartOfSpeech::Noun);
+    }
+
+    #[test]
+    fn test_meta_is_mutable_marker() {
+        assert!(is_mutable_marker("μετα"));
+    }
+
+    #[test]
+    fn test_meta_lexicon_entry() {
+        let entry = lookup("μετα").unwrap();
+        assert_eq!(entry.pos, PartOfSpeech::Preposition);
+        assert_eq!(entry.rust_equiv, Some("mut"));
+    }
+
+    #[test]
+    fn test_non_mutable_marker() {
+        assert!(!is_mutable_marker("εστω"));
+        assert!(!is_mutable_marker("λεγε"));
+    }
+
+    #[test]
+    fn test_gignetai_is_assignment_verb() {
+        assert!(is_assignment_verb("γιγνεται"));
+        assert!(is_assignment_verb("γιγνομαι"));
+    }
+
+    #[test]
+    fn test_gignetai_lexicon_entry() {
+        let entry = lookup("γιγνεται").unwrap();
+        assert_eq!(entry.pos, PartOfSpeech::Verb);
+        assert_eq!(entry.voice, Some(Voice::Middle));
+        assert_eq!(entry.lemma, "γιγνομαι");
+    }
+
+    #[test]
+    fn test_non_assignment_verb() {
+        assert!(!is_assignment_verb("εστω"));
+        assert!(!is_assignment_verb("λεγε"));
     }
 }

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -122,6 +122,8 @@ pub struct AssembledStatement {
     pub is_query: bool,
     /// Whether this statement propagates (ends with ;) - converts to `?` in Rust
     pub is_propagate: bool,
+    /// Whether this binding has the mutable marker (μετά)
+    pub has_mutable_marker: bool,
 }
 
 /// A noun/pronoun constituent with its grammatical info
@@ -154,6 +156,8 @@ pub struct VerbConstituent {
     pub tense: Option<Tense>,
     /// Mood (indicative, imperative, etc.)
     pub mood: Option<Mood>,
+    /// Voice (active, middle, passive)
+    pub voice: Option<Voice>,
 }
 
 /// A participle constituent (used for lambdas/closures)
@@ -225,6 +229,7 @@ pub struct Assembler {
     pending_nested_phrases: Vec<Vec<Expr>>,
     pending_participles: Vec<ParticipleConstituent>,
     pending_unwraps: Vec<Expr>,
+    pending_mutable_marker: bool,
     is_query: bool,
     is_propagate: bool,
 }
@@ -287,6 +292,7 @@ impl Assembler {
             pending_nested_phrases: Vec::new(),
             pending_participles: Vec::new(),
             pending_unwraps: Vec::new(),
+            pending_mutable_marker: false,
             is_query: false,
             is_propagate: false,
         }
@@ -314,6 +320,7 @@ impl Assembler {
         self.pending_nested_phrases.clear();
         self.pending_participles.clear();
         self.pending_unwraps.clear();
+        self.pending_mutable_marker = false;
         self.is_query = false;
         self.is_propagate = false;
     }
@@ -350,6 +357,12 @@ impl Assembler {
     /// ```
     pub fn feed(&mut self, analysis: &MorphAnalysis, original: &str) -> Result<(), AssemblyError> {
         let normalized = normalize_greek(original);
+
+        // Check for mutable marker (μετά) first
+        if crate::morphology::lexicon::is_mutable_marker(&normalized) {
+            self.pending_mutable_marker = true;
+            return Ok(());
+        }
 
         // Check for operators first (before normal part-of-speech handling)
         // Boolean operators: καί (&&), ἤ (||)
@@ -562,6 +575,7 @@ impl Assembler {
             number: analysis.number,
             tense: analysis.tense,
             mood: analysis.mood,
+            voice: analysis.voice,
         });
 
         Ok(())
@@ -662,6 +676,7 @@ impl Assembler {
             nested_phrases: std::mem::take(&mut self.pending_nested_phrases),
             participles: std::mem::take(&mut self.pending_participles),
             unwraps: std::mem::take(&mut self.pending_unwraps),
+            has_mutable_marker: self.pending_mutable_marker,
             is_query: self.is_query,
             is_propagate: self.is_propagate,
         };
@@ -883,5 +898,19 @@ mod tests {
 
         let stmt = asm.finalize().unwrap();
         assert!(stmt.indirect.is_some());
+    }
+
+    #[test]
+    fn test_verb_constituent_has_voice() {
+        let mut asm = Assembler::new();
+
+        // γίγνεται - middle voice verb
+        let verb = analyze("γιγνεται");
+        asm.feed(&verb, "γίγνεται").unwrap();
+
+        let stmt = asm.finalize().unwrap();
+        assert!(stmt.verb.is_some());
+        let verb_const = stmt.verb.unwrap();
+        assert_eq!(verb_const.voice, Some(Voice::Middle));
     }
 }

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -394,6 +394,7 @@ fn try_parse_struct_instantiation(
                     kind: StatementKind::Binding {
                         name: var_name.clone(),
                         value_type: struct_type.clone(),
+                        mutable: false,
                     },
                     expressions: vec![
                         AnalyzedExpr {
@@ -2735,6 +2736,7 @@ fn classify_assembled_statement(
                         StatementKind::Binding {
                             name: var_name.clone(),
                             value_type: struct_type.clone(),
+                            mutable: false,
                         },
                         vec![
                             AnalyzedExpr {
@@ -2828,6 +2830,7 @@ fn classify_assembled_statement(
                     StatementKind::Binding {
                         name: var_name.clone(),
                         value_type: return_type.clone(),
+                        mutable: false,
                     },
                     vec![
                         AnalyzedExpr {
@@ -2933,13 +2936,19 @@ fn classify_assembled_statement(
                 value_expr
             };
 
-            // Register binding in scope
-            scope.define(var_name.clone(), value_type.clone());
+            // Register binding in scope (mutable if μετά marker present)
+            let is_mutable = asm_stmt.has_mutable_marker;
+            if is_mutable {
+                scope.define_mut(var_name.clone(), value_type.clone());
+            } else {
+                scope.define(var_name.clone(), value_type.clone());
+            }
 
             return Ok((
                 StatementKind::Binding {
                     name: var_name.clone(),
                     value_type: value_type.clone(),
+                    mutable: is_mutable,
                 },
                 vec![
                     AnalyzedExpr {
@@ -2949,6 +2958,50 @@ fn classify_assembled_statement(
                     final_value_expr,
                 ],
             ));
+        }
+
+        // Check for assignment: ξ δέκα γίγνεται (middle voice)
+        if crate::morphology::lexicon::is_assignment_verb(&verb_lemma) {
+            // Get the variable name from the subject
+            let var_name = if let Some(ref subject) = asm_stmt.subject {
+                normalize_greek(&subject.original)
+            } else {
+                return Err(GlossaError::semantic("Assignment without subject"));
+            };
+
+            // Check if variable is defined and mutable
+            let binding = scope.lookup_binding(&var_name);
+            match binding {
+                None => {
+                    return Err(GlossaError::semantic(format!(
+                        "Τὸ «{}» οὐχ ὡρίσθη — πρῶτον ὅρισον αὐτό",
+                        var_name
+                    )));
+                }
+                Some(b) if !b.mutable => {
+                    return Err(GlossaError::semantic(crate::errors::immutable_assignment(
+                        &var_name,
+                    )));
+                }
+                Some(b) => {
+                    let value_type = b.glossa_type.clone();
+                    let (value_expr, _) = extract_value(asm_stmt);
+                    scope.mark_used(&var_name);
+                    return Ok((
+                        StatementKind::Assignment {
+                            name: var_name.clone(),
+                            value_type: value_type.clone(),
+                        },
+                        vec![
+                            AnalyzedExpr {
+                                expr: AnalyzedExprKind::Variable(var_name),
+                                glossa_type: value_type.clone(),
+                            },
+                            value_expr,
+                        ],
+                    ));
+                }
+            }
         }
 
         // Check for pop pattern: subject ἕλκεται (middle voice)
@@ -3716,6 +3769,12 @@ pub enum StatementKind {
     Binding {
         name: String,
         value_type: GlossaType,
+        mutable: bool,
+    },
+    /// Assignment: ξ δέκα γίγνεται
+    Assignment {
+        name: String,
+        value_type: GlossaType,
     },
     /// Print statement: «χαῖρε» λέγε
     Print,
@@ -4049,6 +4108,7 @@ impl SemanticAnalyzer {
                                     StatementKind::Binding {
                                         name: var_name.clone(),
                                         value_type: struct_type.clone(),
+                                        mutable: false,
                                     },
                                     vec![
                                         AnalyzedExpr {
@@ -4122,15 +4182,28 @@ impl SemanticAnalyzer {
         }
 
         if is_binding {
-            // Pattern: name value... ἔστω
+            // Pattern: [μετά] name value... ἔστω
             // e.g., ξ πέντε ἔστω
+            // e.g., μετά ξ πέντε ἔστω (mutable)
             // e.g., τοπικον ξ ἓν ἄθροισμα ἔστω
             if terms.len() >= 3 {
-                let name = self.extract_name(&terms[0])?;
+                // Check for μετά mutable marker
+                let (is_mutable, name_start) = if let Expr::Word(w) = &terms[0] {
+                    if crate::morphology::lexicon::is_mutable_marker(&w.normalized) {
+                        (true, 1)
+                    } else {
+                        (false, 0)
+                    }
+                } else {
+                    (false, 0)
+                };
+
+                let name = self.extract_name(&terms[name_start])?;
 
                 // Collect all terms between the name and the ἔστω verb
                 let verb_position = verb_idx.unwrap();
-                let value_terms = &terms[1..verb_position];
+                let value_start = name_start + 1;
+                let value_terms = &terms[value_start..verb_position];
 
                 // Analyze the value expression using the assembler
                 // Create a phrase expression from the value terms and analyze it
@@ -4159,14 +4232,20 @@ impl SemanticAnalyzer {
                     classify_value_expression(&assembled, &mut self.scope)?
                 };
 
-                // Register in scope
-                self.scope
-                    .define(name.clone(), value_expr.glossa_type.clone());
+                // Register in scope (mutable if μετά marker present)
+                if is_mutable {
+                    self.scope
+                        .define_mut(name.clone(), value_expr.glossa_type.clone());
+                } else {
+                    self.scope
+                        .define(name.clone(), value_expr.glossa_type.clone());
+                }
 
                 return Ok((
                     StatementKind::Binding {
                         name: name.clone(),
                         value_type: value_expr.glossa_type.clone(),
+                        mutable: is_mutable,
                     },
                     vec![
                         AnalyzedExpr {

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -2984,6 +2984,22 @@ fn classify_assembled_statement(
                     )));
                 }
                 Some(b) => {
+                    // An assignment must have a value
+                    let has_value = !asm_stmt.literals.is_empty()
+                        || asm_stmt.object.is_some()
+                        || !asm_stmt.arrays.is_empty()
+                        || !asm_stmt.unwraps.is_empty()
+                        || !asm_stmt.index_accesses.is_empty()
+                        || !asm_stmt.property_accesses.is_empty()
+                        || !asm_stmt.nested_phrases.is_empty();
+
+                    if !has_value {
+                        return Err(GlossaError::semantic(format!(
+                            "Τῇ πράξει «{} γίγνεται» δεῖ τιμῆς",
+                            var_name
+                        )));
+                    }
+
                     let value_type = b.glossa_type.clone();
                     let (value_expr, _) = extract_value(asm_stmt);
                     scope.mark_used(&var_name);

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -231,6 +231,13 @@ impl Scope {
         }
     }
 
+    /// Look up full binding information by name, searching parent scopes
+    pub fn lookup_binding(&self, name: &str) -> Option<&Binding> {
+        self.bindings
+            .get(name)
+            .or_else(|| self.parent.as_ref()?.lookup_binding(name))
+    }
+
     /// Check if a name is defined in this scope (not parents)
     pub fn is_defined_locally(&self, name: &str) -> bool {
         self.bindings.contains_key(name)
@@ -325,5 +332,44 @@ mod tests {
         let unused = scope.unused_bindings();
         assert_eq!(unused.len(), 1);
         assert_eq!(unused[0].name, "υ");
+    }
+
+    #[test]
+    fn test_lookup_binding_returns_full_binding() {
+        let mut scope = Scope::new();
+        scope.define_mut("μ".to_string(), GlossaType::Number);
+
+        let binding = scope.lookup_binding("μ").unwrap();
+        assert_eq!(binding.name, "μ");
+        assert_eq!(binding.glossa_type, GlossaType::Number);
+        assert!(binding.mutable);
+    }
+
+    #[test]
+    fn test_lookup_binding_immutable() {
+        let mut scope = Scope::new();
+        scope.define("ξ".to_string(), GlossaType::String);
+
+        let binding = scope.lookup_binding("ξ").unwrap();
+        assert_eq!(binding.name, "ξ");
+        assert_eq!(binding.glossa_type, GlossaType::String);
+        assert!(!binding.mutable);
+    }
+
+    #[test]
+    fn test_lookup_binding_parent_scope() {
+        let mut parent = Scope::new();
+        parent.define_mut("π".to_string(), GlossaType::Number);
+
+        let child = parent.child();
+        let binding = child.lookup_binding("π").unwrap();
+        assert_eq!(binding.name, "π");
+        assert!(binding.mutable);
+    }
+
+    #[test]
+    fn test_lookup_binding_not_found() {
+        let scope = Scope::new();
+        assert!(scope.lookup_binding("ζ").is_none());
     }
 }

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -59,3 +59,39 @@ fn test_preserves_greek_in_strings() {
     let code = compile("«Ἑλλάς» λέγε.").unwrap();
     assert!(code.contains("Ἑλλάς"));
 }
+
+#[test]
+fn test_mutable_binding() {
+    let code = compile("μετά ξ πέντε ἔστω.").unwrap();
+    assert!(code.contains("let mut xi"));
+    assert!(code.contains("5"));
+}
+
+#[test]
+fn test_assignment_codegen() {
+    let code = compile("μετά ξ πέντε ἔστω. ξ δέκα γίγνεται.").unwrap();
+    assert!(code.contains("let mut xi = 5"));
+    assert!(code.contains("xi = 10"));
+}
+
+#[test]
+fn test_immutable_assignment_error() {
+    let result = compile("ξ πέντε ἔστω. ξ δέκα γίγνεται.");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("ἀμετάβλητόν"));
+}
+
+#[test]
+fn test_undefined_assignment_error() {
+    let result = compile("ξ δέκα γίγνεται.");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("οὐχ ὡρίσθη"));
+}
+
+#[test]
+fn test_mutable_binding_and_reassignment() {
+    let code = compile("μετά ξ πέντε ἔστω. ξ λέγε. ξ δέκα γίγνεται. ξ λέγε.").unwrap();
+    assert!(code.contains("let mut xi = 5"));
+    assert!(code.contains("xi = 10"));
+    assert!(code.matches("println").count() >= 2);
+}

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -95,3 +95,10 @@ fn test_mutable_binding_and_reassignment() {
     assert!(code.contains("xi = 10"));
     assert!(code.matches("println").count() >= 2);
 }
+
+#[test]
+fn test_assignment_missing_value_error() {
+    let result = compile("μετά ξ πέντε ἔστω. ξ γίγνεται.");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("δεῖ τιμῆς"));
+}


### PR DESCRIPTION
## Summary
- Add μετά prefix for mutable bindings: `μετά ξ πέντε ἔστω.` → `let mut xi = 5;`
- Add γίγνεται verb for assignment: `ξ δέκα γίγνεται.` → `xi = 10;`
- Greek error messages for immutable/undefined assignment attempts

## Changes
- `src/morphology/lexicon.rs`: Added `μετα` + `γιγνεται` entries, `is_mutable_marker()`, `is_assignment_verb()`
- `src/semantic/resolver.rs`: Added `lookup_binding()` returning full `&Binding`
- `src/semantic/assembler.rs`: Added `voice` to `VerbConstituent`, `has_mutable_marker` to `AssembledStatement`
- `src/semantic/mod.rs`: Added `mutable: bool` to `StatementKind::Binding`, added `StatementKind::Assignment`
- `src/ir/hir.rs`: Added `HirStatement::Assign`
- `src/codegen/rust.rs`: Added `Assign` codegen
- `src/errors/messages.rs`: Added `immutable_assignment()` Greek error
- `tests/compile_tests.rs`: 5 new integration tests
- `docs/reference/9-Variables-And-Binding.md`: Added sections 9.4 + 9.5

## Test plan
- [x] All 376+ tests passing
- [x] `cargo test test_mutable_binding`
- [x] `cargo test test_assignment_codegen`
- [x] `cargo test test_immutable_assignment_error`
- [x] `cargo test test_undefined_assignment_error`
- [x] `cargo test test_mutable_binding_and_reassignment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)