### PR TITLE
🔒 Warden: Fix Identifier Collision Logic Bug

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -41,3 +41,11 @@
 2. Enforced `MAX_REPL_BINDINGS` (50) and `MAX_REPL_SOURCE_LEN` (50KB) in `src/main.rs`.
 
 **Severity:** Low (Logic bug) / Medium (DoS).
+
+## 2026-06-02 - Identifier Collision Logic Bug
+
+**Threat:** Identifier collision in `src/codegen/rust.rs`. `sanitize_name` mapped single Greek letters (e.g., `σ`) to their full names (`sigma`), causing collisions with variables named with the full name (`σίγμα`). This allowed variable shadowing and potential logic errors. Also `ψ` collided with `πσ`.
+
+**Defense:** Removed special single-letter mapping in `sanitize_name` and enforced strict transliteration in `transliterate`. `σ` now maps to `s`, while `σίγμα` maps to `sigma`. `ψ` maps to `_u3c8_` (hex encoded) to avoid collision with `ps`.
+
+**Severity:** Medium (Logic Bug).

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -1056,7 +1056,7 @@ mod tests {
         assert_eq!(transliterate("λογος"), "logos");
         // φ (phi) -> hex
         // φ is 0x3c6
-        assert_eq!(transliterate("φιλοσοφια"), "_u3c6_ilosofia");
+        assert_eq!(transliterate("φιλοσοφια"), "_u3c6_iloso_u3c6_ia");
     }
 
     #[test]

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -936,39 +936,9 @@ fn is_self_parameter(param_name: &str, idx: usize) -> bool {
 
 /// Sanitize a Greek name for use as a Rust identifier
 fn sanitize_name(name: &str) -> String {
-    // Map single Greek letters to their names
-    if name.len() <= 2 {
-        // Could be a single Greek letter (2 bytes for UTF-8)
-        match name {
-            "α" => return "alpha".to_string(),
-            "β" => return "beta".to_string(),
-            "γ" => return "gamma".to_string(),
-            "δ" => return "delta".to_string(),
-            "ε" => return "epsilon".to_string(),
-            "ζ" => return "zeta".to_string(),
-            "η" => return "eta".to_string(),
-            "θ" => return "theta".to_string(),
-            "ι" => return "iota".to_string(),
-            "κ" => return "kappa".to_string(),
-            "λ" => return "lambda".to_string(),
-            "μ" => return "mu".to_string(),
-            "ν" => return "nu".to_string(),
-            "ξ" => return "xi".to_string(),
-            "ο" => return "omicron".to_string(),
-            "π" => return "pi".to_string(),
-            "ρ" => return "rho".to_string(),
-            "σ" | "ς" => return "sigma".to_string(),
-            "τ" => return "tau".to_string(),
-            "υ" => return "upsilon".to_string(),
-            "φ" => return "phi".to_string(),
-            "χ" => return "chi".to_string(),
-            "ψ" => return "psi".to_string(),
-            "ω" => return "omega".to_string(),
-            _ => {}
-        }
-    }
-
-    // Transliterate the full name
+    // Directly transliterate without special casing single letters
+    // This prevents collisions between single letters and their full names
+    // e.g. "σ" (sigma) vs "σίγμα" (sigma)
     transliterate(name)
 }
 
@@ -984,8 +954,7 @@ fn transliterate(greek: &str) -> String {
             'δ' => "d",
             'ε' => "e",
             'ζ' => "z",
-            'η' => "e",
-            'θ' => "th",
+            'η' => "h", // Distinct from 'e' (epsilon)
             'ι' => "i",
             'κ' => "k",
             'λ' => "l",
@@ -998,10 +967,9 @@ fn transliterate(greek: &str) -> String {
             'σ' | 'ς' => "s",
             'τ' => "t",
             'υ' => "u",
-            'φ' => "ph",
-            'χ' => "ch",
-            'ψ' => "ps",
-            'ω' => "o",
+            'ω' => "w", // Distinct from 'o' (omicron)
+            // Digraphs and other characters are hex-encoded to prevent collisions
+            // θ, φ, χ, ψ map to _u..._ because th, ph, ch, ps collide with sequences
             _ => {
                 // Keep only ASCII alphanumeric characters and underscore
                 if c.is_ascii_alphanumeric() || c == '_' {
@@ -1062,7 +1030,7 @@ mod tests {
     #[test]
     fn test_generate_binding() {
         let code = compile("ξ πέντε ἔστω.");
-        assert!(code.contains("let xi"));
+        assert!(code.contains("let x"));
         assert!(code.contains("5"));
     }
 
@@ -1075,16 +1043,20 @@ mod tests {
 
     #[test]
     fn test_sanitize_greek_letter() {
-        assert_eq!(sanitize_name("ξ"), "xi");
-        assert_eq!(sanitize_name("α"), "alpha");
-        assert_eq!(sanitize_name("ω"), "omega");
+        assert_eq!(sanitize_name("ξ"), "x");
+        assert_eq!(sanitize_name("α"), "a");
+        assert_eq!(sanitize_name("ω"), "w");
     }
 
     #[test]
     fn test_transliterate() {
-        assert_eq!(transliterate("χρηστος"), "chrestos");
+        // χ (chi) -> hex, ρ -> r, η -> h, σ -> s, τ -> t, ο -> o, ς -> s
+        // χ is 0x3c7
+        assert_eq!(transliterate("χρηστος"), "_u3c7_rhstos");
         assert_eq!(transliterate("λογος"), "logos");
-        assert_eq!(transliterate("φιλοσοφια"), "philosophia");
+        // φ (phi) -> hex
+        // φ is 0x3c6
+        assert_eq!(transliterate("φιλοσοφια"), "_u3c6_ilosofia");
     }
 
     #[test]
@@ -1115,7 +1087,7 @@ mod tests {
     #[test]
     fn test_generate_full_program() {
         let code = compile("ξ πέντε ἔστω. ξ λέγε.");
-        assert!(code.contains("let xi = 5"), "Expected binding in: {}", code);
+        assert!(code.contains("let x = 5"), "Expected binding in: {}", code);
         assert!(code.contains("println"), "Expected println in: {}", code);
     }
 }

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -21,16 +21,16 @@ fn test_hello_cosmos() {
 #[test]
 fn test_variable_binding() {
     let code = compile("ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let xi"));
+    assert!(code.contains("let x"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_variable_binding_and_use() {
     let code = compile("ξ πέντε ἔστω. ξ λέγε.").unwrap();
-    assert!(code.contains("let xi = 5"));
+    assert!(code.contains("let x = 5"));
     assert!(code.contains("println"));
-    assert!(code.contains("xi"));
+    assert!(code.contains("x"));
 }
 
 #[test]
@@ -42,8 +42,8 @@ fn test_number_literal() {
 #[test]
 fn test_multiple_statements() {
     let code = compile("α πέντε ἔστω. β δέκα ἔστω. α λέγε.").unwrap();
-    assert!(code.contains("let alpha = 5"));
-    assert!(code.contains("let beta = 10"));
+    assert!(code.contains("let a = 5"));
+    assert!(code.contains("let b = 10"));
 }
 
 #[test]
@@ -61,15 +61,15 @@ fn test_preserves_greek_in_strings() {
 #[test]
 fn test_mutable_binding() {
     let code = compile("μετά ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let mut xi"));
+    assert!(code.contains("let mut x"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_assignment_codegen() {
     let code = compile("μετά ξ πέντε ἔστω. ξ δέκα γίγνεται.").unwrap();
-    assert!(code.contains("let mut xi = 5"));
-    assert!(code.contains("xi = 10"));
+    assert!(code.contains("let mut x = 5"));
+    assert!(code.contains("x = 10"));
 }
 
 #[test]
@@ -89,8 +89,8 @@ fn test_undefined_assignment_error() {
 #[test]
 fn test_mutable_binding_and_reassignment() {
     let code = compile("μετά ξ πέντε ἔστω. ξ λέγε. ξ δέκα γίγνεται. ξ λέγε.").unwrap();
-    assert!(code.contains("let mut xi = 5"));
-    assert!(code.contains("xi = 10"));
+    assert!(code.contains("let mut x = 5"));
+    assert!(code.contains("x = 10"));
     assert!(code.matches("println").count() >= 2);
 }
 

--- a/tests/function_tests.rs
+++ b/tests/function_tests.rs
@@ -39,7 +39,8 @@ fn test_function_with_two_params() {
     let code = compile("προσθεσις ὁρίζειν τῷ ξ τῷ ψ· δός ξ ψ ἄθροισμα.");
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("fn"));
-    assert!(code.contains("xi") && code.contains("psi"));
+    // ξ -> x, ψ -> _u3c8_
+    assert!(code.contains("x") && code.contains("_u3c8_"));
 }
 
 #[test]
@@ -57,8 +58,8 @@ fn test_simple_return() {
     let code = compile("διπλασιασμος ὁρίζειν τῷ ξ· δός ξ δύο γινόμενον.");
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("return"));
-    // Should return xi * 2, not just a literal
-    assert!(code.contains("xi") || code.contains("*") || code.contains("2"));
+    // Should return x * 2, not just a literal
+    assert!(code.contains("x") || code.contains("*") || code.contains("2"));
 }
 
 #[test]
@@ -81,9 +82,10 @@ fn test_function_call() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
+    // πρόσθεσις -> pros_u3b8_esis
     assert!(
-        code.contains("prosthesis")
-            && (code.contains("prosthesis(") || code.contains("prosthesis ("))
+        code.contains("pros_u3b8_esis")
+            && (code.contains("pros_u3b8_esis(") || code.contains("pros_u3b8_esis ("))
     );
 }
 

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -561,8 +561,11 @@ mod cycle11_variable_capture {
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(code_no_space.contains(".filter("), "Should have .filter(");
             // Should reference theta variable in closure
+            // theta (θ) is hex-encoded as _u3b8_ to prevent collisions
             assert!(
-                code_no_space.contains("theta") || code_no_space.contains("θ"),
+                code_no_space.contains("theta")
+                    || code_no_space.contains("θ")
+                    || code_no_space.contains("_u3b8_"),
                 "Should capture theta"
             );
         } else {
@@ -588,8 +591,11 @@ mod cycle11_variable_capture {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(code_no_space.contains(".any("), "Should have .any(");
+            // theta (θ) is hex-encoded as _u3b8_
             assert!(
-                code_no_space.contains("theta") || code_no_space.contains("θ"),
+                code_no_space.contains("theta")
+                    || code_no_space.contains("θ")
+                    || code_no_space.contains("_u3b8_"),
                 "Should capture theta"
             );
         } else {
@@ -616,9 +622,11 @@ mod cycle11_variable_capture {
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(code_no_space.contains("5"), "Should use literal 5");
-            // Should NOT reference theta
+            // Should NOT reference theta (encoded or not)
             assert!(
-                !code_no_space.contains("theta") && !code_no_space.contains("θ"),
+                !code_no_space.contains("theta")
+                    && !code_no_space.contains("θ")
+                    && !code_no_space.contains("_u3b8_"),
                 "Should NOT capture theta"
             );
         } else {

--- a/tests/test_assertions_test.rs
+++ b/tests/test_assertions_test.rs
@@ -46,13 +46,13 @@ fn test_assert_eq_compiles() {
 
     eprintln!("Generated code:\n{}", rust_str);
 
-    // Should generate assert_eq !(kappa, 5i64)
+    // Should generate assert_eq !(k, 5i64)
     assert!(
         rust_str.contains("assert_eq !"),
         "Missing assert_eq ! macro. Got:\n{}",
         rust_str
     );
-    assert!(rust_str.contains("kappa"), "Missing variable reference");
+    assert!(rust_str.contains("k"), "Missing variable reference");
     assert!(rust_str.contains("5i64"), "Missing literal value");
     assert!(rust_str.contains("# [test]"), "Missing #[test] attribute");
 }

--- a/tests/trait_tests.rs
+++ b/tests/trait_tests.rs
@@ -582,7 +582,7 @@ fn test_standalone_method_call() {
     let code = compile(source);
 
     // Should contain the method call
-    assert!(code.contains("pi . show") || code.contains("pi.show"));
+    assert!(code.contains("p . show") || code.contains("p.show"));
 }
 
 // ============================================================================

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -43,7 +43,8 @@ fn test_instantiation() {
         π νέον σημεῖον πέντε ἔστω.
     "#;
     let code = compile(source);
-    assert!(code.contains("Semeion") || code.contains("semeion"));
+    // σημεῖον -> Shmeion (η -> h)
+    assert!(code.contains("Shmeion") || code.contains("shmeion"));
     assert!(code.contains("5"));
 }
 
@@ -54,7 +55,7 @@ fn test_instantiation_multiple_fields() {
         π νέον σημεῖον πέντε τρία ἔστω.
     "#;
     let code = compile(source);
-    assert!(code.contains("Semeion") || code.contains("semeion"));
+    assert!(code.contains("Shmeion") || code.contains("shmeion"));
 }
 
 // Cycle 5: Field Access
@@ -67,7 +68,8 @@ fn test_field_access() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    assert!(code.contains(".xi") || code.contains(". xi"));
+    // ξ -> x
+    assert!(code.contains(".x") || code.contains(". x"));
 }
 
 #[test]
@@ -80,8 +82,10 @@ fn test_field_access_multiple_fields() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    assert!(code.contains(". xi") || code.contains(".xi"));
-    assert!(code.contains(". psi") || code.contains(".psi"));
+    // ξ -> x
+    assert!(code.contains(". x") || code.contains(".x"));
+    // ψ -> _u3c8_
+    assert!(code.contains(". _u3c8_") || code.contains("._u3c8_"));
 }
 
 #[test]
@@ -93,9 +97,9 @@ fn test_instantiation_with_literals() {
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
     // It should generate struct instantiation, not string assignment
-    // We expect: let chrestes = Chrestes { onoma: "Σωκράτης".to_string(), elikia: 70 };
-    assert!(code.contains("struct Chrestes"));
-    assert!(code.contains("let chrestes = Chrestes"));
+    // Χρήστης -> _u3c7_rhsths (chi -> _u3c7_, eta -> h)
+    assert!(code.contains("struct _u3c7_rhsths"));
+    assert!(code.contains("let _u3c7_rhsths = _u3c7_rhsths"));
     assert!(code.contains("Σωκράτης"));
     assert!(code.contains("70"));
 }

--- a/tests/word_order_tests.rs
+++ b/tests/word_order_tests.rs
@@ -23,7 +23,7 @@ fn test_binding_word_order_independence() {
     let sov = compile_to_rust("ξ πέντε ἔστω.");
 
     // These should all produce equivalent output
-    assert!(sov.contains("let xi"));
+    assert!(sov.contains("let x"));
     assert!(sov.contains("5i64") || sov.contains("5 "));
 }
 
@@ -44,7 +44,7 @@ fn test_variable_binding_and_reference() {
     let output = compile_to_rust(source);
 
     // Should have binding
-    assert!(output.contains("let xi"));
+    assert!(output.contains("let x"));
     // Should have print
     assert!(output.contains("println"));
 }
@@ -54,12 +54,12 @@ fn test_variable_binding_and_reference() {
 fn test_number_binding_variations() {
     // Arabic numeral
     let arabic = compile_to_rust("ξ 42 ἔστω.");
-    assert!(arabic.contains("let xi"));
+    assert!(arabic.contains("let x"));
     assert!(arabic.contains("42"));
 
     // Greek numeral word
     let greek_word = compile_to_rust("ξ πέντε ἔστω.");
-    assert!(greek_word.contains("let xi"));
+    assert!(greek_word.contains("let x"));
     assert!(greek_word.contains("5"));
 }
 
@@ -104,8 +104,8 @@ fn test_multiple_statement_scope() {
     let output = compile_to_rust(source);
 
     // Both bindings should exist
-    assert!(output.contains("let alpha"));
-    assert!(output.contains("let beta"));
+    assert!(output.contains("let a"));
+    assert!(output.contains("let b"));
 }
 
 /// Test that queries produce output


### PR DESCRIPTION
Hardened identifier sanitization in `src/codegen/rust.rs` to prevent variable shadowing and collisions.

**Threat:** Logic bug where distinct Greek identifiers could map to the same Rust identifier (e.g., `σ` and `σίγμα` both becoming `sigma`, or `ψ` and `πσ` both becoming `ps`), causing variable shadowing or redefinition errors.

**Defense:** Enforced strict, unique transliteration. Single-letter shortcuts were removed. Distinct mappings were added for `η` (h) and `ω` (w). Ambiguous or multi-character mappings (`θ`, `φ`, `χ`, `ψ`) now use safe hex-encoding (`_u{hex}_`) to guarantee uniqueness.

**Verification:** Verified with `collision.gl` reproduction case and updated unit tests.

---
*PR created automatically by Jules for task [4317839790996694341](https://jules.google.com/task/4317839790996694341) started by @madmax983*