### PR TITLE
📜 Codex: ADR 003 & Architecture Update

### DIFF
--- a/docs/adr/003-decouple-storage.md
+++ b/docs/adr/003-decouple-storage.md
@@ -1,0 +1,18 @@
+# 3. Decouple Storage from Core
+
+Date: 2024-10-25
+Status: Proposed
+
+## Context
+
+Circular dependencies were causing build failures and making the codebase difficult to maintain. The Core module depended on Storage for persistence, while Storage depended on Core for data structures.
+
+## Decision
+
+Move persistence logic to a dedicated crate. The Storage crate will be independent of Core, or depend on it only via interfaces/traits defined in a common location if necessary.
+
+## Consequences
+
+- **Build times improve:** Parallel compilation is enabled.
+- **FFI complexity increases:** Crossing the crate boundary might require more complex FFI or serialization.
+- **Clearer boundaries:** Enforces separation of concerns.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,3 +40,15 @@ C4Container
     Rel(semantic, ir, "Typed AST")
     Rel(ir, codegen, "IR")
 ```
+
+## Core-Storage Decoupling (Class Level)
+
+The following diagram illustrates the decoupled relationship between Core and Storage.
+
+```mermaid
+classDiagram
+  class Core
+  class Storage
+  Core --> Storage : Uses (Trait Bound)
+  %% Removed the circular dependency arrow
+```


### PR DESCRIPTION
Recorded the move to `storage` crate in ADR 003 and updated the architecture diagram to show the decoupled relationship between Core and Storage. Link: `docs/adr/003-decouple-storage.md`.

---
*PR created automatically by Jules for task [8342662588720780548](https://jules.google.com/task/8342662588720780548) started by @madmax983*