### PR TITLE
[Razor] Remove unused abstractions (Expr::Lambda, ExecutionMode)

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -12,3 +12,8 @@
 **Bloat:** `convert_expr_to_analyzed` in `src/semantic/expressions.rs` duplicated logic from `analyze_argument_expr` and silently returned `0` for unknown expressions.
 **Cut:** Merged logic into `analyze_argument_expr` and deleted `convert_expr_to_analyzed` and `convert_array_elements`.
 **Saved:** Removed dangerous silent failure bug, reduced code duplication (~50 lines removed), enforced error propagation.
+
+## [Reduction]
+**Bloat:** `ExecutionMode`, `AnalyzedWord`, `LambdaKind`, `Expr::Lambda` were dead or duplicated abstractions.
+**Cut:** Deleted them.
+**Saved:** Simplified AST and type system. Removed zombie code that wasn't used by the parser or semantic analyzer.

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -191,30 +191,6 @@ pub enum Expr {
 
     /// A block of statements in braces { ... }
     Block(Vec<Statement>),
-
-    /// A lambda/closure constructed from a participle
-    /// e.g., γράφων → |x| x.write()
-    Lambda {
-        kind: LambdaKind,
-        verb_lemma: String,
-        implicit_param: bool, // true if parameter inferred from context
-    },
-}
-
-/// Lambda kind derived from participle tense/voice
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LambdaKind {
-    /// Present participle - streaming/borrowing closure
-    /// e.g., γράφων → |x| body
-    Streaming,
-
-    /// Aorist participle - one-shot/consuming closure
-    /// e.g., γράψας → move |x| body
-    OneShot,
-
-    /// Perfect participle - memoized/cached closure
-    /// e.g., γεγραμμένος → cached |x| body
-    Memoized,
 }
 
 /// Capture mode for closures
@@ -291,34 +267,6 @@ impl Word {
         Word {
             original,
             normalized,
-        }
-    }
-}
-
-/// Analyzed word with morphological information
-#[derive(Debug, Clone, PartialEq)]
-pub struct AnalyzedWord {
-    pub word: Word,
-    pub case: Option<crate::morphology::Case>,
-    pub number: Option<crate::morphology::Number>,
-    pub gender: Option<crate::morphology::Gender>,
-    pub person: Option<crate::morphology::Person>,
-    pub tense: Option<crate::morphology::Tense>,
-    pub mood: Option<crate::morphology::Mood>,
-    pub voice: Option<crate::morphology::Voice>,
-}
-
-impl From<Word> for AnalyzedWord {
-    fn from(word: Word) -> Self {
-        AnalyzedWord {
-            word,
-            case: None,
-            number: None,
-            gender: None,
-            person: None,
-            tense: None,
-            mood: None,
-            voice: None,
         }
     }
 }

--- a/src/morphology/case.rs
+++ b/src/morphology/case.rs
@@ -74,32 +74,6 @@ pub enum Tense {
     Pluperfect,
 }
 
-impl Tense {
-    /// Convert tense to execution semantics
-    pub fn execution_mode(&self) -> ExecutionMode {
-        match self {
-            Tense::Present => ExecutionMode::Streaming,
-            Tense::Aorist => ExecutionMode::OneShot,
-            Tense::Perfect => ExecutionMode::Cached,
-            Tense::Future => ExecutionMode::Lazy,
-            _ => ExecutionMode::OneShot,
-        }
-    }
-}
-
-/// Execution mode derived from verbal aspect
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExecutionMode {
-    /// Streaming/iterative - process elements one by one
-    Streaming,
-    /// One-shot - execute once, consume input
-    OneShot,
-    /// Cached - compute once, reuse result
-    Cached,
-    /// Lazy - defer until needed
-    Lazy,
-}
-
 /// Mood - encodes modality
 ///
 /// In ΓΛΩΣΣΑ:
@@ -141,12 +115,5 @@ mod tests {
         assert_eq!(Case::Genitive.to_rust_ownership(), "&");
         assert_eq!(Case::Dative.to_rust_ownership(), "&mut");
         assert_eq!(Case::Accusative.to_rust_ownership(), "");
-    }
-
-    #[test]
-    fn test_tense_execution_mode() {
-        assert_eq!(Tense::Present.execution_mode(), ExecutionMode::Streaming);
-        assert_eq!(Tense::Aorist.execution_mode(), ExecutionMode::OneShot);
-        assert_eq!(Tense::Perfect.execution_mode(), ExecutionMode::Cached);
     }
 }

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -361,15 +361,6 @@ pub fn feed_expr_to_assembler_with_context(
             // Feed index access to assembler
             asm.feed_index_access(array.as_ref().clone(), index.as_ref().clone());
         }
-        Expr::Lambda {
-            kind,
-            verb_lemma,
-            implicit_param,
-        } => {
-            // TODO: Implement lambda handling in Cycle 3+
-            // For now, just acknowledge the lambda exists
-            let _ = (kind, verb_lemma, implicit_param);
-        }
     }
     Ok(())
 }
@@ -731,25 +722,6 @@ mod tests {
         let scope = Scope::new();
         let result = analyze_argument_expr(&expr, &scope);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_analyze_argument_expr_errors_on_unsupported_variant() {
-        // Lambda is currently unsupported in analyze_argument_expr
-        let expr = Expr::Lambda {
-            kind: crate::ast::LambdaKind::Streaming,
-            verb_lemma: "run".to_string(),
-            implicit_param: false,
-        };
-        let scope = Scope::new();
-        let result = analyze_argument_expr(&expr, &scope);
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            GlossaError::SemanticError { message } => {
-                assert_eq!(message, "Unsupported argument expression type");
-            }
-            _ => panic!("Expected SemanticError"),
-        }
     }
 
     #[test]

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -10,7 +10,7 @@
 //! - Optative mood → `Option<T>` (value that "might be")
 //! - ἀποτέλεσμα (apotelasma) → `Result<T,E>` (outcome/result)
 
-use crate::morphology::{Case, Gender, Tense};
+use crate::morphology::{Case, Gender};
 use smol_str::SmolStr;
 
 /// Types in ΓΛΩΣΣΑ
@@ -166,31 +166,6 @@ impl Ownership {
             Ownership::Borrow => "&",
             Ownership::BorrowMut => "&mut ",
             Ownership::Copy => "",
-        }
-    }
-}
-
-/// Execution mode derived from verbal aspect
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExecutionMode {
-    /// Present tense: streaming/iterative
-    Streaming,
-    /// Aorist tense: one-shot/complete
-    OneShot,
-    /// Perfect tense: cached/memoized
-    Cached,
-    /// Future tense: lazy/deferred
-    Lazy,
-}
-
-impl ExecutionMode {
-    pub fn from_tense(tense: Tense) -> Self {
-        match tense {
-            Tense::Present => ExecutionMode::Streaming,
-            Tense::Aorist => ExecutionMode::OneShot,
-            Tense::Perfect => ExecutionMode::Cached,
-            Tense::Future => ExecutionMode::Lazy,
-            _ => ExecutionMode::OneShot,
         }
     }
 }


### PR DESCRIPTION
Enforced KISS/YAGNI by deleting "Zombie Code" that was either duplicated or completely unused.
Specifically:
- `ExecutionMode`: Was duplicated in morphology and semantic modules and unused except for mapping from Tense (also unused).
- `AnalyzedWord`: Was defined in AST but never used.
- `Expr::Lambda` / `LambdaKind`: AST nodes that were not being generated by the parser (lambda logic is handled directly from participles in the semantic assembler).

Verified with `cargo test` and `cargo clippy`.

---
*PR created automatically by Jules for task [2800077542595511486](https://jules.google.com/task/2800077542595511486) started by @madmax983*