### PR TITLE
Refactor TraitDef and TraitImpl semantic models

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -27,3 +27,8 @@
 **Bloat:** Duplicated logic for extracting comparison values and creating predicates in iterator patterns (`filter`, `any`, `all`, `find`).
 **Cut:** Extracted `extract_comparison_value` and `create_comparison_predicate` helper functions.
 **Saved:** ~150 lines of duplicated code. Reduced cognitive load for understanding iterator pattern logic.
+
+## [Reduction]
+**Bloat:** `MethodSignature`, `DefaultMethod`, `ImplMethod`, and redundant `TraitDef` fields in `src/semantic/model.rs`.
+**Cut:** Consolidated into `TraitDef` using `Vec<AnalyzedTraitMethod>` and simplified `TraitImpl`. Deleted redundant structs.
+**Saved:** Reduced code duplication and complexity in semantic model and declarations. ~50 lines removed.

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -68,8 +68,6 @@ pub fn analyze_trait_definition(
     }
 
     // Analyze methods
-    let mut required_methods = Vec::new();
-    let mut default_methods = Vec::new();
     let mut analyzed_methods = Vec::new();
 
     for method in &trait_def.methods {
@@ -83,13 +81,6 @@ pub fn analyze_trait_definition(
             // They'll be inferred based on the impl
             params.push((param_name, GlossaType::Unknown));
         }
-
-        let signature = crate::semantic::model::MethodSignature {
-            name: method_name.clone(),
-            params: params.clone(),
-            return_type: None,
-            has_default: method.is_default,
-        };
 
         if method.is_default {
             // Analyze default method body
@@ -132,11 +123,6 @@ pub fn analyze_trait_definition(
                 None
             };
 
-            default_methods.push(crate::semantic::model::DefaultMethod {
-                signature: signature.clone(),
-                body: body.clone().unwrap_or_default(),
-            });
-
             analyzed_methods.push(AnalyzedTraitMethod {
                 name: method_name,
                 params,
@@ -145,8 +131,6 @@ pub fn analyze_trait_definition(
                 return_type,
             });
         } else {
-            required_methods.push(signature);
-
             analyzed_methods.push(AnalyzedTraitMethod {
                 name: method_name,
                 params,
@@ -160,8 +144,7 @@ pub fn analyze_trait_definition(
     // Create the trait definition
     let trait_def_semantic = crate::semantic::model::TraitDef {
         name: trait_name.clone(),
-        required_methods,
-        default_methods,
+        methods: analyzed_methods.clone(),
     };
 
     // Store the trait in scope
@@ -261,11 +244,11 @@ pub fn analyze_trait_impl(
     }
 
     // Validate: all required methods must be implemented
-    for required_method in &trait_def.required_methods {
-        if !implemented_method_names.contains(&required_method.name) {
+    for method in &trait_def.methods {
+        if !method.is_default && !implemented_method_names.contains(&method.name) {
             return Err(GlossaError::semantic(format!(
                 "Type {} does not implement required method {} from trait {}",
-                type_name, required_method.name, trait_name
+                type_name, method.name, trait_name
             )));
         }
     }
@@ -274,7 +257,6 @@ pub fn analyze_trait_impl(
     let trait_impl_semantic = crate::semantic::model::TraitImpl {
         trait_name: trait_name.clone(),
         type_name: type_name.clone(),
-        methods: vec![], // Semantic tracking only needs names for now
     };
 
     // Register the trait impl in scope

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -242,24 +242,7 @@ pub enum AnalyzedExprKind {
 #[derive(Debug, Clone)]
 pub struct TraitDef {
     pub name: SmolStr,
-    pub required_methods: Vec<MethodSignature>,
-    pub default_methods: Vec<DefaultMethod>,
-}
-
-/// Method signature in a trait
-#[derive(Debug, Clone, PartialEq)]
-pub struct MethodSignature {
-    pub name: SmolStr,
-    pub params: Vec<(SmolStr, GlossaType)>,
-    pub return_type: Option<GlossaType>,
-    pub has_default: bool,
-}
-
-/// Default method with implementation
-#[derive(Debug, Clone)]
-pub struct DefaultMethod {
-    pub signature: MethodSignature,
-    pub body: Vec<AnalyzedStatement>,
+    pub methods: Vec<AnalyzedTraitMethod>,
 }
 
 /// Trait implementation for a type
@@ -267,13 +250,4 @@ pub struct DefaultMethod {
 pub struct TraitImpl {
     pub trait_name: SmolStr,
     pub type_name: SmolStr,
-    pub methods: Vec<ImplMethod>,
-}
-
-/// Method implementation in a trait impl
-#[derive(Debug, Clone)]
-pub struct ImplMethod {
-    pub name: SmolStr,
-    pub params: Vec<(SmolStr, GlossaType)>,
-    pub body: Vec<AnalyzedStatement>,
 }

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -222,14 +222,7 @@ impl Scope {
                 }
                 // Check if the trait has this method
                 if let Some(trait_def) = self.lookup_trait(&trait_impl.trait_name) {
-                    let has_method = trait_def
-                        .required_methods
-                        .iter()
-                        .any(|m| m.name == method_name)
-                        || trait_def
-                            .default_methods
-                            .iter()
-                            .any(|m| m.signature.name == method_name);
+                    let has_method = trait_def.methods.iter().any(|m| m.name == method_name);
                     if has_method {
                         return true;
                     }


### PR DESCRIPTION
Simplified the semantic model for Traits by coalescing redundant data structures into a single `AnalyzedTraitMethod` and removing unused implementation details. This reduces cognitive load and removes dead code. Verified with `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [340981675292759224](https://jules.google.com/task/340981675292759224) started by @madmax983*