### PR TITLE
⚡ Bolt: Optimized Scope resolution to use stack instead of cloning

### DIFF
--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -230,11 +230,15 @@ pub fn analyze_trait_impl(
                     analyzed_body.push(control_flow);
                 }
                 // Try struct instantiation pattern
-                else if let Some(struct_inst) = try_parse_struct_instantiation(body_stmt, &mut scope)? {
+                else if let Some(struct_inst) =
+                    try_parse_struct_instantiation(body_stmt, &mut scope)?
+                {
                     analyzed_body.push(struct_inst);
                 }
                 // Try trait method call pattern
-                else if let Some(method_call) = try_parse_trait_method_call(body_stmt, &mut scope)? {
+                else if let Some(method_call) =
+                    try_parse_trait_method_call(body_stmt, &mut scope)?
+                {
                     analyzed_body.push(method_call);
                 } else {
                     // Use assembler for regular statements

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -96,29 +96,29 @@ pub fn analyze_trait_definition(
             let body = if let Some(body_stmts) = &method.body {
                 let mut analyzed_body = Vec::new();
                 // Create a child scope for the method
-                let mut method_scope = scope.child();
-                // Add method parameters to scope (including self)
-                for (param_name, param_type) in &params {
-                    method_scope.define(param_name.clone(), param_type.clone());
-                }
-                // Properly analyze statements in the body
-                for body_stmt in body_stmts {
-                    if let Some(control_flow) = analyze_control_flow(body_stmt, &mut method_scope)?
-                    {
-                        analyzed_body.push(control_flow);
-                    } else if let Some(struct_inst) =
-                        try_parse_struct_instantiation(body_stmt, &mut method_scope)?
-                    {
-                        analyzed_body.push(struct_inst);
-                    } else if let Some(method_call) =
-                        try_parse_trait_method_call(body_stmt, &mut method_scope)?
-                    {
-                        analyzed_body.push(method_call);
-                    } else {
-                        let assembled = analyze_single_statement_with_assembler(body_stmt)?;
-                        let analyzed =
-                            convert_assembled_to_analyzed(&assembled, &mut method_scope)?;
-                        analyzed_body.push(analyzed);
+                {
+                    let mut scope = scope.enter_scope();
+                    // Add method parameters to scope (including self)
+                    for (param_name, param_type) in &params {
+                        scope.define(param_name.clone(), param_type.clone());
+                    }
+                    // Properly analyze statements in the body
+                    for body_stmt in body_stmts {
+                        if let Some(control_flow) = analyze_control_flow(body_stmt, &mut scope)? {
+                            analyzed_body.push(control_flow);
+                        } else if let Some(struct_inst) =
+                            try_parse_struct_instantiation(body_stmt, &mut scope)?
+                        {
+                            analyzed_body.push(struct_inst);
+                        } else if let Some(method_call) =
+                            try_parse_trait_method_call(body_stmt, &mut scope)?
+                        {
+                            analyzed_body.push(method_call);
+                        } else {
+                            let assembled = analyze_single_statement_with_assembler(body_stmt)?;
+                            let analyzed = convert_assembled_to_analyzed(&assembled, &mut scope)?;
+                            analyzed_body.push(analyzed);
+                        }
                     }
                 }
                 Some(analyzed_body)
@@ -188,6 +188,7 @@ pub fn analyze_trait_impl(
     // Validate: trait must exist
     let trait_def = scope
         .lookup_trait(&trait_name)
+        .cloned()
         .ok_or_else(|| GlossaError::semantic(format!("Trait {} is not defined", trait_name)))?;
 
     // Validate: type must exist
@@ -212,37 +213,35 @@ pub fn analyze_trait_impl(
         }
 
         // Create a child scope for the method body with self bound
-        let mut method_scope = scope.child();
-        method_scope.define("self".to_string(), struct_type.clone());
-
-        // Also bind parameters
-        for (param_name, param_type) in &params {
-            method_scope.define(param_name.clone(), param_type.clone());
-        }
-
-        // Analyze the method body
         let mut analyzed_body = Vec::new();
-        for body_stmt in &method.body {
-            // Try control flow first
-            if let Some(control_flow) = analyze_control_flow(body_stmt, &mut method_scope)? {
-                analyzed_body.push(control_flow);
+        {
+            let mut scope = scope.enter_scope();
+            scope.define("self".to_string(), struct_type.clone());
+
+            // Also bind parameters
+            for (param_name, param_type) in &params {
+                scope.define(param_name.clone(), param_type.clone());
             }
-            // Try struct instantiation pattern
-            else if let Some(struct_inst) =
-                try_parse_struct_instantiation(body_stmt, &mut method_scope)?
-            {
-                analyzed_body.push(struct_inst);
-            }
-            // Try trait method call pattern
-            else if let Some(method_call) =
-                try_parse_trait_method_call(body_stmt, &mut method_scope)?
-            {
-                analyzed_body.push(method_call);
-            } else {
-                // Use assembler for regular statements
-                let assembled = analyze_single_statement_with_assembler(body_stmt)?;
-                let analyzed = convert_assembled_to_analyzed(&assembled, &mut method_scope)?;
-                analyzed_body.push(analyzed);
+
+            // Analyze the method body
+            for body_stmt in &method.body {
+                // Try control flow first
+                if let Some(control_flow) = analyze_control_flow(body_stmt, &mut scope)? {
+                    analyzed_body.push(control_flow);
+                }
+                // Try struct instantiation pattern
+                else if let Some(struct_inst) = try_parse_struct_instantiation(body_stmt, &mut scope)? {
+                    analyzed_body.push(struct_inst);
+                }
+                // Try trait method call pattern
+                else if let Some(method_call) = try_parse_trait_method_call(body_stmt, &mut scope)? {
+                    analyzed_body.push(method_call);
+                } else {
+                    // Use assembler for regular statements
+                    let assembled = analyze_single_statement_with_assembler(body_stmt)?;
+                    let analyzed = convert_assembled_to_analyzed(&assembled, &mut scope)?;
+                    analyzed_body.push(analyzed);
+                }
             }
         }
 

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -115,7 +115,9 @@ impl Scope {
     }
 
     fn current_level(&mut self) -> &mut ScopeLevel {
-        self.levels.last_mut().expect("Scope must have at least one level")
+        self.levels
+            .last_mut()
+            .expect("Scope must have at least one level")
     }
 
     /// Define a function in this scope
@@ -407,8 +409,8 @@ mod tests {
         scope.define("ξ".to_string(), GlossaType::Number);
 
         {
-             let binding = scope.lookup_binding("ξ").unwrap();
-             assert!(!binding.used);
+            let binding = scope.lookup_binding("ξ").unwrap();
+            assert!(!binding.used);
         }
 
         scope.mark_used("ξ");

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -6,9 +6,9 @@ use crate::semantic::GlossaType;
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
 
-/// A scope containing variable bindings
+/// A scope level containing variable bindings
 #[derive(Debug, Clone, Default)]
-pub struct Scope {
+struct ScopeLevel {
     /// Variable bindings in this scope
     bindings: FxHashMap<SmolStr, Binding>,
     /// Function definitions in this scope
@@ -19,8 +19,18 @@ pub struct Scope {
     traits: FxHashMap<SmolStr, crate::semantic::model::TraitDef>,
     /// Trait implementations in this scope
     trait_impls: Vec<crate::semantic::model::TraitImpl>,
-    /// Parent scope (for nested scopes)
-    parent: Option<Box<Scope>>,
+}
+
+impl ScopeLevel {
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// A scope containing variable bindings
+#[derive(Debug, Clone)]
+pub struct Scope {
+    levels: Vec<ScopeLevel>,
 }
 
 /// A function signature for tracking defined functions
@@ -32,6 +42,30 @@ pub struct FunctionSignature {
     pub param_types: Vec<GlossaType>,
     /// Return type (None for void)
     pub return_type: Option<GlossaType>,
+}
+
+/// A RAII guard for a scope level. Exits the scope when dropped.
+pub struct ScopeGuard<'a> {
+    scope: &'a mut Scope,
+}
+
+impl<'a> Drop for ScopeGuard<'a> {
+    fn drop(&mut self) {
+        self.scope.exit();
+    }
+}
+
+impl<'a> std::ops::Deref for ScopeGuard<'a> {
+    type Target = Scope;
+    fn deref(&self) -> &Scope {
+        self.scope
+    }
+}
+
+impl<'a> std::ops::DerefMut for ScopeGuard<'a> {
+    fn deref_mut(&mut self) -> &mut Scope {
+        self.scope
+    }
 }
 
 /// A variable binding with type and metadata
@@ -51,25 +85,37 @@ impl Scope {
     /// Create a new empty scope
     pub fn new() -> Self {
         Scope {
-            bindings: FxHashMap::default(),
-            functions: FxHashMap::default(),
-            types: FxHashMap::default(),
-            traits: FxHashMap::default(),
-            trait_impls: Vec::new(),
-            parent: None,
+            levels: vec![ScopeLevel::new()],
+        }
+    }
+
+    /// Enter a new scope level
+    pub fn enter(&mut self) {
+        self.levels.push(ScopeLevel::new());
+    }
+
+    /// Enter a new scope level and return a RAII guard that exits it on drop
+    pub fn enter_scope(&mut self) -> ScopeGuard<'_> {
+        self.enter();
+        ScopeGuard { scope: self }
+    }
+
+    /// Exit the current scope level
+    pub fn exit(&mut self) {
+        if self.levels.len() > 1 {
+            self.levels.pop();
         }
     }
 
     /// Create a child scope with this scope as parent
     pub fn child(&self) -> Self {
-        Scope {
-            bindings: FxHashMap::default(),
-            functions: FxHashMap::default(),
-            types: FxHashMap::default(),
-            traits: FxHashMap::default(),
-            trait_impls: Vec::new(),
-            parent: Some(Box::new(self.clone())),
-        }
+        let mut new_scope = self.clone();
+        new_scope.enter();
+        new_scope
+    }
+
+    fn current_level(&mut self) -> &mut ScopeLevel {
+        self.levels.last_mut().expect("Scope must have at least one level")
     }
 
     /// Define a function in this scope
@@ -80,7 +126,7 @@ impl Scope {
         return_type: Option<GlossaType>,
     ) {
         let name = name.into();
-        self.functions.insert(
+        self.current_level().functions.insert(
             name.clone(),
             FunctionSignature {
                 name,
@@ -92,40 +138,37 @@ impl Scope {
 
     /// Check if a name is a defined function
     pub fn is_function(&self, name: &str) -> bool {
-        if self.functions.contains_key(name) {
-            true
-        } else if let Some(parent) = &self.parent {
-            parent.is_function(name)
-        } else {
-            false
+        for level in self.levels.iter().rev() {
+            if level.functions.contains_key(name) {
+                return true;
+            }
         }
+        false
     }
 
     /// Look up a function signature
     pub fn lookup_function(&self, name: &str) -> Option<&FunctionSignature> {
-        if let Some(sig) = self.functions.get(name) {
-            Some(sig)
-        } else if let Some(parent) = &self.parent {
-            parent.lookup_function(name)
-        } else {
-            None
+        for level in self.levels.iter().rev() {
+            if let Some(sig) = level.functions.get(name) {
+                return Some(sig);
+            }
         }
+        None
     }
 
     /// Define a type in this scope
     pub fn define_type(&mut self, name: impl Into<SmolStr>, glossa_type: GlossaType) {
-        self.types.insert(name.into(), glossa_type);
+        self.current_level().types.insert(name.into(), glossa_type);
     }
 
     /// Look up a type by name
     pub fn lookup_type(&self, name: &str) -> Option<&GlossaType> {
-        if let Some(ty) = self.types.get(name) {
-            Some(ty)
-        } else if let Some(parent) = &self.parent {
-            parent.lookup_type(name)
-        } else {
-            None
+        for level in self.levels.iter().rev() {
+            if let Some(ty) = level.types.get(name) {
+                return Some(ty);
+            }
         }
+        None
     }
 
     /// Define a trait in this scope
@@ -134,23 +177,22 @@ impl Scope {
         name: impl Into<SmolStr>,
         trait_def: crate::semantic::model::TraitDef,
     ) {
-        self.traits.insert(name.into(), trait_def);
+        self.current_level().traits.insert(name.into(), trait_def);
     }
 
     /// Look up a trait by name
     pub fn lookup_trait(&self, name: &str) -> Option<&crate::semantic::model::TraitDef> {
-        if let Some(trait_def) = self.traits.get(name) {
-            Some(trait_def)
-        } else if let Some(parent) = &self.parent {
-            parent.lookup_trait(name)
-        } else {
-            None
+        for level in self.levels.iter().rev() {
+            if let Some(trait_def) = level.traits.get(name) {
+                return Some(trait_def);
+            }
         }
+        None
     }
 
     /// Register a trait implementation
     pub fn register_trait_impl(&mut self, impl_def: crate::semantic::model::TraitImpl) {
-        self.trait_impls.push(impl_def);
+        self.current_level().trait_impls.push(impl_def);
     }
 
     /// Look up a trait implementation for a given type and trait
@@ -159,51 +201,46 @@ impl Scope {
         type_name: &str,
         trait_name: &str,
     ) -> Option<&crate::semantic::model::TraitImpl> {
-        for impl_def in &self.trait_impls {
-            if impl_def.type_name == type_name && impl_def.trait_name == trait_name {
-                return Some(impl_def);
+        for level in self.levels.iter().rev() {
+            for impl_def in &level.trait_impls {
+                if impl_def.type_name == type_name && impl_def.trait_name == trait_name {
+                    return Some(impl_def);
+                }
             }
         }
-        if let Some(parent) = &self.parent {
-            parent.lookup_trait_impl(type_name, trait_name)
-        } else {
-            None
-        }
+        None
     }
 
     /// Check if a type has a trait method with the given name
     pub fn has_trait_method(&self, type_name: &str, method_name: &str) -> bool {
-        for trait_impl in &self.trait_impls {
-            if trait_impl.type_name != type_name {
-                continue;
-            }
-            // Check if the trait has this method
-            if let Some(trait_def) = self.lookup_trait(&trait_impl.trait_name) {
-                let has_method = trait_def
-                    .required_methods
-                    .iter()
-                    .any(|m| m.name == method_name)
-                    || trait_def
-                        .default_methods
+        for level in self.levels.iter().rev() {
+            for trait_impl in &level.trait_impls {
+                if trait_impl.type_name != type_name {
+                    continue;
+                }
+                // Check if the trait has this method
+                if let Some(trait_def) = self.lookup_trait(&trait_impl.trait_name) {
+                    let has_method = trait_def
+                        .required_methods
                         .iter()
-                        .any(|m| m.signature.name == method_name);
-                if has_method {
-                    return true;
+                        .any(|m| m.name == method_name)
+                        || trait_def
+                            .default_methods
+                            .iter()
+                            .any(|m| m.signature.name == method_name);
+                    if has_method {
+                        return true;
+                    }
                 }
             }
         }
-        // Check parent scope
-        if let Some(parent) = &self.parent {
-            parent.has_trait_method(type_name, method_name)
-        } else {
-            false
-        }
+        false
     }
 
     /// Define a new binding in this scope
     pub fn define(&mut self, name: impl Into<SmolStr>, glossa_type: GlossaType) {
         let name = name.into();
-        self.bindings.insert(
+        self.current_level().bindings.insert(
             name.clone(),
             Binding {
                 name,
@@ -217,7 +254,7 @@ impl Scope {
     /// Define a mutable binding
     pub fn define_mut(&mut self, name: impl Into<SmolStr>, glossa_type: GlossaType) {
         let name = name.into();
-        self.bindings.insert(
+        self.current_level().bindings.insert(
             name.clone(),
             Binding {
                 name,
@@ -230,25 +267,30 @@ impl Scope {
 
     /// Look up a binding by name, searching parent scopes
     pub fn lookup(&self, name: &str) -> Option<&GlossaType> {
-        if let Some(binding) = self.bindings.get(name) {
-            Some(&binding.glossa_type)
-        } else if let Some(parent) = &self.parent {
-            parent.lookup(name)
-        } else {
-            None
+        for level in self.levels.iter().rev() {
+            if let Some(binding) = level.bindings.get(name) {
+                return Some(&binding.glossa_type);
+            }
         }
+        None
     }
 
     /// Look up full binding information by name, searching parent scopes
     pub fn lookup_binding(&self, name: &str) -> Option<&Binding> {
-        self.bindings
-            .get(name)
-            .or_else(|| self.parent.as_ref()?.lookup_binding(name))
+        for level in self.levels.iter().rev() {
+            if let Some(binding) = level.bindings.get(name) {
+                return Some(binding);
+            }
+        }
+        None
     }
 
     /// Check if a name is defined in this scope (not parents)
     pub fn is_defined_locally(&self, name: &str) -> bool {
-        self.bindings.contains_key(name)
+        self.levels
+            .last()
+            .map(|l| l.bindings.contains_key(name))
+            .unwrap_or(false)
     }
 
     /// Check if a name is defined anywhere in scope chain
@@ -256,23 +298,34 @@ impl Scope {
         self.lookup(name).is_some()
     }
 
-    /// Get all bindings in this scope
+    /// Get all bindings in this scope (from all levels)
     pub fn bindings(&self) -> impl Iterator<Item = (&SmolStr, &Binding)> {
-        self.bindings.iter()
+        self.levels.iter().flat_map(|l| l.bindings.iter())
     }
 
     /// Mark a binding as used
     pub fn mark_used(&mut self, name: &str) {
-        if let Some(binding) = self.bindings.get_mut(name) {
-            binding.used = true;
-        } else if let Some(parent) = &mut self.parent {
-            parent.mark_used(name);
+        for level in self.levels.iter_mut().rev() {
+            if let Some(binding) = level.bindings.get_mut(name) {
+                binding.used = true;
+                return;
+            }
         }
     }
 
     /// Get unused bindings (for warnings)
     pub fn unused_bindings(&self) -> Vec<&Binding> {
-        self.bindings.values().filter(|b| !b.used).collect()
+        self.levels
+            .iter()
+            .flat_map(|l| l.bindings.values())
+            .filter(|b| !b.used)
+            .collect()
+    }
+}
+
+impl Default for Scope {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -312,11 +365,39 @@ mod tests {
     }
 
     #[test]
+    fn test_enter_exit_scope() {
+        let mut scope = Scope::new();
+        scope.define("ξ".to_string(), GlossaType::Number);
+
+        scope.enter();
+        assert!(scope.is_defined("ξ")); // Inherits
+        scope.define("υ".to_string(), GlossaType::String);
+        assert!(scope.is_defined("υ"));
+
+        scope.exit();
+        assert!(scope.is_defined("ξ"));
+        assert!(!scope.is_defined("υ")); // υ was popped
+    }
+
+    #[test]
+    fn test_enter_shadowing() {
+        let mut scope = Scope::new();
+        scope.define("ξ".to_string(), GlossaType::Number);
+
+        scope.enter();
+        scope.define("ξ".to_string(), GlossaType::String);
+        assert_eq!(scope.lookup("ξ"), Some(&GlossaType::String));
+
+        scope.exit();
+        assert_eq!(scope.lookup("ξ"), Some(&GlossaType::Number));
+    }
+
+    #[test]
     fn test_mutable_binding() {
         let mut scope = Scope::new();
         scope.define_mut("μ".to_string(), GlossaType::Number);
 
-        let binding = scope.bindings.get("μ").unwrap();
+        let binding = scope.lookup_binding("μ").unwrap();
         assert!(binding.mutable);
     }
 
@@ -325,9 +406,14 @@ mod tests {
         let mut scope = Scope::new();
         scope.define("ξ".to_string(), GlossaType::Number);
 
-        assert!(!scope.bindings.get("ξ").unwrap().used);
+        {
+             let binding = scope.lookup_binding("ξ").unwrap();
+             assert!(!binding.used);
+        }
+
         scope.mark_used("ξ");
-        assert!(scope.bindings.get("ξ").unwrap().used);
+        let binding = scope.lookup_binding("ξ").unwrap();
+        assert!(binding.used);
     }
 
     #[test]


### PR DESCRIPTION
*   💡 **What**: Refactored `Scope` to use a single `Vec<ScopeLevel>` stack instead of a linked list of boxed `Scope` clones. Added `ScopeGuard` for RAII-based scope management.
*   🎯 **Why**: The previous implementation recursively cloned the entire parent scope chain (O(N^2) in worst case deep nesting) every time a child scope was created (e.g., for every method in a trait definition).
*   📊 **Impact**: Reduces memory allocations from O(Total Scopes) to O(1) per scope creation/destruction in `analyze_trait_definition` and `analyze_trait_impl`.
*   🔬 **Measurement**: Verified with `cargo test` and ensured no regressions. Exception safety guaranteed by `ScopeGuard`.

---
*PR created automatically by Jules for task [9325208314553664706](https://jules.google.com/task/9325208314553664706) started by @madmax983*