### PR TITLE
fix(dx): fix README example by improving parser and morphology

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here is a simple program that defines a user struct and greets them.
 εἶδος Χρήστης ὁρίζειν {
     ὄνομα ὄνομα.      // field: String
     ἡλικία ἀριθμός.   // field: i64
-}
+}.
 
 // Create a new user instance
 // "user" (nominative) "new" (adjective) "User" (type) ...

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -678,7 +678,12 @@ fn generate_struct_lit(type_name: &str, fields: &[String], args: &[HirExpr]) -> 
         .map(|(field_name, arg)| {
             let field_ident = format_ident!("{}", sanitize_name(field_name));
             let arg_token = generate_expr(arg);
-            quote! { #field_ident: #arg_token }
+            // Glossa structs use String for text fields, so convert string literals
+            if matches!(arg, HirExpr::StringLit(_)) {
+                quote! { #field_ident: #arg_token.to_string() }
+            } else {
+                quote! { #field_ident: #arg_token }
+            }
         })
         .collect();
 

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -257,6 +257,23 @@ static LEXICON: LazyLock<FxHashMap<&'static str, LexiconEntry>> = LazyLock::new(
         },
     );
 
+    m.insert(
+        "χρηστου",
+        LexiconEntry {
+            lemma: "χρηστης",
+            pos: PartOfSpeech::Noun,
+            gender: Some(Gender::Masculine),
+            meaning: "of user (genitive)",
+            rust_equiv: Some("user"),
+            case: Some(Case::Genitive),
+            number: Some(Number::Singular),
+            person: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        },
+    );
+
     // ὄνομα - name/string
     m.insert(
         "ονομα",

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -297,6 +297,13 @@ pub fn map_genitive_to_type(genitive_name: &str, scope: &Scope) -> GlossaType {
     if genitive_name == "ονοματος" {
         return GlossaType::String;
     }
+
+    // Try to infer type (handles nominative forms like ἀριθμός)
+    let inferred = crate::semantic::types::infer_type(genitive_name);
+    if inferred != GlossaType::Unknown {
+        return inferred;
+    }
+
     // Check for user-defined types
     // Strip genitive ending and look up the nominative form
     // For now, just try the name as-is

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -86,38 +86,47 @@ pub fn try_parse_struct_instantiation(
             return Ok(None);
         }
 
-        // Should be a Phrase with at least 4 words
+        // Should be a Phrase with at least 4 terms
         if let Expr::Phrase(terms) = &clause.expressions[0] {
             if terms.len() < 4 {
                 return Ok(None);
             }
 
-            // Extract words
-            let mut words = Vec::new();
-            for term in terms {
-                if let Expr::Word(w) = term {
-                    words.push(w);
-                } else {
-                    return Ok(None); // Not all words
-                }
-            }
-
-            // Check pattern: var_name νέον TypeName args... ἔστω
-            // Last word should be ἔστω (binding verb)
-            if !crate::morphology::lexicon::is_binding_verb(&words.last().unwrap().normalized) {
-                return Ok(None);
-            }
-
-            // Second word should be νέον (new) - check both normalized form and if it's "new" via morphology
-            let normalized_adj = crate::grammar::normalize_greek(&words[1].normalized);
-            // Check if it's "new" - could be νέον, νεον, etc.
-            if normalized_adj != "νεον" && normalized_adj != "νεος" {
-                return Ok(None);
-            }
-
             // Extract components
-            let var_name = &words[0].normalized;
-            let type_name = &words[2].normalized;
+            // 1. Variable name (must be a word)
+            let var_name = if let Expr::Word(w) = &terms[0] {
+                &w.normalized
+            } else {
+                return Ok(None);
+            };
+
+            // 2. Keyword "new" (must be a word)
+            let is_new = if let Expr::Word(w) = &terms[1] {
+                let norm = crate::grammar::normalize_greek(&w.normalized);
+                norm == "νεον" || norm == "νεος"
+            } else {
+                false
+            };
+            if !is_new {
+                return Ok(None);
+            }
+
+            // 3. Type name (must be a word)
+            let type_name = if let Expr::Word(w) = &terms[2] {
+                &w.normalized
+            } else {
+                return Ok(None);
+            };
+
+            // 4. Last term must be "let be" (binding verb)
+            let is_binding = if let Expr::Word(w) = terms.last().unwrap() {
+                crate::morphology::lexicon::is_binding_verb(&w.normalized)
+            } else {
+                false
+            };
+            if !is_binding {
+                return Ok(None);
+            }
 
             // Check for built-in collection types first (HashSet, HashMap)
             let collection_type = match type_name.as_str() {
@@ -170,32 +179,50 @@ pub fn try_parse_struct_instantiation(
 
                 // Collect constructor arguments (everything between type_name and ἔστω)
                 let mut args = Vec::new();
-                for word in &words[3..words.len() - 1] {
-                    // Convert word to analyzed expression
-                    let analyzed_arg = if let Ok(num) = word.original.parse::<i64>() {
-                        // Direct numeric literal like "5"
-                        AnalyzedExpr {
-                            expr: AnalyzedExprKind::NumberLiteral(num),
+
+                // Arguments start at index 3 and end before the last term
+                for term in &terms[3..terms.len() - 1] {
+                    let analyzed_arg = match term {
+                        Expr::NumberLiteral(n) => AnalyzedExpr {
+                            expr: AnalyzedExprKind::NumberLiteral(*n),
                             glossa_type: GlossaType::Number,
+                        },
+                        Expr::StringLiteral(s) => AnalyzedExpr {
+                            expr: AnalyzedExprKind::StringLiteral(s.clone()),
+                            glossa_type: GlossaType::String,
+                        },
+                        Expr::BooleanLiteral(b) => AnalyzedExpr {
+                            expr: AnalyzedExprKind::BooleanLiteral(*b),
+                            glossa_type: GlossaType::Boolean,
+                        },
+                        Expr::Word(w) => {
+                            if let Ok(num) = w.original.parse::<i64>() {
+                                // Direct numeric literal like "5" parsed as word
+                                AnalyzedExpr {
+                                    expr: AnalyzedExprKind::NumberLiteral(num),
+                                    glossa_type: GlossaType::Number,
+                                }
+                            } else if let Some(num) =
+                                crate::morphology::lexicon::numeral_value(&w.normalized)
+                            {
+                                // Greek numeral word like πέντε -> 5
+                                AnalyzedExpr {
+                                    expr: AnalyzedExprKind::NumberLiteral(num),
+                                    glossa_type: GlossaType::Number,
+                                }
+                            } else {
+                                // Variable reference
+                                let var_type = scope
+                                    .lookup(&w.normalized)
+                                    .cloned()
+                                    .unwrap_or(GlossaType::Unknown);
+                                AnalyzedExpr {
+                                    expr: AnalyzedExprKind::Variable(w.normalized.clone()),
+                                    glossa_type: var_type,
+                                }
+                            }
                         }
-                    } else if let Some(num) =
-                        crate::morphology::lexicon::numeral_value(&word.normalized)
-                    {
-                        // Greek numeral word like πέντε -> 5
-                        AnalyzedExpr {
-                            expr: AnalyzedExprKind::NumberLiteral(num),
-                            glossa_type: GlossaType::Number,
-                        }
-                    } else {
-                        // Variable reference
-                        let var_type = scope
-                            .lookup(&word.normalized)
-                            .cloned()
-                            .unwrap_or(GlossaType::Unknown);
-                        AnalyzedExpr {
-                            expr: AnalyzedExprKind::Variable(word.normalized.clone()),
-                            glossa_type: var_type,
-                        }
+                        _ => return Ok(None), // Unsupported term type in args
                     };
                     args.push(analyzed_arg);
                 }

--- a/tests/dx_regression_tests.rs
+++ b/tests/dx_regression_tests.rs
@@ -1,0 +1,48 @@
+use glossa::ast::build_ast;
+use glossa::codegen::generate_rust;
+use glossa::ir::lower_to_hir;
+use glossa::semantic::analyze_program;
+
+fn compile(source: &str) -> String {
+    let ast = build_ast(source).unwrap();
+    let analyzed = analyze_program(&ast).unwrap();
+    let hir = lower_to_hir(&analyzed);
+    generate_rust(&hir)
+}
+
+#[test]
+fn test_readme_hero_example() {
+    let source = r#"
+        // Define a type (struct) using nominative types (DX fix)
+        εἶδος Χρήστης ὁρίζειν {
+            ὄνομα ὄνομα.      // field: String
+            ἡλικία ἀριθμός.   // field: i64
+        }.
+
+        // Create a new user instance using literals (DX fix)
+        χρήστης νέον Χρήστης
+            «Σωκράτης»
+            70
+        ἔστω.
+
+        // Access property using genitive form (Lexicon fix)
+        χρήστου ὄνομα λέγε.
+    "#;
+
+    let code = compile(source);
+    println!("Generated code:\n{}", code);
+
+    // Verify nominative type resolution
+    assert!(code.contains("struct Chrestes"));
+    // quote! puts spaces around colons
+    assert!(code.contains("onoma : String"));
+    assert!(code.contains("elikia : i64"));
+
+    // Verify literal instantiation and string conversion
+    assert!(code.contains("Chrestes {"));
+    assert!(code.contains("onoma : \"Σωκράτης\" . to_string ()"));
+    assert!(code.contains("elikia : 70"));
+
+    // Verify genitive access
+    assert!(code.contains("println ! (\"{}\" , chrestes . onoma)"));
+}


### PR DESCRIPTION
This PR fixes the "Getting Started" example in `README.md` and the underlying compiler issues that prevented it from running.

Changes:
- **Docs:** Fixed a syntax error in `README.md` (missing period in struct definition).
- **Semantic Analysis:** 
    - Updated `try_parse_struct_instantiation` in `src/semantic/patterns.rs` to support string and number literals in struct constructors (previously only accepted variables).
    - Updated `map_genitive_to_type` in `src/semantic/declarations.rs` to use `infer_type` as a fallback, allowing nominative type names (like `ἀριθμός`) in struct definitions.
- **Morphology:** Added `χρηστου` (genitive of user) to `src/morphology/lexicon.rs` to ensure correct resolution of `χρήστου ὄνομα` (user.name).
- **Codegen:** Updated `src/codegen/rust.rs` to automatically convert string literals to `String` (via `.to_string()`) when used in struct instantiations, matching Glossa's owned `String` semantics.

Verified by running the `hero.γλ` example and existing test suite.

---
*PR created automatically by Jules for task [2790550182612200770](https://jules.google.com/task/2790550182612200770) started by @madmax983*