### PR TITLE
DX: Improve error readability and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This allows for **Free Word Order**:
 
 ## Quick Start: The Hero's Journey
 
-Here is a simple program that defines a user struct and greets them.
+Here is a simple program that defines a user struct and greets them. Save this code as `hero.γλ`.
 
 ```glossa
 // Define a type (struct)
@@ -48,6 +48,12 @@ Here is a simple program that defines a user struct and greets them.
 // Access property and print
 // "of the user" (genitive) "name" (nominative) "say" (verb)
 χρήστου ὄνομα λέγε.
+```
+
+Run the program:
+
+```bash
+cargo run --release -- hero.γλ
 ```
 
 ## Control Flow

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -906,89 +906,28 @@ fn is_self_parameter(param_name: &str, idx: usize) -> bool {
 
 /// Sanitize a Greek name for use as a Rust identifier
 fn sanitize_name(name: &str) -> String {
-    // Map single Greek letters to their names
-    if name.len() <= 2 {
-        // Could be a single Greek letter (2 bytes for UTF-8)
-        match name {
-            "α" => return "alpha".to_string(),
-            "β" => return "beta".to_string(),
-            "γ" => return "gamma".to_string(),
-            "δ" => return "delta".to_string(),
-            "ε" => return "epsilon".to_string(),
-            "ζ" => return "zeta".to_string(),
-            "η" => return "eta".to_string(),
-            "θ" => return "theta".to_string(),
-            "ι" => return "iota".to_string(),
-            "κ" => return "kappa".to_string(),
-            "λ" => return "lambda".to_string(),
-            "μ" => return "mu".to_string(),
-            "ν" => return "nu".to_string(),
-            "ξ" => return "xi".to_string(),
-            "ο" => return "omicron".to_string(),
-            "π" => return "pi".to_string(),
-            "ρ" => return "rho".to_string(),
-            "σ" | "ς" => return "sigma".to_string(),
-            "τ" => return "tau".to_string(),
-            "υ" => return "upsilon".to_string(),
-            "φ" => return "phi".to_string(),
-            "χ" => return "chi".to_string(),
-            "ψ" => return "psi".to_string(),
-            "ω" => return "omega".to_string(),
-            _ => {}
+    // Sanitize the full name (preserves Greek characters)
+    sanitize_identifier(name)
+}
+
+/// Sanitize characters for Rust identifier
+fn sanitize_identifier(input: &str) -> String {
+    let mut result = String::new();
+
+    for c in input.chars() {
+        // Keep alphanumeric characters (including Greek) and underscore
+        if c.is_alphanumeric() || c == '_' {
+            result.push(c);
+        } else {
+            // Replace invalid characters with unique hex code to prevent collisions
+            // e.g. ϟ -> _u3df_
+            use std::fmt::Write;
+            write!(result, "_u{:x}_", c as u32).unwrap();
         }
     }
 
-    // Transliterate the full name
-    transliterate(name)
-}
-
-/// Transliterate Greek to Latin characters
-fn transliterate(greek: &str) -> String {
-    let mut result = String::new();
-
-    for c in greek.chars() {
-        let trans = match c {
-            'α' => "a",
-            'β' => "b",
-            'γ' => "g",
-            'δ' => "d",
-            'ε' => "e",
-            'ζ' => "z",
-            'η' => "e",
-            'θ' => "th",
-            'ι' => "i",
-            'κ' => "k",
-            'λ' => "l",
-            'μ' => "m",
-            'ν' => "n",
-            'ξ' => "x",
-            'ο' => "o",
-            'π' => "p",
-            'ρ' => "r",
-            'σ' | 'ς' => "s",
-            'τ' => "t",
-            'υ' => "u",
-            'φ' => "ph",
-            'χ' => "ch",
-            'ψ' => "ps",
-            'ω' => "o",
-            _ => {
-                // Keep only ASCII alphanumeric characters and underscore
-                if c.is_ascii_alphanumeric() || c == '_' {
-                    result.push(c);
-                } else {
-                    // Replace invalid characters with unique hex code to prevent collisions
-                    // e.g. ϟ -> _u3df_
-                    use std::fmt::Write;
-                    write!(result, "_u{:x}_", c as u32).unwrap();
-                }
-                continue;
-            }
-        };
-        result.push_str(trans);
-    }
-
     // Ensure it starts with a letter or underscore (valid Rust identifier)
+    // Rust identifiers cannot start with a number
     if result
         .chars()
         .next()
@@ -1032,7 +971,7 @@ mod tests {
     #[test]
     fn test_generate_binding() {
         let code = compile("ξ πέντε ἔστω.");
-        assert!(code.contains("let xi"));
+        assert!(code.contains("let ξ"));
         assert!(code.contains("5"));
     }
 
@@ -1045,47 +984,48 @@ mod tests {
 
     #[test]
     fn test_sanitize_greek_letter() {
-        assert_eq!(sanitize_name("ξ"), "xi");
-        assert_eq!(sanitize_name("α"), "alpha");
-        assert_eq!(sanitize_name("ω"), "omega");
+        assert_eq!(sanitize_name("ξ"), "ξ");
+        assert_eq!(sanitize_name("α"), "α");
+        assert_eq!(sanitize_name("ω"), "ω");
     }
 
     #[test]
-    fn test_transliterate() {
-        assert_eq!(transliterate("χρηστος"), "chrestos");
-        assert_eq!(transliterate("λογος"), "logos");
-        assert_eq!(transliterate("φιλοσοφια"), "philosophia");
+    fn test_sanitize_identifier() {
+        assert_eq!(sanitize_identifier("χρηστος"), "χρηστος");
+        assert_eq!(sanitize_identifier("λογος"), "λογος");
+        assert_eq!(sanitize_identifier("φιλοσοφια"), "φιλοσοφια");
     }
 
     #[test]
-    fn test_transliterate_unique() {
+    fn test_sanitize_identifier_unique() {
         // Test that different invalid characters produce different outputs
-        let koppa = "ϟ";
-        let stigma = "ϛ";
+        // Use emojis or symbols that are not valid Rust identifiers
+        let pile = "💩";
+        let clown = "🤡";
 
-        let t_koppa = transliterate(koppa);
-        let t_stigma = transliterate(stigma);
+        let t_pile = sanitize_identifier(pile);
+        let t_clown = sanitize_identifier(clown);
 
         assert_ne!(
-            t_koppa, t_stigma,
+            t_pile, t_clown,
             "Different invalid chars should not collide"
         );
-        assert!(t_koppa.contains("_u3df_")); // Koppa is 0x3DF
-        assert!(t_stigma.contains("_u3db_")); // Stigma is 0x3DB
+        assert!(t_pile.contains("_u1f4a9_")); // Pile of poo
+        assert!(t_clown.contains("_u1f921_")); // Clown face
     }
 
     #[test]
-    fn test_transliterate_mixed_valid_invalid() {
+    fn test_sanitize_identifier_mixed_valid_invalid() {
         // Test mixing valid and invalid characters
-        let input = "αϟβ";
-        let output = transliterate(input);
-        assert_eq!(output, "a_u3df_b");
+        let input = "α💩β";
+        let output = sanitize_identifier(input);
+        assert_eq!(output, "α_u1f4a9_β");
     }
 
     #[test]
     fn test_generate_full_program() {
         let code = compile("ξ πέντε ἔστω. ξ λέγε.");
-        assert!(code.contains("let xi = 5"), "Expected binding in: {}", code);
+        assert!(code.contains("let ξ = 5"), "Expected binding in: {}", code);
         assert!(code.contains("println"), "Expected println in: {}", code);
     }
 }

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -21,16 +21,16 @@ fn test_hello_cosmos() {
 #[test]
 fn test_variable_binding() {
     let code = compile("ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let xi"));
+    assert!(code.contains("let ξ"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_variable_binding_and_use() {
     let code = compile("ξ πέντε ἔστω. ξ λέγε.").unwrap();
-    assert!(code.contains("let xi = 5"));
+    assert!(code.contains("let ξ = 5"));
     assert!(code.contains("println"));
-    assert!(code.contains("xi"));
+    assert!(code.contains("ξ"));
 }
 
 #[test]
@@ -42,8 +42,8 @@ fn test_number_literal() {
 #[test]
 fn test_multiple_statements() {
     let code = compile("α πέντε ἔστω. β δέκα ἔστω. α λέγε.").unwrap();
-    assert!(code.contains("let alpha = 5"));
-    assert!(code.contains("let beta = 10"));
+    assert!(code.contains("let α = 5"));
+    assert!(code.contains("let β = 10"));
 }
 
 #[test]
@@ -61,15 +61,15 @@ fn test_preserves_greek_in_strings() {
 #[test]
 fn test_mutable_binding() {
     let code = compile("μετά ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let mut xi"));
+    assert!(code.contains("let mut ξ"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_assignment_codegen() {
     let code = compile("μετά ξ πέντε ἔστω. ξ δέκα γίγνεται.").unwrap();
-    assert!(code.contains("let mut xi = 5"));
-    assert!(code.contains("xi = 10"));
+    assert!(code.contains("let mut ξ = 5"));
+    assert!(code.contains("ξ = 10"));
 }
 
 #[test]
@@ -89,8 +89,8 @@ fn test_undefined_assignment_error() {
 #[test]
 fn test_mutable_binding_and_reassignment() {
     let code = compile("μετά ξ πέντε ἔστω. ξ λέγε. ξ δέκα γίγνεται. ξ λέγε.").unwrap();
-    assert!(code.contains("let mut xi = 5"));
-    assert!(code.contains("xi = 10"));
+    assert!(code.contains("let mut ξ = 5"));
+    assert!(code.contains("ξ = 10"));
     assert!(code.matches("println").count() >= 2);
 }
 

--- a/tests/function_tests.rs
+++ b/tests/function_tests.rs
@@ -39,7 +39,7 @@ fn test_function_with_two_params() {
     let code = compile("προσθεσις ὁρίζειν τῷ ξ τῷ ψ· δός ξ ψ ἄθροισμα.");
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("fn"));
-    assert!(code.contains("xi") && code.contains("psi"));
+    assert!(code.contains("ξ") && code.contains("ψ"));
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn test_simple_return() {
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("return"));
     // Should return xi * 2, not just a literal
-    assert!(code.contains("xi") || code.contains("*") || code.contains("2"));
+    assert!(code.contains("ξ") || code.contains("*") || code.contains("2"));
 }
 
 #[test]
@@ -82,8 +82,8 @@ fn test_function_call() {
     );
     eprintln!("Generated code:\n{}", code);
     assert!(
-        code.contains("prosthesis")
-            && (code.contains("prosthesis(") || code.contains("prosthesis ("))
+        code.contains("προσθεσις")
+            && (code.contains("προσθεσις(") || code.contains("προσθεσις ("))
     );
 }
 
@@ -98,7 +98,7 @@ fn test_nested_calls() {
     eprintln!("Generated code:\n{}", code);
     // Check for nested diplasiasmos calls (allowing for whitespace)
     assert!(
-        code.matches("diplasiasmos").count() >= 3,
+        code.matches("διπλασιασμος").count() >= 3,
         "Expected at least 3 occurrences of diplasiasmos (fn def + 2 calls)"
     );
     assert!(code.contains("5i64"), "Expected literal 5 as argument");
@@ -118,7 +118,7 @@ fn test_function_local_variables() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
-    assert!(code.contains("let topikon"));
+    assert!(code.contains("let τοπικον"));
 }
 
 #[test]

--- a/tests/trait_tests.rs
+++ b/tests/trait_tests.rs
@@ -582,7 +582,7 @@ fn test_standalone_method_call() {
     let code = compile(source);
 
     // Should contain the method call
-    assert!(code.contains("pi . show") || code.contains("pi.show"));
+    assert!(code.contains("π . show") || code.contains("π.show"));
 }
 
 // ============================================================================

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -43,7 +43,8 @@ fn test_instantiation() {
         π νέον σημεῖον πέντε ἔστω.
     "#;
     let code = compile(source);
-    assert!(code.contains("Semeion") || code.contains("semeion"));
+    // Compiler normalizes names (removes accents), so expect unaccented
+    assert!(code.contains("Σημειον") || code.contains("σημειον"));
     assert!(code.contains("5"));
 }
 
@@ -54,7 +55,7 @@ fn test_instantiation_multiple_fields() {
         π νέον σημεῖον πέντε τρία ἔστω.
     "#;
     let code = compile(source);
-    assert!(code.contains("Semeion") || code.contains("semeion"));
+    assert!(code.contains("Σημειον") || code.contains("σημειον"));
 }
 
 // Cycle 5: Field Access
@@ -67,7 +68,7 @@ fn test_field_access() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    assert!(code.contains(".xi") || code.contains(". xi"));
+    assert!(code.contains(".ξ") || code.contains(". ξ"));
 }
 
 #[test]
@@ -80,8 +81,8 @@ fn test_field_access_multiple_fields() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    assert!(code.contains(". xi") || code.contains(".xi"));
-    assert!(code.contains(". psi") || code.contains(".psi"));
+    assert!(code.contains(". ξ") || code.contains(".ξ"));
+    assert!(code.contains(". ψ") || code.contains(".ψ"));
 }
 
 #[test]
@@ -93,9 +94,10 @@ fn test_instantiation_with_literals() {
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
     // It should generate struct instantiation, not string assignment
-    // We expect: let chrestes = Chrestes { onoma: "Σωκράτης".to_string(), elikia: 70 };
-    assert!(code.contains("struct Chrestes"));
-    assert!(code.contains("let chrestes = Chrestes"));
+    // We expect: let χρήστης = Χρηστης { ονομα: "Σωκράτης".to_string(), ηλικια: 70 };
+    // Names are normalized (accents removed)
+    assert!(code.contains("struct Χρηστης"));
+    assert!(code.contains("let χρηστης = Χρηστης"));
     assert!(code.contains("Σωκράτης"));
     assert!(code.contains("70"));
 }

--- a/tests/warden_exploit.rs
+++ b/tests/warden_exploit.rs
@@ -20,18 +20,13 @@ fn test_exploit_unicode_panic() {
     let rust = generate_rust(&analyzed);
 
     // Verify sanitization
-    // ᾽ (U+1FBD) should be replaced by _, and α becomes a
-    // So "᾽α" -> "_a"
-    // And since it starts with _, it stays "_a" (or maybe "__a" if prefixing logic applies)
-    // sanitize_name calls transliterate.
-    // transliterate("᾽α") -> "_" + "a" = "_a"
-    // sanitize_name then checks if it starts with digit. It starts with _.
-    // So it returns "_a".
-    // format_ident!("_a") is valid.
+    // ᾽ (U+1FBD) is not alphanumeric, so it becomes _u1fbd_.
+    // α is alphanumeric, so it stays α.
+    // So "᾽α" -> "_u1fbd_α"
 
     assert!(
-        rust.contains("_a"),
-        "Generated code should contain sanitized identifier '_a'. Code: {}",
+        rust.contains("_u1fbd_α"),
+        "Generated code should contain sanitized identifier '_u1fbd_α'. Code: {}",
         rust
     );
 }

--- a/tests/word_order_tests.rs
+++ b/tests/word_order_tests.rs
@@ -23,7 +23,7 @@ fn test_binding_word_order_independence() {
     let sov = compile_to_rust("ξ πέντε ἔστω.");
 
     // These should all produce equivalent output
-    assert!(sov.contains("let xi"));
+    assert!(sov.contains("let ξ"));
     assert!(sov.contains("5i64") || sov.contains("5 "));
 }
 
@@ -44,7 +44,7 @@ fn test_variable_binding_and_reference() {
     let output = compile_to_rust(source);
 
     // Should have binding
-    assert!(output.contains("let xi"));
+    assert!(output.contains("let ξ"));
     // Should have print
     assert!(output.contains("println"));
 }
@@ -54,12 +54,12 @@ fn test_variable_binding_and_reference() {
 fn test_number_binding_variations() {
     // Arabic numeral
     let arabic = compile_to_rust("ξ 42 ἔστω.");
-    assert!(arabic.contains("let xi"));
+    assert!(arabic.contains("let ξ"));
     assert!(arabic.contains("42"));
 
     // Greek numeral word
     let greek_word = compile_to_rust("ξ πέντε ἔστω.");
-    assert!(greek_word.contains("let xi"));
+    assert!(greek_word.contains("let ξ"));
     assert!(greek_word.contains("5"));
 }
 
@@ -104,8 +104,8 @@ fn test_multiple_statement_scope() {
     let output = compile_to_rust(source);
 
     // Both bindings should exist
-    assert!(output.contains("let alpha"));
-    assert!(output.contains("let beta"));
+    assert!(output.contains("let α"));
+    assert!(output.contains("let β"));
 }
 
 /// Test that queries produce output


### PR DESCRIPTION
This PR addresses DX issues identified by the 'Echo' audit. 

1. **Docs**: Explicitly documented how to run .glossa files in the README.
2. **Error Messages**: Removed transliteration of Greek identifiers. Rust compiler errors now refer to `Χρήστης` instead of `Chrestes`, making debugging significantly easier.
3. **Tests**: Updated all codegen integration tests to reflect the preservation of Greek characters.


---
*PR created automatically by Jules for task [17633130161084706345](https://jules.google.com/task/17633130161084706345) started by @madmax983*