### PR TITLE
⚡ Bolt: Remove allocations in noun analysis

### DIFF
--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -19,82 +19,92 @@ pub enum Declension {
 
 /// Second declension endings (masculine -ος type)
 /// The most common pattern: λόγος, χρήστος, etc.
+/// NOTE: Must be sorted by ending length (descending) for greedy matching!
 const SECOND_DECLENSION_MASC: &[(&str, Case, Number)] = &[
-    // Singular
-    ("ος", Case::Nominative, Number::Singular),
-    ("ου", Case::Genitive, Number::Singular),
-    ("ω", Case::Dative, Number::Singular), // ῳ normalized to ω
-    ("ον", Case::Accusative, Number::Singular),
-    ("ε", Case::Vocative, Number::Singular),
-    // Plural
-    ("οι", Case::Nominative, Number::Plural),
-    ("ων", Case::Genitive, Number::Plural),
+    // Length 3
     ("οις", Case::Dative, Number::Plural),
     ("ους", Case::Accusative, Number::Plural),
+    // Length 2
+    ("ος", Case::Nominative, Number::Singular),
+    ("ου", Case::Genitive, Number::Singular),
+    ("ον", Case::Accusative, Number::Singular),
+    ("οι", Case::Nominative, Number::Plural),
+    ("ων", Case::Genitive, Number::Plural),
+    // Length 1
+    ("ω", Case::Dative, Number::Singular), // ῳ normalized to ω
+    ("ε", Case::Vocative, Number::Singular),
 ];
 
 /// Second declension endings (neuter -ον type)
 /// Pattern: δῶρον, ἔργον, etc.
+/// NOTE: Must be sorted by ending length (descending) for greedy matching!
 const SECOND_DECLENSION_NEUT: &[(&str, Case, Number)] = &[
-    // Singular
+    // Length 3
+    ("οις", Case::Dative, Number::Plural),
+    // Length 2
     ("ον", Case::Nominative, Number::Singular),
-    ("ου", Case::Genitive, Number::Singular),
-    ("ω", Case::Dative, Number::Singular),
     ("ον", Case::Accusative, Number::Singular),
     ("ον", Case::Vocative, Number::Singular),
-    // Plural
-    ("α", Case::Nominative, Number::Plural),
+    ("ου", Case::Genitive, Number::Singular),
     ("ων", Case::Genitive, Number::Plural),
-    ("οις", Case::Dative, Number::Plural),
+    // Length 1
+    ("ω", Case::Dative, Number::Singular),
+    ("α", Case::Nominative, Number::Plural),
     ("α", Case::Accusative, Number::Plural),
 ];
 
 /// First declension endings (-η type)
 /// Pattern: τιμή, ψυχή, etc.
+/// NOTE: Must be sorted by ending length (descending) for greedy matching!
 const FIRST_DECLENSION_ETA: &[(&str, Case, Number)] = &[
-    // Singular
-    ("η", Case::Nominative, Number::Singular),
+    // Length 3
+    ("αις", Case::Dative, Number::Plural),
+    // Length 2
     ("ης", Case::Genitive, Number::Singular),
-    ("η", Case::Dative, Number::Singular), // ῃ normalized
     ("ην", Case::Accusative, Number::Singular),
-    ("η", Case::Vocative, Number::Singular),
-    // Plural
     ("αι", Case::Nominative, Number::Plural),
     ("ων", Case::Genitive, Number::Plural),
-    ("αις", Case::Dative, Number::Plural),
     ("ας", Case::Accusative, Number::Plural),
+    // Length 1
+    ("η", Case::Nominative, Number::Singular),
+    ("η", Case::Dative, Number::Singular), // ῃ normalized
+    ("η", Case::Vocative, Number::Singular),
 ];
 
 /// First declension endings (-α type, pure alpha)
 /// Pattern: χώρα, θάλαττα, etc.
+/// NOTE: Must be sorted by ending length (descending) for greedy matching!
 const FIRST_DECLENSION_ALPHA: &[(&str, Case, Number)] = &[
-    // Singular
-    ("α", Case::Nominative, Number::Singular),
+    // Length 3
+    ("αις", Case::Dative, Number::Plural),
+    // Length 2
     ("ας", Case::Genitive, Number::Singular),
-    ("α", Case::Dative, Number::Singular), // ᾳ normalized
     ("αν", Case::Accusative, Number::Singular),
-    ("α", Case::Vocative, Number::Singular),
-    // Plural (same as eta type)
     ("αι", Case::Nominative, Number::Plural),
     ("ων", Case::Genitive, Number::Plural),
-    ("αις", Case::Dative, Number::Plural),
     ("ας", Case::Accusative, Number::Plural),
+    // Length 1
+    ("α", Case::Nominative, Number::Singular),
+    ("α", Case::Dative, Number::Singular), // ᾳ normalized
+    ("α", Case::Vocative, Number::Singular),
 ];
 
 /// Third declension endings (-μα type)
 /// Pattern: ὄνομα, πρᾶγμα, σῶμα, etc.
+/// NOTE: Must be sorted by ending length (descending) for greedy matching!
 const THIRD_DECLENSION_MA: &[(&str, Case, Number)] = &[
-    // Singular
-    ("μα", Case::Nominative, Number::Singular),
+    // Length 5
     ("ματος", Case::Genitive, Number::Singular),
-    ("ματι", Case::Dative, Number::Singular),
-    ("μα", Case::Accusative, Number::Singular),
-    ("μα", Case::Vocative, Number::Singular),
-    // Plural
-    ("ματα", Case::Nominative, Number::Plural),
     ("ματων", Case::Genitive, Number::Plural),
+    // Length 4
+    ("ματι", Case::Dative, Number::Singular),
+    ("ματα", Case::Nominative, Number::Plural),
     ("μασι", Case::Dative, Number::Plural), // μασι(ν)
     ("ματα", Case::Accusative, Number::Plural),
+    // Length 2
+    ("μα", Case::Nominative, Number::Singular),
+    ("μα", Case::Accusative, Number::Singular),
+    ("μα", Case::Vocative, Number::Singular),
 ];
 
 /// Declension configuration pattern
@@ -163,12 +173,13 @@ pub fn analyze_noun(word: &str) -> Option<MorphAnalysis> {
 }
 
 /// Match a word against a list of endings, returning the stem and grammatical info
+///
+/// NOTE: `endings` must be pre-sorted by length (descending) to ensure
+/// greedy matching (longest match wins).
 fn match_endings(word: &str, endings: &[(&str, Case, Number)]) -> Option<(String, Case, Number)> {
-    // Sort by ending length (longest first) to match most specific
-    let mut sorted_endings: Vec<_> = endings.iter().collect();
-    sorted_endings.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
-
-    for (ending, case, number) in sorted_endings {
+    // Endings are pre-sorted by length (descending) in the const definitions.
+    // We can iterate directly without allocation or sorting.
+    for (ending, case, number) in endings {
         if let Some(stem) = word.strip_suffix(ending)
             && !stem.is_empty()
         {


### PR DESCRIPTION
⚡ Bolt: Optimized noun declension analysis

💡 What: Refactored `src/morphology/declension.rs` to use pre-sorted constant arrays for suffix matching.
🎯 Why: `analyze_noun` was allocating a `Vec` and sorting it by length *every time* it checked a word against a declension pattern. This happened multiple times per word analysis.
📊 Impact: Removes up to 5 `Vec` allocations and 5 sorts per word analysis.
🔬 Measurement: Verified with `cargo test`. Correctness preserved (longest match wins).

---
*PR created automatically by Jules for task [4390477051048690875](https://jules.google.com/task/4390477051048690875) started by @madmax983*