### PR TITLE
🗺️ Atlas: Split Assembler "God Struct"

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -20,3 +20,12 @@
 4. Refactored `mod.rs` to re-export `model` contents.
 5. Removed legacy `SemanticAnalyzer` code that was duplicating logic.
 **Stability:** Strictly separates Data (Model), Types (Type System), and Logic (Analysis). `model.rs` depends on `types.rs`, but `types.rs` is now leaf-level with no dependencies on the AST.
+
+## 2026-01-31 - [Splitting The Blob: Assembler]
+**Tangle:** `src/semantic/assembler.rs` was a single file mixing data models, error definitions, and complex state machine logic, making it a "God Struct" candidate and difficult to maintain.
+**Blueprint:**
+1. Created `src/semantic/assembler/` directory.
+2. Extracted data models (`AssembledStatement`, `Constituent`, etc.) to `src/semantic/assembler/model.rs`.
+3. Extracted errors (`AssemblyError`) to `src/semantic/assembler/errors.rs`.
+4. Moved core logic and tests to `src/semantic/assembler/mod.rs`.
+**Stability:** Improves cohesion by separating data, errors, and logic. Reduces the size of the assembler module file and makes types easier to find.

--- a/src/semantic/assembler/errors.rs
+++ b/src/semantic/assembler/errors.rs
@@ -1,0 +1,63 @@
+//! Errors for the semantic assembler
+//!
+//! This module defines errors that can occur during sentence assembly,
+//! such as grammatical disagreement or duplicate constituents.
+
+use crate::morphology::{Gender, Number, Person};
+use thiserror::Error;
+
+/// Errors that can occur during assembly
+#[derive(Debug, Clone, Error)]
+pub enum AssemblyError {
+    /// Two subjects found in the same statement (Nominative collision)
+    ///
+    /// # Example
+    /// `ὁ ἄνθρωπος ὁ θεὸς λέγει` (The man the god says)
+    #[error("Διπλοῦν ὑποκείμενον! Δύο βασιλεῖς οὐ δύνανται μιᾶς πόλεως ἄρχειν.")]
+    DoubleSubject,
+
+    /// Two objects found in the same statement (Accusative collision)
+    ///
+    /// # Example
+    /// `τὸν λόγον τὴν πόλιν βλέπω` (I see the word the city)
+    #[error("Διπλοῦν ἀντικείμενον! Ἓν μόνον κατηγορεῖς.")]
+    DoubleObject,
+
+    /// Two verbs found in the same statement
+    ///
+    /// # Example
+    /// `λέγει γράφει ὁ ἄνθρωπος` (The man says writes)
+    #[error("Διπλοῦν ῥῆμα! Μία πρᾶξις ἑκάστοτε.")]
+    DoubleVerb,
+
+    /// No verb found in the statement
+    ///
+    /// Note: Pure expressions (like `5`) are allowed, but incomplete sentences trigger this.
+    ///
+    /// # Example
+    /// `ὁ ἄνθρωπος τὸν λόγον` (The man the word ... [missing action])
+    #[error("Ῥῆμα οὐχ εὑρέθη! Οὐδὲν ἐγένετο.")]
+    MissingVerb,
+
+    /// Subject and Verb do not agree in number/person
+    ///
+    /// # Example
+    /// `ὁ ἄνθρωπος (Singular) λέγουσιν (Plural)`
+    #[error("Ἀσυμφωνία: ὑποκείμενον {subject:?} ἀλλὰ ῥῆμα {verb:?}")]
+    SubjectVerbDisagreement {
+        subject: (Option<Person>, Option<Number>),
+        verb: (Option<Person>, Option<Number>),
+    },
+
+    /// Adjective and Noun do not agree in gender
+    ///
+    /// # Example
+    /// `ὁ καλὸς (Masc) γυνή (Fem)`
+    #[error("Ἀσυμφωνία γένους: {word1} ({gender1:?}) πρὸς {word2} ({gender2:?})")]
+    GenderMismatch {
+        word1: String,
+        gender1: Gender,
+        word2: String,
+        gender2: Gender,
+    },
+}

--- a/src/semantic/assembler/mod.rs
+++ b/src/semantic/assembler/mod.rs
@@ -660,7 +660,7 @@ impl Default for Assembler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::morphology::{analyze, Voice};
+    use crate::morphology::{Voice, analyze};
 
     #[test]
     fn test_operator_detection() {

--- a/src/semantic/assembler/mod.rs
+++ b/src/semantic/assembler/mod.rs
@@ -51,196 +51,16 @@
 //!
 //! The assembler handles all of these correctly, producing the same assembled semantic representation.
 
+pub mod errors;
+pub mod model;
+
+pub use errors::*;
+pub use model::*;
+
 use crate::ast::{Expr, Word};
 use crate::grammar::normalize_greek;
 use crate::morphology::lexicon::BinaryOp;
-use crate::morphology::{
-    Case, Gender, Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice,
-};
-
-/// A fully assembled statement with all grammatical roles filled
-///
-/// This struct represents the "final state" of a sentence after parsing.
-/// It contains all the semantic components (subject, verb, object, etc.)
-/// extracted from the input stream.
-#[derive(Debug, Clone)]
-pub struct AssembledStatement {
-    /// The subject (nominative) - the agent/doer
-    ///
-    /// Example: **ὁ ἄνθρωπος** λέγει (The **man** speaks)
-    pub subject: Option<Constituent>,
-
-    /// Additional nominatives (for function names, etc.)
-    ///
-    /// Used in patterns where multiple nominatives appear, such as
-    /// function calls or predicate nominatives.
-    pub nominatives: Vec<Constituent>,
-
-    /// The verb - the action
-    ///
-    /// Example: ὁ ἄνθρωπος **λέγει** (The man **speaks**)
-    pub verb: Option<VerbConstituent>,
-
-    /// The direct object (accusative) - receives the action
-    ///
-    /// Example: βλέπω **τὸν ἄνθρωπον** (I see **the man**)
-    pub object: Option<Constituent>,
-    /// The indirect object (dative) - recipient/beneficiary
-    ///
-    /// Example: δίδωμι **τῷ ἀνθρώπῳ** (I give **to the man**)
-    pub indirect: Option<Constituent>,
-
-    /// Possessors/sources (genitive) - attached to other constituents
-    ///
-    /// Example: τὸ τοῦ **ἀνθρώπου** βιβλίον (The **man's** book)
-    pub genitives: Vec<Constituent>,
-
-    /// Adjectives modifying nouns (νέον for "new")
-    ///
-    /// These are accumulated and applied to the relevant nouns during semantic analysis.
-    pub adjectives: Vec<Constituent>,
-
-    /// Literal values (strings, numbers) that appeared
-    pub literals: Vec<Literal>,
-    /// Array literals that appeared
-    pub arrays: Vec<Vec<Expr>>,
-    /// Index accesses (array, index)
-    pub index_accesses: Vec<(Expr, Expr)>,
-    /// Property accesses (owner, property)
-    pub property_accesses: Vec<(String, String)>,
-    /// Binary operators found between expressions
-    pub operators: Vec<BinaryOp>,
-    /// Parenthesized blocks (nested expressions)
-    pub blocks: Vec<Vec<crate::ast::Statement>>,
-    /// Nested phrases (parenthesized function calls)
-    pub nested_phrases: Vec<Vec<Expr>>,
-    /// Participles (used for lambdas/closures)
-    pub participles: Vec<ParticipleConstituent>,
-    /// Unwrap expressions (expr!)
-    pub unwraps: Vec<Expr>,
-    /// Whether this is a query (ends with ?)
-    pub is_query: bool,
-    /// Whether this statement propagates (ends with ;) - converts to `?` in Rust
-    pub is_propagate: bool,
-    /// Whether this binding has the mutable marker (μετά)
-    pub has_mutable_marker: bool,
-    /// Whether this statement has the containment preposition (ἐν)
-    /// Used for contains patterns: element ἐν set? → set.contains(&element)
-    pub has_containment_preposition: bool,
-    /// Whether this statement has the delimiter preposition (κατά)
-    /// Used for split/join patterns: string κατά delimiter σχίζεται → string.split(delimiter)
-    pub has_delimiter_preposition: bool,
-    /// String method call: (method_name, delimiter)
-    /// Used for split/join patterns
-    pub string_method: Option<(String, String)>,
-}
-
-/// A noun/pronoun constituent with its grammatical info
-///
-/// This represents a word that fills a nominal slot (Subject, Object, etc.).
-/// It carries both its original surface form and its normalized lemma.
-#[derive(Debug, Clone)]
-pub struct Constituent {
-    /// The dictionary form
-    ///
-    /// Used for semantic analysis and code generation.
-    /// Example: "ανθρωπος" (from "ἄνθρωπος")
-    pub lemma: String,
-
-    /// Original text as it appeared
-    ///
-    /// Preserved for error messages and display purposes.
-    /// Example: "ἄνθρωπος"
-    pub original: String,
-
-    /// Grammatical case
-    ///
-    /// Determines which slot this constituent fills:
-    /// - `Nominative` -> Subject
-    /// - `Accusative` -> Object
-    /// - `Dative` -> Indirect Object
-    pub case: Case,
-
-    /// Grammatical number
-    ///
-    /// Used for subject-verb agreement checks.
-    pub number: Option<Number>,
-
-    /// Grammatical gender
-    ///
-    /// Used for adjective-noun agreement checks.
-    pub gender: Option<Gender>,
-}
-
-/// A verb constituent with its grammatical info
-///
-/// This represents the main action of the sentence.
-#[derive(Debug, Clone)]
-pub struct VerbConstituent {
-    /// The dictionary form (1st person singular present)
-    ///
-    /// Example: "λεγω" (from "λέγει")
-    pub lemma: String,
-
-    /// Original text as it appeared
-    ///
-    /// Example: "λέγει"
-    pub original: String,
-
-    /// Person (1st, 2nd, 3rd)
-    ///
-    /// Used for agreement with the subject.
-    pub person: Option<Person>,
-
-    /// Number (singular, plural)
-    ///
-    /// Used for agreement with the subject.
-    pub number: Option<Number>,
-
-    /// Tense (present, aorist, etc.)
-    ///
-    /// Determines execution semantics (e.g., Aorist = immediate, Present = continuous).
-    pub tense: Option<Tense>,
-
-    /// Mood (indicative, imperative, etc.)
-    ///
-    /// Determines sentence type (Statement vs Command).
-    pub mood: Option<Mood>,
-
-    /// Voice (active, middle, passive)
-    ///
-    /// Determines the relationship between subject and action.
-    /// - Active: Subject does action
-    /// - Middle: Subject acts on self/for self (often used for specific ops like `.pop()`)
-    pub voice: Option<Voice>,
-}
-
-/// A participle constituent (used for lambdas/closures)
-#[derive(Debug, Clone)]
-pub struct ParticipleConstituent {
-    /// The verb stem extracted from the participle
-    pub verb_lemma: String,
-    /// Original text as it appeared
-    pub original: String,
-    /// Tense (present, aorist, perfect)
-    pub tense: Tense,
-    /// Voice (active, middle, passive)
-    pub voice: Voice,
-    /// Case (adjectival property)
-    pub case: Case,
-    /// Gender (adjectival property)
-    pub gender: Gender,
-    /// Number (adjectival property)
-    pub number: Number,
-}
-
-/// A literal value
-#[derive(Debug, Clone)]
-pub enum Literal {
-    String(String),
-    Number(i64),
-    Boolean(bool),
-}
+use crate::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech, Person};
 
 /// The slot-based assembler
 ///
@@ -293,62 +113,6 @@ pub struct Assembler {
     pending_string_method: Option<(String, String)>,
     is_query: bool,
     is_propagate: bool,
-}
-
-/// Errors that can occur during assembly
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum AssemblyError {
-    /// Two subjects found in the same statement (Nominative collision)
-    ///
-    /// # Example
-    /// `ὁ ἄνθρωπος ὁ θεὸς λέγει` (The man the god says)
-    #[error("Διπλοῦν ὑποκείμενον! Δύο βασιλεῖς οὐ δύνανται μιᾶς πόλεως ἄρχειν.")]
-    DoubleSubject,
-
-    /// Two objects found in the same statement (Accusative collision)
-    ///
-    /// # Example
-    /// `τὸν λόγον τὴν πόλιν βλέπω` (I see the word the city)
-    #[error("Διπλοῦν ἀντικείμενον! Ἓν μόνον κατηγορεῖς.")]
-    DoubleObject,
-
-    /// Two verbs found in the same statement
-    ///
-    /// # Example
-    /// `λέγει γράφει ὁ ἄνθρωπος` (The man says writes)
-    #[error("Διπλοῦν ῥῆμα! Μία πρᾶξις ἑκάστοτε.")]
-    DoubleVerb,
-
-    /// No verb found in the statement
-    ///
-    /// Note: Pure expressions (like `5`) are allowed, but incomplete sentences trigger this.
-    ///
-    /// # Example
-    /// `ὁ ἄνθρωπος τὸν λόγον` (The man the word ... [missing action])
-    #[error("Ῥῆμα οὐχ εὑρέθη! Οὐδὲν ἐγένετο.")]
-    MissingVerb,
-
-    /// Subject and Verb do not agree in number/person
-    ///
-    /// # Example
-    /// `ὁ ἄνθρωπος (Singular) λέγουσιν (Plural)`
-    #[error("Ἀσυμφωνία: ὑποκείμενον {subject:?} ἀλλὰ ῥῆμα {verb:?}")]
-    SubjectVerbDisagreement {
-        subject: (Option<Person>, Option<Number>),
-        verb: (Option<Person>, Option<Number>),
-    },
-
-    /// Adjective and Noun do not agree in gender
-    ///
-    /// # Example
-    /// `ὁ καλὸς (Masc) γυνή (Fem)`
-    #[error("Ἀσυμφωνία γένους: {word1} ({gender1:?}) πρὸς {word2} ({gender2:?})")]
-    GenderMismatch {
-        word1: String,
-        gender1: Gender,
-        word2: String,
-        gender2: Gender,
-    },
 }
 
 impl Assembler {
@@ -896,7 +660,7 @@ impl Default for Assembler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::morphology::analyze;
+    use crate::morphology::{analyze, Voice};
 
     #[test]
     fn test_operator_detection() {

--- a/src/semantic/assembler/model.rs
+++ b/src/semantic/assembler/model.rs
@@ -1,0 +1,192 @@
+//! Data models for the semantic assembler
+//!
+//! This module contains the data structures representing the assembled
+//! sentence components.
+
+use crate::ast::Expr;
+use crate::morphology::lexicon::BinaryOp;
+use crate::morphology::{Case, Gender, Mood, Number, Person, Tense, Voice};
+
+/// A fully assembled statement with all grammatical roles filled
+///
+/// This struct represents the "final state" of a sentence after parsing.
+/// It contains all the semantic components (subject, verb, object, etc.)
+/// extracted from the input stream.
+#[derive(Debug, Clone)]
+pub struct AssembledStatement {
+    /// The subject (nominative) - the agent/doer
+    ///
+    /// Example: **ὁ ἄνθρωπος** λέγει (The **man** speaks)
+    pub subject: Option<Constituent>,
+
+    /// Additional nominatives (for function names, etc.)
+    ///
+    /// Used in patterns where multiple nominatives appear, such as
+    /// function calls or predicate nominatives.
+    pub nominatives: Vec<Constituent>,
+
+    /// The verb - the action
+    ///
+    /// Example: ὁ ἄνθρωπος **λέγει** (The man **speaks**)
+    pub verb: Option<VerbConstituent>,
+
+    /// The direct object (accusative) - receives the action
+    ///
+    /// Example: βλέπω **τὸν ἄνθρωπον** (I see **the man**)
+    pub object: Option<Constituent>,
+    /// The indirect object (dative) - recipient/beneficiary
+    ///
+    /// Example: δίδωμι **τῷ ἀνθρώπῳ** (I give **to the man**)
+    pub indirect: Option<Constituent>,
+
+    /// Possessors/sources (genitive) - attached to other constituents
+    ///
+    /// Example: τὸ τοῦ **ἀνθρώπου** βιβλίον (The **man's** book)
+    pub genitives: Vec<Constituent>,
+
+    /// Adjectives modifying nouns (νέον for "new")
+    ///
+    /// These are accumulated and applied to the relevant nouns during semantic analysis.
+    pub adjectives: Vec<Constituent>,
+
+    /// Literal values (strings, numbers) that appeared
+    pub literals: Vec<Literal>,
+    /// Array literals that appeared
+    pub arrays: Vec<Vec<Expr>>,
+    /// Index accesses (array, index)
+    pub index_accesses: Vec<(Expr, Expr)>,
+    /// Property accesses (owner, property)
+    pub property_accesses: Vec<(String, String)>,
+    /// Binary operators found between expressions
+    pub operators: Vec<BinaryOp>,
+    /// Parenthesized blocks (nested expressions)
+    pub blocks: Vec<Vec<crate::ast::Statement>>,
+    /// Nested phrases (parenthesized function calls)
+    pub nested_phrases: Vec<Vec<Expr>>,
+    /// Participles (used for lambdas/closures)
+    pub participles: Vec<ParticipleConstituent>,
+    /// Unwrap expressions (expr!)
+    pub unwraps: Vec<Expr>,
+    /// Whether this is a query (ends with ?)
+    pub is_query: bool,
+    /// Whether this statement propagates (ends with ;) - converts to `?` in Rust
+    pub is_propagate: bool,
+    /// Whether this binding has the mutable marker (μετά)
+    pub has_mutable_marker: bool,
+    /// Whether this statement has the containment preposition (ἐν)
+    /// Used for contains patterns: element ἐν set? → set.contains(&element)
+    pub has_containment_preposition: bool,
+    /// Whether this statement has the delimiter preposition (κατά)
+    /// Used for split/join patterns: string κατά delimiter σχίζεται → string.split(delimiter)
+    pub has_delimiter_preposition: bool,
+    /// String method call: (method_name, delimiter)
+    /// Used for split/join patterns
+    pub string_method: Option<(String, String)>,
+}
+
+/// A noun/pronoun constituent with its grammatical info
+///
+/// This represents a word that fills a nominal slot (Subject, Object, etc.).
+/// It carries both its original surface form and its normalized lemma.
+#[derive(Debug, Clone)]
+pub struct Constituent {
+    /// The dictionary form
+    ///
+    /// Used for semantic analysis and code generation.
+    /// Example: "ανθρωπος" (from "ἄνθρωπος")
+    pub lemma: String,
+
+    /// Original text as it appeared
+    ///
+    /// Preserved for error messages and display purposes.
+    /// Example: "ἄνθρωπος"
+    pub original: String,
+
+    /// Grammatical case
+    ///
+    /// Determines which slot this constituent fills:
+    /// - `Nominative` -> Subject
+    /// - `Accusative` -> Object
+    /// - `Dative` -> Indirect Object
+    pub case: Case,
+
+    /// Grammatical number
+    ///
+    /// Used for subject-verb agreement checks.
+    pub number: Option<Number>,
+
+    /// Grammatical gender
+    ///
+    /// Used for adjective-noun agreement checks.
+    pub gender: Option<Gender>,
+}
+
+/// A verb constituent with its grammatical info
+///
+/// This represents the main action of the sentence.
+#[derive(Debug, Clone)]
+pub struct VerbConstituent {
+    /// The dictionary form (1st person singular present)
+    ///
+    /// Example: "λεγω" (from "λέγει")
+    pub lemma: String,
+
+    /// Original text as it appeared
+    ///
+    /// Example: "λέγει"
+    pub original: String,
+
+    /// Person (1st, 2nd, 3rd)
+    ///
+    /// Used for agreement with the subject.
+    pub person: Option<Person>,
+
+    /// Number (singular, plural)
+    ///
+    /// Used for agreement with the subject.
+    pub number: Option<Number>,
+
+    /// Tense (present, aorist, etc.)
+    ///
+    /// Determines execution semantics (e.g., Aorist = immediate, Present = continuous).
+    pub tense: Option<Tense>,
+
+    /// Mood (indicative, imperative, etc.)
+    ///
+    /// Determines sentence type (Statement vs Command).
+    pub mood: Option<Mood>,
+
+    /// Voice (active, middle, passive)
+    ///
+    /// Determines the relationship between subject and action.
+    /// - Active: Subject does action
+    /// - Middle: Subject acts on self/for self (often used for specific ops like `.pop()`)
+    pub voice: Option<Voice>,
+}
+
+/// A participle constituent (used for lambdas/closures)
+#[derive(Debug, Clone)]
+pub struct ParticipleConstituent {
+    /// The verb stem extracted from the participle
+    pub verb_lemma: String,
+    /// Original text as it appeared
+    pub original: String,
+    /// Tense (present, aorist, perfect)
+    pub tense: Tense,
+    /// Voice (active, middle, passive)
+    pub voice: Voice,
+    /// Case (adjectival property)
+    pub case: Case,
+    /// Gender (adjectival property)
+    pub gender: Gender,
+    /// Number (adjectival property)
+    pub number: Number,
+}
+
+/// A literal value
+#[derive(Debug, Clone)]
+pub enum Literal {
+    String(String),
+    Number(i64),
+    Boolean(bool),
+}


### PR DESCRIPTION
This PR refactors the monolithic `src/semantic/assembler.rs` file into a modular structure to improve cohesion and maintainability. It breaks down the "God Struct" pattern by separating data models, error definitions, and core logic into distinct files. This structural change aligns with the "Tree" architecture philosophy and makes the codebase easier to navigate.

## Changes
- Created `src/semantic/assembler/` directory.
- `model.rs`: Contains `AssembledStatement`, `Constituent`, etc.
- `errors.rs`: Contains `AssemblyError`.
- `mod.rs`: Contains `Assembler` struct, logic, and tests.
- Removed original `src/semantic/assembler.rs`.

## Verification
- Ran `cargo test` - All tests passed.
- Ran `cargo clippy` - Fixed unused import warnings.

---
*PR created automatically by Jules for task [1905460855058889139](https://jules.google.com/task/1905460855058889139) started by @madmax983*