### PR TITLE
⚡ Bolt: Zero-allocation ending matching

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -423,21 +423,17 @@ fn match_verb_endings(
 }
 
 /// Match a word against ALL verb endings (for ambiguity resolution)
-fn match_verb_endings_all(
-    word: &str,
-    endings: &[(&str, Person, Number)],
-) -> Vec<(String, Person, Number)> {
-    let mut matches = Vec::new();
-
+fn match_verb_endings_all<F>(word: &str, endings: &[(&str, Person, Number)], mut callback: F)
+where
+    F: FnMut(&str, Person, Number),
+{
     for (ending, person, number) in endings {
         if let Some(stem) = word.strip_suffix(ending)
             && !stem.is_empty()
         {
-            matches.push((stem.to_string(), *person, *number));
+            callback(stem, *person, *number);
         }
     }
-
-    matches
 }
 
 /// Analyze a word as a verb, returning ALL possible analyses
@@ -530,14 +526,12 @@ pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
     ];
 
     for pattern in &patterns {
-        let matches = match_verb_endings_all(word, pattern.endings);
-
-        for (stem, person, number) in matches {
+        match_verb_endings_all(word, pattern.endings, |stem, person, number| {
             // Handle augment stripping for indicative aorists
             let lemma_stem = if pattern.has_augment {
-                strip_augment(&stem)
+                Cow::Owned(strip_augment(stem))
             } else {
-                stem.clone()
+                Cow::Borrowed(stem)
             };
 
             // Calculate confidence
@@ -557,7 +551,7 @@ pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
                 voice: Some(pattern.voice),
                 confidence,
             });
-        }
+        });
     }
 
     // Try infinitives

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -203,19 +203,18 @@ fn match_endings(word: &str, endings: &[(&str, Case, Number)]) -> Option<(String
     None
 }
 
-/// Match a word against ALL possible endings, returning all matches
-fn match_endings_all(word: &str, endings: &[(&str, Case, Number)]) -> Vec<(String, Case, Number)> {
-    let mut matches = Vec::new();
-
+/// Match a word against ALL possible endings, calling callback for each match
+fn match_endings_all<F>(word: &str, endings: &[(&str, Case, Number)], mut callback: F)
+where
+    F: FnMut(&str, Case, Number),
+{
     for (ending, case, number) in endings {
         if let Some(stem) = word.strip_suffix(ending)
             && !stem.is_empty()
         {
-            matches.push((stem.to_string(), *case, *number));
+            callback(stem, *case, *number);
         }
     }
-
-    matches
 }
 
 /// Analyze a word as a noun, returning ALL possible analyses
@@ -271,9 +270,7 @@ pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
     ];
 
     for decl in &declensions {
-        let matches = match_endings_all(word, decl.endings);
-
-        for (stem, case, number) in matches {
+        match_endings_all(word, decl.endings, |stem, case, number| {
             // Calculate confidence based on ending length and distinctiveness
             let ending_len = word.len() - stem.len();
             let length_bonus = (ending_len as f32 - 1.0) * 0.05; // Longer = better
@@ -291,7 +288,7 @@ pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
                 voice: None,
                 confidence,
             });
-        }
+        });
     }
 
     // Deduplicate identical analyses (same case/number/gender)


### PR DESCRIPTION
⚡ Bolt: Zero-allocation ending matching

💡 What: Switched `match_endings_all` and `match_verb_endings_all` to use closures (`FnMut`) instead of returning `Vec<(String, ...)>`. Also optimized verb lemma generation to use `Cow` and avoid `String::clone()`.

🎯 Why: The previous implementation allocated an intermediate `Vec` and multiple `String`s (for stems) for every word analysis, even though they were immediately consumed and discarded. This created unnecessary heap pressure in the compiler's hot path (morphological analysis).

📊 Impact: 
- Eliminates 1 `Vec` allocation per word per analysis type (noun/verb).
- Eliminates `String` allocation for every matching stem candidate.
- Eliminates `String` clone for non-augmented verb stems.
- Expected to significantly reduce allocator traffic during parsing of large files.

🔬 Measurement: `cargo test` confirms no regressions. Performance gain is structural (zero-allocation iteration vs vector allocation).

---
*PR created automatically by Jules for task [2054164403866090861](https://jules.google.com/task/2054164403866090861) started by @madmax983*