### PR TITLE
🛡️ Sentry: Fix silent swallowing of special tokens in Assembler

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -13,3 +13,7 @@
 ## [Grammar] Person Agreement Check
 **Learning:** The assembler was checking Number agreement but missing Person agreement, allowing incorrect sentences like "I (1st) says (3rd)".
 **Action:** Added `person` field to `Constituent` and updated `finalize` to check `subj_person != verb_person`. Nouns default to 3rd person.
+
+## [Silent Token Swallowing in Special Checks]
+**Learning:** Functions like `check_method_verbs` and `check_special_properties` were returning `true` (indicating "handled") even when they failed to match the full pattern (e.g., missing subject), causing tokens like "split" or "length" to be silently ignored instead of falling back to normal verb/noun processing.
+**Action:** Ensure that special handling functions only return `true` when they *successfully* handle the token. If prerequisites aren't met, return `false` to allow fallback to standard processing.

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -965,9 +965,9 @@ impl Assembler {
                     // Push back a property access for the split result
                     self.pending_property_accesses
                         .push((normalized_original.to_string(), "split".to_string()));
+                    return true;
                 }
             }
-            return true;
         }
 
         // Check for join verb
@@ -989,9 +989,9 @@ impl Assembler {
                     // Push back a property access for the join result
                     self.pending_property_accesses
                         .push((normalized_original.to_string(), "join".to_string()));
+                    return true;
                 }
             }
-            return true;
         }
 
         false
@@ -1041,8 +1041,8 @@ impl Assembler {
                 self.pending_property_accesses
                     .push((normalized_original.to_string(), "len".to_string()));
                 self.pending_subject = None; // Consume the subject
+                return true;
             }
-            return true;
         }
 
         // Ordinal adjectives
@@ -1061,8 +1061,8 @@ impl Assembler {
 
                 self.pending_index_accesses.push((array, index_expr));
                 self.pending_subject = None; // Consume the subject
+                return true;
             }
-            return true;
         }
 
         false

--- a/tests/semantic_assembler_edge_cases.rs
+++ b/tests/semantic_assembler_edge_cases.rs
@@ -27,8 +27,10 @@ fn test_split_verb_consumes_literal_without_subject() {
     asm.feed(&subject, "λόγος").unwrap();
 
     // 5. Feed "λέγε" (print verb)
-    let verb = analyze("λεγε");
-    asm.feed(&verb, "λέγε").unwrap();
+    // REMOVED: Since "split" is now correctly identified as a verb when the pattern match fails,
+    // adding another verb would cause a DoubleVerb error.
+    // let verb = analyze("λεγε");
+    // asm.feed(&verb, "λέγε").unwrap();
 
     let stmt = asm.finalize().unwrap();
 
@@ -38,4 +40,94 @@ fn test_split_verb_consumes_literal_without_subject() {
         !stmt.literals.is_empty(),
         "Literal should not be consumed if split pattern fails to match due to missing subject"
     );
+
+    // Also verify that "split" was captured as the verb
+    assert!(stmt.verb.is_some(), "Split should be captured as the verb");
+    assert_eq!(stmt.verb.unwrap().lemma, "σχιζω");
+}
+
+#[test]
+fn test_split_verb_not_ignored_without_delimiter() {
+    let mut asm = Assembler::new();
+
+    // Feed subject "word"
+    let subj = analyze("λογος"); // "word"
+    asm.feed(&subj, "λόγος").unwrap();
+
+    // Feed "splits" (σχίζει) without "by" (κατά) and delimiter string
+    // normalized: σχιζει
+    // This should now be treated as a normal verb because the split pattern didn't match!
+    let split_verb = analyze("σχιζει");
+    asm.feed(&split_verb, "σχίζει").unwrap();
+
+    let stmt = asm.finalize();
+
+    match stmt {
+        Ok(s) => {
+            // Now we expect the verb to be present!
+            assert!(s.verb.is_some(), "Verb should be present (treated as normal verb) when split pattern fails");
+            let verb = s.verb.unwrap();
+            assert_eq!(verb.original, "σχίζει");
+            assert!(s.string_method.is_none(), "String method should be None");
+        },
+        Err(e) => {
+             panic!("Should not error: {:?}", e);
+        }
+    }
+}
+
+#[test]
+fn test_ordinal_not_ignored_without_subject() {
+    let mut asm = Assembler::new();
+
+    // Feed "first" (πρῶτον) - Ordinal
+    // normalized: πρωτον
+    // Since there is no subject yet, it should fall through and be treated as an Adjective
+    let first = analyze("πρωτον");
+    asm.feed(&first, "πρῶτον").unwrap();
+
+    // Feed "man" (ἄνθρωπος) - Subject
+    let man = analyze("ανθρωπος");
+    asm.feed(&man, "ἄνθρωπος").unwrap();
+
+    // Feed "is" (ἐστί) - Verb
+    let is_verb = analyze("εστι");
+    asm.feed(&is_verb, "ἐστί").unwrap();
+
+    let stmt = asm.finalize().unwrap();
+
+    assert!(stmt.subject.is_some(), "Subject should be present");
+    assert_eq!(stmt.subject.unwrap().original, "ἄνθρωπος");
+
+    // "first" should be in adjectives now!
+    assert!(!stmt.adjectives.is_empty(), "Adjectives should NOT be empty; 'first' should be captured");
+    assert_eq!(stmt.adjectives[0].original, "πρῶτον");
+
+    assert!(stmt.index_accesses.is_empty(), "Index accesses should be empty");
+}
+
+#[test]
+fn test_length_property_not_ignored_without_subject() {
+    let mut asm = Assembler::new();
+
+    // Feed "length" (μῆκος) - Noun
+    // normalized: μηκος
+    // Since there is no subject, it should fall through and be treated as a Noun (Subject/Object)
+    let len = analyze("μηκος");
+    asm.feed(&len, "μῆκος").unwrap();
+
+    // Feed "is" (ἐστί)
+    let is_verb = analyze("εστι");
+    asm.feed(&is_verb, "ἐστί").unwrap();
+
+    // Feed "5"
+    asm.feed_number(5);
+
+    let stmt = asm.finalize().unwrap();
+
+    // "length" should be the subject now!
+    assert!(stmt.subject.is_some(), "Subject should be present (length)");
+    assert_eq!(stmt.subject.unwrap().lemma, "μηκος");
+
+    assert!(stmt.property_accesses.is_empty(), "Property accesses should be empty");
 }

--- a/tests/semantic_assembler_edge_cases.rs
+++ b/tests/semantic_assembler_edge_cases.rs
@@ -65,13 +65,16 @@ fn test_split_verb_not_ignored_without_delimiter() {
     match stmt {
         Ok(s) => {
             // Now we expect the verb to be present!
-            assert!(s.verb.is_some(), "Verb should be present (treated as normal verb) when split pattern fails");
+            assert!(
+                s.verb.is_some(),
+                "Verb should be present (treated as normal verb) when split pattern fails"
+            );
             let verb = s.verb.unwrap();
             assert_eq!(verb.original, "σχίζει");
             assert!(s.string_method.is_none(), "String method should be None");
-        },
+        }
         Err(e) => {
-             panic!("Should not error: {:?}", e);
+            panic!("Should not error: {:?}", e);
         }
     }
 }
@@ -100,10 +103,16 @@ fn test_ordinal_not_ignored_without_subject() {
     assert_eq!(stmt.subject.unwrap().original, "ἄνθρωπος");
 
     // "first" should be in adjectives now!
-    assert!(!stmt.adjectives.is_empty(), "Adjectives should NOT be empty; 'first' should be captured");
+    assert!(
+        !stmt.adjectives.is_empty(),
+        "Adjectives should NOT be empty; 'first' should be captured"
+    );
     assert_eq!(stmt.adjectives[0].original, "πρῶτον");
 
-    assert!(stmt.index_accesses.is_empty(), "Index accesses should be empty");
+    assert!(
+        stmt.index_accesses.is_empty(),
+        "Index accesses should be empty"
+    );
 }
 
 #[test]
@@ -129,5 +138,8 @@ fn test_length_property_not_ignored_without_subject() {
     assert!(stmt.subject.is_some(), "Subject should be present (length)");
     assert_eq!(stmt.subject.unwrap().lemma, "μηκος");
 
-    assert!(stmt.property_accesses.is_empty(), "Property accesses should be empty");
+    assert!(
+        stmt.property_accesses.is_empty(),
+        "Property accesses should be empty"
+    );
 }


### PR DESCRIPTION
This PR fixes a critical bug in the semantic assembler where certain tokens were being "swallowed" (consumed but ignored) when they appeared in unexpected contexts.

### The Bug
The `Assembler` has special checks for patterns like:
- `check_method_verbs`: Checks for "split" (`σχίζει`) or "join" (`ἑνοῖ`) verbs to convert them into method calls if a delimiter is present.
- `check_special_properties`: Checks for "length" (`μῆκος`) or ordinals ("first") to convert them into property/index accesses if a subject is present.

The issue was that these functions would return `true` (meaning "I handled this token, stop processing") even if the prerequisites (like having a subject or delimiter) were *not* met. This meant the token was effectively deleted from the stream.

### The Fix
I updated these functions to only return `true` inside the success block where the transformation actually happens. If the conditions are not met, the function returns `false` (or falls through), allowing the `Assembler` to treat the token as a normal constituent (Verb, Noun, Adjective).

### Verification
- Added new regression tests in `tests/semantic_assembler_edge_cases.rs`:
    - `test_split_verb_not_ignored_without_delimiter`: Verifies "split" is treated as a verb when no delimiter is present.
    - `test_ordinal_not_ignored_without_subject`: Verifies "first" is treated as an adjective when no subject is present.
    - `test_length_property_not_ignored_without_subject`: Verifies "length" is treated as a noun (subject) when no subject is present.
- Updated `test_split_verb_consumes_literal_without_subject` to assert that "split" is captured as the verb (previously it asserted the literal wasn't consumed but relied on "split" being ignored to avoid a double verb error).
- Ran all tests in `tests/semantic_assembler_edge_cases.rs` and the full suite.

### Learnings
Recorded in `.jules/sentry.md`: Ensure special handling functions verify all prerequisites before returning `true`.


---
*PR created automatically by Jules for task [11866592984566689511](https://jules.google.com/task/11866592984566689511) started by @madmax983*