### PR TITLE
feat(dx): improve developer experience with ascii quotes and robust printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ Here is a simple program that defines a user struct and greets them.
 χρήστου ὄνομα λέγε.
 ```
 
+### Running the Code
+
+Save the code above as `hero.glossa` and run it:
+
+```bash
+cargo run -- hero.glossa
+```
+
+## Syntax Notes
+
+### String Literals
+ΓΛΩΣΣΑ supports both Greek guillemets (`«...»`) and standard ASCII quotes (`"..."`).
+
+```glossa
+«Σωκράτης»  // Traditional
+"Σωκράτης"  // Modern
+```
+
 ## Control Flow
 
 ### Conditionals

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -270,14 +270,36 @@ fn generate_print(args: &[AnalyzedExpr]) -> TokenStream {
     if args.is_empty() {
         quote! { println!(); }
     } else if args.len() == 1 {
-        let arg = generate_expr(&args[0]);
-        // Use Display formatting
-        quote! { println!("{}", #arg); }
+        let arg = &args[0];
+        let arg_token = generate_expr(arg);
+
+        if is_primitive_type(&arg.glossa_type) {
+            quote! { println!("{}", #arg_token); }
+        } else {
+            quote! { println!("{:?}", #arg_token); }
+        }
     } else {
         // Multiple args - join with space
-        let arg_tokens: Vec<TokenStream> = args.iter().map(generate_expr).collect();
-        quote! { println!("{}", vec![#(format!("{}", #arg_tokens)),*].join(" ")); }
+        let arg_tokens: Vec<TokenStream> = args
+            .iter()
+            .map(|arg| {
+                let token = generate_expr(arg);
+                if is_primitive_type(&arg.glossa_type) {
+                    quote! { format!("{}", #token) }
+                } else {
+                    quote! { format!("{:?}", #token) }
+                }
+            })
+            .collect();
+        quote! { println!("{}", vec![#(#arg_tokens),*].join(" ")); }
     }
+}
+
+fn is_primitive_type(ty: &GlossaType) -> bool {
+    matches!(
+        ty,
+        GlossaType::String | GlossaType::Number | GlossaType::Boolean
+    )
 }
 
 fn generate_if(

--- a/src/grammar/glossa.pest
+++ b/src/grammar/glossa.pest
@@ -111,9 +111,10 @@ block = { "{" ~ statement* ~ "}" }
 // Literals
 // =============================================================================
 
-// Greek guillemets for strings: «text»
-string_literal = { "«" ~ string_content ~ "»" }
-string_content = { (!"»" ~ ANY)* }
+// Greek guillemets for strings: «text» or ASCII "text"
+string_literal = { ("«" ~ guillemet_content ~ "»") | ("\"" ~ ascii_content ~ "\"") }
+guillemet_content = { (!"»" ~ ANY)* }
+ascii_content = { (!"\"" ~ ANY)* }
 
 // Numbers (Arabic numerals for now, Greek numerals later)
 number_literal = @{ ASCII_DIGIT+ }

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -452,7 +452,9 @@ fn build_term(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
         Rule::string_literal => {
             let content = inner
                 .into_inner()
-                .find(|p| p.as_rule() == Rule::guillemet_content || p.as_rule() == Rule::ascii_content)
+                .find(|p| {
+                    p.as_rule() == Rule::guillemet_content || p.as_rule() == Rule::ascii_content
+                })
                 .map(|p| p.as_str().to_string())
                 .unwrap_or_default();
             Ok(Expr::StringLiteral(content))
@@ -501,7 +503,9 @@ fn build_array_element(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
         Rule::string_literal => {
             let content = inner
                 .into_inner()
-                .find(|p| p.as_rule() == Rule::guillemet_content || p.as_rule() == Rule::ascii_content)
+                .find(|p| {
+                    p.as_rule() == Rule::guillemet_content || p.as_rule() == Rule::ascii_content
+                })
                 .map(|p| p.as_str().to_string())
                 .unwrap_or_default();
             Ok(Expr::StringLiteral(content))

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -452,7 +452,7 @@ fn build_term(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
         Rule::string_literal => {
             let content = inner
                 .into_inner()
-                .find(|p| p.as_rule() == Rule::string_content)
+                .find(|p| p.as_rule() == Rule::guillemet_content || p.as_rule() == Rule::ascii_content)
                 .map(|p| p.as_str().to_string())
                 .unwrap_or_default();
             Ok(Expr::StringLiteral(content))
@@ -501,7 +501,7 @@ fn build_array_element(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
         Rule::string_literal => {
             let content = inner
                 .into_inner()
-                .find(|p| p.as_rule() == Rule::string_content)
+                .find(|p| p.as_rule() == Rule::guillemet_content || p.as_rule() == Rule::ascii_content)
                 .map(|p| p.as_str().to_string())
                 .unwrap_or_default();
             Ok(Expr::StringLiteral(content))

--- a/tests/option_result_tests.rs
+++ b/tests/option_result_tests.rs
@@ -851,14 +851,16 @@ fn test_statement_end_with_semicolon() {
     let regular_output = compile(regular).unwrap();
     let propagate_output = compile(propagate).unwrap();
 
-    // Regular should NOT have ?
+    // Regular should NOT have ? (ignoring println! debug formatting)
+    let cleaned_regular = regular_output.replace("{:?}", "");
     assert!(
-        !regular_output.contains("?"),
-        "Should not have ? in regular statement"
+        !cleaned_regular.contains("?"),
+        "Should not have ? in regular statement (excluding println formatting)"
     );
 
-    // Propagate should have ?
-    assert!(propagate_output.contains("?"), "Expected ? in propagation");
+    // Propagate should have ? (ignoring println! debug formatting)
+    let cleaned_propagate = propagate_output.replace("{:?}", "");
+    assert!(cleaned_propagate.contains("?"), "Expected ? in propagation");
 }
 
 #[test]


### PR DESCRIPTION
This PR addresses critical Developer Experience (DX) friction points identified during the "Echo" audit.

### Changes
1.  **ASCII Quotes:** Users can now use standard `"..."` quotes alongside traditional `«...»`. This lowers the entry barrier for users without Greek keyboard layouts.
2.  **Robust Printing:** The compiler now intelligently selects `Debug` formatting (`{:?}`) for complex types (like structs) in `print` statements. This prevents "Trait not implemented" Rust errors when users print custom structs, transforming a compiler crash into helpful output.
3.  **Documentation:** `README.md` now explicitly explains how to run code and notes the quote syntax options.
4.  **Test Fixes:** Updated integration tests to account for the new debug formatting in `println!` output.

### Verification
- `hero_quotes.glossa` (using `"`) compiles and runs successfully.
- `broken_case.glossa` (printing a struct) prints the struct debug representation instead of crashing.
- All existing tests pass.

---
*PR created automatically by Jules for task [18442014584955436129](https://jules.google.com/task/18442014584955436129) started by @madmax983*