### PR TITLE
🛡️ Sentry: Fix stack overflow in assembler recursion

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -17,3 +17,7 @@
 ## [Silent Token Swallowing in Special Checks]
 **Learning:** Functions like `check_method_verbs` and `check_special_properties` were returning `true` (indicating "handled") even when they failed to match the full pattern (e.g., missing subject), causing tokens like "split" or "length" to be silently ignored instead of falling back to normal verb/noun processing.
 **Action:** Ensure that special handling functions only return `true` when they *successfully* handle the token. If prerequisites aren't met, return `false` to allow fallback to standard processing.
+
+## [Recursion Safety in Assembler]
+**Learning:** `feed_expr_to_assembler_with_context` was recursing indefinitely on deeply nested structures like `PropertyAccess` or `Phrase`, causing a stack overflow.
+**Action:** Added a `depth` parameter and recursion limit (50) to all recursive semantic analysis functions. Always validate recursion depth when processing untrusted AST structures.

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -314,6 +314,21 @@ pub fn feed_expr_to_assembler_with_context(
     expr: &Expr,
     context: &mut DisambiguationContext,
 ) -> Result<(), GlossaError> {
+    feed_expr_recursive(asm, expr, context, 0)
+}
+
+fn feed_expr_recursive(
+    asm: &mut Assembler,
+    expr: &Expr,
+    context: &mut DisambiguationContext,
+    depth: usize,
+) -> Result<(), GlossaError> {
+    if depth > 50 {
+        return Err(GlossaError::semantic(
+            "Recursion limit exceeded in assembler feed",
+        ));
+    }
+
     match expr {
         Expr::StringLiteral(s) => {
             asm.feed_string(s.clone());
@@ -373,14 +388,14 @@ pub fn feed_expr_to_assembler_with_context(
                         asm.feed_nested_phrase(nested_terms.clone());
                     }
                 } else {
-                    feed_expr_to_assembler_with_context(asm, term, context)?;
+                    feed_expr_recursive(asm, term, context, depth + 1)?;
                 }
             }
         }
         Expr::PropertyAccess { owner, property } => {
             // Owner is genitive, property is what it attaches to
-            feed_expr_to_assembler_with_context(asm, owner, context)?;
-            feed_expr_to_assembler_with_context(asm, property, context)?;
+            feed_expr_recursive(asm, owner, context, depth + 1)?;
+            feed_expr_recursive(asm, property, context, depth + 1)?;
         }
         Expr::Call { verb, arguments } => {
             // Feed the verb - verbs can set context for subjects
@@ -396,7 +411,7 @@ pub fn feed_expr_to_assembler_with_context(
 
             // Feed arguments
             for arg in arguments {
-                feed_expr_to_assembler_with_context(asm, arg, context)?;
+                feed_expr_recursive(asm, arg, context, depth + 1)?;
             }
         }
         Expr::Binding { name, value } => {
@@ -407,12 +422,12 @@ pub fn feed_expr_to_assembler_with_context(
             if let Err(e) = asm.feed(&best_name, &name.original) {
                 return Err(GlossaError::semantic(e.to_string()));
             }
-            feed_expr_to_assembler_with_context(asm, value, context)?;
+            feed_expr_recursive(asm, value, context, depth + 1)?;
         }
         Expr::BinOp { left, op: _, right } => {
             // TODO: Implement binary operation handling
-            feed_expr_to_assembler_with_context(asm, left, context)?;
-            feed_expr_to_assembler_with_context(asm, right, context)?;
+            feed_expr_recursive(asm, left, context, depth + 1)?;
+            feed_expr_recursive(asm, right, context, depth + 1)?;
         }
         Expr::UnaryOp { op, operand } => {
             // Handle unwrap operator specially - it's a postfix operator that doesn't need word-order handling
@@ -421,7 +436,7 @@ pub fn feed_expr_to_assembler_with_context(
                 asm.feed_unwrap(operand.as_ref().clone());
             } else {
                 // TODO: Implement other unary operations (Not, Neg)
-                feed_expr_to_assembler_with_context(asm, operand, context)?;
+                feed_expr_recursive(asm, operand, context, depth + 1)?;
             }
         }
         Expr::Block(statements) => {

--- a/tests/havoc_stack_overflow_assembler.rs
+++ b/tests/havoc_stack_overflow_assembler.rs
@@ -1,0 +1,31 @@
+use glossa::ast::{Expr, Word};
+use glossa::semantic::expressions::feed_expr_to_assembler_with_context;
+use glossa::semantic::Assembler;
+use glossa::morphology::DisambiguationContext;
+
+#[test]
+fn test_stack_overflow_in_assembler_feed() {
+    // Construct a deeply nested expression
+    // PropertyAccess { owner: PropertyAccess { ... }, property: "prop" }
+
+    let mut expr = Expr::Word(Word::new("base"));
+
+    // 5000 levels deep should trigger stack overflow on most default stack sizes
+    for _ in 0..5000 {
+        expr = Expr::PropertyAccess {
+            owner: Box::new(expr),
+            property: Box::new(Expr::Word(Word::new("prop"))),
+        };
+    }
+
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+
+    // This should now return an error instead of aborting
+    // We call the public function which handles depth internally
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(format!("{}", err).contains("Recursion limit exceeded"));
+}

--- a/tests/havoc_stack_overflow_assembler.rs
+++ b/tests/havoc_stack_overflow_assembler.rs
@@ -1,7 +1,7 @@
 use glossa::ast::{Expr, Word};
-use glossa::semantic::expressions::feed_expr_to_assembler_with_context;
-use glossa::semantic::Assembler;
 use glossa::morphology::DisambiguationContext;
+use glossa::semantic::Assembler;
+use glossa::semantic::expressions::feed_expr_to_assembler_with_context;
 
 #[test]
 fn test_stack_overflow_in_assembler_feed() {

--- a/tests/sentry_coverage_assembler.rs
+++ b/tests/sentry_coverage_assembler.rs
@@ -1,7 +1,7 @@
-use glossa::ast::{Expr, Word, BinOperator, UnaryOperator, Statement, Clause};
-use glossa::semantic::expressions::feed_expr_to_assembler_with_context;
-use glossa::semantic::Assembler;
+use glossa::ast::{BinOperator, Clause, Expr, Statement, UnaryOperator, Word};
 use glossa::morphology::DisambiguationContext;
+use glossa::semantic::Assembler;
+use glossa::semantic::expressions::feed_expr_to_assembler_with_context;
 
 #[test]
 fn test_assembler_coverage_variants() {
@@ -10,18 +10,13 @@ fn test_assembler_coverage_variants() {
 
     // 1. Phrase (non-nested)
     // "1 2"
-    let phrase_expr = Expr::Phrase(vec![
-        Expr::NumberLiteral(1),
-        Expr::NumberLiteral(2),
-    ]);
+    let phrase_expr = Expr::Phrase(vec![Expr::NumberLiteral(1), Expr::NumberLiteral(2)]);
     let res = feed_expr_to_assembler_with_context(&mut asm, &phrase_expr, &mut ctx);
     assert!(res.is_ok());
 
     // 2. Phrase (nested)
     // "(1)" - nested phrase handling
-    let nested_phrase = Expr::Phrase(vec![
-        Expr::Phrase(vec![Expr::NumberLiteral(1)])
-    ]);
+    let nested_phrase = Expr::Phrase(vec![Expr::Phrase(vec![Expr::NumberLiteral(1)])]);
     let res = feed_expr_to_assembler_with_context(&mut asm, &nested_phrase, &mut ctx);
     assert!(res.is_ok());
 
@@ -63,13 +58,13 @@ fn test_assembler_coverage_variants() {
     assert!(res.is_ok());
 
     // 7. Block
-    let block_expr = Expr::Block(vec![
-        Statement::Regular {
-            clauses: vec![Clause { expressions: vec![Expr::NumberLiteral(1)] }],
-            is_query: false,
-            is_propagate: false,
-        }
-    ]);
+    let block_expr = Expr::Block(vec![Statement::Regular {
+        clauses: vec![Clause {
+            expressions: vec![Expr::NumberLiteral(1)],
+        }],
+        is_query: false,
+        is_propagate: false,
+    }]);
     let res = feed_expr_to_assembler_with_context(&mut asm, &block_expr, &mut ctx);
     assert!(res.is_ok());
 

--- a/tests/sentry_coverage_assembler.rs
+++ b/tests/sentry_coverage_assembler.rs
@@ -1,0 +1,88 @@
+use glossa::ast::{Expr, Word, BinOperator, UnaryOperator, Statement, Clause};
+use glossa::semantic::expressions::feed_expr_to_assembler_with_context;
+use glossa::semantic::Assembler;
+use glossa::morphology::DisambiguationContext;
+
+#[test]
+fn test_assembler_coverage_variants() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+
+    // 1. Phrase (non-nested)
+    // "1 2"
+    let phrase_expr = Expr::Phrase(vec![
+        Expr::NumberLiteral(1),
+        Expr::NumberLiteral(2),
+    ]);
+    let res = feed_expr_to_assembler_with_context(&mut asm, &phrase_expr, &mut ctx);
+    assert!(res.is_ok());
+
+    // 2. Phrase (nested)
+    // "(1)" - nested phrase handling
+    let nested_phrase = Expr::Phrase(vec![
+        Expr::Phrase(vec![Expr::NumberLiteral(1)])
+    ]);
+    let res = feed_expr_to_assembler_with_context(&mut asm, &nested_phrase, &mut ctx);
+    assert!(res.is_ok());
+
+    // 3. Call
+    // "add 1"
+    let call_expr = Expr::Call {
+        verb: Word::new("λεγε"), // Use a known verb so it analyzes
+        arguments: vec![Expr::NumberLiteral(1)],
+    };
+    let res = feed_expr_to_assembler_with_context(&mut asm, &call_expr, &mut ctx);
+    assert!(res.is_ok());
+
+    // 4. Binding
+    // "x = 1" (Binding expr, not statement)
+    let binding_expr = Expr::Binding {
+        name: Word::new("χ"),
+        value: Box::new(Expr::NumberLiteral(1)),
+    };
+    let res = feed_expr_to_assembler_with_context(&mut asm, &binding_expr, &mut ctx);
+    assert!(res.is_ok());
+
+    // 5. BinOp
+    // "1 + 2"
+    let binop_expr = Expr::BinOp {
+        left: Box::new(Expr::NumberLiteral(1)),
+        op: BinOperator::Add,
+        right: Box::new(Expr::NumberLiteral(2)),
+    };
+    let res = feed_expr_to_assembler_with_context(&mut asm, &binop_expr, &mut ctx);
+    assert!(res.is_ok());
+
+    // 6. UnaryOp (Not Unwrap)
+    // "!x"
+    let unary_expr = Expr::UnaryOp {
+        op: UnaryOperator::Not,
+        operand: Box::new(Expr::BooleanLiteral(true)),
+    };
+    let res = feed_expr_to_assembler_with_context(&mut asm, &unary_expr, &mut ctx);
+    assert!(res.is_ok());
+
+    // 7. Block
+    let block_expr = Expr::Block(vec![
+        Statement::Regular {
+            clauses: vec![Clause { expressions: vec![Expr::NumberLiteral(1)] }],
+            is_query: false,
+            is_propagate: false,
+        }
+    ]);
+    let res = feed_expr_to_assembler_with_context(&mut asm, &block_expr, &mut ctx);
+    assert!(res.is_ok());
+
+    // 8. ArrayLiteral
+    let array_expr = Expr::ArrayLiteral(vec![Expr::NumberLiteral(1)]);
+    let res = feed_expr_to_assembler_with_context(&mut asm, &array_expr, &mut ctx);
+    assert!(res.is_ok());
+
+    // 9. IndexAccess
+    let index_expr = Expr::IndexAccess {
+        array: Box::new(Expr::ArrayLiteral(vec![])),
+        index: Box::new(Expr::NumberLiteral(0)),
+    };
+    let res = feed_expr_to_assembler_with_context(&mut asm, &index_expr, &mut ctx);
+    assert!(res.is_ok());
+}


### PR DESCRIPTION
This PR addresses a critical stability issue identified during Sentry audit.

## Summary
The function `feed_expr_to_assembler_with_context` in `src/semantic/expressions.rs` was susceptible to stack overflow when processing deeply nested AST structures (such as chained property accesses or nested phrases). This function lacked a recursion depth check, unlike its counterpart `analyze_argument_expr`.

## Changes
- Introduced a private helper function `feed_expr_recursive` that accepts a `depth` parameter.
- Refactored `feed_expr_to_assembler_with_context` to wrap this helper, initializing depth at 0.
- Enforced a recursion depth limit of 50. If exceeded, it returns a `GlossaError`.
- Added a regression test `tests/havoc_stack_overflow_assembler.rs` that attempts to feed a 5000-level deep expression structure, verifying that it now returns an error instead of aborting the process.

## Verification
- Run `cargo test --test havoc_stack_overflow_assembler` to verify the fix.
- Run `cargo test` to ensure no regressions.


---
*PR created automatically by Jules for task [11266705946010981894](https://jules.google.com/task/11266705946010981894) started by @madmax983*