### PR TITLE
Refactor trait model to unify AnalyzedTraitMethod

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -37,3 +37,8 @@
 **Bloat:** Duplicate logic for struct instantiation in `src/semantic/conversion.rs` (broken, handled only literals) and `src/semantic/patterns.rs` (working, handled variables).
 **Cut:** Deleted `classify_struct_instantiation` from `conversion.rs` and consolidated `detect_collection_type` into `src/semantic/types.rs`.
 **Saved:** Removed ~100 lines of duplicate/broken code and fixed a bug preventing variable arguments in constructors.
+
+## [Reduction]
+**Bloat:** `AnalyzedImplMethod` in `src/semantic/model.rs` was a near-duplicate of `AnalyzedTraitMethod`. `is_default` field was redundant.
+**Cut:** Merged into `AnalyzedTraitMethod`. Removed `is_default` (inferred from `body.is_some()`). Unified codegen logic.
+**Saved:** Reduced semantic model complexity. Removed redundant struct and field. Simplified trait implementation handling.

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -22,8 +22,8 @@
 
 use crate::morphology::lexicon::{BinaryOp, UnaryOp};
 use crate::semantic::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedImplMethod, AnalyzedIteratorOp, AnalyzedProgram,
-    AnalyzedStatement, AnalyzedTraitMethod, GlossaType, StatementKind,
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedIteratorOp, AnalyzedProgram, AnalyzedStatement,
+    AnalyzedTraitMethod, GlossaType, StatementKind,
 };
 use crate::text::normalize_greek;
 use proc_macro2::TokenStream;
@@ -124,9 +124,12 @@ fn statement_uses_collections(stmt: &AnalyzedStatement) -> bool {
                 })
         }
         StatementKind::FunctionDef { body, .. } => body.iter().any(statement_uses_collections),
-        StatementKind::TraitImplementation { methods, .. } => methods
-            .iter()
-            .any(|m| m.body.iter().any(statement_uses_collections)),
+        StatementKind::TraitImplementation { methods, .. } => methods.iter().any(|m| {
+            m.body
+                .as_ref()
+                .map(|b| b.iter().any(statement_uses_collections))
+                .unwrap_or(false)
+        }),
         StatementKind::TraitDefinition { methods, .. } => methods.iter().any(|m| {
             m.body
                 .as_ref()
@@ -458,18 +461,12 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedTraitMethod]) -> TokenStrea
                 let ret_str = type_to_rust_string(ret_type);
                 let ret_ty = format_ident!("{}", ret_str);
 
-                if method.is_default {
-                    if let Some(body) = &method.body {
-                        let body_stmts: Vec<TokenStream> =
-                            body.iter().map(generate_statement).collect();
-                        quote! {
-                            fn #method_name(#(#param_tokens),*) -> #ret_ty {
-                                #(#body_stmts)*
-                            }
-                        }
-                    } else {
-                        quote! {
-                            fn #method_name(#(#param_tokens),*) -> #ret_ty;
+                if let Some(body) = &method.body {
+                    let body_stmts: Vec<TokenStream> =
+                        body.iter().map(generate_statement).collect();
+                    quote! {
+                        fn #method_name(#(#param_tokens),*) -> #ret_ty {
+                            #(#body_stmts)*
                         }
                     }
                 } else {
@@ -477,18 +474,11 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedTraitMethod]) -> TokenStrea
                         fn #method_name(#(#param_tokens),*) -> #ret_ty;
                     }
                 }
-            } else if method.is_default {
-                if let Some(body) = &method.body {
-                    let body_stmts: Vec<TokenStream> =
-                        body.iter().map(generate_statement).collect();
-                    quote! {
-                        fn #method_name(#(#param_tokens),*) {
-                            #(#body_stmts)*
-                        }
-                    }
-                } else {
-                    quote! {
-                        fn #method_name(#(#param_tokens),*);
+            } else if let Some(body) = &method.body {
+                let body_stmts: Vec<TokenStream> = body.iter().map(generate_statement).collect();
+                quote! {
+                    fn #method_name(#(#param_tokens),*) {
+                        #(#body_stmts)*
                     }
                 }
             } else {
@@ -509,7 +499,7 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedTraitMethod]) -> TokenStrea
 fn generate_trait_impl(
     trait_name: &str,
     type_name: &str,
-    methods: &[AnalyzedImplMethod],
+    methods: &[AnalyzedTraitMethod],
 ) -> TokenStream {
     // Capitalize trait and type names for Rust conventions
     let trait_ident = format_ident!("{}", capitalize(&sanitize_name(trait_name)));
@@ -538,8 +528,9 @@ fn generate_trait_impl(
                 })
                 .collect();
 
-            // Generate method body
-            let body_stmts: Vec<TokenStream> = method.body.iter().map(generate_statement).collect();
+            // Generate method body (must exist for impl methods)
+            let body = method.body.as_ref().expect("Trait impl method must have a body");
+            let body_stmts: Vec<TokenStream> = body.iter().map(generate_statement).collect();
 
             // Generate return type
             if let Some(ret_type) = &method.return_type {

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -1,7 +1,7 @@
 //! Declaration analysis (functions, types, traits)
 
 use super::{
-    AnalyzedImplMethod, AnalyzedStatement, AnalyzedTraitMethod, GlossaType, Scope, StatementKind,
+    AnalyzedStatement, AnalyzedTraitMethod, GlossaType, Scope, StatementKind,
     analyze_single_statement_with_assembler, convert_assembled_to_analyzed,
 };
 use crate::ast::{Expr, Statement};
@@ -126,7 +126,6 @@ pub fn analyze_trait_definition(
             analyzed_methods.push(AnalyzedTraitMethod {
                 name: method_name,
                 params,
-                is_default: true,
                 body,
                 return_type,
             });
@@ -134,7 +133,6 @@ pub fn analyze_trait_definition(
             analyzed_methods.push(AnalyzedTraitMethod {
                 name: method_name,
                 params,
-                is_default: false,
                 body: None,
                 return_type: None,
             });
@@ -235,17 +233,17 @@ pub fn analyze_trait_impl(
         let return_type = infer_return_type_from_body(&analyzed_body);
 
         implemented_method_names.push(method_name.clone());
-        analyzed_methods.push(AnalyzedImplMethod {
+        analyzed_methods.push(AnalyzedTraitMethod {
             name: method_name,
             params,
-            body: analyzed_body,
+            body: Some(analyzed_body),
             return_type,
         });
     }
 
     // Validate: all required methods must be implemented
     for method in &trait_def.methods {
-        if !method.is_default && !implemented_method_names.contains(&method.name) {
+        if method.body.is_none() && !implemented_method_names.contains(&method.name) {
             return Err(GlossaError::semantic(format!(
                 "Type {} does not implement required method {} from trait {}",
                 type_name, method.name, trait_name

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -82,26 +82,16 @@ pub enum StatementKind {
     TraitImplementation {
         trait_name: SmolStr,
         type_name: SmolStr,
-        methods: Vec<AnalyzedImplMethod>,
+        methods: Vec<AnalyzedTraitMethod>,
     },
 }
 
-/// An analyzed method in a trait definition (AST node)
+/// An analyzed method in a trait definition or implementation
 #[derive(Debug, Clone)]
 pub struct AnalyzedTraitMethod {
     pub name: SmolStr,
     pub params: Vec<(SmolStr, GlossaType)>,
-    pub is_default: bool,
-    pub body: Option<Vec<AnalyzedStatement>>, // Some for default methods, None for required
-    pub return_type: Option<GlossaType>,
-}
-
-/// An analyzed method in a trait implementation (AST node)
-#[derive(Debug, Clone)]
-pub struct AnalyzedImplMethod {
-    pub name: SmolStr,
-    pub params: Vec<(SmolStr, GlossaType)>,
-    pub body: Vec<AnalyzedStatement>,
+    pub body: Option<Vec<AnalyzedStatement>>, // Some for methods with body, None for required/abstract
     pub return_type: Option<GlossaType>,
 }
 


### PR DESCRIPTION
Simplified the semantic model by removing the redundant `AnalyzedImplMethod` struct and merging it into `AnalyzedTraitMethod`. Also removed the `is_default` field as it can be inferred from the presence of a body. This reduces code duplication and complexity in the semantic analyzer and code generator.

---
*PR created automatically by Jules for task [13850663075394587626](https://jules.google.com/task/13850663075394587626) started by @madmax983*