### PR TITLE
Refactor struct instantiation to remove duplicate logic

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -32,3 +32,8 @@
 **Bloat:** `MethodSignature`, `DefaultMethod`, `ImplMethod`, and redundant `TraitDef` fields in `src/semantic/model.rs`.
 **Cut:** Consolidated into `TraitDef` using `Vec<AnalyzedTraitMethod>` and simplified `TraitImpl`. Deleted redundant structs.
 **Saved:** Reduced code duplication and complexity in semantic model and declarations. ~50 lines removed.
+
+## [Reduction]
+**Bloat:** Duplicate logic for struct instantiation in `src/semantic/conversion.rs` (broken, handled only literals) and `src/semantic/patterns.rs` (working, handled variables).
+**Cut:** Deleted `classify_struct_instantiation` from `conversion.rs` and consolidated `detect_collection_type` into `src/semantic/types.rs`.
+**Saved:** Removed ~100 lines of duplicate/broken code and fixed a bug preventing variable arguments in constructors.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -47,7 +47,6 @@ use crate::ast::Expr;
 use crate::errors::GlossaError;
 use crate::morphology::{self};
 use crate::text::normalize_greek;
-use smol_str::SmolStr;
 
 /// Convert an AssembledStatement to an AnalyzedStatement
 ///
@@ -79,9 +78,6 @@ pub fn classify_assembled_statement(
         return Ok(res);
     }
     if let Some(res) = classify_property_access_print(asm_stmt, scope)? {
-        return Ok(res);
-    }
-    if let Some(res) = classify_struct_instantiation(asm_stmt, scope)? {
         return Ok(res);
     }
     if let Some(res) = classify_function_call(asm_stmt, scope)? {
@@ -172,120 +168,6 @@ fn classify_property_access_print(
                 };
 
                 return Ok(Some((StatementKind::Print, vec![prop_access])));
-            }
-        }
-    }
-    Ok(None)
-}
-
-/// Helper: Detect struct instantiation or collection creation
-fn classify_struct_instantiation(
-    asm_stmt: &AssembledStatement,
-    scope: &mut Scope,
-) -> Result<Option<(StatementKind, Vec<AnalyzedExpr>)>, GlossaError> {
-    if let Some(ref verb) = asm_stmt.verb {
-        let verb_lemma = normalize_greek(&verb.lemma);
-
-        if crate::morphology::lexicon::is_binding_verb(&verb_lemma)
-            && !asm_stmt.adjectives.is_empty()
-            && let (Some(subject), Some(object)) = (&asm_stmt.subject, &asm_stmt.object)
-        {
-            // Check if adjective is νέον (new)
-            let adj_lemma = normalize_greek(&asm_stmt.adjectives[0].lemma);
-            if adj_lemma == "νεος" {
-                // Get variable name from subject
-                let var_name = normalize_greek(&subject.original);
-
-                // Get type name from object
-                let type_name = normalize_greek(&object.original);
-
-                // Check if type exists in scope
-                if let Some(struct_type) = scope.lookup_type(&type_name).cloned() {
-                    // Extract field names from struct type
-                    let field_names: Vec<SmolStr> =
-                        if let GlossaType::Struct { fields, .. } = &struct_type {
-                            fields.iter().map(|(name, _)| name.clone()).collect()
-                        } else {
-                            vec![]
-                        };
-
-                    // Get constructor arguments from literals
-                    let args: Vec<AnalyzedExpr> = asm_stmt
-                        .literals
-                        .iter()
-                        .map(literal_to_analyzed_expr)
-                        .collect();
-
-                    // Build struct instantiation
-                    let struct_inst = AnalyzedExpr {
-                        expr: AnalyzedExprKind::StructInstantiation {
-                            type_name: type_name.clone(),
-                            fields: field_names,
-                            args,
-                        },
-                        glossa_type: struct_type.clone(),
-                    };
-
-                    // Register variable in scope
-                    scope.define(var_name.clone(), struct_type.clone());
-
-                    return Ok(Some((
-                        StatementKind::Binding {
-                            name: var_name.clone(),
-                            value_type: struct_type.clone(),
-                            mutable: false,
-                        },
-                        vec![
-                            AnalyzedExpr {
-                                expr: AnalyzedExprKind::Variable(var_name),
-                                glossa_type: struct_type.clone(),
-                            },
-                            struct_inst,
-                        ],
-                    )));
-                }
-
-                // Check for built-in collection types (HashSet, HashMap)
-                let collection_type = match type_name.as_str() {
-                    "συνολον" => {
-                        Some(("HashSet", GlossaType::Set(Box::new(GlossaType::Unknown))))
-                    }
-                    "χαρτης" => Some((
-                        "HashMap",
-                        GlossaType::Map(
-                            Box::new(GlossaType::Unknown),
-                            Box::new(GlossaType::Unknown),
-                        ),
-                    )),
-                    _ => None,
-                };
-
-                if let Some((rust_type, glossa_type)) = collection_type {
-                    let collection_new = AnalyzedExpr {
-                        expr: AnalyzedExprKind::CollectionNew {
-                            collection_type: rust_type.to_string(),
-                        },
-                        glossa_type: glossa_type.clone(),
-                    };
-
-                    // Register variable in scope (mutable for collection operations)
-                    scope.define_mut(var_name.clone(), glossa_type.clone());
-
-                    return Ok(Some((
-                        StatementKind::Binding {
-                            name: var_name.clone(),
-                            value_type: glossa_type.clone(),
-                            mutable: true, // Collections are implicitly mutable
-                        },
-                        vec![
-                            AnalyzedExpr {
-                                expr: AnalyzedExprKind::Variable(var_name),
-                                glossa_type: glossa_type.clone(),
-                            },
-                            collection_new,
-                        ],
-                    )));
-                }
             }
         }
     }

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -147,7 +147,9 @@ pub fn try_parse_struct_instantiation(
             let type_name = &type_word.normalized;
 
             // Check for built-in collection types first (HashSet, HashMap)
-            if let Some((rust_type, glossa_type)) = crate::semantic::types::detect_collection_type(type_name) {
+            if let Some((rust_type, glossa_type)) =
+                crate::semantic::types::detect_collection_type(type_name)
+            {
                 let collection_new = AnalyzedExpr {
                     expr: AnalyzedExprKind::CollectionNew {
                         collection_type: rust_type.to_string(),
@@ -784,4 +786,3 @@ fn create_comparison_predicate(
         },
     }
 }
-

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -147,7 +147,7 @@ pub fn try_parse_struct_instantiation(
             let type_name = &type_word.normalized;
 
             // Check for built-in collection types first (HashSet, HashMap)
-            if let Some((rust_type, glossa_type)) = detect_collection_type(type_name) {
+            if let Some((rust_type, glossa_type)) = crate::semantic::types::detect_collection_type(type_name) {
                 let collection_new = AnalyzedExpr {
                     expr: AnalyzedExprKind::CollectionNew {
                         collection_type: rust_type.to_string(),
@@ -785,14 +785,3 @@ fn create_comparison_predicate(
     }
 }
 
-/// Helper: Detect built-in collection types
-fn detect_collection_type(type_name: &str) -> Option<(&str, GlossaType)> {
-    match type_name {
-        "συνολον" => Some(("HashSet", GlossaType::Set(Box::new(GlossaType::Unknown)))),
-        "χαρτης" => Some((
-            "HashMap",
-            GlossaType::Map(Box::new(GlossaType::Unknown), Box::new(GlossaType::Unknown)),
-        )),
-        _ => None,
-    }
-}

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -193,6 +193,18 @@ pub fn infer_type(word: &str) -> GlossaType {
     GlossaType::Unknown
 }
 
+/// Detect built-in collection types (HashSet, HashMap)
+pub fn detect_collection_type(type_name: &str) -> Option<(&'static str, GlossaType)> {
+    match type_name {
+        "συνολον" => Some(("HashSet", GlossaType::Set(Box::new(GlossaType::Unknown)))),
+        "χαρτης" => Some((
+            "HashMap",
+            GlossaType::Map(Box::new(GlossaType::Unknown), Box::new(GlossaType::Unknown)),
+        )),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,5 +247,12 @@ mod tests {
         assert!(GlossaType::Number.is_compatible(&GlossaType::Number));
         assert!(!GlossaType::Number.is_compatible(&GlossaType::String));
         assert!(GlossaType::Unknown.is_compatible(&GlossaType::Number));
+    }
+
+    #[test]
+    fn test_detect_collection_type() {
+        assert!(detect_collection_type("συνολον").is_some());
+        assert!(detect_collection_type("χαρτης").is_some());
+        assert!(detect_collection_type("other").is_none());
     }
 }

--- a/tests/struct_instantiation.rs
+++ b/tests/struct_instantiation.rs
@@ -1,0 +1,56 @@
+use glossa::parser::parse;
+use glossa::semantic::{analyze_program, StatementKind, AnalyzedExprKind};
+
+#[test]
+fn test_struct_instantiation_with_variable_args() {
+    // Define struct Point { x: i64, y: i64 }
+    // let a = 10;
+    // let p = new Point(a, 20);
+
+    // In Glossa:
+    // εἶδος Σημεῖον ὁρίζειν { χ ἀριθμοῦ. ψ ἀριθμοῦ. }
+    // α 10 ἔστω.
+    // π νέον Σημεῖον α 20 ἔστω.
+
+    let code = "
+    εἶδος Σημεῖον ὁρίζειν { χ ἀριθμοῦ. ψ ἀριθμοῦ. }.
+    α 10 ἔστω.
+    π νέον Σημεῖον α 20 ἔστω.
+    ";
+
+    let ast = parse(code).unwrap();
+    let analyzed = analyze_program(&ast).unwrap();
+
+    // 3 statements: TypeDef, Binding(a), Binding(p)
+    println!("Analyzed statements count: {}", analyzed.statements.len());
+    for (i, s) in analyzed.statements.iter().enumerate() {
+        println!("Stmt {}: {:?}", i, s.kind);
+    }
+    assert_eq!(analyzed.statements.len(), 3);
+
+    let stmt = &analyzed.statements[2];
+    if let StatementKind::Binding { name, .. } = &stmt.kind {
+        assert_eq!(name, "π");
+    } else {
+        panic!("Expected Binding statement, got {:?}", stmt.kind);
+    }
+
+    // Check args
+    let exprs = &stmt.expressions;
+    // expressions[0] is the variable 'p', expressions[1] is the instantiation
+    if let AnalyzedExprKind::StructInstantiation { args, .. } = &exprs[1].expr {
+        assert_eq!(args.len(), 2);
+        // First arg should be variable 'α'
+        match &args[0].expr {
+            AnalyzedExprKind::Variable(v) => assert_eq!(v, "α"),
+            _ => panic!("Expected variable 'α', got {:?}", args[0].expr),
+        }
+        // Second arg should be literal 20
+        match &args[1].expr {
+            AnalyzedExprKind::NumberLiteral(n) => assert_eq!(*n, 20),
+            _ => panic!("Expected literal 20, got {:?}", args[1].expr),
+        }
+    } else {
+        panic!("Expected StructInstantiation, got {:?}", exprs[1].expr);
+    }
+}

--- a/tests/struct_instantiation.rs
+++ b/tests/struct_instantiation.rs
@@ -1,5 +1,5 @@
 use glossa::parser::parse;
-use glossa::semantic::{analyze_program, StatementKind, AnalyzedExprKind};
+use glossa::semantic::{AnalyzedExprKind, StatementKind, analyze_program};
 
 #[test]
 fn test_struct_instantiation_with_variable_args() {


### PR DESCRIPTION
This PR simplifies the semantic analysis pipeline by removing duplicate logic for struct instantiation.
Previously, `src/semantic/conversion.rs` contained a simplified version of struct instantiation that only supported literal arguments, which broke when users tried to pass variables to constructors.
The robust implementation in `src/semantic/patterns.rs` handles both literals and variables correctly.

Changes:
1. Deleted `classify_struct_instantiation` from `src/semantic/conversion.rs`.
2. Moved `detect_collection_type` helper to `src/semantic/types.rs` to be shared.
3. Updated `src/semantic/patterns.rs` to use the shared helper.
4. Added regression test `tests/struct_instantiation.rs`.

This adheres to Razor's philosophy of cutting dead/duplicate code and fixing bugs through simplification.

---
*PR created automatically by Jules for task [4119408607037153734](https://jules.google.com/task/4119408607037153734) started by @madmax983*