### PR TITLE
🗺️ Atlas: Unify AssemblyError into GlossaError

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -20,3 +20,11 @@
 4. Refactored `mod.rs` to re-export `model` contents.
 5. Removed legacy `SemanticAnalyzer` code that was duplicating logic.
 **Stability:** Strictly separates Data (Model), Types (Type System), and Logic (Analysis). `model.rs` depends on `types.rs`, but `types.rs` is now leaf-level with no dependencies on the AST.
+
+## [Breaking The Leak: Semantic Assembly Error]
+**Tangle:** `src/semantic/assembler.rs` defined `AssemblyError`, but `src/semantic/mod.rs` was stringifying it into `GlossaError::SemanticError` to avoid circular dependencies (since `errors` depends on `semantic` if `GlossaError` wraps `AssemblyError`). This caused loss of structured error information.
+**Blueprint:**
+1. Created `src/errors/assembly.rs` and moved `AssemblyError` there.
+2. Updated `GlossaError` to include `AssemblyError` as a transparent variant.
+3. Updated `src/semantic/assembler.rs` to use the shared error type.
+**Stability:** Centralizes error definition, preserves error structure for better diagnostics, and maintains acyclic graph (`errors` -> `morphology`, `semantic` -> `errors`).

--- a/src/errors/assembly.rs
+++ b/src/errors/assembly.rs
@@ -1,0 +1,67 @@
+//! Errors related to semantic assembly
+
+use crate::morphology::{Gender, Number, Person};
+use miette::Diagnostic;
+use thiserror::Error;
+
+/// Errors that can occur during assembly
+#[derive(Debug, Clone, Error, Diagnostic)]
+pub enum AssemblyError {
+    /// Two subjects found in the same statement (Nominative collision)
+    ///
+    /// # Example
+    /// `ὁ ἄνθρωπος ὁ θεὸς λέγει` (The man the god says)
+    #[error("Διπλοῦν ὑποκείμενον! Δύο βασιλεῖς οὐ δύνανται μιᾶς πόλεως ἄρχειν.")]
+    #[diagnostic(code(glossa::assembly::double_subject))]
+    DoubleSubject,
+
+    /// Two objects found in the same statement (Accusative collision)
+    ///
+    /// # Example
+    /// `τὸν λόγον τὴν πόλιν βλέπω` (I see the word the city)
+    #[error("Διπλοῦν ἀντικείμενον! Ἓν μόνον κατηγορεῖς.")]
+    #[diagnostic(code(glossa::assembly::double_object))]
+    DoubleObject,
+
+    /// Two verbs found in the same statement
+    ///
+    /// # Example
+    /// `λέγει γράφει ὁ ἄνθρωπος` (The man says writes)
+    #[error("Διπλοῦν ῥῆμα! Μία πρᾶξις ἑκάστοτε.")]
+    #[diagnostic(code(glossa::assembly::double_verb))]
+    DoubleVerb,
+
+    /// No verb found in the statement
+    ///
+    /// Note: Pure expressions (like `5`) are allowed, but incomplete sentences trigger this.
+    ///
+    /// # Example
+    /// `ὁ ἄνθρωπος τὸν λόγον` (The man the word ... [missing action])
+    #[error("Ῥῆμα οὐχ εὑρέθη! Οὐδὲν ἐγένετο.")]
+    #[diagnostic(code(glossa::assembly::missing_verb))]
+    MissingVerb,
+
+    /// Subject and Verb do not agree in number/person
+    ///
+    /// # Example
+    /// `ὁ ἄνθρωπος (Singular) λέγουσιν (Plural)`
+    #[error("Ἀσυμφωνία: ὑποκείμενον {subject:?} ἀλλὰ ῥῆμα {verb:?}")]
+    #[diagnostic(code(glossa::assembly::subject_verb_disagreement))]
+    SubjectVerbDisagreement {
+        subject: (Option<Person>, Option<Number>),
+        verb: (Option<Person>, Option<Number>),
+    },
+
+    /// Adjective and Noun do not agree in gender
+    ///
+    /// # Example
+    /// `ὁ καλὸς (Masc) γυνή (Fem)`
+    #[error("Ἀσυμφωνία γένους: {word1} ({gender1:?}) πρὸς {word2} ({gender2:?})")]
+    #[diagnostic(code(glossa::assembly::gender_mismatch))]
+    GenderMismatch {
+        word1: String,
+        gender1: Gender,
+        word2: String,
+        gender2: Gender,
+    },
+}

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -4,8 +4,10 @@
 
 #![allow(unused_assignments)]
 
+pub mod assembly;
 mod messages;
 
+pub use assembly::*;
 pub use messages::*;
 
 use miette::{Diagnostic, SourceSpan};
@@ -49,6 +51,10 @@ pub enum GlossaError {
     #[error("Σφάλμα ἀρχείου: {message}")]
     #[diagnostic(code(glossa::io))]
     IoError { message: String },
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    AssemblyError(#[from] assembly::AssemblyError),
 }
 
 impl GlossaError {
@@ -124,6 +130,7 @@ impl GlossaError {
             GlossaError::AgreementError { .. } => "Συμφωνία",
             GlossaError::CodegenError { .. } => "Κῶδιξ",
             GlossaError::IoError { .. } => "Ἀρχεῖον",
+            GlossaError::AssemblyError(_) => "Συναρμογή",
         }
     }
 }

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -94,6 +94,7 @@
 //! ```
 
 use crate::ast::{Expr, Word};
+pub use crate::errors::assembly::AssemblyError;
 use crate::grammar::normalize_greek;
 use crate::morphology::lexicon::BinaryOp;
 use crate::morphology::{
@@ -368,62 +369,6 @@ pub struct Assembler {
     pending_string_method: Option<(String, String)>,
     is_query: bool,
     is_propagate: bool,
-}
-
-/// Errors that can occur during assembly
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum AssemblyError {
-    /// Two subjects found in the same statement (Nominative collision)
-    ///
-    /// # Example
-    /// `ὁ ἄνθρωπος ὁ θεὸς λέγει` (The man the god says)
-    #[error("Διπλοῦν ὑποκείμενον! Δύο βασιλεῖς οὐ δύνανται μιᾶς πόλεως ἄρχειν.")]
-    DoubleSubject,
-
-    /// Two objects found in the same statement (Accusative collision)
-    ///
-    /// # Example
-    /// `τὸν λόγον τὴν πόλιν βλέπω` (I see the word the city)
-    #[error("Διπλοῦν ἀντικείμενον! Ἓν μόνον κατηγορεῖς.")]
-    DoubleObject,
-
-    /// Two verbs found in the same statement
-    ///
-    /// # Example
-    /// `λέγει γράφει ὁ ἄνθρωπος` (The man says writes)
-    #[error("Διπλοῦν ῥῆμα! Μία πρᾶξις ἑκάστοτε.")]
-    DoubleVerb,
-
-    /// No verb found in the statement
-    ///
-    /// Note: Pure expressions (like `5`) are allowed, but incomplete sentences trigger this.
-    ///
-    /// # Example
-    /// `ὁ ἄνθρωπος τὸν λόγον` (The man the word ... [missing action])
-    #[error("Ῥῆμα οὐχ εὑρέθη! Οὐδὲν ἐγένετο.")]
-    MissingVerb,
-
-    /// Subject and Verb do not agree in number/person
-    ///
-    /// # Example
-    /// `ὁ ἄνθρωπος (Singular) λέγουσιν (Plural)`
-    #[error("Ἀσυμφωνία: ὑποκείμενον {subject:?} ἀλλὰ ῥῆμα {verb:?}")]
-    SubjectVerbDisagreement {
-        subject: (Option<Person>, Option<Number>),
-        verb: (Option<Person>, Option<Number>),
-    },
-
-    /// Adjective and Noun do not agree in gender
-    ///
-    /// # Example
-    /// `ὁ καλὸς (Masc) γυνή (Fem)`
-    #[error("Ἀσυμφωνία γένους: {word1} ({gender1:?}) πρὸς {word2} ({gender2:?})")]
-    GenderMismatch {
-        word1: String,
-        gender1: Gender,
-        word2: String,
-        gender2: Gender,
-    },
 }
 
 impl Assembler {

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -210,4 +210,5 @@ mod tests {
         let first_expr = &analyzed.statements[0].expressions[0];
         assert_eq!(first_expr.glossa_type, GlossaType::Number);
     }
+
 }

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -145,10 +145,7 @@ fn analyze_single_statement_with_assembler(
     }
 
     // Finalize the statement
-    match asm.finalize() {
-        Ok(assembled) => Ok(assembled),
-        Err(e) => Err(GlossaError::semantic(e.to_string())),
-    }
+    Ok(asm.finalize()?)
 }
 
 /// Analyzed program with resolved names and types

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -210,5 +210,4 @@ mod tests {
         let first_expr = &analyzed.statements[0].expressions[0];
         assert_eq!(first_expr.glossa_type, GlossaType::Number);
     }
-
 }

--- a/tests/assembly_error_coverage.rs
+++ b/tests/assembly_error_coverage.rs
@@ -64,6 +64,22 @@ fn test_glossa_error_conversion() {
 }
 
 #[test]
+fn test_assembly_error_diagnostic_code() {
+    use miette::Diagnostic;
+    let err = AssemblyError::DoubleSubject;
+    assert_eq!(
+        err.code().map(|c| c.to_string()),
+        Some("glossa::assembly::double_subject".to_string())
+    );
+}
+
+#[test]
+fn test_category_greek_assembly() {
+    let err = GlossaError::AssemblyError(AssemblyError::DoubleSubject);
+    assert_eq!(err.category_greek(), "Συναρμογή");
+}
+
+#[test]
 fn test_unused_variants_coverage() {
     // These errors are currently not thrown by Assembler logic or are unreachable,
     // but we want to ensure their definitions are compiled and covered.

--- a/tests/assembly_error_coverage.rs
+++ b/tests/assembly_error_coverage.rs
@@ -1,6 +1,6 @@
 use glossa::errors::GlossaError;
 use glossa::errors::assembly::AssemblyError;
-use glossa::morphology::{analyze, Case, Gender, Number, Person};
+use glossa::morphology::{Case, Gender, Number, Person, analyze};
 use glossa::semantic::assembler::Assembler;
 
 #[test]
@@ -43,7 +43,10 @@ fn test_subject_verb_disagreement_error() {
     asm.feed(&verb, "λέγει").unwrap();
 
     let result = asm.finalize();
-    assert!(matches!(result, Err(AssemblyError::SubjectVerbDisagreement { .. })));
+    assert!(matches!(
+        result,
+        Err(AssemblyError::SubjectVerbDisagreement { .. })
+    ));
 }
 
 #[test]

--- a/tests/assembly_error_coverage.rs
+++ b/tests/assembly_error_coverage.rs
@@ -1,0 +1,84 @@
+use glossa::errors::GlossaError;
+use glossa::errors::assembly::AssemblyError;
+use glossa::morphology::{analyze, Case, Gender, Number, Person};
+use glossa::semantic::assembler::Assembler;
+
+#[test]
+fn test_double_object_error() {
+    let mut asm = Assembler::new();
+
+    // Feed first object
+    let obj1 = analyze("λόγον");
+    asm.feed(&obj1, "λόγον").unwrap();
+
+    // Feed second object
+    let obj2 = analyze("ἄνθρωπον");
+    let result = asm.feed(&obj2, "ἄνθρωπον");
+
+    assert!(matches!(result, Err(AssemblyError::DoubleObject)));
+}
+
+#[test]
+fn test_subject_verb_disagreement_error() {
+    let mut asm = Assembler::new();
+
+    // Subject: I (1st person sg) - needs manual construction as "ego" might not be in lexicon
+    use glossa::morphology::{MorphAnalysis, PartOfSpeech};
+    let subject = MorphAnalysis {
+        lemma: "εγω".into(),
+        part_of_speech: PartOfSpeech::Pronoun,
+        case: Some(Case::Nominative),
+        number: Some(Number::Singular),
+        gender: None,
+        person: Some(Person::First),
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+    asm.feed(&subject, "ἐγώ").unwrap();
+
+    // Verb: He says (3rd person sg)
+    let verb = analyze("λέγει"); // λεγει is 3rd person sg
+    asm.feed(&verb, "λέγει").unwrap();
+
+    let result = asm.finalize();
+    assert!(matches!(result, Err(AssemblyError::SubjectVerbDisagreement { .. })));
+}
+
+#[test]
+fn test_glossa_error_conversion() {
+    let asm_err = AssemblyError::DoubleVerb;
+    let glossa_err: GlossaError = asm_err.clone().into();
+
+    match &glossa_err {
+        GlossaError::AssemblyError(e) => assert!(matches!(e, AssemblyError::DoubleVerb)),
+        _ => panic!("Expected AssemblyError variant"),
+    }
+
+    // Check error message contains the Greek text
+    assert!(glossa_err.to_string().contains("Διπλοῦν ῥῆμα"));
+}
+
+#[test]
+fn test_unused_variants_coverage() {
+    // These errors are currently not thrown by Assembler logic or are unreachable,
+    // but we want to ensure their definitions are compiled and covered.
+
+    let double_subject = AssemblyError::DoubleSubject;
+    assert!(double_subject.to_string().contains("Διπλοῦν ὑποκείμενον"));
+
+    let missing_verb = AssemblyError::MissingVerb;
+    assert!(missing_verb.to_string().contains("Ῥῆμα οὐχ εὑρέθη"));
+
+    let gender_mismatch = AssemblyError::GenderMismatch {
+        word1: "καλός".to_string(),
+        gender1: Gender::Masculine,
+        word2: "γυνή".to_string(),
+        gender2: Gender::Feminine,
+    };
+    assert!(gender_mismatch.to_string().contains("Ἀσυμφωνία γένους"));
+    // Uses Debug formatting ({:?}) so it prints English enum variant names
+    assert!(gender_mismatch.to_string().contains("Masculine"));
+    assert!(gender_mismatch.to_string().contains("Feminine"));
+}


### PR DESCRIPTION
I have refactored the error handling for the Semantic Assembler. Previously, `AssemblyError` was defined inside `src/semantic/assembler.rs` and stringified into `GlossaError::SemanticError` in `src/semantic/mod.rs`. This was done to avoid circular dependencies but resulted in a "Leaky Abstraction" where structured error data was lost.

I have moved `AssemblyError` to `src/errors/assembly.rs`, making it a first-class citizen in the error module. `GlossaError` now wraps `AssemblyError` transparently. This preserves error details (like specific subject/verb disagreement info) for better diagnostics via `miette`, while keeping the dependency graph clean (`errors` depends on `morphology`, `semantic` depends on `errors`).

I also updated the `.jules/atlas.md` journal with this architectural improvement.

Verification:
- `cargo test` passes.
- `cargo clippy` passes.
- `cargo fmt` applied.

---
*PR created automatically by Jules for task [11483127268374157409](https://jules.google.com/task/11483127268374157409) started by @madmax983*