### PR TITLE
🎻 Bard: Documentation improvements for core modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,52 @@
 [![CI](https://github.com/madmax983/glossa/actions/workflows/ci.yml/badge.svg)](https://github.com/madmax983/glossa/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/madmax983/glossa/branch/trunk/graph/badge.svg)](https://codecov.io/gh/madmax983/glossa)
 
-A programming language using Ancient Greek syntax that compiles to Rust.
+> *Code as the ancients intended.*
+
+ΓΛΩΣΣΑ is a compiled programming language where Ancient Greek morphology determines semantics. It compiles directly to Rust, offering type safety with authentic linguistic structure.
+
+## The Philosophy
+
+In modern languages, meaning is determined by word order: `func(a, b)` is different from `func(b, a)`.
+In Ancient Greek, meaning is determined by **case endings**.
+
+ΓΛΩΣΣΑ embraces this paradigm:
+
+* **Nominative Case** (-ος, -η, -α) marks the **Subject** (Agent).
+* **Accusative Case** (-ον, -ην, -αν) marks the **Object** (Patient).
+* **Verb Endings** (-ω, -ει, -ετε) encode Person, Number, and Aspect.
+
+This allows for **Free Word Order**:
+
+```glossa
+// All of these are identical:
+ὁ ἄνθρωπος τὸν λόγον λέγει.  // The man says the word.
+τὸν λόγον λέγει ὁ ἄνθρωπος.  // The word says the man.
+λέγει ὁ ἄνθρωπος τὸν λόγον.  // Says the man the word.
+```
+
+## Quick Start: The Hero's Journey
+
+Here is a simple program that defines a user struct and greets them.
+
+```glossa
+// Define a type (struct)
+εἶδος Χρήστης ὁρίζειν {
+    ὄνομα ὄνομα.      // field: String
+    ἡλικία ἀριθμός.   // field: i64
+}
+
+// Create a new user instance
+// "user" (nominative) "new" (adjective) "User" (type) ...
+χρήστης νέον Χρήστης
+    «Σωκράτης»
+    70
+ἔστω.
+
+// Access property and print
+// "of the user" (genitive) "name" (nominative) "say" (verb)
+χρήστου ὄνομα λέγε.
+```
 
 ## Features
 

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -188,6 +188,10 @@ pub fn analyze_all(word: &str) -> Vec<MorphAnalysis> {
 }
 
 /// Check if the word is a single Greek letter (used as mathematical variable)
+///
+/// Single letters like `α`, `β`, `π` are often used as variable names in ΓΛΩΣΣΑ.
+/// This function identifies them so the fallback logic can treat them as
+/// nominative nouns even if they aren't in the lexicon.
 fn is_single_greek_letter(word: &str) -> bool {
     let chars: Vec<char> = word.chars().collect();
     if chars.len() != 1 {
@@ -204,6 +208,24 @@ fn is_single_greek_letter(word: &str) -> bool {
 }
 
 /// Check if two analyses are compatible (could refer to the same word in context)
+///
+/// Returns `true` if the analyses do not have conflicting grammatical features.
+/// Used during disambiguation to check if a word's potential analysis fits
+/// with the surrounding context (e.g., article agreement).
+///
+/// # Examples
+///
+/// ```
+/// use glossa::morphology::{analyses_compatible, MorphAnalysis, PartOfSpeech, Case};
+///
+/// let mut a = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
+/// a.case = Some(Case::Nominative);
+///
+/// let mut b = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
+/// b.case = Some(Case::Accusative);
+///
+/// assert!(!analyses_compatible(&a, &b));
+/// ```
 pub fn analyses_compatible(a: &MorphAnalysis, b: &MorphAnalysis) -> bool {
     // Check case agreement if both have cases
     if let (Some(case_a), Some(case_b)) = (a.case, b.case)

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -300,31 +300,38 @@ pub struct Assembler {
 pub enum AssemblyError {
     /// Two subjects found in the same statement (Nominative collision)
     ///
-    /// Example: `ὁ ἄνθρωπος ὁ θεὸς λέγει` (The man the god says)
+    /// # Example
+    /// `ὁ ἄνθρωπος ὁ θεὸς λέγει` (The man the god says)
     #[error("Διπλοῦν ὑποκείμενον! Δύο βασιλεῖς οὐ δύνανται μιᾶς πόλεως ἄρχειν.")]
     DoubleSubject,
 
     /// Two objects found in the same statement (Accusative collision)
     ///
-    /// Example: `τὸν λόγον τὴν πόλιν βλέπω` (I see the word the city)
+    /// # Example
+    /// `τὸν λόγον τὴν πόλιν βλέπω` (I see the word the city)
     #[error("Διπλοῦν ἀντικείμενον! Ἓν μόνον κατηγορεῖς.")]
     DoubleObject,
 
     /// Two verbs found in the same statement
     ///
-    /// Example: `λέγει γράφει ὁ ἄνθρωπος` (The man says writes)
+    /// # Example
+    /// `λέγει γράφει ὁ ἄνθρωπος` (The man says writes)
     #[error("Διπλοῦν ῥῆμα! Μία πρᾶξις ἑκάστοτε.")]
     DoubleVerb,
 
     /// No verb found in the statement
     ///
     /// Note: Pure expressions (like `5`) are allowed, but incomplete sentences trigger this.
+    ///
+    /// # Example
+    /// `ὁ ἄνθρωπος τὸν λόγον` (The man the word ... [missing action])
     #[error("Ῥῆμα οὐχ εὑρέθη! Οὐδὲν ἐγένετο.")]
     MissingVerb,
 
     /// Subject and Verb do not agree in number/person
     ///
-    /// Example: `ὁ ἄνθρωπος (Singular) λέγουσιν (Plural)`
+    /// # Example
+    /// `ὁ ἄνθρωπος (Singular) λέγουσιν (Plural)`
     #[error("Ἀσυμφωνία: ὑποκείμενον {subject:?} ἀλλὰ ῥῆμα {verb:?}")]
     SubjectVerbDisagreement {
         subject: (Option<Person>, Option<Number>),
@@ -333,7 +340,8 @@ pub enum AssemblyError {
 
     /// Adjective and Noun do not agree in gender
     ///
-    /// Example: `ὁ καλὸς (Masc) γυνή (Fem)`
+    /// # Example
+    /// `ὁ καλὸς (Masc) γυνή (Fem)`
     #[error("Ἀσυμφωνία γένους: {word1} ({gender1:?}) πρὸς {word2} ({gender2:?})")]
     GenderMismatch {
         word1: String,

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -1,4 +1,31 @@
 //! Conversion from assembled statements to analyzed statements
+//!
+//! This module acts as the "interpreter" of the assembled semantic structure.
+//! While the [`Assembler`](crate::semantic::Assembler) ensures grammatical correctness (Subject-Verb agreement),
+//! this module assigns *meaning* to the grammatical structures.
+//!
+//! # Pattern Detection Strategy
+//!
+//! The [`classify_assembled_statement`] function uses a combination of strategies to
+//! understand the statement's intent:
+//!
+//! 1. **Pattern Delegation**: Complex patterns are delegated to specialized detectors in `patterns.rs`.
+//!    - Iterator chains (map/filter/fold)
+//!    - Struct instantiation (via `try_parse_struct_instantiation`)
+//!    - Trait method calls (via `try_parse_trait_method_call`)
+//!
+//! 2. **Verb-Based Classification**: The main verb determines the primary statement kind.
+//!    - **Binding** (`ἔστω`): Variable definition (`let x = ...`)
+//!    - **Assignment** (`γίγνεται`): Variable mutation (`x = ...`)
+//!    - **Collection Ops** (`ὠθεῖ`, `ἕλκεται`, `τίθησι`): `push`, `pop`, `insert`
+//!    - **Print** (`λέγε`, `γράφε`): Output (`println!`)
+//!    - **Query** (`?`): Expressions ending in a question mark
+//!
+//! 3. **Constituent Analysis**:
+//!    - **Subject**: Usually the target or agent (e.g., the collection being pushed to).
+//!    - **Object/Literals**: The value or argument.
+//!    - **Nominatives**: Extra nominatives often denote function names or predicate values.
+//!    - **Genitives**: Used for property access (`pi.xi`) or ownership.
 
 use super::expressions::{
     analyze_argument_expr, build_binary_expr, build_expressions_from_literals_and_ops,


### PR DESCRIPTION
Updated documentation across key modules to improve clarity and tell the "story" of the codebase.

## Morphology (`src/morphology/mod.rs`)
- Documented `is_single_greek_letter`: Explains why single letters (α, β) are treated as nouns (variables).
- Documented `analyses_compatible`: Added examples showing how disambiguation checks agreement.

## Assembler (`src/semantic/assembler.rs`)
- Enhanced `AssemblyError` with examples: Each error now shows a code snippet that would trigger it (e.g., "The man the god says" for `DoubleSubject`).

## Conversion (`src/semantic/conversion.rs`)
- Added module-level documentation: Explains the "Pattern Detection Strategy" used to convert assembled statements into analyzed expressions.
- Clarifies the hybrid approach of verb-based classification (inline) vs. pattern delegation (to `patterns.rs`).

## README (`README.md`)
- Added "The Philosophy": Explains word order independence via case endings.
- Added "Quick Start": A "Hero's Journey" example showing struct definition, instantiation, and property access.


---
*PR created automatically by Jules for task [9669440854780491620](https://jules.google.com/task/9669440854780491620) started by @madmax983*