### PR TITLE
📜 Codex: ADR 003 & Architecture Diagram Update

### DIFF
--- a/docs/adr/003-separate-parser-from-grammar.md
+++ b/docs/adr/003-separate-parser-from-grammar.md
@@ -1,0 +1,23 @@
+# 3. Separate Parser from Grammar
+
+Date: 2024-10-24
+Status: Accepted
+
+## Context
+
+Originally, the compiler's frontend logic was heavily concentrated in the `grammar` module. This module was responsible for both defining the PEG grammar (using `pest`) and constructing the Abstract Syntax Tree (AST) from the parse results.
+
+As the language grew (adding Traits, Lambda expressions, and complex morphological rules), the complexity of converting the Concrete Syntax Tree (CST) to the AST increased. Mixing tokenization logic with AST construction logic made the code harder to navigate and test.
+
+## Decision
+
+We have separated the AST construction logic into a dedicated `parser` module (`src/parser`), while keeping the grammar definition and tokenization in the `grammar` module (`src/grammar`).
+
+- `src/grammar`: Contains `glossa.pest` and normalization logic. Responsible for producing a stream of tokens.
+- `src/parser`: Contains the logic to consume those tokens and build the `Program` AST.
+
+## Consequences
+
+- **Separation of Concerns**: The `grammar` module focuses solely on the "shape" of the text, while `parser` focuses on the "structure" of the program.
+- **Maintainability**: Changes to the AST builder do not require touching the grammar definition, and vice versa.
+- **Clarity**: The architecture diagram now explicitly reflects this split, making the pipeline easier to understand for new contributors.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ C4Container
     title Container Diagram for ΓΛΩΣΣΑ Compiler
 
     Container(lexer, "Lexer", "src/grammar", "Tokenizes source, handling Unicode normalization")
-    Container(parser, "Parser", "src/grammar", "Constructs AST from tokens, handling flexible word order")
+    Container(parser, "Parser", "src/parser", "Constructs AST from tokens, handling flexible word order")
     Container(morphology, "Declension Resolver", "src/morphology", "Analyzes case, gender, number, and resolves agreement")
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
     Container(codegen, "Code Generator", "src/codegen", "Generates Rust source code")


### PR DESCRIPTION
Drafted ADR 003 to document the separation of the AST Parser (`src/parser`) from the Grammar/Lexer (`src/grammar`).

Updated `docs/architecture.md` to reflect this structural reality, correcting the previous diagram which incorrectly located the Parser container in `src/grammar`.

*Note:* This change addresses the 'Codex' persona's mandate to enforce Architectural Transparency on the *actual* codebase (Glossa), resolving a discovered discrepancy between the code and the map. The prompt's example scenario regarding a 'Storage' module was interpreted as an illustrative process guide rather than a literal instruction to document a non-existent module.

---
*PR created automatically by Jules for task [18351178915998786248](https://jules.google.com/task/18351178915998786248) started by @madmax983*