### PR TITLE
🗺️ Atlas: Decouple text normalization from grammar module

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -28,3 +28,11 @@
 2. Updated `GlossaError` to include `AssemblyError` as a transparent variant.
 3. Updated `src/semantic/assembler.rs` to use the shared error type.
 **Stability:** Centralizes error definition, preserves error structure for better diagnostics, and maintains acyclic graph (`errors` -> `morphology`, `semantic` -> `errors`).
+
+## [Breaking The Knot: Grammar Module Coupling]
+**Tangle:** The `grammar` module (parser) was exposing `normalize_greek`, a text utility. Every other module (`ast`, `morphology`, `semantic`, `codegen`) depended on `grammar` solely for this function. This coupled the entire compiler to the parser implementation details, even for modules that should be lower-level (like `ast` and `morphology`).
+**Blueprint:**
+1. Extracted `normalize_greek` to a new `src/text.rs` module.
+2. Updated all imports to point to `crate::text::normalize_greek`.
+3. Removed `normalize` submodule from `grammar`.
+**Stability:** Decouples core logic from parsing implementation. `text` becomes a leaf utility module, allowing `ast` and `morphology` to be independent of `grammar`.

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -263,7 +263,7 @@ impl Word {
     /// Create a new word, automatically generating the normalized form
     pub fn new(original: impl Into<SmolStr>) -> Self {
         let original = original.into();
-        let normalized = crate::grammar::normalize_greek(&original);
+        let normalized = crate::text::normalize_greek(&original);
         Word {
             original,
             normalized,

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -20,12 +20,12 @@
 //!
 //! See [`sanitize_name`] for details.
 
-use crate::grammar::normalize_greek;
 use crate::morphology::lexicon::{BinaryOp, UnaryOp};
 use crate::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedImplMethod, AnalyzedIteratorOp, AnalyzedProgram,
     AnalyzedStatement, AnalyzedTraitMethod, GlossaType, StatementKind,
 };
+use crate::text::normalize_greek;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! # The Parsing Pipeline
 //!
-//! 1. **Text Normalization** (`normalize.rs`):
+//! 1. **Text Normalization** (`text` module):
 //!    Greek is polytonic (has accents/breathings: ἄ, ῆ, ῶ).
 //!    We normalize everything to monotonic lowercase to simplify processing.
 //!    `ἄνθρωπος` -> `ανθρωπος`.
@@ -33,10 +33,6 @@
 //!     println!("Text: {}", pair.as_str());
 //! }
 //! ```
-
-mod normalize;
-
-pub use normalize::normalize_greek;
 
 use pest::Parser;
 use pest_derive::Parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,11 @@
 //! * [`ast`]: Abstract Syntax Tree definitions.
 //! * [`codegen`]: Rust code generation logic.
 //! * [`errors`]: Greek-native error messages and diagnostics.
-//! * [`grammar`]: PEG parser and text normalization.
+//! * [`grammar`]: PEG parser.
 //! * [`morphology`]: Word analysis, lexicon, and participle parsing.
 //! * [`parser`]: AST Builder and parsing logic.
 //! * [`semantic`]: The slot-based assembler and semantic analysis.
+//! * [`text`]: Text utilities and normalization.
 
 pub mod ast;
 pub mod codegen;
@@ -49,3 +50,4 @@ pub mod grammar;
 pub mod morphology;
 pub mod parser;
 pub mod semantic;
+pub mod text;

--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -8,7 +8,7 @@
 use std::borrow::Cow;
 
 use super::{Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice};
-use crate::grammar::normalize_greek;
+use crate::text::normalize_greek;
 
 /// Present Active Indicative endings (ω-conjugation)
 /// Pattern: λέγω, γράφω, etc.

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -35,7 +35,7 @@ pub use participle::*;
 
 use std::borrow::Cow;
 
-use crate::grammar::normalize_greek;
+use crate::text::normalize_greek;
 
 /// Result of morphological analysis
 #[derive(Debug, Clone, PartialEq)]

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -89,7 +89,7 @@ fn build_type_definition(pair: Pair<'_, Rule>) -> Result<TypeDef, ParseError> {
                 // This is the type name (between εἶδος and ὁρίζειν)
                 type_name = Some(Word {
                     original: inner.as_str().into(),
-                    normalized: crate::grammar::normalize_greek(inner.as_str()),
+                    normalized: crate::text::normalize_greek(inner.as_str()),
                 });
             }
             Rule::field_list => {
@@ -122,7 +122,7 @@ fn build_field_declaration(pair: Pair<'_, Rule>) -> Result<FieldDecl, ParseError
         if inner.as_rule() == Rule::greek_word {
             words.push(Word {
                 original: inner.as_str().into(),
-                normalized: crate::grammar::normalize_greek(inner.as_str()),
+                normalized: crate::text::normalize_greek(inner.as_str()),
             });
         }
     }
@@ -151,7 +151,7 @@ fn build_trait_definition(pair: Pair<'_, Rule>) -> Result<TraitDef, ParseError> 
                 // This is the trait name (between χαρακτήρ and ὁρίζειν)
                 trait_name = Some(Word {
                     original: inner.as_str().into(),
-                    normalized: crate::grammar::normalize_greek(inner.as_str()),
+                    normalized: crate::text::normalize_greek(inner.as_str()),
                 });
             }
             Rule::trait_method_list => {
@@ -194,7 +194,7 @@ fn build_trait_method(pair: Pair<'_, Rule>) -> Result<TraitMethodDecl, ParseErro
             Rule::greek_word => {
                 words.push(Word {
                     original: inner.as_str().into(),
-                    normalized: crate::grammar::normalize_greek(inner.as_str()),
+                    normalized: crate::text::normalize_greek(inner.as_str()),
                 });
             }
             Rule::statement => {
@@ -260,12 +260,12 @@ fn build_trait_impl(pair: Pair<'_, Rule>) -> Result<TraitImplDef, ParseError> {
                 if type_name.is_none() {
                     type_name = Some(Word {
                         original: inner.as_str().into(),
-                        normalized: crate::grammar::normalize_greek(inner.as_str()),
+                        normalized: crate::text::normalize_greek(inner.as_str()),
                     });
                 } else if trait_name.is_none() {
                     trait_name = Some(Word {
                         original: inner.as_str().into(),
-                        normalized: crate::grammar::normalize_greek(inner.as_str()),
+                        normalized: crate::text::normalize_greek(inner.as_str()),
                     });
                 }
             }
@@ -302,7 +302,7 @@ fn build_impl_method(pair: Pair<'_, Rule>) -> Result<ImplMethodDef, ParseError> 
             Rule::greek_word => {
                 words.push(Word {
                     original: inner.as_str().into(),
-                    normalized: crate::grammar::normalize_greek(inner.as_str()),
+                    normalized: crate::text::normalize_greek(inner.as_str()),
                 });
             }
             Rule::statement => {
@@ -417,7 +417,7 @@ fn build_term(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
             let array_word = parts.next().ok_or(ParseError::EmptyTerm)?;
             let array = Expr::Word(Word {
                 original: array_word.as_str().into(),
-                normalized: crate::grammar::normalize_greek(array_word.as_str()),
+                normalized: crate::text::normalize_greek(array_word.as_str()),
             });
             // Second is the index_expr
             let index_pair = parts.next().ok_or(ParseError::EmptyTerm)?;
@@ -435,7 +435,7 @@ fn build_term(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
                 }
                 Rule::greek_word => Expr::Word(Word {
                     original: index_inner.as_str().into(),
-                    normalized: crate::grammar::normalize_greek(index_inner.as_str()),
+                    normalized: crate::text::normalize_greek(index_inner.as_str()),
                 }),
                 _ => {
                     return Err(ParseError::UnexpectedRule(format!(
@@ -465,13 +465,13 @@ fn build_term(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
             Ok(Expr::NumberLiteral(value))
         }
         Rule::boolean_literal => {
-            let normalized = crate::grammar::normalize_greek(inner.as_str());
+            let normalized = crate::text::normalize_greek(inner.as_str());
             let value = normalized == "αληθες";
             Ok(Expr::BooleanLiteral(value))
         }
         Rule::greek_word => Ok(Expr::Word(Word {
             original: inner.as_str().into(),
-            normalized: crate::grammar::normalize_greek(inner.as_str()),
+            normalized: crate::text::normalize_greek(inner.as_str()),
         })),
         Rule::parenthesized_expr => {
             // Unwrap the parentheses and build the inner expression
@@ -483,7 +483,7 @@ fn build_term(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
             let word_pair = inner.into_inner().next().ok_or(ParseError::EmptyTerm)?;
             let word = Expr::Word(Word {
                 original: word_pair.as_str().into(),
-                normalized: crate::grammar::normalize_greek(word_pair.as_str()),
+                normalized: crate::text::normalize_greek(word_pair.as_str()),
             });
             Ok(Expr::UnaryOp {
                 op: UnaryOperator::Unwrap,
@@ -514,13 +514,13 @@ fn build_array_element(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
             Ok(Expr::NumberLiteral(value))
         }
         Rule::boolean_literal => {
-            let normalized = crate::grammar::normalize_greek(inner.as_str());
+            let normalized = crate::text::normalize_greek(inner.as_str());
             let value = normalized == "αληθες";
             Ok(Expr::BooleanLiteral(value))
         }
         Rule::greek_word => Ok(Expr::Word(Word {
             original: inner.as_str().into(),
-            normalized: crate::grammar::normalize_greek(inner.as_str()),
+            normalized: crate::text::normalize_greek(inner.as_str()),
         })),
         _ => Err(ParseError::UnexpectedRule(format!("{:?}", inner.as_rule()))),
     }

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -95,11 +95,11 @@
 
 use crate::ast::{Expr, Word};
 pub use crate::errors::assembly::AssemblyError;
-use crate::grammar::normalize_greek;
 use crate::morphology::lexicon::BinaryOp;
 use crate::morphology::{
     Case, Gender, Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice,
 };
+use crate::text::normalize_greek;
 use smol_str::SmolStr;
 
 /// A fully assembled statement with all grammatical roles filled
@@ -982,7 +982,7 @@ impl Assembler {
         if crate::morphology::lexicon::is_length_property(normalized) {
             // If we have a subject, create a property access (use normalized original, not lemma)
             if let Some(ref subj) = self.pending_subject {
-                let normalized_original = crate::grammar::normalize_greek(&subj.original);
+                let normalized_original = crate::text::normalize_greek(&subj.original);
                 self.pending_property_accesses
                     .push((normalized_original.to_string(), "len".to_string()));
                 self.pending_subject = None; // Consume the subject
@@ -997,7 +997,7 @@ impl Assembler {
                 && let Some(index) = crate::morphology::lexicon::ordinal_to_index(normalized)
             {
                 // Create array and index expressions (use normalized original, not lemma)
-                let normalized_original = crate::grammar::normalize_greek(&subj.original);
+                let normalized_original = crate::text::normalize_greek(&subj.original);
                 let array = Expr::Word(Word {
                     original: subj.original.clone(),
                     normalized: normalized_original.clone(),

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -8,8 +8,8 @@ use super::{
 };
 use crate::ast::{Clause, Expr, Statement};
 use crate::errors::GlossaError;
-use crate::grammar::normalize_greek;
 use crate::morphology::lexicon;
+use crate::text::normalize_greek;
 // Circular dependencies handled by crate structure
 use super::declarations::parse_function_definition;
 use super::expressions::{contains_function_definition_verb, get_first_word};

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -45,8 +45,8 @@ use super::{
 };
 use crate::ast::Expr;
 use crate::errors::GlossaError;
-use crate::grammar::normalize_greek;
 use crate::morphology::{self};
+use crate::text::normalize_greek;
 use smol_str::SmolStr;
 
 /// Convert an AssembledStatement to an AnalyzedStatement

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -6,8 +6,8 @@ use super::{
 };
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
-use crate::grammar::normalize_greek;
 use crate::morphology;
+use crate::text::normalize_greek;
 use smol_str::SmolStr;
 // Circular dependencies handled by crate structure
 use super::control_flow::analyze_control_flow;

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -3,8 +3,8 @@
 use super::{AnalyzedExpr, AnalyzedExprKind, Assembler, GlossaType, Literal, Scope};
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
-use crate::grammar::normalize_greek;
 use crate::morphology::{self, DisambiguationContext, analyze_article, resolve_best};
+use crate::text::normalize_greek;
 
 /// Analyze an argument expression (could be literal, variable, or nested call)
 ///

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
-use crate::grammar::normalize_greek;
+use crate::text::normalize_greek;
 use smol_str::SmolStr;
 
 /// Try to parse a trait method call: method_name receiver
@@ -136,7 +136,7 @@ pub fn try_parse_struct_instantiation(
             }
 
             // Second word should be νέον (new) - check both normalized form and if it's "new" via morphology
-            let normalized_adj = crate::grammar::normalize_greek(&adj_word.normalized);
+            let normalized_adj = crate::text::normalize_greek(&adj_word.normalized);
             // Check if it's "new" - could be νέον, νεον, etc.
             if normalized_adj != "νεον" && normalized_adj != "νεος" {
                 return Ok(None);

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -172,7 +172,7 @@ impl Ownership {
 
 /// Infer type from a Greek word (by looking at lexicon or morphology)
 pub fn infer_type(word: &str) -> GlossaType {
-    let normalized = crate::grammar::normalize_greek(word);
+    let normalized = crate::text::normalize_greek(word);
 
     // Check lexicon first
     if let Some(entry) = crate::morphology::lexicon::lookup(&normalized) {

--- a/src/text.rs
+++ b/src/text.rs
@@ -19,7 +19,7 @@ use unicode_normalization::UnicodeNormalization;
 /// # Examples
 ///
 /// ```
-/// use glossa::grammar::normalize_greek;
+/// use glossa::text::normalize_greek;
 ///
 /// assert_eq!(normalize_greek("ἄνθρωπος"), "ανθρωπος");
 /// assert_eq!(normalize_greek("Ἀθῆναι"), "αθηναι");


### PR DESCRIPTION
Extracted `normalize_greek` to `src/text.rs` to decouple the `grammar` module. Updated all imports and added an ADR.

---
*PR created automatically by Jules for task [3793131961001082646](https://jules.google.com/task/3793131961001082646) started by @madmax983*