### PR TITLE
🔒 Warden: Prevent DoS in code generation

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -7,3 +7,11 @@
 **Defense:** Switch to `strip_suffix("ου")` which removes only the last occurrence, preserving the stem if it naturally ends in the pattern.
 
 **Severity:** Low (Logic bug/DoS via compilation error), but strictly incorrect string handling.
+
+## 2026-02-02 - Code Generation Panic (DoS)
+
+**Threat:** Unhandled Unicode characters in `src/codegen/rust.rs`'s `transliterate` function allowed arbitrary characters to be passed to `format_ident!`, causing compiler panics (DoS) when compiling code with specially crafted variable names (e.g. using Greek Koronis `᾽`).
+
+**Defense:** Enforced strict ASCII allowlist in `transliterate`. Any character not matching `is_ascii_alphanumeric()` or `_` is replaced with `_`.
+
+**Severity:** Medium (DoS via compiler crash).

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -911,7 +911,13 @@ fn transliterate(greek: &str) -> String {
             'ψ' => "ps",
             'ω' => "o",
             _ => {
-                result.push(c);
+                // Keep only ASCII alphanumeric characters and underscore
+                if c.is_ascii_alphanumeric() || c == '_' {
+                    result.push(c);
+                } else {
+                    // Replace invalid characters with underscore to prevent panic in format_ident!
+                    result.push('_');
+                }
                 continue;
             }
         };

--- a/tests/warden_exploit.rs
+++ b/tests/warden_exploit.rs
@@ -1,0 +1,39 @@
+use glossa::codegen::generate_rust;
+use glossa::ir::lower_to_hir;
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_exploit_unicode_panic() {
+    // U+1FBD (GREEK KORONIS) is a modifier symbol, valid in our grammar's greek_word range,
+    // but likely invalid in Rust identifiers.
+    // Our grammar: '\u{1F00}'..'\u{1FFF}' includes 1FBD.
+
+    // We construct a variable name containing it.
+    let malicious_var = "᾽α"; // U+1FBD + alpha
+    let source = format!("{} πέντε ἔστω.", malicious_var);
+
+    // This should succeed parsing and analysis if the grammar allows it
+    let ast = parse(&source).expect("Parsing failed");
+    let analyzed = analyze_program(&ast).expect("Analysis failed");
+    let hir = lower_to_hir(&analyzed);
+
+    // This should NOT panic anymore
+    let rust = generate_rust(&hir);
+
+    // Verify sanitization
+    // ᾽ (U+1FBD) should be replaced by _, and α becomes a
+    // So "᾽α" -> "_a"
+    // And since it starts with _, it stays "_a" (or maybe "__a" if prefixing logic applies)
+    // sanitize_name calls transliterate.
+    // transliterate("᾽α") -> "_" + "a" = "_a"
+    // sanitize_name then checks if it starts with digit. It starts with _.
+    // So it returns "_a".
+    // format_ident!("_a") is valid.
+
+    assert!(
+        rust.contains("_a"),
+        "Generated code should contain sanitized identifier '_a'. Code: {}",
+        rust
+    );
+}


### PR DESCRIPTION
Fixed a vulnerability where specially crafted Greek variable names could cause the compiler to panic (DoS) during Rust code generation. Enforced strict ASCII sanitization in `transliterate`.

---
*PR created automatically by Jules for task [12261627308810609919](https://jules.google.com/task/12261627308810609919) started by @madmax983*