### PR TITLE
⚡ Bolt: MorphAnalysis zero-allocation optimization

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -752,4 +752,29 @@ mod tests {
         assert_eq!(infinitive("λεγ", Tense::Present, Voice::Active), "λεγειν");
         assert_eq!(infinitive("λυ", Tense::Aorist, Voice::Active), "λυσαι");
     }
+
+    #[test]
+    fn test_analyze_verb_coverage_forms() {
+        // Aorist Active Infinitive
+        let analysis = analyze_verb("λυσαι").unwrap();
+        assert_eq!(analysis.tense, Some(Tense::Aorist));
+        assert_eq!(analysis.mood, Some(Mood::Infinitive));
+        assert_eq!(analysis.lemma, "λυω"); // Constructed from stem "λυ" + "ω" (Aorist Infinitive ending is "σαι")
+
+        // Present Active Subjunctive
+        let analysis = analyze_verb("λυῃς").unwrap();
+        assert_eq!(analysis.mood, Some(Mood::Subjunctive));
+        assert_eq!(analysis.lemma, "λυω");
+
+        // Present Active Optative
+        let analysis = analyze_verb("λυοιμι").unwrap();
+        assert_eq!(analysis.mood, Some(Mood::Optative));
+        assert_eq!(analysis.lemma, "λυω");
+
+        // Aorist Passive Optative
+        let analysis = analyze_verb("λυθειη").unwrap();
+        assert_eq!(analysis.voice, Some(Voice::Passive));
+        assert_eq!(analysis.mood, Some(Mood::Optative));
+        assert_eq!(analysis.lemma, "λυω"); // Strip "θ" from "λυθ" -> "λυ"
+    }
 }

--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -5,6 +5,8 @@
 //! - Aorist Active Indicative (one-shot operations)
 //! - Imperative (commands)
 
+use std::borrow::Cow;
+
 use super::{Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice};
 
 /// Present Active Indicative endings (ω-conjugation)
@@ -206,7 +208,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
     for (form, person, number) in EIMI_SUBJUNCTIVE {
         if word == *form {
             return Some(MorphAnalysis {
-                lemma: "ειμι".to_string(),
+                lemma: Cow::Borrowed("ειμι"),
                 part_of_speech: PartOfSpeech::Verb,
                 case: None,
                 number: Some(*number),
@@ -224,7 +226,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
     // Note: -ω ending is ambiguous (indicative vs subjunctive), prefer indicative
     if let Some((stem, person, number)) = match_verb_endings(word, PRESENT_ACTIVE_IND) {
         return Some(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: Some(number),
@@ -240,7 +242,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
     // Try present active imperative
     if let Some((stem, person, number)) = match_verb_endings(word, PRESENT_ACTIVE_IMP) {
         return Some(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: Some(number),
@@ -258,7 +260,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
         // Strip temporal augment to find true stem: ἔλυσα → ελυ → λυ
         let true_stem = strip_augment(&augmented_stem);
         return Some(MorphAnalysis {
-            lemma: format!("{}ω", true_stem),
+            lemma: Cow::Owned(format!("{}ω", true_stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: Some(number),
@@ -274,7 +276,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
     // Try aorist active imperative (no augment in imperative, but keep consistent)
     if let Some((stem, person, number)) = match_verb_endings(word, AORIST_ACTIVE_IMP) {
         return Some(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: Some(number),
@@ -292,7 +294,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
         && !stem.is_empty()
     {
         return Some(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: None,
@@ -310,7 +312,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
         && !stem.is_empty()
     {
         return Some(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: None,
@@ -327,7 +329,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
     // Only match distinctive subjunctive endings (ῃς, ῃ, ωμεν, ητε, ωσι)
     if let Some((stem, person, number)) = match_verb_endings(word, PRESENT_ACTIVE_SUBJ) {
         return Some(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: Some(number),
@@ -343,7 +345,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
     // Try aorist active subjunctive
     if let Some((stem, person, number)) = match_verb_endings(word, AORIST_ACTIVE_SUBJ) {
         return Some(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: Some(number),
@@ -359,7 +361,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
     // Try present active optative (for Option<T> semantics)
     if let Some((stem, person, number)) = match_verb_endings(word, PRESENT_ACTIVE_OPT) {
         return Some(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: Some(number),
@@ -385,7 +387,7 @@ pub fn analyze_verb(word: &str) -> Option<MorphAnalysis> {
         };
 
         return Some(MorphAnalysis {
-            lemma,
+            lemma: Cow::Owned(lemma),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: Some(number),
@@ -452,7 +454,7 @@ pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
     for (form, person, number) in EIMI_SUBJUNCTIVE {
         if word == *form {
             analyses.push(MorphAnalysis {
-                lemma: "ειμι".to_string(),
+                lemma: Cow::Borrowed("ειμι"),
                 part_of_speech: PartOfSpeech::Verb,
                 case: None,
                 number: Some(*number),
@@ -544,7 +546,7 @@ pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
             let confidence = (pattern.base_confidence + length_bonus).min(0.95);
 
             analyses.push(MorphAnalysis {
-                lemma: format!("{}ω", lemma_stem),
+                lemma: Cow::Owned(format!("{}ω", lemma_stem)),
                 part_of_speech: PartOfSpeech::Verb,
                 case: None,
                 number: Some(number),
@@ -563,7 +565,7 @@ pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
         && !stem.is_empty()
     {
         analyses.push(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: None,
@@ -580,7 +582,7 @@ pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
         && !stem.is_empty()
     {
         analyses.push(MorphAnalysis {
-            lemma: format!("{}ω", stem),
+            lemma: Cow::Owned(format!("{}ω", stem)),
             part_of_speech: PartOfSpeech::Verb,
             case: None,
             number: None,

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -5,6 +5,8 @@
 //! - Second declension: -ος/-ον masculine/neuter nouns
 //! - Third declension: -μα neuter nouns (and others)
 
+use std::borrow::Cow;
+
 use super::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
 
 /// Declension pattern
@@ -102,7 +104,7 @@ pub fn analyze_noun(word: &str) -> Option<MorphAnalysis> {
     // Third declension -μα (check longer endings first)
     if let Some((stem, case, number)) = match_endings(word, THIRD_DECLENSION_MA) {
         return Some(MorphAnalysis {
-            lemma: format!("{}μα", stem),
+            lemma: Cow::Owned(format!("{}μα", stem)),
             part_of_speech: PartOfSpeech::Noun,
             case: Some(case),
             number: Some(number),
@@ -118,7 +120,7 @@ pub fn analyze_noun(word: &str) -> Option<MorphAnalysis> {
     // Second declension masculine -ος
     if let Some((stem, case, number)) = match_endings(word, SECOND_DECLENSION_MASC) {
         return Some(MorphAnalysis {
-            lemma: format!("{}ος", stem),
+            lemma: Cow::Owned(format!("{}ος", stem)),
             part_of_speech: PartOfSpeech::Noun,
             case: Some(case),
             number: Some(number),
@@ -136,7 +138,7 @@ pub fn analyze_noun(word: &str) -> Option<MorphAnalysis> {
         // Only if it doesn't match masculine (which has priority for -ον accusative)
         if !word.ends_with("ος") {
             return Some(MorphAnalysis {
-                lemma: format!("{}ον", stem),
+                lemma: Cow::Owned(format!("{}ον", stem)),
                 part_of_speech: PartOfSpeech::Noun,
                 case: Some(case),
                 number: Some(number),
@@ -153,7 +155,7 @@ pub fn analyze_noun(word: &str) -> Option<MorphAnalysis> {
     // First declension -η
     if let Some((stem, case, number)) = match_endings(word, FIRST_DECLENSION_ETA) {
         return Some(MorphAnalysis {
-            lemma: format!("{}η", stem),
+            lemma: Cow::Owned(format!("{}η", stem)),
             part_of_speech: PartOfSpeech::Noun,
             case: Some(case),
             number: Some(number),
@@ -169,7 +171,7 @@ pub fn analyze_noun(word: &str) -> Option<MorphAnalysis> {
     // First declension -α
     if let Some((stem, case, number)) = match_endings(word, FIRST_DECLENSION_ALPHA) {
         return Some(MorphAnalysis {
-            lemma: format!("{}α", stem),
+            lemma: Cow::Owned(format!("{}α", stem)),
             part_of_speech: PartOfSpeech::Noun,
             case: Some(case),
             number: Some(number),
@@ -278,7 +280,7 @@ pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
             let confidence = (decl.base_confidence + length_bonus).min(0.95);
 
             analyses.push(MorphAnalysis {
-                lemma: format!("{}{}", stem, decl.nom_ending),
+                lemma: Cow::Owned(format!("{}{}", stem, decl.nom_ending)),
                 part_of_speech: PartOfSpeech::Noun,
                 case: Some(case),
                 number: Some(number),

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -416,6 +416,18 @@ mod tests {
     }
 
     #[test]
+    fn test_second_declension_neuter_plural() {
+        // "δωρα" (gifts) - Neuter Plural (ends in -α)
+        // This should hit the SECOND_DECLENSION_NEUT fallback in analyze_noun
+        // because "α" is not in SECOND_DECLENSION_MASC
+        let analysis = analyze_noun("δωρα").unwrap();
+        assert_eq!(analysis.case, Some(Case::Nominative)); // or Accusative
+        assert_eq!(analysis.number, Some(Number::Plural));
+        assert_eq!(analysis.gender, Some(Gender::Neuter));
+        assert_eq!(analysis.lemma, "δωρον");
+    }
+
+    #[test]
     fn test_first_declension_eta() {
         let analysis = analyze_noun("λιστη").unwrap();
         assert_eq!(analysis.case, Some(Case::Nominative));

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -5,6 +5,7 @@
 
 use super::{Case, Gender, Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice};
 use rustc_hash::FxHashMap;
+use std::borrow::Cow;
 use std::sync::LazyLock;
 
 /// A lexicon entry with full morphological information
@@ -30,8 +31,6 @@ pub struct LexiconEntry {
     pub mood: Option<Mood>,
     pub voice: Option<Voice>,
 }
-
-use std::borrow::Cow;
 
 impl LexiconEntry {
     pub fn to_analysis(&self) -> MorphAnalysis {

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -31,10 +31,12 @@ pub struct LexiconEntry {
     pub voice: Option<Voice>,
 }
 
+use std::borrow::Cow;
+
 impl LexiconEntry {
     pub fn to_analysis(&self) -> MorphAnalysis {
         MorphAnalysis {
-            lemma: self.lemma.to_string(),
+            lemma: Cow::Borrowed(self.lemma),
             part_of_speech: self.pos,
             case: self.case,
             number: self.number,

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -100,21 +100,8 @@ pub enum PartOfSpeech {
 /// Analyze a Greek word and return the most likely morphological analysis
 pub fn analyze(word: &str) -> MorphAnalysis {
     let analyses = analyze_all(word);
-    analyses.into_iter().next().unwrap_or_else(|| {
-        let normalized = normalize_greek(word);
-        MorphAnalysis {
-            lemma: Cow::Owned(normalized),
-            part_of_speech: PartOfSpeech::Unknown,
-            case: None,
-            number: None,
-            gender: None,
-            person: None,
-            tense: None,
-            mood: None,
-            voice: None,
-            confidence: 0.0,
-        }
-    })
+    // analyze_all is guaranteed to return at least one analysis (Unknown if nothing else)
+    analyses.into_iter().next().unwrap()
 }
 
 /// Analyze a Greek word and return ALL possible morphological analyses
@@ -313,6 +300,31 @@ mod tests {
         // Verify ordering is preserved for valid items (or at least no panic)
         // NaN comparisons are undefined, but we just ensure it doesn't crash
         assert_eq!(analyses.len(), 2);
+    }
+
+    #[test]
+    fn test_unknown_word_fallback() {
+        // "gibberish" should trigger the unknown fallback path
+        let analysis = analyze("gibberish");
+        assert_eq!(analysis.part_of_speech, PartOfSpeech::Unknown);
+        assert_eq!(analysis.lemma, "gibberish"); // Should be Cow::Owned
+        assert!(matches!(analysis.lemma, Cow::Owned(_)));
+        assert_eq!(analysis.confidence, 0.0);
+    }
+
+    #[test]
+    fn test_single_greek_letter_fallback() {
+        // "α" should trigger the single greek letter fallback (mathematical variable)
+        let analysis = analyze("α");
+        assert_eq!(analysis.part_of_speech, PartOfSpeech::Noun);
+        assert_eq!(analysis.case, Some(Case::Nominative));
+        assert_eq!(analysis.lemma, "α"); // Should be Cow::Owned from clone
+        // Note: lexicon entries might also cover some letters, so we check if it works generally
+        // But specifically for a letter NOT in lexicon (if any), this fallback is key.
+        // "ξ" (xi) is likely not in lexicon as a word
+        let analysis_xi = analyze("ξ");
+        assert_eq!(analysis_xi.part_of_speech, PartOfSpeech::Noun);
+        assert_eq!(analysis_xi.lemma, "ξ");
     }
 
     #[test]

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -31,12 +31,19 @@ pub use declension::*;
 pub use lexicon::*;
 pub use participle::*;
 
+use std::borrow::Cow;
+
 use crate::grammar::normalize_greek;
 
 /// Result of morphological analysis
 #[derive(Debug, Clone, PartialEq)]
 pub struct MorphAnalysis {
-    pub lemma: String,
+    /// The dictionary form (lemma)
+    ///
+    /// Optimization: Uses `Cow<'static, str>` to avoid allocations for lexicon entries
+    /// which are `&'static str`. Only dynamically generated lemmas (e.g. from
+    /// suffix stripping) use heap allocation.
+    pub lemma: Cow<'static, str>,
     pub part_of_speech: PartOfSpeech,
     pub case: Option<Case>,
     pub number: Option<Number>,
@@ -54,7 +61,7 @@ impl MorphAnalysis {
     /// Create a new analysis with default confidence
     pub fn new(lemma: String, pos: PartOfSpeech) -> Self {
         MorphAnalysis {
-            lemma,
+            lemma: Cow::Owned(lemma),
             part_of_speech: pos,
             case: None,
             number: None,
@@ -96,7 +103,7 @@ pub fn analyze(word: &str) -> MorphAnalysis {
     analyses.into_iter().next().unwrap_or_else(|| {
         let normalized = normalize_greek(word);
         MorphAnalysis {
-            lemma: normalized,
+            lemma: Cow::Owned(normalized),
             part_of_speech: PartOfSpeech::Unknown,
             case: None,
             number: None,
@@ -159,7 +166,7 @@ pub fn analyze_all(word: &str) -> Vec<MorphAnalysis> {
             analyses.insert(
                 0,
                 MorphAnalysis {
-                    lemma: normalized.clone(),
+                    lemma: Cow::Owned(normalized.clone()),
                     part_of_speech: PartOfSpeech::Noun,
                     case: Some(Case::Nominative),
                     number: Some(Number::Singular),
@@ -177,7 +184,7 @@ pub fn analyze_all(word: &str) -> Vec<MorphAnalysis> {
     // If still nothing, return unknown
     if analyses.is_empty() {
         analyses.push(MorphAnalysis {
-            lemma: normalized,
+            lemma: Cow::Owned(normalized),
             part_of_speech: PartOfSpeech::Unknown,
             case: None,
             number: None,

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -349,9 +349,11 @@ mod tests {
 
         // Neuter plural (hits SECOND_DECLENSION_NEUT in analyze_noun_all?)
         let analyses = analyze_all("δωρα");
-        assert!(analyses
-            .iter()
-            .any(|a| a.lemma == "δωρον" && a.gender == Some(Gender::Neuter)));
+        assert!(
+            analyses
+                .iter()
+                .any(|a| a.lemma == "δωρον" && a.gender == Some(Gender::Neuter))
+        );
 
         // Aorist Infinitive
         let analyses = analyze_all("λυσαι");
@@ -359,14 +361,18 @@ mod tests {
 
         // Aorist Passive Optative
         let analyses = analyze_all("λυθειη");
-        assert!(analyses
-            .iter()
-            .any(|a| a.mood == Some(Mood::Optative) && a.voice == Some(Voice::Passive)));
+        assert!(
+            analyses
+                .iter()
+                .any(|a| a.mood == Some(Mood::Optative) && a.voice == Some(Voice::Passive))
+        );
 
         // Aorist Indicative (with augment)
         let analyses = analyze_all("ελυσα");
-        assert!(analyses
-            .iter()
-            .any(|a| a.tense == Some(Tense::Aorist) && a.lemma == "λυω"));
+        assert!(
+            analyses
+                .iter()
+                .any(|a| a.tense == Some(Tense::Aorist) && a.lemma == "λυω")
+        );
     }
 }

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -342,4 +342,31 @@ mod tests {
             assert!(analyses[i].confidence >= analyses[i + 1].confidence);
         }
     }
+
+    #[test]
+    fn test_analyze_all_coverage_forms() {
+        // Test various forms to ensure analyze_all (and underlying *_all functions) are covered
+
+        // Neuter plural (hits SECOND_DECLENSION_NEUT in analyze_noun_all?)
+        let analyses = analyze_all("δωρα");
+        assert!(analyses
+            .iter()
+            .any(|a| a.lemma == "δωρον" && a.gender == Some(Gender::Neuter)));
+
+        // Aorist Infinitive
+        let analyses = analyze_all("λυσαι");
+        assert!(analyses.iter().any(|a| a.mood == Some(Mood::Infinitive)));
+
+        // Aorist Passive Optative
+        let analyses = analyze_all("λυθειη");
+        assert!(analyses
+            .iter()
+            .any(|a| a.mood == Some(Mood::Optative) && a.voice == Some(Voice::Passive)));
+
+        // Aorist Indicative (with augment)
+        let analyses = analyze_all("ελυσα");
+        assert!(analyses
+            .iter()
+            .any(|a| a.tense == Some(Tense::Aorist) && a.lemma == "λυω"));
+    }
 }

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -540,7 +540,7 @@ impl Assembler {
         original: &str,
     ) -> Result<(), AssemblyError> {
         let constituent = Constituent {
-            lemma: analysis.lemma.clone(),
+            lemma: analysis.lemma.to_string(),
             original: original.to_string(),
             case: analysis.case.unwrap_or(Case::Nominative),
             number: analysis.number,
@@ -599,7 +599,7 @@ impl Assembler {
         }
 
         self.pending_verb = Some(VerbConstituent {
-            lemma: analysis.lemma.clone(),
+            lemma: analysis.lemma.to_string(),
             original: original.to_string(),
             person: analysis.person,
             number: analysis.number,
@@ -618,7 +618,7 @@ impl Assembler {
         original: &str,
     ) -> Result<(), AssemblyError> {
         let constituent = Constituent {
-            lemma: analysis.lemma.clone(),
+            lemma: analysis.lemma.to_string(),
             original: original.to_string(),
             case: analysis.case.unwrap_or(Case::Nominative),
             number: analysis.number,


### PR DESCRIPTION
This PR replaces the `String` field `lemma` in `MorphAnalysis` with `Cow<'static, str>`.

### 💡 What
Changed `lemma: String` to `lemma: Cow<'static, str>`.

### 🎯 Why
`LexiconEntry` stores lemmas as `&'static str`. Previously, `to_analysis()` would allocate a new `String` for every lookup. Since `analyze_all` is called for every word and checks the lexicon first, this caused unnecessary allocations for every single keyword and common word in the source code.

### 📊 Impact
Reduces heap allocations for all lexicon-based words (keywords like `εἰ`, `ἕως`, `λεγε`, and common built-ins). For a program consisting mostly of keywords and built-ins, this eliminates a large portion of short-lived string allocations during the morphology phase.

###  microsc Measurement
Verified with `cargo test`. All tests pass. Existing semantics are preserved. Downstream `Constituent` still owns a `String`, so the allocation is deferred to when a valid sentence constituent is formed, rather than for every candidate analysis.

---
*PR created automatically by Jules for task [4621214819617987776](https://jules.google.com/task/4621214819617987776) started by @madmax983*