### PR TITLE
Refactor semantic model to use unified AnalyzedMethod

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -37,3 +37,8 @@
 **Bloat:** Duplicate logic for struct instantiation in `src/semantic/conversion.rs` (broken, handled only literals) and `src/semantic/patterns.rs` (working, handled variables).
 **Cut:** Deleted `classify_struct_instantiation` from `conversion.rs` and consolidated `detect_collection_type` into `src/semantic/types.rs`.
 **Saved:** Removed ~100 lines of duplicate/broken code and fixed a bug preventing variable arguments in constructors.
+
+## [Reduction]
+**Bloat:** `AnalyzedTraitMethod` and `AnalyzedImplMethod` in `src/semantic/model.rs`.
+**Cut:** Merged into a unified `AnalyzedMethod` struct. Removed redundant `is_default` field.
+**Saved:** Reduced code duplication in semantic model and codegen (~60 lines removed/simplified). Unified method representation.

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -22,8 +22,8 @@
 
 use crate::morphology::lexicon::{BinaryOp, UnaryOp};
 use crate::semantic::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedImplMethod, AnalyzedIteratorOp, AnalyzedProgram,
-    AnalyzedStatement, AnalyzedTraitMethod, GlossaType, StatementKind,
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedIteratorOp, AnalyzedMethod, AnalyzedProgram,
+    AnalyzedStatement, GlossaType, StatementKind,
 };
 use crate::text::normalize_greek;
 use proc_macro2::TokenStream;
@@ -124,10 +124,8 @@ fn statement_uses_collections(stmt: &AnalyzedStatement) -> bool {
                 })
         }
         StatementKind::FunctionDef { body, .. } => body.iter().any(statement_uses_collections),
-        StatementKind::TraitImplementation { methods, .. } => methods
-            .iter()
-            .any(|m| m.body.iter().any(statement_uses_collections)),
-        StatementKind::TraitDefinition { methods, .. } => methods.iter().any(|m| {
+        StatementKind::TraitImplementation { methods, .. }
+        | StatementKind::TraitDefinition { methods, .. } => methods.iter().any(|m| {
             m.body
                 .as_ref()
                 .map(|b| b.iter().any(statement_uses_collections))
@@ -425,7 +423,7 @@ fn generate_struct_def(name: &str, fields: &[(smol_str::SmolStr, GlossaType)]) -
     }
 }
 
-fn generate_trait_def(name: &str, methods: &[AnalyzedTraitMethod]) -> TokenStream {
+fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
     // Capitalize trait name for Rust conventions
     let trait_name = format_ident!("{}", capitalize(&sanitize_name(name)));
 
@@ -458,18 +456,12 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedTraitMethod]) -> TokenStrea
                 let ret_str = type_to_rust_string(ret_type);
                 let ret_ty = format_ident!("{}", ret_str);
 
-                if method.is_default {
-                    if let Some(body) = &method.body {
-                        let body_stmts: Vec<TokenStream> =
-                            body.iter().map(generate_statement).collect();
-                        quote! {
-                            fn #method_name(#(#param_tokens),*) -> #ret_ty {
-                                #(#body_stmts)*
-                            }
-                        }
-                    } else {
-                        quote! {
-                            fn #method_name(#(#param_tokens),*) -> #ret_ty;
+                if let Some(body) = &method.body {
+                    let body_stmts: Vec<TokenStream> =
+                        body.iter().map(generate_statement).collect();
+                    quote! {
+                        fn #method_name(#(#param_tokens),*) -> #ret_ty {
+                            #(#body_stmts)*
                         }
                     }
                 } else {
@@ -477,18 +469,12 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedTraitMethod]) -> TokenStrea
                         fn #method_name(#(#param_tokens),*) -> #ret_ty;
                     }
                 }
-            } else if method.is_default {
-                if let Some(body) = &method.body {
-                    let body_stmts: Vec<TokenStream> =
-                        body.iter().map(generate_statement).collect();
-                    quote! {
-                        fn #method_name(#(#param_tokens),*) {
-                            #(#body_stmts)*
-                        }
-                    }
-                } else {
-                    quote! {
-                        fn #method_name(#(#param_tokens),*);
+            } else if let Some(body) = &method.body {
+                let body_stmts: Vec<TokenStream> =
+                    body.iter().map(generate_statement).collect();
+                quote! {
+                    fn #method_name(#(#param_tokens),*) {
+                        #(#body_stmts)*
                     }
                 }
             } else {
@@ -509,7 +495,7 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedTraitMethod]) -> TokenStrea
 fn generate_trait_impl(
     trait_name: &str,
     type_name: &str,
-    methods: &[AnalyzedImplMethod],
+    methods: &[AnalyzedMethod],
 ) -> TokenStream {
     // Capitalize trait and type names for Rust conventions
     let trait_ident = format_ident!("{}", capitalize(&sanitize_name(trait_name)));
@@ -539,7 +525,11 @@ fn generate_trait_impl(
                 .collect();
 
             // Generate method body
-            let body_stmts: Vec<TokenStream> = method.body.iter().map(generate_statement).collect();
+            let body_stmts: Vec<TokenStream> = if let Some(body) = &method.body {
+                body.iter().map(generate_statement).collect()
+            } else {
+                Vec::new()
+            };
 
             // Generate return type
             if let Some(ret_type) = &method.return_type {

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -470,8 +470,7 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
                     }
                 }
             } else if let Some(body) = &method.body {
-                let body_stmts: Vec<TokenStream> =
-                    body.iter().map(generate_statement).collect();
+                let body_stmts: Vec<TokenStream> = body.iter().map(generate_statement).collect();
                 quote! {
                     fn #method_name(#(#param_tokens),*) {
                         #(#body_stmts)*

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -1,7 +1,7 @@
 //! Declaration analysis (functions, types, traits)
 
 use super::{
-    AnalyzedImplMethod, AnalyzedStatement, AnalyzedTraitMethod, GlossaType, Scope, StatementKind,
+    AnalyzedMethod, AnalyzedStatement, GlossaType, Scope, StatementKind,
     analyze_single_statement_with_assembler, convert_assembled_to_analyzed,
 };
 use crate::ast::{Expr, Statement};
@@ -123,18 +123,16 @@ pub fn analyze_trait_definition(
                 None
             };
 
-            analyzed_methods.push(AnalyzedTraitMethod {
+            analyzed_methods.push(AnalyzedMethod {
                 name: method_name,
                 params,
-                is_default: true,
                 body,
                 return_type,
             });
         } else {
-            analyzed_methods.push(AnalyzedTraitMethod {
+            analyzed_methods.push(AnalyzedMethod {
                 name: method_name,
                 params,
-                is_default: false,
                 body: None,
                 return_type: None,
             });
@@ -235,17 +233,17 @@ pub fn analyze_trait_impl(
         let return_type = infer_return_type_from_body(&analyzed_body);
 
         implemented_method_names.push(method_name.clone());
-        analyzed_methods.push(AnalyzedImplMethod {
+        analyzed_methods.push(AnalyzedMethod {
             name: method_name,
             params,
-            body: analyzed_body,
+            body: Some(analyzed_body),
             return_type,
         });
     }
 
     // Validate: all required methods must be implemented
     for method in &trait_def.methods {
-        if !method.is_default && !implemented_method_names.contains(&method.name) {
+        if method.body.is_none() && !implemented_method_names.contains(&method.name) {
             return Err(GlossaError::semantic(format!(
                 "Type {} does not implement required method {} from trait {}",
                 type_name, method.name, trait_name

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -76,32 +76,22 @@ pub enum StatementKind {
     /// Trait definition: χαρακτήρ name ὁρίζειν { methods }
     TraitDefinition {
         name: SmolStr,
-        methods: Vec<AnalyzedTraitMethod>,
+        methods: Vec<AnalyzedMethod>,
     },
     /// Trait implementation: εἶδος Type τῷ Trait ἐμπίπτειν { methods }
     TraitImplementation {
         trait_name: SmolStr,
         type_name: SmolStr,
-        methods: Vec<AnalyzedImplMethod>,
+        methods: Vec<AnalyzedMethod>,
     },
 }
 
-/// An analyzed method in a trait definition (AST node)
+/// An analyzed method (used in traits and implementations)
 #[derive(Debug, Clone)]
-pub struct AnalyzedTraitMethod {
+pub struct AnalyzedMethod {
     pub name: SmolStr,
     pub params: Vec<(SmolStr, GlossaType)>,
-    pub is_default: bool,
-    pub body: Option<Vec<AnalyzedStatement>>, // Some for default methods, None for required
-    pub return_type: Option<GlossaType>,
-}
-
-/// An analyzed method in a trait implementation (AST node)
-#[derive(Debug, Clone)]
-pub struct AnalyzedImplMethod {
-    pub name: SmolStr,
-    pub params: Vec<(SmolStr, GlossaType)>,
-    pub body: Vec<AnalyzedStatement>,
+    pub body: Option<Vec<AnalyzedStatement>>, // Some for default/impl methods, None for required
     pub return_type: Option<GlossaType>,
 }
 
@@ -242,7 +232,7 @@ pub enum AnalyzedExprKind {
 #[derive(Debug, Clone)]
 pub struct TraitDef {
     pub name: SmolStr,
-    pub methods: Vec<AnalyzedTraitMethod>,
+    pub methods: Vec<AnalyzedMethod>,
 }
 
 /// Trait implementation for a type


### PR DESCRIPTION
Merged `AnalyzedTraitMethod` and `AnalyzedImplMethod` into a single `AnalyzedMethod` struct in `src/semantic/model.rs` to reduce duplication and complexity. Updated usages in declaration analysis and code generation. Removed redundant `is_default` field, relying on the presence of `body` (`Option<Vec<AnalyzedStatement>>`) to distinguish between required and provided methods.

---
*PR created automatically by Jules for task [297411555915381376](https://jules.google.com/task/297411555915381376) started by @madmax983*