### PR TITLE
🎻 Bard: Documented the AST Module

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2,6 +2,39 @@
 //!
 //! The AST captures the semantic structure of a GLOSSA program,
 //! preserving morphological information from Greek words.
+//!
+//! # The Tree Structure
+//!
+//! The AST hierarchy reflects the grammatical structure of the language:
+//!
+//! * [`Program`]: The root node, containing a list of statements.
+//! * [`Statement`]: A sentence, ending with a period (`.`) or query mark (`?` / `;`).
+//!   * A statement consists of one or more [`Clause`]s.
+//! * [`Clause`]: A comma-separated part of a statement.
+//!   * Example: `ὁ ἄνθρωπος, τὸν λόγον λέγει.` (Two clauses: "The man", "says the word").
+//! * [`Expr`]: An expression (word, literal, operation).
+//!   * [`Expr::Word`]: A raw Greek word with its original and normalized forms.
+//!
+//! # Design Philosophy
+//!
+//! Unlike traditional ASTs that might discard surface-level details, the GLOSSA AST
+//! preserves the *original* Greek text in [`Word`] nodes. This is crucial for:
+//!
+//! 1. **Error Reporting**: Using the original polytonic Greek in error messages.
+//! 2. **Morphological Analysis**: The semantic phase needs the original form to
+//!    distinguish subtle variations if needed.
+//!
+//! # Example
+//!
+//! A simple program like `«χαῖρε» λέγε.` produces:
+//!
+//! ```text
+//! Program
+//! └── Statement::Regular
+//!     └── Clause
+//!         ├── Expr::StringLiteral("χαῖρε")
+//!         └── Expr::Word("λέγε")
+//! ```
 
 mod nodes;
 


### PR DESCRIPTION
🎻 **Bard: Documented the AST Module**

📖 **Chapter:** The `ast` module.
🔦 **Insight:** Clarified the hierarchy of the Abstract Syntax Tree (`Program` -> `Statement` -> `Clause` -> `Expr`) and explained *why* we preserve the original Greek text in `Word` nodes (for error reporting and morphological analysis).
🖼️ **Preview:**
```rust
//! # Example
//!
//! A simple program like `«χαῖρε» λέγε.` produces:
//!
//! ```text
//! Program
//! └── Statement::Regular
//!     └── Clause
//!         ├── Expr::StringLiteral("χαῖρε")
//!         └── Expr::Word("λέγε")
//! ```
```

---
*PR created automatically by Jules for task [5461823045995079107](https://jules.google.com/task/5461823045995079107) started by @madmax983*