### PR TITLE
⚡ Bolt: Zero-alloc morphology analysis

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -465,6 +465,15 @@ where
 /// - 3rd person singular aorist indicative (ἔλυσε)
 pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
     let mut analyses = Vec::new();
+    analyze_verb_all_into(word, &mut analyses);
+    analyses
+}
+
+/// Analyze a word as a verb, pushing results into an existing vector
+///
+/// Zero-allocation version of `analyze_verb_all`.
+pub fn analyze_verb_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
+    let start_len = analyses.len();
 
     // Special handling for εἰμί (to be) subjunctive forms
     // These are irregular and essential for conditionals (εἰ ... ᾖ)
@@ -555,21 +564,37 @@ pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
         });
     }
 
-    // Deduplicate identical analyses
-    analyses.sort_by(|a, b| {
+    // Sort the newly added analyses (the tail)
+    analyses[start_len..].sort_by(|a, b| {
         let key_a = (a.tense, a.mood, a.person, a.number, &a.lemma);
         let key_b = (b.tense, b.mood, b.person, b.number, &b.lemma);
-        format!("{:?}", key_a).cmp(&format!("{:?}", key_b))
-    });
-    analyses.dedup_by(|a, b| {
-        a.tense == b.tense
-            && a.mood == b.mood
-            && a.person == b.person
-            && a.number == b.number
-            && a.lemma == b.lemma
+        key_a.cmp(&key_b)
     });
 
-    analyses
+    // Deduplicate identical analyses in the tail
+    let len = analyses.len();
+    if len > start_len + 1 {
+        let mut w = start_len + 1;
+        for r in start_len + 1..len {
+            let matches = {
+                let a = &analyses[w - 1];
+                let b = &analyses[r];
+                a.tense == b.tense
+                    && a.mood == b.mood
+                    && a.person == b.person
+                    && a.number == b.number
+                    && a.lemma == b.lemma
+            };
+
+            if !matches {
+                if r != w {
+                    analyses.swap(r, w);
+                }
+                w += 1;
+            }
+        }
+        analyses.truncate(w);
+    }
 }
 
 /// Conjugate a verb stem to a specific form

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -201,6 +201,15 @@ where
 /// The caller should use syntactic context to pick the right one.
 pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
     let mut analyses = Vec::new();
+    analyze_noun_all_into(word, &mut analyses);
+    analyses
+}
+
+/// Analyze a word as a noun, pushing results into an existing vector
+///
+/// Zero-allocation version of `analyze_noun_all`.
+pub fn analyze_noun_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
+    let start_len = analyses.len();
 
     for decl in DECLENSION_PATTERNS {
         match_endings_all(word, decl.endings, |stem, case, number| {
@@ -228,17 +237,36 @@ pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
         });
     }
 
-    // Deduplicate identical analyses (same case/number/gender)
-    analyses.sort_by(|a, b| {
+    // Sort the newly added analyses (the tail)
+    analyses[start_len..].sort_by(|a, b| {
         let key_a = (a.case, a.number, a.gender, &a.lemma);
         let key_b = (b.case, b.number, b.gender, &b.lemma);
         key_a.cmp(&key_b)
     });
-    analyses.dedup_by(|a, b| {
-        a.case == b.case && a.number == b.number && a.gender == b.gender && a.lemma == b.lemma
-    });
 
-    analyses
+    // Deduplicate identical analyses in the tail
+    let len = analyses.len();
+    if len > start_len + 1 {
+        let mut w = start_len + 1;
+        for r in start_len + 1..len {
+            let matches = {
+                let a = &analyses[w - 1];
+                let b = &analyses[r];
+                a.case == b.case
+                    && a.number == b.number
+                    && a.gender == b.gender
+                    && a.lemma == b.lemma
+            };
+
+            if !matches {
+                if r != w {
+                    analyses.swap(r, w);
+                }
+                w += 1;
+            }
+        }
+        analyses.truncate(w);
+    }
 }
 
 /// Extract stem from a word given its nominative form and declension

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -123,7 +123,9 @@ pub fn analyze(word: &str) -> MorphAnalysis {
 /// ```
 pub fn analyze_all(word: &str) -> Vec<MorphAnalysis> {
     let normalized = normalize_greek(word);
-    let mut analyses = Vec::new();
+    // Pre-allocate capacity to avoid reallocations
+    // Lexicon (1) + Noun variants (~2-3) + Verb variants (~2-3)
+    let mut analyses = Vec::with_capacity(8);
 
     // First check the lexicon - these get highest confidence
     if let Some(entry) = lexicon::lookup(&normalized) {
@@ -132,13 +134,11 @@ pub fn analyze_all(word: &str) -> Vec<MorphAnalysis> {
         analyses.push(analysis);
     }
 
-    // Get all possible noun analyses
-    let noun_analyses = declension::analyze_noun_all(&normalized);
-    analyses.extend(noun_analyses);
+    // Get all possible noun analyses (zero allocation)
+    declension::analyze_noun_all_into(&normalized, &mut analyses);
 
-    // Get all possible verb analyses
-    let verb_analyses = conjugation::analyze_verb_all(&normalized);
-    analyses.extend(verb_analyses);
+    // Get all possible verb analyses (zero allocation)
+    conjugation::analyze_verb_all_into(&normalized, &mut analyses);
 
     // Sort by confidence (highest first)
     analyses.sort_by(|a, b| {


### PR DESCRIPTION
⚡ Bolt: Zero-alloc morphology analysis

## 💡 What
- Introduced `analyze_noun_all_into` and `analyze_verb_all_into` which accept a `&mut Vec<MorphAnalysis>`.
- Updated `analyze_all` to reuse a single `Vec` for all candidates.
- Replaced `format!("{:?}")` based sorting in `conjugation.rs` with direct tuple comparison.
- Implemented in-place deduplication for the vector tail.

## 🎯 Why
Morphological analysis is the hottest path in the compiler, running for every word. Previously, it allocated multiple vectors per word and copied data between them. This refactor eliminates those intermediates.

## 📊 Impact
- Removes at least 2 vector allocations per word.
- Removes string formatting overhead during sorting.
- Zero API breakage (original functions preserved as wrappers).

##  microscrope Measurement
Verified with `cargo test --lib morphology`. No regressions.

---
*PR created automatically by Jules for task [718427359165127661](https://jules.google.com/task/718427359165127661) started by @madmax983*