### PR TITLE
👺 Havoc: Fix stack overflow in semantic analysis recursion

### DIFF
--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -314,6 +314,21 @@ pub fn feed_expr_to_assembler_with_context(
     expr: &Expr,
     context: &mut DisambiguationContext,
 ) -> Result<(), GlossaError> {
+    feed_expr_recursive(asm, expr, context, 0)
+}
+
+fn feed_expr_recursive(
+    asm: &mut Assembler,
+    expr: &Expr,
+    context: &mut DisambiguationContext,
+    depth: usize,
+) -> Result<(), GlossaError> {
+    if depth > 50 {
+        return Err(GlossaError::semantic(
+            "Recursion limit exceeded in expression analysis",
+        ));
+    }
+
     match expr {
         Expr::StringLiteral(s) => {
             asm.feed_string(s.clone());
@@ -373,14 +388,14 @@ pub fn feed_expr_to_assembler_with_context(
                         asm.feed_nested_phrase(nested_terms.clone());
                     }
                 } else {
-                    feed_expr_to_assembler_with_context(asm, term, context)?;
+                    feed_expr_recursive(asm, term, context, depth + 1)?;
                 }
             }
         }
         Expr::PropertyAccess { owner, property } => {
             // Owner is genitive, property is what it attaches to
-            feed_expr_to_assembler_with_context(asm, owner, context)?;
-            feed_expr_to_assembler_with_context(asm, property, context)?;
+            feed_expr_recursive(asm, owner, context, depth + 1)?;
+            feed_expr_recursive(asm, property, context, depth + 1)?;
         }
         Expr::Call { verb, arguments } => {
             // Feed the verb - verbs can set context for subjects
@@ -396,7 +411,7 @@ pub fn feed_expr_to_assembler_with_context(
 
             // Feed arguments
             for arg in arguments {
-                feed_expr_to_assembler_with_context(asm, arg, context)?;
+                feed_expr_recursive(asm, arg, context, depth + 1)?;
             }
         }
         Expr::Binding { name, value } => {
@@ -407,12 +422,12 @@ pub fn feed_expr_to_assembler_with_context(
             if let Err(e) = asm.feed(&best_name, &name.original) {
                 return Err(GlossaError::semantic(e.to_string()));
             }
-            feed_expr_to_assembler_with_context(asm, value, context)?;
+            feed_expr_recursive(asm, value, context, depth + 1)?;
         }
         Expr::BinOp { left, op: _, right } => {
             // TODO: Implement binary operation handling
-            feed_expr_to_assembler_with_context(asm, left, context)?;
-            feed_expr_to_assembler_with_context(asm, right, context)?;
+            feed_expr_recursive(asm, left, context, depth + 1)?;
+            feed_expr_recursive(asm, right, context, depth + 1)?;
         }
         Expr::UnaryOp { op, operand } => {
             // Handle unwrap operator specially - it's a postfix operator that doesn't need word-order handling
@@ -421,7 +436,7 @@ pub fn feed_expr_to_assembler_with_context(
                 asm.feed_unwrap(operand.as_ref().clone());
             } else {
                 // TODO: Implement other unary operations (Not, Neg)
-                feed_expr_to_assembler_with_context(asm, operand, context)?;
+                feed_expr_recursive(asm, operand, context, depth + 1)?;
             }
         }
         Expr::Block(statements) => {

--- a/tests/havoc_coverage.rs
+++ b/tests/havoc_coverage.rs
@@ -1,0 +1,75 @@
+use glossa::ast::{BinOperator, Clause, Expr, Program, Statement, UnaryOperator, Word};
+use glossa::semantic::analyze_program;
+
+fn run_analysis(expr: Expr) {
+    let stmt = Statement::Regular {
+        clauses: vec![Clause {
+            expressions: vec![expr],
+        }],
+        is_query: false,
+        is_propagate: false,
+    };
+    let program = Program {
+        statements: vec![stmt],
+    };
+    // We just want to ensure it runs without error and covers the recursion paths
+    let _ = analyze_program(&program);
+}
+
+#[test]
+fn test_binop_recursion_coverage() {
+    // 1 + 2
+    let expr = Expr::BinOp {
+        left: Box::new(Expr::NumberLiteral(1)),
+        op: BinOperator::Add,
+        right: Box::new(Expr::NumberLiteral(2)),
+    };
+    run_analysis(expr);
+}
+
+#[test]
+fn test_unaryop_recursion_coverage() {
+    // !true (Not operator is not Unwrap)
+    let expr = Expr::UnaryOp {
+        op: UnaryOperator::Not,
+        operand: Box::new(Expr::BooleanLiteral(true)),
+    };
+    run_analysis(expr);
+}
+
+#[test]
+fn test_binding_recursion_coverage() {
+    // x = 1
+    let expr = Expr::Binding {
+        name: Word::new("x"),
+        value: Box::new(Expr::NumberLiteral(1)),
+    };
+    run_analysis(expr);
+}
+
+#[test]
+fn test_phrase_recursion_coverage() {
+    // (1, 2) - phrase of expressions
+    let expr = Expr::Phrase(vec![Expr::NumberLiteral(1), Expr::NumberLiteral(2)]);
+    run_analysis(expr);
+}
+
+#[test]
+fn test_call_recursion_coverage() {
+    // f(1)
+    let expr = Expr::Call {
+        verb: Word::new("f"),
+        arguments: vec![Expr::NumberLiteral(1)],
+    };
+    run_analysis(expr);
+}
+
+#[test]
+fn test_property_access_recursion_happy_path() {
+    // owner.prop
+    let expr = Expr::PropertyAccess {
+        owner: Box::new(Expr::Word(Word::new("owner"))),
+        property: Box::new(Expr::Word(Word::new("prop"))),
+    };
+    run_analysis(expr);
+}

--- a/tests/havoc_feed_recursion.rs
+++ b/tests/havoc_feed_recursion.rs
@@ -1,0 +1,49 @@
+use glossa::ast::{Clause, Expr, Statement, Word, Program};
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_property_access_stack_overflow() {
+    // Manually build deep AST with PropertyAccess
+    // Depth needs to be sufficient to cause stack overflow.
+    // On many systems 5000 is enough for debug builds, 20000+ for release.
+    let depth = 5000;
+    let mut expr = Expr::Word(Word::new("root"));
+
+    for _ in 0..depth {
+        expr = Expr::PropertyAccess {
+            owner: Box::new(expr),
+            property: Box::new(Expr::Word(Word::new("prop"))),
+        };
+    }
+
+    // Wrap in a simple statement: "expr;"
+    let stmt = Statement::Regular {
+        clauses: vec![Clause {
+            expressions: vec![expr],
+        }],
+        is_query: false,
+        is_propagate: false,
+    };
+
+    let program = Program {
+        statements: vec![stmt],
+    };
+
+    println!("Analyzing deep property access (depth {})...", depth);
+    // This should panic with stack overflow if not protected
+    let result = analyze_program(&program);
+
+    // We expect this to FAIL with a proper error message if fixed,
+    // or CRASH if not fixed.
+    match result {
+        Ok(_) => panic!("Should have failed with recursion limit error"),
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("Recursion limit"),
+                "Expected recursion limit error, got: {}",
+                msg
+            );
+        }
+    }
+}

--- a/tests/havoc_feed_recursion.rs
+++ b/tests/havoc_feed_recursion.rs
@@ -1,4 +1,4 @@
-use glossa::ast::{Clause, Expr, Statement, Word, Program};
+use glossa::ast::{Clause, Expr, Program, Statement, Word};
 use glossa::semantic::analyze_program;
 
 #[test]


### PR DESCRIPTION
👺 Havoc Report: Stack Overflow in Semantic Analysis

🧨 **The Trigger:** deeply nested `Expr::PropertyAccess` (depth > 5000).
📉 **The Stack Trace:** Stack overflow (SIGABRT).
🧪 **Reproduction:** `cargo test --test havoc_feed_recursion`
😈 **Comment:** "You assumed the stack was infinite. It wasn't."

Fix:
- Introduced `feed_expr_recursive` helper in `src/semantic/expressions.rs`.
- Added depth tracking and a hard limit of 50 frames.
- Returns `GlossaError::SemanticError` when recursion limit is exceeded.
- Added regression test `tests/havoc_feed_recursion.rs`.

---
*PR created automatically by Jules for task [10447156826203447717](https://jules.google.com/task/10447156826203447717) started by @madmax983*