### PR TITLE
🛡️ Sentry: Prevent silent overwrite of indirect objects

### DIFF
--- a/src/errors/assembly.rs
+++ b/src/errors/assembly.rs
@@ -23,6 +23,14 @@ pub enum AssemblyError {
     #[diagnostic(code(glossa::assembly::double_object))]
     DoubleObject,
 
+    /// Two indirect objects found in the same statement (Dative collision)
+    ///
+    /// # Example
+    /// `τῷ ἀνθρώπῳ τῷ θεῷ δίδωμι` (I give to the man to the god)
+    #[error("Διπλοῦν ἔμμεσον αντικείμενον! Ἓν μόνον παραλήπτην ἔχεις.")]
+    #[diagnostic(code(glossa::assembly::double_indirect))]
+    DoubleIndirect,
+
     /// Two verbs found in the same statement
     ///
     /// # Example

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -714,6 +714,9 @@ impl Assembler {
             }
             Some(Case::Dative) => {
                 // Dative can stack (multiple recipients) but for simplicity, one for now
+                if self.pending_indirect.is_some() {
+                    return Err(AssemblyError::DoubleIndirect);
+                }
                 self.pending_indirect = Some(constituent);
             }
             Some(Case::Genitive) => {

--- a/tests/sentry_assembler_tests.rs
+++ b/tests/sentry_assembler_tests.rs
@@ -1,0 +1,109 @@
+use glossa::semantic::{Assembler, AssemblyError};
+use glossa::morphology::{MorphAnalysis, PartOfSpeech, Case, Number, Gender, Person};
+
+#[test]
+fn test_double_indirect_object_error() {
+    let mut asm = Assembler::new();
+
+    // First indirect object: τῷ ἀνθρώπῳ (to the man)
+    let dat1 = MorphAnalysis {
+        lemma: std::borrow::Cow::Borrowed("ανθρωπος"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Dative),
+        number: Some(Number::Singular),
+        gender: Some(Gender::Masculine),
+        person: Some(Person::Third),
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+    asm.feed(&dat1, "ἀνθρώπῳ").unwrap();
+
+    // Second indirect object: τῷ θεῷ (to the god)
+    let dat2 = MorphAnalysis {
+        lemma: std::borrow::Cow::Borrowed("θεος"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Dative),
+        number: Some(Number::Singular),
+        gender: Some(Gender::Masculine),
+        person: Some(Person::Third),
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    let result = asm.feed(&dat2, "θεῷ");
+
+    // SENTRY: This assertion enforces that we DO NOT allow silent overwrites.
+    // This test is expected to FAIL until the fix is applied.
+    assert!(matches!(result, Err(AssemblyError::DoubleIndirect)), "Should return DoubleIndirect error, got {:?}", result);
+}
+
+#[test]
+fn test_neuter_plural_agreement() {
+    let mut asm = Assembler::new();
+
+    // Subject: τὰ ζῷα (Neuter Plural)
+    let subj = MorphAnalysis {
+        lemma: std::borrow::Cow::Borrowed("ζωον"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Nominative),
+        number: Some(Number::Plural),
+        gender: Some(Gender::Neuter),
+        person: Some(Person::Third),
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+    asm.feed(&subj, "ζῷα").unwrap();
+
+    // Verb: τρέχουσιν (Plural)
+    let verb = MorphAnalysis {
+        lemma: std::borrow::Cow::Borrowed("τρεχω"),
+        part_of_speech: PartOfSpeech::Verb,
+        case: None,
+        number: Some(Number::Plural),
+        gender: None,
+        person: Some(Person::Third),
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+    asm.feed(&verb, "τρέχουσιν").unwrap();
+
+    let stmt = asm.finalize();
+    assert!(stmt.is_ok(), "Neuter plural subject should allow plural verb (current behavior), got {:?}", stmt.err());
+}
+
+#[test]
+fn test_verbless_statement() {
+    let mut asm = Assembler::new();
+
+    // Subject: ὁ ἄνθρωπος
+    let subj = MorphAnalysis {
+        lemma: std::borrow::Cow::Borrowed("ανθρωπος"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Nominative),
+        number: Some(Number::Singular),
+        gender: Some(Gender::Masculine),
+        person: Some(Person::Third),
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+    asm.feed(&subj, "ἄνθρωπος").unwrap();
+
+    // No verb fed.
+
+    let stmt = asm.finalize();
+    // Current behavior allows verbless statements if they have content.
+    assert!(stmt.is_ok(), "Verbless statement with content should be allowed");
+    let s = stmt.unwrap();
+    assert!(s.subject.is_some());
+    assert!(s.verb.is_none());
+}

--- a/tests/sentry_assembler_tests.rs
+++ b/tests/sentry_assembler_tests.rs
@@ -1,5 +1,5 @@
+use glossa::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech, Person};
 use glossa::semantic::{Assembler, AssemblyError};
-use glossa::morphology::{MorphAnalysis, PartOfSpeech, Case, Number, Gender, Person};
 
 #[test]
 fn test_double_indirect_object_error() {
@@ -38,7 +38,11 @@ fn test_double_indirect_object_error() {
 
     // SENTRY: This assertion enforces that we DO NOT allow silent overwrites.
     // This test is expected to FAIL until the fix is applied.
-    assert!(matches!(result, Err(AssemblyError::DoubleIndirect)), "Should return DoubleIndirect error, got {:?}", result);
+    assert!(
+        matches!(result, Err(AssemblyError::DoubleIndirect)),
+        "Should return DoubleIndirect error, got {:?}",
+        result
+    );
 }
 
 #[test]
@@ -76,7 +80,11 @@ fn test_neuter_plural_agreement() {
     asm.feed(&verb, "τρέχουσιν").unwrap();
 
     let stmt = asm.finalize();
-    assert!(stmt.is_ok(), "Neuter plural subject should allow plural verb (current behavior), got {:?}", stmt.err());
+    assert!(
+        stmt.is_ok(),
+        "Neuter plural subject should allow plural verb (current behavior), got {:?}",
+        stmt.err()
+    );
 }
 
 #[test]
@@ -102,7 +110,10 @@ fn test_verbless_statement() {
 
     let stmt = asm.finalize();
     // Current behavior allows verbless statements if they have content.
-    assert!(stmt.is_ok(), "Verbless statement with content should be allowed");
+    assert!(
+        stmt.is_ok(),
+        "Verbless statement with content should be allowed"
+    );
     let s = stmt.unwrap();
     assert!(s.subject.is_some());
     assert!(s.verb.is_none());


### PR DESCRIPTION
This PR addresses a silent failure mode in `src/semantic/assembler.rs` where feeding multiple Dative nouns (indirect objects) would result in the last one overwriting the first without error.

Changes:
- Added `AssemblyError::DoubleIndirect` variant.
- Updated `Assembler::handle_nominal` to check for existing indirect objects.
- Added `tests/sentry_assembler_tests.rs` to verify the fix and document other assembler behaviors (Neuter Plural agreement, Verbless statements).

Risk: Low (Safety improvement).
Testing: `cargo test --test sentry_assembler_tests` passes.


---
*PR created automatically by Jules for task [5634255441915027324](https://jules.google.com/task/5634255441915027324) started by @madmax983*