### PR TITLE
👺 Havoc: Harden system against NaN panics and Stack Overflows

### DIFF
--- a/src/morphology/disambiguation.rs
+++ b/src/morphology/disambiguation.rs
@@ -97,9 +97,11 @@ pub fn disambiguate(
 
     // Sort by score (descending), then by original confidence
     scored.sort_by(|a, b| {
-        let score_cmp = b.1.partial_cmp(&a.1).unwrap();
+        let score_cmp = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
         if score_cmp == std::cmp::Ordering::Equal {
-            b.0.confidence.partial_cmp(&a.0.confidence).unwrap()
+            b.0.confidence
+                .partial_cmp(&a.0.confidence)
+                .unwrap_or(std::cmp::Ordering::Equal)
         } else {
             score_cmp
         }

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -8,6 +8,20 @@ use crate::morphology::{self, DisambiguationContext, analyze_article, resolve_be
 
 /// Analyze an argument expression (could be literal, variable, or nested call)
 pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr, GlossaError> {
+    analyze_argument_expr_recursive(expr, scope, 0)
+}
+
+fn analyze_argument_expr_recursive(
+    expr: &Expr,
+    scope: &Scope,
+    depth: usize,
+) -> Result<AnalyzedExpr, GlossaError> {
+    if depth > 50 {
+        return Err(GlossaError::semantic(
+            "Recursion limit exceeded in expression analysis",
+        ));
+    }
+
     match expr {
         Expr::Word(w) => {
             let normalized = normalize_greek(&w.original);
@@ -53,7 +67,7 @@ pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr,
         Expr::ArrayLiteral(elements) => {
             let mut analyzed_elements = Vec::with_capacity(elements.len());
             for el in elements {
-                analyzed_elements.push(analyze_argument_expr(el, scope)?);
+                analyzed_elements.push(analyze_argument_expr_recursive(el, scope, depth + 1)?);
             }
 
             let element_type = analyzed_elements
@@ -68,8 +82,8 @@ pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr,
         }
 
         Expr::IndexAccess { array, index } => {
-            let array_analyzed = analyze_argument_expr(array, scope)?;
-            let index_analyzed = analyze_argument_expr(index, scope)?;
+            let array_analyzed = analyze_argument_expr_recursive(array, scope, depth + 1)?;
+            let index_analyzed = analyze_argument_expr_recursive(index, scope, depth + 1)?;
 
             Ok(AnalyzedExpr {
                 expr: AnalyzedExprKind::IndexAccess {
@@ -94,7 +108,7 @@ pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr,
                     // It's a function call - recursively analyze arguments
                     let mut args = Vec::new();
                     for arg_expr in &terms[1..] {
-                        args.push(analyze_argument_expr(arg_expr, scope)?);
+                        args.push(analyze_argument_expr_recursive(arg_expr, scope, depth + 1)?);
                     }
 
                     let return_type = scope
@@ -114,7 +128,7 @@ pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr,
 
             // Not a function call - could be a complex expression
             // For now, just analyze the first term
-            analyze_argument_expr(&terms[0], scope)
+            analyze_argument_expr_recursive(&terms[0], scope, depth + 1)
         }
 
         Expr::Block(statements) => {
@@ -124,14 +138,14 @@ pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr,
                 && let Some(clause) = stmt.clauses().first()
                 && let Some(expr) = clause.expressions.first()
             {
-                return analyze_argument_expr(expr, scope);
+                return analyze_argument_expr_recursive(expr, scope, depth + 1);
             }
             Err(GlossaError::semantic("Empty or invalid block expression"))
         }
 
         Expr::BinOp { left, op, right } => {
-            let left_analyzed = analyze_argument_expr(left, scope)?;
-            let right_analyzed = analyze_argument_expr(right, scope)?;
+            let left_analyzed = analyze_argument_expr_recursive(left, scope, depth + 1)?;
+            let right_analyzed = analyze_argument_expr_recursive(right, scope, depth + 1)?;
             // Map AST op to semantic op
             let sem_op = match op {
                 crate::ast::BinOperator::Add => crate::morphology::lexicon::BinaryOp::Add,
@@ -155,7 +169,7 @@ pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr,
         Expr::UnaryOp { op, operand } => {
             match op {
                 crate::ast::UnaryOperator::Unwrap => {
-                    let inner = analyze_argument_expr(operand, scope)?;
+                    let inner = analyze_argument_expr_recursive(operand, scope, depth + 1)?;
                     Ok(AnalyzedExpr {
                         expr: AnalyzedExprKind::Unwrap(Box::new(inner)),
                         glossa_type: GlossaType::Unknown,
@@ -173,7 +187,7 @@ pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr,
             // This is simplified; usually property access is handled by the assembler context
             // But if we encounter it directly as an expression, we try to resolve it.
             // For now, if it's a simple property access, we might need more context or just return it as PropertyAccess
-            let owner_analyzed = analyze_argument_expr(owner, scope)?;
+            let owner_analyzed = analyze_argument_expr_recursive(owner, scope, depth + 1)?;
             if let Expr::Word(prop_word) = property.as_ref() {
                 Ok(AnalyzedExpr {
                     expr: AnalyzedExprKind::PropertyAccess {

--- a/tests/havoc_disambiguation_panic.rs
+++ b/tests/havoc_disambiguation_panic.rs
@@ -1,0 +1,20 @@
+use glossa::morphology::{disambiguate, Case, DisambiguationContext, MorphAnalysis, PartOfSpeech};
+
+#[test]
+// #[should_panic] // No longer should panic
+fn test_disambiguate_nan_panic() {
+    let nan_analysis = MorphAnalysis::new("test".to_string(), PartOfSpeech::Noun)
+        .with_confidence(f32::NAN);
+
+    let valid_analysis = MorphAnalysis::new("valid".to_string(), PartOfSpeech::Noun)
+        .with_confidence(1.0);
+
+    let analyses = vec![nan_analysis, valid_analysis];
+
+    // Must provide context to bypass the "no context" early return
+    let mut context = DisambiguationContext::new();
+    context.expected_case = Some(Case::Nominative);
+
+    // This should NOT panic now
+    disambiguate(analyses, &context);
+}

--- a/tests/havoc_disambiguation_panic.rs
+++ b/tests/havoc_disambiguation_panic.rs
@@ -1,13 +1,13 @@
-use glossa::morphology::{disambiguate, Case, DisambiguationContext, MorphAnalysis, PartOfSpeech};
+use glossa::morphology::{Case, DisambiguationContext, MorphAnalysis, PartOfSpeech, disambiguate};
 
 #[test]
 // #[should_panic] // No longer should panic
 fn test_disambiguate_nan_panic() {
-    let nan_analysis = MorphAnalysis::new("test".to_string(), PartOfSpeech::Noun)
-        .with_confidence(f32::NAN);
+    let nan_analysis =
+        MorphAnalysis::new("test".to_string(), PartOfSpeech::Noun).with_confidence(f32::NAN);
 
-    let valid_analysis = MorphAnalysis::new("valid".to_string(), PartOfSpeech::Noun)
-        .with_confidence(1.0);
+    let valid_analysis =
+        MorphAnalysis::new("valid".to_string(), PartOfSpeech::Noun).with_confidence(1.0);
 
     let analyses = vec![nan_analysis, valid_analysis];
 

--- a/tests/havoc_stack_overflow.rs
+++ b/tests/havoc_stack_overflow.rs
@@ -1,33 +1,53 @@
-use glossa::parser::parse;
+use glossa::ast::{Expr, Word, Statement, Clause};
 use glossa::semantic::analyze_program;
 
 #[test]
-#[ignore = "Causes stack overflow (process abort) which fails CI. Run explicitly with -- --ignored to witness the wreckage."]
 fn test_stack_overflow_recursion() {
-    // 1. Define a function f
-    let func_def = "f ὁρίζειν τῷ χ. δός χ.";
+    // 1. Define 'φ' (phi) using parser
+    let func_def_src = "φ ὁρίζειν τῷ χ · δός χ.";
+    let mut ast = glossa::parser::parse(func_def_src).expect("Failed to parse function definition");
 
-    // 2. Generate deeply nested call: f (f (f ... (1) ...))
-    let depth = 5000; // 5000 frames should be enough to overflow standard stack
-    let mut call = String::new();
+    // 2. Manually build deep AST to bypass parser recursion limits
+    // φ(φ(φ(...))) -> Phrase([Word("φ"), Phrase([Word("φ"), ...])])
+
+    let depth = 500;
+    let mut expr = Expr::NumberLiteral(1);
 
     for _ in 0..depth {
-        call.push_str("f (");
+        expr = Expr::Phrase(vec![
+            Expr::Word(Word::new("φ")),
+            expr
+        ]);
     }
-    call.push('1');
-    for _ in 0..depth {
-        call.push(')');
-    }
-    call.push_str(" λέγε.");
 
-    let source = format!("{}\n{}", func_def, call);
+    // Wrap expression in a statement that triggers function call analysis
+    // Structure: res φ (nested...) ἔστω.
+    // Assembler:
+    // - res (Nom) -> Subject
+    // - φ (Nom) -> Extra Nominative (Function Name)
+    // - (nested) -> Nested Phrase
+    // - ἔστω (Verb) -> Binding Verb
 
-    // 3. Build AST
-    println!("Building AST with depth {}...", depth);
-    let ast = parse(&source).expect("Failed to build AST");
+    let call_stmt = Statement::Regular {
+        clauses: vec![Clause { expressions: vec![
+            Expr::Word(Word::new("res")),
+            Expr::Word(Word::new("φ")),
+            expr,
+            Expr::Word(Word::new("ἔστω"))
+        ] }],
+        is_query: false,
+        is_propagate: false,
+    };
 
-    // 4. Analyze (this should crash)
-    println!("Analyzing program...");
-    let _ = analyze_program(&ast).expect("Analysis failed");
-    println!("Survived!");
+    // Add to program
+    ast.statements.push(call_stmt);
+
+    println!("Analyzing deep expression (depth {})...", depth);
+    let result = analyze_program(&ast);
+
+    // 3. Assert we got an error (recursion limit exceeded) instead of crashing
+    assert!(result.is_err(), "Expected recursion limit error, but got success");
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("Recursion limit"), "Error message should mention recursion limit. Got: {}", err_msg);
 }

--- a/tests/havoc_stack_overflow.rs
+++ b/tests/havoc_stack_overflow.rs
@@ -1,4 +1,4 @@
-use glossa::ast::{Expr, Word, Statement, Clause};
+use glossa::ast::{Clause, Expr, Statement, Word};
 use glossa::semantic::analyze_program;
 
 #[test]
@@ -14,10 +14,7 @@ fn test_stack_overflow_recursion() {
     let mut expr = Expr::NumberLiteral(1);
 
     for _ in 0..depth {
-        expr = Expr::Phrase(vec![
-            Expr::Word(Word::new("φ")),
-            expr
-        ]);
+        expr = Expr::Phrase(vec![Expr::Word(Word::new("φ")), expr]);
     }
 
     // Wrap expression in a statement that triggers function call analysis
@@ -29,12 +26,14 @@ fn test_stack_overflow_recursion() {
     // - ἔστω (Verb) -> Binding Verb
 
     let call_stmt = Statement::Regular {
-        clauses: vec![Clause { expressions: vec![
-            Expr::Word(Word::new("res")),
-            Expr::Word(Word::new("φ")),
-            expr,
-            Expr::Word(Word::new("ἔστω"))
-        ] }],
+        clauses: vec![Clause {
+            expressions: vec![
+                Expr::Word(Word::new("res")),
+                Expr::Word(Word::new("φ")),
+                expr,
+                Expr::Word(Word::new("ἔστω")),
+            ],
+        }],
         is_query: false,
         is_propagate: false,
     };
@@ -46,8 +45,15 @@ fn test_stack_overflow_recursion() {
     let result = analyze_program(&ast);
 
     // 3. Assert we got an error (recursion limit exceeded) instead of crashing
-    assert!(result.is_err(), "Expected recursion limit error, but got success");
+    assert!(
+        result.is_err(),
+        "Expected recursion limit error, but got success"
+    );
 
     let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("Recursion limit"), "Error message should mention recursion limit. Got: {}", err_msg);
+    assert!(
+        err_msg.contains("Recursion limit"),
+        "Error message should mention recursion limit. Got: {}",
+        err_msg
+    );
 }


### PR DESCRIPTION
👺 Havoc: Harden system against NaN panics and Stack Overflows

This PR fixes two critical fragility issues identified by Chaos Engineering:

1.  **NaN Panic in Disambiguation:**
    *   **The Trigger:** Injecting `NaN` into `MorphAnalysis.confidence` caused `unwrap()` panic during `sort_by` in `disambiguate`.
    *   **The Fix:** Replaced `unwrap()` with `unwrap_or(Equal)` to handle floating point uncertainty safely.
    *   **Test:** Added `tests/havoc_disambiguation_panic.rs`.

2.  **Stack Overflow in Analysis:**
    *   **The Trigger:** Deeply nested function calls (e.g., `f(f(f(...)))`) caused process abort due to unbounded recursion in `analyze_argument_expr`.
    *   **The Fix:** Implemented recursion depth tracking in `src/semantic/expressions.rs` with a hard limit (50). Returns a semantic error instead of crashing.
    *   **Test:** Updated `tests/havoc_stack_overflow.rs` to verify graceful error handling.

😈 **Comment:** "You assumed `NaN` would never happen and the stack was infinite. You were wrong. Now prove me wrong again."

---
*PR created automatically by Jules for task [1877588764218184148](https://jules.google.com/task/1877588764218184148) started by @madmax983*