### PR TITLE
🛡️ Sentry: Fix state modification in failed condition check in Assembler

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -5,3 +5,7 @@
 ## [Panic Safety in Morphology Analysis]
 **Learning:** `analyze_all` in `src/morphology/mod.rs` was sorting analyses by confidence using `unwrap()` on `partial_cmp`. If `confidence` is `NaN`, this causes a panic.
 **Action:** Replaced `unwrap()` with `unwrap_or(std::cmp::Ordering::Equal)` to handle NaN safely. Always verify `partial_cmp` on floats is handled safely.
+
+## [State Modification in Condition Evaluation]
+**Learning:** In `src/semantic/assembler.rs`, `check_method_verbs` was popping from `pending_literals` inside a complex `if` condition using `&&`. If subsequent conditions (like `pending_subject` check) failed, the literal was already consumed and lost, causing a logic bug.
+**Action:** Always verify all preconditions (using `peek` or `last()`) before performing state-modifying operations (like `pop()`), especially in `if` conditions.

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -746,22 +746,23 @@ impl Assembler {
         // Check for split verb
         if crate::morphology::lexicon::is_split_verb(normalized) {
             // If we have a delimiter, create a split method
+            #[allow(clippy::collapsible_if)]
             if self.has_delimiter_preposition
-                && self.pending_subject.is_some()
                 && matches!(self.pending_literals.last(), Some(Literal::String(_)))
             {
-                // Safe to unwrap here because of the checks above
-                let delim = match self.pending_literals.pop() {
-                    Some(Literal::String(s)) => s,
-                    _ => unreachable!(),
-                };
-                let subj = self.pending_subject.as_ref().unwrap();
+                if let Some(ref subj) = self.pending_subject {
+                    // Safe to unwrap here because of the checks above
+                    let delim = match self.pending_literals.pop() {
+                        Some(Literal::String(s)) => s,
+                        _ => unreachable!(),
+                    };
 
-                let normalized_original = normalize_greek(&subj.original);
-                self.pending_string_method = Some(("split".to_string(), delim));
-                // Push back a property access for the split result
-                self.pending_property_accesses
-                    .push((normalized_original, "split".to_string()));
+                    let normalized_original = normalize_greek(&subj.original);
+                    self.pending_string_method = Some(("split".to_string(), delim));
+                    // Push back a property access for the split result
+                    self.pending_property_accesses
+                        .push((normalized_original, "split".to_string()));
+                }
             }
             return true;
         }
@@ -769,22 +770,23 @@ impl Assembler {
         // Check for join verb
         if crate::morphology::lexicon::is_join_verb(normalized) {
             // If we have a delimiter, create a join method
+            #[allow(clippy::collapsible_if)]
             if self.has_delimiter_preposition
-                && self.pending_subject.is_some()
                 && matches!(self.pending_literals.last(), Some(Literal::String(_)))
             {
-                // Safe to unwrap here because of the checks above
-                let delim = match self.pending_literals.pop() {
-                    Some(Literal::String(s)) => s,
-                    _ => unreachable!(),
-                };
-                let subj = self.pending_subject.as_ref().unwrap();
+                if let Some(ref subj) = self.pending_subject {
+                    // Safe to unwrap here because of the checks above
+                    let delim = match self.pending_literals.pop() {
+                        Some(Literal::String(s)) => s,
+                        _ => unreachable!(),
+                    };
 
-                let normalized_original = normalize_greek(&subj.original);
-                self.pending_string_method = Some(("join".to_string(), delim));
-                // Push back a property access for the join result
-                self.pending_property_accesses
-                    .push((normalized_original, "join".to_string()));
+                    let normalized_original = normalize_greek(&subj.original);
+                    self.pending_string_method = Some(("join".to_string(), delim));
+                    // Push back a property access for the join result
+                    self.pending_property_accesses
+                        .push((normalized_original, "join".to_string()));
+                }
             }
             return true;
         }

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -747,9 +747,16 @@ impl Assembler {
         if crate::morphology::lexicon::is_split_verb(normalized) {
             // If we have a delimiter, create a split method
             if self.has_delimiter_preposition
-                && let Some(Literal::String(delim)) = self.pending_literals.pop()
-                && let Some(ref subj) = self.pending_subject
+                && self.pending_subject.is_some()
+                && matches!(self.pending_literals.last(), Some(Literal::String(_)))
             {
+                // Safe to unwrap here because of the checks above
+                let delim = match self.pending_literals.pop() {
+                    Some(Literal::String(s)) => s,
+                    _ => unreachable!(),
+                };
+                let subj = self.pending_subject.as_ref().unwrap();
+
                 let normalized_original = normalize_greek(&subj.original);
                 self.pending_string_method = Some(("split".to_string(), delim));
                 // Push back a property access for the split result
@@ -763,9 +770,16 @@ impl Assembler {
         if crate::morphology::lexicon::is_join_verb(normalized) {
             // If we have a delimiter, create a join method
             if self.has_delimiter_preposition
-                && let Some(Literal::String(delim)) = self.pending_literals.pop()
-                && let Some(ref subj) = self.pending_subject
+                && self.pending_subject.is_some()
+                && matches!(self.pending_literals.last(), Some(Literal::String(_)))
             {
+                // Safe to unwrap here because of the checks above
+                let delim = match self.pending_literals.pop() {
+                    Some(Literal::String(s)) => s,
+                    _ => unreachable!(),
+                };
+                let subj = self.pending_subject.as_ref().unwrap();
+
                 let normalized_original = normalize_greek(&subj.original);
                 self.pending_string_method = Some(("join".to_string(), delim));
                 // Push back a property access for the join result

--- a/tests/semantic_assembler_edge_cases.rs
+++ b/tests/semantic_assembler_edge_cases.rs
@@ -1,52 +1,41 @@
-#[cfg(test)]
-mod tests {
-    use glossa::morphology::analyze;
-    use glossa::semantic::assembler::Assembler;
+use glossa::morphology::analyze;
+use glossa::semantic::assembler::Assembler;
 
-    #[test]
-    fn test_split_verb_consumes_literal_without_subject() {
-        let mut asm = Assembler::new();
+#[test]
+fn test_split_verb_consumes_literal_without_subject() {
+    let mut asm = Assembler::new();
 
-        // 1. Feed "κατά" (delimiter preposition)
-        // We need to feed it as a constituent or via a specialized method?
-        // Assembler::feed handles "κατά" via check_special_markers inside feed.
-        // But we need to pass a MorphAnalysis.
-        // Since "κατά" is a preposition, let's analyze it properly or mock it.
-        // The lexicon lookup inside feed does check_special_markers using normalized text.
-        // So any analysis with original="κατά" should work, provided it passes the initial checks.
-        // Actually, check_special_markers uses `normalized`.
+    // 1. Feed "κατά" (delimiter preposition)
+    let kata = analyze("κατα"); // Should be preposition
+    asm.feed(&kata, "κατά").unwrap();
 
-        let kata = analyze("κατα"); // Should be preposition
-        asm.feed(&kata, "κατά").unwrap();
+    // 2. Feed string literal " "
+    asm.feed_string(" ".to_string());
 
-        // 2. Feed string literal " "
-        asm.feed_string(" ".to_string());
+    // 3. Feed "σχίζεται" (split verb)
+    // This triggers check_method_verbs
+    let split = analyze("σχιζεται");
+    asm.feed(&split, "σχίζεται").unwrap();
 
-        // 3. Feed "σχίζεται" (split verb)
-        // This triggers check_method_verbs
-        let split = analyze("σχιζεται");
-        asm.feed(&split, "σχίζεται").unwrap();
+    // At this point, if the bug exists:
+    // - check_method_verbs returned true (so it was "handled")
+    // - pending_literals.pop() was called and consumed " "
+    // - pending_subject was None, so no property access was created.
 
-        // At this point, if the bug exists:
-        // - check_method_verbs returned true (so it was "handled")
-        // - pending_literals.pop() was called and consumed " "
-        // - pending_subject was None, so no property access was created.
+    // 4. Feed "λόγος" (subject)
+    let subject = analyze("λογος");
+    asm.feed(&subject, "λόγος").unwrap();
 
-        // 4. Feed "λόγος" (subject)
-        let subject = analyze("λογος");
-        asm.feed(&subject, "λόγος").unwrap();
+    // 5. Feed "λέγε" (print verb)
+    let verb = analyze("λεγε");
+    asm.feed(&verb, "λέγε").unwrap();
 
-        // 5. Feed "λέγε" (print verb)
-        let verb = analyze("λεγε");
-        asm.feed(&verb, "λέγε").unwrap();
+    let stmt = asm.finalize().unwrap();
 
-        let stmt = asm.finalize().unwrap();
-
-        // If the literal was consumed by the failed split pattern match, it will be missing.
-        // If it was preserved, it should be in stmt.literals.
-        assert!(
-            !stmt.literals.is_empty(),
-            "Literal should not be consumed if split pattern fails to match due to missing subject"
-        );
-    }
+    // If the literal was consumed by the failed split pattern match, it will be missing.
+    // If it was preserved, it should be in stmt.literals.
+    assert!(
+        !stmt.literals.is_empty(),
+        "Literal should not be consumed if split pattern fails to match due to missing subject"
+    );
 }

--- a/tests/semantic_assembler_edge_cases.rs
+++ b/tests/semantic_assembler_edge_cases.rs
@@ -1,0 +1,52 @@
+#[cfg(test)]
+mod tests {
+    use glossa::morphology::analyze;
+    use glossa::semantic::assembler::Assembler;
+
+    #[test]
+    fn test_split_verb_consumes_literal_without_subject() {
+        let mut asm = Assembler::new();
+
+        // 1. Feed "κατά" (delimiter preposition)
+        // We need to feed it as a constituent or via a specialized method?
+        // Assembler::feed handles "κατά" via check_special_markers inside feed.
+        // But we need to pass a MorphAnalysis.
+        // Since "κατά" is a preposition, let's analyze it properly or mock it.
+        // The lexicon lookup inside feed does check_special_markers using normalized text.
+        // So any analysis with original="κατά" should work, provided it passes the initial checks.
+        // Actually, check_special_markers uses `normalized`.
+
+        let kata = analyze("κατα"); // Should be preposition
+        asm.feed(&kata, "κατά").unwrap();
+
+        // 2. Feed string literal " "
+        asm.feed_string(" ".to_string());
+
+        // 3. Feed "σχίζεται" (split verb)
+        // This triggers check_method_verbs
+        let split = analyze("σχιζεται");
+        asm.feed(&split, "σχίζεται").unwrap();
+
+        // At this point, if the bug exists:
+        // - check_method_verbs returned true (so it was "handled")
+        // - pending_literals.pop() was called and consumed " "
+        // - pending_subject was None, so no property access was created.
+
+        // 4. Feed "λόγος" (subject)
+        let subject = analyze("λογος");
+        asm.feed(&subject, "λόγος").unwrap();
+
+        // 5. Feed "λέγε" (print verb)
+        let verb = analyze("λεγε");
+        asm.feed(&verb, "λέγε").unwrap();
+
+        let stmt = asm.finalize().unwrap();
+
+        // If the literal was consumed by the failed split pattern match, it will be missing.
+        // If it was preserved, it should be in stmt.literals.
+        assert!(
+            !stmt.literals.is_empty(),
+            "Literal should not be consumed if split pattern fails to match due to missing subject"
+        );
+    }
+}


### PR DESCRIPTION
This PR fixes a bug in the `Assembler` where string literals were consumed from `pending_literals` inside an `if` condition check for split/join verbs. If the subsequent check for `pending_subject` failed, the literal was already removed and lost, leading to incorrect parsing.

The fix involves checking for the subject's presence and peeking at the literal before consuming it.

A regression test was added to verify the fix.

---
*PR created automatically by Jules for task [17435540599848902895](https://jules.google.com/task/17435540599848902895) started by @madmax983*