### PR TITLE
🗺️ Atlas: Extract Codegen Mappings

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -36,3 +36,11 @@
 2. Updated all imports to point to `crate::text::normalize_greek`.
 3. Removed `normalize` submodule from `grammar`.
 **Stability:** Decouples core logic from parsing implementation. `text` becomes a leaf utility module, allowing `ast` and `morphology` to be independent of `grammar`.
+
+## [Breaking The Leak: Codegen Logic in Domain Models]
+**Tangle:** `GlossaType`, `Case`, and `Lexicon` models contained `to_rust()` methods, coupling the Semantic and Morphology layers directly to the Rust target language implementation details.
+**Blueprint:**
+1. Created `src/codegen/mappings.rs` to house all Logic for mapping Domain Objects -> Rust Code.
+2. Moved `sanitize_name` and transliteration logic to `mappings.rs`.
+3. Removed `to_rust`, `to_rust_prefix`, and `to_rust_ownership` from `src/semantic` and `src/morphology`.
+**Stability:** Ensures Domain Models are target-agnostic. `codegen` depends on `semantic`/`morphology`, but they no longer "know" about `codegen`.

--- a/src/codegen/mappings.rs
+++ b/src/codegen/mappings.rs
@@ -1,0 +1,246 @@
+//! Mappings from Domain Models to Rust code
+//!
+//! This module handles the translation of Semantic and Morphological types
+//! into their Rust string equivalents. It isolates the "Leak" where domain
+//! objects previously knew about their Rust representation.
+
+use crate::morphology::Case;
+use crate::morphology::lexicon::{BinaryOp, UnaryOp};
+use crate::semantic::{GlossaType, Ownership};
+use std::fmt::Write;
+
+/// Map a GlossaType to its Rust type annotation
+pub fn map_type(ty: &GlossaType) -> String {
+    match ty {
+        GlossaType::Number => "i64".to_string(),
+        GlossaType::String => "String".to_string(),
+        GlossaType::Boolean => "bool".to_string(),
+        GlossaType::List(inner) => format!("Vec<{}>", map_type(inner)),
+        GlossaType::Set(inner) => format!("HashSet<{}>", map_type(inner)),
+        GlossaType::Map(key, value) => {
+            format!("HashMap<{}, {}>", map_type(key), map_type(value))
+        }
+        GlossaType::Option(inner) => format!("Option<{}>", map_type(inner)),
+        GlossaType::Result(ok, err) => format!("Result<{}, {}>", map_type(ok), map_type(err)),
+        GlossaType::Unit => "()".to_string(),
+        GlossaType::Struct { name, .. } => capitalize(&sanitize_name(name)),
+        GlossaType::Function { .. } => "fn".to_string(), // Placeholder/TODO
+        GlossaType::Unknown => "_".to_string(),
+    }
+}
+
+/// Map Ownership semantic to Rust reference prefix
+pub fn map_ownership(ownership: Ownership) -> &'static str {
+    match ownership {
+        Ownership::Move => "",
+        Ownership::Borrow => "&",
+        Ownership::BorrowMut => "&mut ",
+        Ownership::Copy => "",
+    }
+}
+
+/// Map Case to Rust ownership prefix (Legacy/Direct mapping)
+pub fn map_case_ownership(case: Case) -> &'static str {
+    match case {
+        Case::Nominative => "",
+        Case::Genitive => "&",
+        Case::Dative => "&mut",
+        Case::Accusative => "",
+        Case::Vocative => "",
+    }
+}
+
+/// Map BinaryOp to Rust operator string
+pub fn map_bin_op(op: BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Add => "+",
+        BinaryOp::Sub => "-",
+        BinaryOp::Mul => "*",
+        BinaryOp::Div => "/",
+        BinaryOp::Mod => "%",
+        BinaryOp::Eq => "==",
+        BinaryOp::Ne => "!=",
+        BinaryOp::Lt => "<",
+        BinaryOp::Le => "<=",
+        BinaryOp::Gt => ">",
+        BinaryOp::Ge => ">=",
+        BinaryOp::And => "&&",
+        BinaryOp::Or => "||",
+    }
+}
+
+/// Map UnaryOp to Rust operator string
+pub fn map_unary_op(op: UnaryOp) -> &'static str {
+    match op {
+        UnaryOp::Not => "!",
+        UnaryOp::Neg => "-",
+    }
+}
+
+/// Capitalize the first letter of a string (for Rust type/trait names)
+pub fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+/// Sanitize a Greek name for use as a Rust identifier
+pub fn sanitize_name(name: &str) -> String {
+    // Map single Greek letters to their names
+    if name.len() <= 2 {
+        // Could be a single Greek letter (2 bytes for UTF-8)
+        match name {
+            "α" => return "alpha".to_string(),
+            "β" => return "beta".to_string(),
+            "γ" => return "gamma".to_string(),
+            "δ" => return "delta".to_string(),
+            "ε" => return "epsilon".to_string(),
+            "ζ" => return "zeta".to_string(),
+            "η" => return "eta".to_string(),
+            "θ" => return "theta".to_string(),
+            "ι" => return "iota".to_string(),
+            "κ" => return "kappa".to_string(),
+            "λ" => return "lambda".to_string(),
+            "μ" => return "mu".to_string(),
+            "ν" => return "nu".to_string(),
+            "ξ" => return "xi".to_string(),
+            "ο" => return "omicron".to_string(),
+            "π" => return "pi".to_string(),
+            "ρ" => return "rho".to_string(),
+            "σ" | "ς" => return "sigma".to_string(),
+            "τ" => return "tau".to_string(),
+            "υ" => return "upsilon".to_string(),
+            "φ" => return "phi".to_string(),
+            "χ" => return "chi".to_string(),
+            "ψ" => return "psi".to_string(),
+            "ω" => return "omega".to_string(),
+            _ => {}
+        }
+    }
+
+    // Transliterate the full name
+    transliterate(name)
+}
+
+/// Transliterate Greek to Latin characters
+pub fn transliterate(greek: &str) -> String {
+    let mut result = String::new();
+
+    for c in greek.chars() {
+        let trans = match c {
+            'α' => "a",
+            'β' => "b",
+            'γ' => "g",
+            'δ' => "d",
+            'ε' => "e",
+            'ζ' => "z",
+            'η' => "e",
+            'θ' => "th",
+            'ι' => "i",
+            'κ' => "k",
+            'λ' => "l",
+            'μ' => "m",
+            'ν' => "n",
+            'ξ' => "x",
+            'ο' => "o",
+            'π' => "p",
+            'ρ' => "r",
+            'σ' | 'ς' => "s",
+            'τ' => "t",
+            'υ' => "u",
+            'φ' => "ph",
+            'χ' => "ch",
+            'ψ' => "ps",
+            'ω' => "o",
+            _ => {
+                // Keep only ASCII alphanumeric characters and underscore
+                if c.is_ascii_alphanumeric() || c == '_' {
+                    result.push(c);
+                } else {
+                    // Replace invalid characters with unique hex code to prevent collisions
+                    // e.g. ϟ -> _u3df_
+                    write!(result, "_u{:x}_", c as u32).unwrap();
+                }
+                continue;
+            }
+        };
+        result.push_str(trans);
+    }
+
+    // Ensure it starts with a letter or underscore (valid Rust identifier)
+    if result
+        .chars()
+        .next()
+        .map(|c| c.is_numeric())
+        .unwrap_or(true)
+    {
+        format!("_{}", result)
+    } else {
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_type() {
+        assert_eq!(map_type(&GlossaType::Number), "i64".to_string());
+        assert_eq!(map_type(&GlossaType::String), "String".to_string());
+        assert_eq!(map_type(&GlossaType::Boolean), "bool".to_string());
+    }
+
+    #[test]
+    fn test_map_ownership() {
+        assert_eq!(map_ownership(Ownership::Borrow), "&");
+        assert_eq!(map_ownership(Ownership::BorrowMut), "&mut ");
+        assert_eq!(map_ownership(Ownership::Move), "");
+    }
+
+    #[test]
+    fn test_map_case_ownership() {
+        assert_eq!(map_case_ownership(Case::Genitive), "&");
+        assert_eq!(map_case_ownership(Case::Dative), "&mut");
+        assert_eq!(map_case_ownership(Case::Accusative), "");
+    }
+
+    #[test]
+    fn test_map_bin_op() {
+        assert_eq!(map_bin_op(BinaryOp::Add), "+");
+        assert_eq!(map_bin_op(BinaryOp::Gt), ">");
+        assert_eq!(map_bin_op(BinaryOp::And), "&&");
+    }
+
+    #[test]
+    fn test_map_unary_op() {
+        assert_eq!(map_unary_op(UnaryOp::Not), "!");
+    }
+
+    #[test]
+    fn test_sanitize_greek_letter() {
+        assert_eq!(sanitize_name("ξ"), "xi");
+        assert_eq!(sanitize_name("α"), "alpha");
+        assert_eq!(sanitize_name("ω"), "omega");
+    }
+
+    #[test]
+    fn test_transliterate() {
+        assert_eq!(transliterate("χρηστος"), "chrestos");
+        assert_eq!(transliterate("λογος"), "logos");
+        assert_eq!(transliterate("φιλοσοφια"), "philosophia");
+    }
+
+    #[test]
+    fn test_transliterate_unique() {
+        let koppa = "ϟ";
+        let stigma = "ϛ";
+        let t_koppa = transliterate(koppa);
+        let t_stigma = transliterate(stigma);
+        assert_ne!(t_koppa, t_stigma);
+        assert!(t_koppa.contains("_u3df_"));
+        assert!(t_stigma.contains("_u3db_"));
+    }
+}

--- a/src/codegen/mappings.rs
+++ b/src/codegen/mappings.rs
@@ -191,6 +191,31 @@ mod tests {
         assert_eq!(map_type(&GlossaType::Number), "i64".to_string());
         assert_eq!(map_type(&GlossaType::String), "String".to_string());
         assert_eq!(map_type(&GlossaType::Boolean), "bool".to_string());
+        assert_eq!(map_type(&GlossaType::Unit), "()".to_string());
+        assert_eq!(map_type(&GlossaType::Unknown), "_".to_string());
+        assert_eq!(map_type(&GlossaType::Function { params: vec![], returns: Box::new(GlossaType::Unit) }), "fn".to_string());
+
+        let list_type = GlossaType::List(Box::new(GlossaType::Number));
+        assert_eq!(map_type(&list_type), "Vec<i64>");
+
+        let set_type = GlossaType::Set(Box::new(GlossaType::String));
+        assert_eq!(map_type(&set_type), "HashSet<String>");
+
+        let map_type_obj = GlossaType::Map(Box::new(GlossaType::String), Box::new(GlossaType::Number));
+        assert_eq!(map_type(&map_type_obj), "HashMap<String, i64>");
+
+        let struct_type = GlossaType::Struct {
+            name: "χρηστης".into(),
+            gender: crate::morphology::Gender::Masculine,
+            fields: vec![]
+        };
+        assert_eq!(map_type(&struct_type), "Chrestes"); // sanitized and capitalized
+
+        let option_type = GlossaType::Option(Box::new(GlossaType::Number));
+        assert_eq!(map_type(&option_type), "Option<i64>");
+
+        let result_type = GlossaType::Result(Box::new(GlossaType::Number), Box::new(GlossaType::String));
+        assert_eq!(map_type(&result_type), "Result<i64, String>");
     }
 
     #[test]
@@ -198,31 +223,67 @@ mod tests {
         assert_eq!(map_ownership(Ownership::Borrow), "&");
         assert_eq!(map_ownership(Ownership::BorrowMut), "&mut ");
         assert_eq!(map_ownership(Ownership::Move), "");
+        assert_eq!(map_ownership(Ownership::Copy), "");
     }
 
     #[test]
     fn test_map_case_ownership() {
+        assert_eq!(map_case_ownership(Case::Nominative), "");
         assert_eq!(map_case_ownership(Case::Genitive), "&");
         assert_eq!(map_case_ownership(Case::Dative), "&mut");
         assert_eq!(map_case_ownership(Case::Accusative), "");
+        assert_eq!(map_case_ownership(Case::Vocative), "");
     }
 
     #[test]
     fn test_map_bin_op() {
         assert_eq!(map_bin_op(BinaryOp::Add), "+");
+        assert_eq!(map_bin_op(BinaryOp::Sub), "-");
+        assert_eq!(map_bin_op(BinaryOp::Mul), "*");
+        assert_eq!(map_bin_op(BinaryOp::Div), "/");
+        assert_eq!(map_bin_op(BinaryOp::Mod), "%");
+        assert_eq!(map_bin_op(BinaryOp::Eq), "==");
+        assert_eq!(map_bin_op(BinaryOp::Ne), "!=");
+        assert_eq!(map_bin_op(BinaryOp::Lt), "<");
+        assert_eq!(map_bin_op(BinaryOp::Le), "<=");
         assert_eq!(map_bin_op(BinaryOp::Gt), ">");
+        assert_eq!(map_bin_op(BinaryOp::Ge), ">=");
         assert_eq!(map_bin_op(BinaryOp::And), "&&");
+        assert_eq!(map_bin_op(BinaryOp::Or), "||");
     }
 
     #[test]
     fn test_map_unary_op() {
         assert_eq!(map_unary_op(UnaryOp::Not), "!");
+        assert_eq!(map_unary_op(UnaryOp::Neg), "-");
     }
 
     #[test]
     fn test_sanitize_greek_letter() {
-        assert_eq!(sanitize_name("ξ"), "xi");
         assert_eq!(sanitize_name("α"), "alpha");
+        assert_eq!(sanitize_name("β"), "beta");
+        assert_eq!(sanitize_name("γ"), "gamma");
+        assert_eq!(sanitize_name("δ"), "delta");
+        assert_eq!(sanitize_name("ε"), "epsilon");
+        assert_eq!(sanitize_name("ζ"), "zeta");
+        assert_eq!(sanitize_name("η"), "eta");
+        assert_eq!(sanitize_name("θ"), "theta");
+        assert_eq!(sanitize_name("ι"), "iota");
+        assert_eq!(sanitize_name("κ"), "kappa");
+        assert_eq!(sanitize_name("λ"), "lambda");
+        assert_eq!(sanitize_name("μ"), "mu");
+        assert_eq!(sanitize_name("ν"), "nu");
+        assert_eq!(sanitize_name("ξ"), "xi");
+        assert_eq!(sanitize_name("ο"), "omicron");
+        assert_eq!(sanitize_name("π"), "pi");
+        assert_eq!(sanitize_name("ρ"), "rho");
+        assert_eq!(sanitize_name("σ"), "sigma");
+        assert_eq!(sanitize_name("ς"), "sigma");
+        assert_eq!(sanitize_name("τ"), "tau");
+        assert_eq!(sanitize_name("υ"), "upsilon");
+        assert_eq!(sanitize_name("φ"), "phi");
+        assert_eq!(sanitize_name("χ"), "chi");
+        assert_eq!(sanitize_name("ψ"), "psi");
         assert_eq!(sanitize_name("ω"), "omega");
     }
 
@@ -242,5 +303,12 @@ mod tests {
         assert_ne!(t_koppa, t_stigma);
         assert!(t_koppa.contains("_u3df_"));
         assert!(t_stigma.contains("_u3db_"));
+    }
+
+    #[test]
+    fn test_transliterate_numbers() {
+        // Rust identifiers cannot start with a number
+        assert_eq!(transliterate("123"), "_123");
+        assert_eq!(transliterate("1α"), "_1a");
     }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -12,6 +12,7 @@
 //! 2. **Code Generation**: `codegen::generate_rust` takes the `AnalyzedProgram` and
 //!    produces a Rust source string.
 
+pub mod mappings;
 mod rust;
 
 pub use rust::*;

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -20,7 +20,10 @@
 //!
 //! See [`sanitize_name`] for details.
 
-use crate::morphology::lexicon::{BinaryOp, UnaryOp};
+use crate::codegen::mappings::{
+    capitalize, map_bin_op, map_type, map_unary_op, sanitize_name,
+};
+use crate::morphology::lexicon::BinaryOp;
 use crate::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedImplMethod, AnalyzedIteratorOp, AnalyzedProgram,
     AnalyzedStatement, AnalyzedTraitMethod, GlossaType, StatementKind,
@@ -375,7 +378,7 @@ fn generate_fn_def(
         .map(|(param_name, param_type)| {
             let param_ident = format_ident!("{}", sanitize_name(param_name));
             if let Some(ty) = param_type {
-                let ty_str = type_to_rust_string(ty);
+                let ty_str = map_type(ty);
                 let ty_ident = format_ident!("{}", ty_str);
                 quote! { #param_ident: #ty_ident }
             } else {
@@ -386,7 +389,7 @@ fn generate_fn_def(
 
     // Generate return type
     if let Some(ret_type) = return_type {
-        let ret_str = type_to_rust_string(ret_type);
+        let ret_str = map_type(ret_type);
         let ret_ty = format_ident!("{}", ret_str);
         quote! {
             fn #fn_name(#(#param_tokens),*) -> #ret_ty {
@@ -411,7 +414,7 @@ fn generate_struct_def(name: &str, fields: &[(smol_str::SmolStr, GlossaType)]) -
         .iter()
         .map(|(field_name, field_type)| {
             let field_ident = format_ident!("{}", sanitize_name(field_name));
-            let type_str = type_to_rust_string(field_type);
+            let type_str = map_type(field_type);
             let type_ident = format_ident!("{}", type_str);
             quote! { #field_ident: #type_ident }
         })
@@ -446,7 +449,7 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedTraitMethod]) -> TokenStrea
                         quote! { &self }
                     } else {
                         let param_ident = format_ident!("{}", sanitize_name(param_name));
-                        let type_str = type_to_rust_string(param_type);
+                        let type_str = map_type(param_type);
                         let ty = format_ident!("{}", type_str);
                         quote! { #param_ident: #ty }
                     }
@@ -455,7 +458,7 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedTraitMethod]) -> TokenStrea
 
             // Generate return type
             if let Some(ret_type) = &method.return_type {
-                let ret_str = type_to_rust_string(ret_type);
+                let ret_str = map_type(ret_type);
                 let ret_ty = format_ident!("{}", ret_str);
 
                 if method.is_default {
@@ -531,7 +534,7 @@ fn generate_trait_impl(
                         quote! { &self }
                     } else {
                         let param_ident = format_ident!("{}", sanitize_name(param_name));
-                        let type_str = type_to_rust_string(param_type);
+                        let type_str = map_type(param_type);
                         let ty = format_ident!("{}", type_str);
                         quote! { #param_ident: #ty }
                     }
@@ -543,7 +546,7 @@ fn generate_trait_impl(
 
             // Generate return type
             if let Some(ret_type) = &method.return_type {
-                let ret_str = type_to_rust_string(ret_type);
+                let ret_str = map_type(ret_type);
                 let ret_ty = format_ident!("{}", ret_str);
                 quote! {
                     fn #method_name(#(#param_tokens),*) -> #ret_ty {
@@ -679,17 +682,11 @@ fn generate_expr(expr: &AnalyzedExpr) -> TokenStream {
         AnalyzedExprKind::BinOp { op, left, right } => generate_bin_op(*op, left, right),
 
         AnalyzedExprKind::UnaryOp { op, operand } => {
-            match op {
-                UnaryOp::Not => {
-                    let operand_tokens = generate_expr(operand);
-                    // Standard Rust logical not or bitwise not
-                    quote! { !#operand_tokens }
-                }
-                UnaryOp::Neg => {
-                    let operand_tokens = generate_expr(operand);
-                    quote! { -#operand_tokens }
-                }
-            }
+            let op_str = map_unary_op(*op);
+            use std::str::FromStr;
+            let op_tokens = TokenStream::from_str(op_str).unwrap();
+            let operand_tokens = generate_expr(operand);
+            quote! { #op_tokens #operand_tokens }
         }
 
         AnalyzedExprKind::Range {
@@ -762,21 +759,21 @@ fn generate_bin_op(op: BinaryOp, left: &AnalyzedExpr, right: &AnalyzedExpr) -> T
     let left_tokens = generate_expr(left);
     let right_tokens = generate_expr(right);
 
-    match op {
-        BinaryOp::Add => quote! { (#left_tokens + #right_tokens) },
-        BinaryOp::Sub => quote! { (#left_tokens - #right_tokens) },
-        BinaryOp::Mul => quote! { (#left_tokens * #right_tokens) },
-        BinaryOp::Div => quote! { (#left_tokens / #right_tokens) },
-        BinaryOp::Mod => quote! { (#left_tokens % #right_tokens) },
-        BinaryOp::Eq => quote! { (#left_tokens == #right_tokens) },
-        BinaryOp::Ne => quote! { (#left_tokens != #right_tokens) },
-        BinaryOp::Lt => quote! { (#left_tokens < #right_tokens) },
-        BinaryOp::Le => quote! { (#left_tokens <= #right_tokens) },
-        BinaryOp::Gt => quote! { (#left_tokens > #right_tokens) },
-        BinaryOp::Ge => quote! { (#left_tokens >= #right_tokens) },
-        BinaryOp::And => quote! { (#left_tokens && #right_tokens) },
-        BinaryOp::Or => quote! { (#left_tokens || #right_tokens) },
-    }
+    // Use mapped operator string to generate quote
+    let op_str = map_bin_op(op);
+
+    // We can't easily interpolate a string into an operator in quote!
+    // But we can parse it, or just fallback to the manual mapping if quote! needs concrete tokens.
+    // quote! supports #ident for identifiers, but operators are Punct.
+    // However, the original code had a match block returning quote!{ ... }
+
+    // Let's stick to the match block for quote generation to ensure correct Punct types,
+    // but we can verify the mapping matches if we wanted.
+    // Actually, `map_bin_op` returns `&str`. Converting that to a TokenStream is easy.
+    use std::str::FromStr;
+    let op_tokens = TokenStream::from_str(op_str).unwrap();
+
+    quote! { (#left_tokens #op_tokens #right_tokens) }
 }
 
 fn generate_struct_lit(
@@ -882,15 +879,6 @@ fn generate_iterator_chain(collection: &AnalyzedExpr, ops: &[AnalyzedIteratorOp]
     current
 }
 
-/// Capitalize the first letter of a string (for Rust type/trait names)
-fn capitalize(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-    }
-}
-
 /// Check if a parameter represents the self parameter in a trait method
 fn is_self_parameter(param_name: &str, idx: usize) -> bool {
     if idx != 0 {
@@ -902,111 +890,6 @@ fn is_self_parameter(param_name: &str, idx: usize) -> bool {
         || param_name == "self"
         || normalized == "τω"
         || param_name.contains("self")
-}
-
-/// Sanitize a Greek name for use as a Rust identifier
-fn sanitize_name(name: &str) -> String {
-    // Map single Greek letters to their names
-    if name.len() <= 2 {
-        // Could be a single Greek letter (2 bytes for UTF-8)
-        match name {
-            "α" => return "alpha".to_string(),
-            "β" => return "beta".to_string(),
-            "γ" => return "gamma".to_string(),
-            "δ" => return "delta".to_string(),
-            "ε" => return "epsilon".to_string(),
-            "ζ" => return "zeta".to_string(),
-            "η" => return "eta".to_string(),
-            "θ" => return "theta".to_string(),
-            "ι" => return "iota".to_string(),
-            "κ" => return "kappa".to_string(),
-            "λ" => return "lambda".to_string(),
-            "μ" => return "mu".to_string(),
-            "ν" => return "nu".to_string(),
-            "ξ" => return "xi".to_string(),
-            "ο" => return "omicron".to_string(),
-            "π" => return "pi".to_string(),
-            "ρ" => return "rho".to_string(),
-            "σ" | "ς" => return "sigma".to_string(),
-            "τ" => return "tau".to_string(),
-            "υ" => return "upsilon".to_string(),
-            "φ" => return "phi".to_string(),
-            "χ" => return "chi".to_string(),
-            "ψ" => return "psi".to_string(),
-            "ω" => return "omega".to_string(),
-            _ => {}
-        }
-    }
-
-    // Transliterate the full name
-    transliterate(name)
-}
-
-/// Transliterate Greek to Latin characters
-fn transliterate(greek: &str) -> String {
-    let mut result = String::new();
-
-    for c in greek.chars() {
-        let trans = match c {
-            'α' => "a",
-            'β' => "b",
-            'γ' => "g",
-            'δ' => "d",
-            'ε' => "e",
-            'ζ' => "z",
-            'η' => "e",
-            'θ' => "th",
-            'ι' => "i",
-            'κ' => "k",
-            'λ' => "l",
-            'μ' => "m",
-            'ν' => "n",
-            'ξ' => "x",
-            'ο' => "o",
-            'π' => "p",
-            'ρ' => "r",
-            'σ' | 'ς' => "s",
-            'τ' => "t",
-            'υ' => "u",
-            'φ' => "ph",
-            'χ' => "ch",
-            'ψ' => "ps",
-            'ω' => "o",
-            _ => {
-                // Keep only ASCII alphanumeric characters and underscore
-                if c.is_ascii_alphanumeric() || c == '_' {
-                    result.push(c);
-                } else {
-                    // Replace invalid characters with unique hex code to prevent collisions
-                    // e.g. ϟ -> _u3df_
-                    use std::fmt::Write;
-                    write!(result, "_u{:x}_", c as u32).unwrap();
-                }
-                continue;
-            }
-        };
-        result.push_str(trans);
-    }
-
-    // Ensure it starts with a letter or underscore (valid Rust identifier)
-    if result
-        .chars()
-        .next()
-        .map(|c| c.is_numeric())
-        .unwrap_or(true)
-    {
-        format!("_{}", result)
-    } else {
-        result
-    }
-}
-
-/// Helper to get Rust type string, working around GlossaType::to_rust issues
-fn type_to_rust_string(ty: &GlossaType) -> String {
-    match ty {
-        GlossaType::Struct { name, .. } => capitalize(&sanitize_name(name)),
-        _ => ty.to_rust(),
-    }
 }
 
 #[cfg(test)]
@@ -1041,45 +924,6 @@ mod tests {
         let code = compile("42 λέγε.");
         assert!(code.contains("println"), "Expected println in: {}", code);
         assert!(code.contains("42"));
-    }
-
-    #[test]
-    fn test_sanitize_greek_letter() {
-        assert_eq!(sanitize_name("ξ"), "xi");
-        assert_eq!(sanitize_name("α"), "alpha");
-        assert_eq!(sanitize_name("ω"), "omega");
-    }
-
-    #[test]
-    fn test_transliterate() {
-        assert_eq!(transliterate("χρηστος"), "chrestos");
-        assert_eq!(transliterate("λογος"), "logos");
-        assert_eq!(transliterate("φιλοσοφια"), "philosophia");
-    }
-
-    #[test]
-    fn test_transliterate_unique() {
-        // Test that different invalid characters produce different outputs
-        let koppa = "ϟ";
-        let stigma = "ϛ";
-
-        let t_koppa = transliterate(koppa);
-        let t_stigma = transliterate(stigma);
-
-        assert_ne!(
-            t_koppa, t_stigma,
-            "Different invalid chars should not collide"
-        );
-        assert!(t_koppa.contains("_u3df_")); // Koppa is 0x3DF
-        assert!(t_stigma.contains("_u3db_")); // Stigma is 0x3DB
-    }
-
-    #[test]
-    fn test_transliterate_mixed_valid_invalid() {
-        // Test mixing valid and invalid characters
-        let input = "αϟβ";
-        let output = transliterate(input);
-        assert_eq!(output, "a_u3df_b");
     }
 
     #[test]

--- a/src/morphology/case.rs
+++ b/src/morphology/case.rs
@@ -20,19 +20,6 @@ pub enum Case {
     Vocative,
 }
 
-impl Case {
-    /// Convert case to its ownership/borrowing semantic
-    pub fn to_rust_ownership(&self) -> &'static str {
-        match self {
-            Case::Nominative => "", // Subject, just the value
-            Case::Genitive => "&",  // Borrow (of/from)
-            Case::Dative => "&mut", // Mutable borrow (to/for)
-            Case::Accusative => "", // Move (direct object)
-            Case::Vocative => "",   // No ownership semantic
-        }
-    }
-}
-
 /// Grammatical number
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Number {
@@ -108,12 +95,4 @@ pub enum Voice {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    #[test]
-    fn test_case_ownership() {
-        assert_eq!(Case::Genitive.to_rust_ownership(), "&");
-        assert_eq!(Case::Dative.to_rust_ownership(), "&mut");
-        assert_eq!(Case::Accusative.to_rust_ownership(), "");
-    }
 }

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -2138,24 +2138,7 @@ pub enum BinaryOp {
 }
 
 impl BinaryOp {
-    /// Get the Rust operator string
-    pub fn to_rust(&self) -> &'static str {
-        match self {
-            BinaryOp::Add => "+",
-            BinaryOp::Sub => "-",
-            BinaryOp::Mul => "*",
-            BinaryOp::Div => "/",
-            BinaryOp::Mod => "%",
-            BinaryOp::Eq => "==",
-            BinaryOp::Ne => "!=",
-            BinaryOp::Lt => "<",
-            BinaryOp::Le => "<=",
-            BinaryOp::Gt => ">",
-            BinaryOp::Ge => ">=",
-            BinaryOp::And => "&&",
-            BinaryOp::Or => "||",
-        }
-    }
+    // Rust mapping moved to codegen::mappings
 }
 
 /// Unary operator type for code generation
@@ -2163,16 +2146,6 @@ impl BinaryOp {
 pub enum UnaryOp {
     Not, // οὐ/οὐκ
     Neg, // arithmetic negation
-}
-
-impl UnaryOp {
-    /// Get the Rust operator string
-    pub fn to_rust(&self) -> &'static str {
-        match self {
-            UnaryOp::Not => "!",
-            UnaryOp::Neg => "-",
-        }
-    }
 }
 
 /// Check if a word is a comparison adjective and return the operator
@@ -2458,14 +2431,6 @@ mod tests {
         assert_eq!(arithmetic_operator("γινομενον"), Some(BinaryOp::Mul));
         assert_eq!(arithmetic_operator("μερος"), Some(BinaryOp::Div));
         assert_eq!(arithmetic_operator("υπολοιπον"), Some(BinaryOp::Mod));
-    }
-
-    #[test]
-    fn test_operator_to_rust() {
-        assert_eq!(BinaryOp::Add.to_rust(), "+");
-        assert_eq!(BinaryOp::Gt.to_rust(), ">");
-        assert_eq!(BinaryOp::And.to_rust(), "&&");
-        assert_eq!(UnaryOp::Not.to_rust(), "!");
     }
 
     #[test]

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -79,26 +79,6 @@ pub enum GlossaType {
 }
 
 impl GlossaType {
-    /// Get the Rust equivalent type
-    pub fn to_rust(&self) -> String {
-        match self {
-            GlossaType::Number => "i64".to_string(),
-            GlossaType::String => "String".to_string(),
-            GlossaType::Boolean => "bool".to_string(),
-            GlossaType::List(inner) => format!("Vec<{}>", inner.to_rust()),
-            GlossaType::Set(inner) => format!("HashSet<{}>", inner.to_rust()),
-            GlossaType::Map(key, value) => {
-                format!("HashMap<{}, {}>", key.to_rust(), value.to_rust())
-            }
-            GlossaType::Option(inner) => format!("Option<{}>", inner.to_rust()),
-            GlossaType::Result(ok, err) => format!("Result<{}, {}>", ok.to_rust(), err.to_rust()),
-            GlossaType::Unit => "()".to_string(),
-            GlossaType::Struct { .. } => "struct".to_string(),
-            GlossaType::Function { .. } => "fn".to_string(),
-            GlossaType::Unknown => "_".to_string(),
-        }
-    }
-
     /// Get the Greek name for this type
     pub fn to_greek(&self) -> &'static str {
         match self {
@@ -158,16 +138,6 @@ impl Ownership {
             _ => Ownership::Copy,
         }
     }
-
-    /// Get the Rust reference prefix
-    pub fn to_rust_prefix(&self) -> &'static str {
-        match self {
-            Ownership::Move => "",
-            Ownership::Borrow => "&",
-            Ownership::BorrowMut => "&mut ",
-            Ownership::Copy => "",
-        }
-    }
 }
 
 /// Infer type from a Greek word (by looking at lexicon or morphology)
@@ -210,13 +180,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_type_to_rust() {
-        assert_eq!(GlossaType::Number.to_rust(), "i64".to_string());
-        assert_eq!(GlossaType::String.to_rust(), "String".to_string());
-        assert_eq!(GlossaType::Boolean.to_rust(), "bool".to_string());
-    }
-
-    #[test]
     fn test_type_to_greek() {
         assert_eq!(GlossaType::Number.to_greek(), "ἀριθμός");
         assert_eq!(GlossaType::String.to_greek(), "ὄνομα");
@@ -227,13 +190,6 @@ mod tests {
         assert_eq!(Ownership::from_case(Case::Genitive), Ownership::Borrow);
         assert_eq!(Ownership::from_case(Case::Dative), Ownership::BorrowMut);
         assert_eq!(Ownership::from_case(Case::Accusative), Ownership::Move);
-    }
-
-    #[test]
-    fn test_ownership_prefix() {
-        assert_eq!(Ownership::Borrow.to_rust_prefix(), "&");
-        assert_eq!(Ownership::BorrowMut.to_rust_prefix(), "&mut ");
-        assert_eq!(Ownership::Move.to_rust_prefix(), "");
     }
 
     #[test]

--- a/tests/option_result_tests.rs
+++ b/tests/option_result_tests.rs
@@ -6,6 +6,7 @@
 /// - τί (ti) → Some
 /// - ἐπιτυχία (epitychia) → Ok
 /// - σφάλμα (sphalma) → Err
+use glossa::codegen::mappings::map_type;
 use glossa::semantic::GlossaType;
 
 /// Helper to compile GLOSSA source to Rust code
@@ -38,13 +39,13 @@ fn test_result_type_exists() {
 #[test]
 fn test_option_to_rust() {
     let opt = GlossaType::Option(Box::new(GlossaType::Number));
-    assert_eq!(opt.to_rust(), "Option<i64>");
+    assert_eq!(map_type(&opt), "Option<i64>");
 }
 
 #[test]
 fn test_result_to_rust() {
     let result = GlossaType::Result(Box::new(GlossaType::Number), Box::new(GlossaType::String));
-    assert_eq!(result.to_rust(), "Result<i64, String>");
+    assert_eq!(map_type(&result), "Result<i64, String>");
 }
 
 #[test]
@@ -64,7 +65,7 @@ fn test_result_type_compatibility() {
 #[test]
 fn test_nested_option() {
     let nested = GlossaType::Option(Box::new(GlossaType::Option(Box::new(GlossaType::Number))));
-    assert_eq!(nested.to_rust(), "Option<Option<i64>>");
+    assert_eq!(map_type(&nested), "Option<Option<i64>>");
 }
 
 // ============================================================================


### PR DESCRIPTION
This PR addresses a structural "Leak" where domain models in `semantic` and `morphology` were coupled to the Rust code generation target via `to_rust()` methods.

Changes:
1.  **New Module**: `src/codegen/mappings.rs` centralizes all logic for converting `GlossaType`, `Case`, and operators into Rust syntax.
2.  **Decoupling**: Removed `to_rust`, `to_rust_prefix`, and `to_rust_ownership` from `src/semantic/types.rs`, `src/morphology/lexicon.rs`, and `src/morphology/case.rs`.
3.  **Refactor**: Updated `src/codegen/rust.rs` to use the new `mappings` module instead of calling methods on domain objects.
4.  **Tests**: Updated `tests/option_result_tests.rs` to use `map_type` for verification.

This ensures that the core domain models are target-agnostic and enforces a cleaner dependency graph.

---
*PR created automatically by Jules for task [4890632814057953050](https://jules.google.com/task/4890632814057953050) started by @madmax983*