### PR TITLE
🎨 Mosaic: UI Polish for REPL and Oracle

### DIFF
--- a/src/experimental/oracle.rs
+++ b/src/experimental/oracle.rs
@@ -77,14 +77,8 @@ impl Oracle {
             }
 
             if let Some(verb) = &assembled.verb {
-                let tense_str = verb
-                    .tense
-                    .map(|t| t.to_greek())
-                    .unwrap_or("Ἄγνωστον");
-                let voice_str = verb
-                    .voice
-                    .map(|v| v.to_greek())
-                    .unwrap_or("Ἄγνωστον");
+                let tense_str = verb.tense.map(|t| t.to_greek()).unwrap_or("Ἄγνωστον");
+                let voice_str = verb.voice.map(|v| v.to_greek()).unwrap_or("Ἄγνωστον");
                 let morph = format!("{} {}", tense_str, voice_str);
 
                 table.add_row(vec![

--- a/src/experimental/oracle.rs
+++ b/src/experimental/oracle.rs
@@ -48,30 +48,30 @@ impl Oracle {
                 .load_preset(UTF8_FULL)
                 .set_content_arrangement(ContentArrangement::Dynamic)
                 .set_header(vec![
-                    Cell::new("Role")
+                    Cell::new("Ῥόλος (Role)")
                         .add_attribute(Attribute::Bold)
                         .fg(Color::Cyan),
-                    Cell::new("Greek Word").add_attribute(Attribute::Bold),
-                    Cell::new("Morphology")
+                    Cell::new("Λέξις (Word)").add_attribute(Attribute::Bold),
+                    Cell::new("Μορφολογία (Morphology)")
                         .add_attribute(Attribute::Bold)
                         .fg(Color::Green),
-                    Cell::new("Lemma/Value").add_attribute(Attribute::Bold),
+                    Cell::new("Λῆμμα/Τιμή (Lemma/Value)").add_attribute(Attribute::Bold),
                 ]);
 
             if let Some(subject) = &assembled.subject {
                 table.add_row(vec![
-                    "Subject (Agent)",
+                    "Ὑποκείμενον (Subject)",
                     &subject.original,
-                    "Nominative Case",
+                    "Ὀνομαστική (Nominative)",
                     subject.lemma.as_ref(),
                 ]);
             }
 
             for nom in &assembled.nominatives {
                 table.add_row(vec![
-                    "Nominative (Secondary)",
+                    "Κατηγορούμενον (Predicate)",
                     &nom.original,
-                    "Nominative Case",
+                    "Ὀνομαστική (Nominative)",
                     nom.lemma.as_ref(),
                 ]);
             }
@@ -79,16 +79,16 @@ impl Oracle {
             if let Some(verb) = &assembled.verb {
                 let tense_str = verb
                     .tense
-                    .map(|t| format!("{:?}", t))
-                    .unwrap_or_else(|| "Unknown".to_string());
+                    .map(|t| t.to_greek())
+                    .unwrap_or("Ἄγνωστον");
                 let voice_str = verb
                     .voice
-                    .map(|v| format!("{:?}", v))
-                    .unwrap_or_else(|| "Unknown".to_string());
+                    .map(|v| v.to_greek())
+                    .unwrap_or("Ἄγνωστον");
                 let morph = format!("{} {}", tense_str, voice_str);
 
                 table.add_row(vec![
-                    "Verb (Action)",
+                    "Ῥῆμα (Verb)",
                     &verb.original,
                     &morph,
                     verb.lemma.as_ref(),
@@ -97,26 +97,28 @@ impl Oracle {
 
             if let Some(object) = &assembled.object {
                 table.add_row(vec![
-                    "Object (Patient)",
+                    "Ἀντικείμενον (Object)",
                     &object.original,
-                    "Accusative Case",
+                    "Αἰτιατική (Accusative)",
                     object.lemma.as_ref(),
                 ]);
             }
 
             if let Some(indirect) = &assembled.indirect {
                 table.add_row(vec![
-                    "Indirect Object",
+                    "Ἔμμεσον (Indirect)",
                     &indirect.original,
-                    "Dative Case",
+                    "Δοτική (Dative)",
                     indirect.lemma.as_ref(),
                 ]);
             }
 
             for participle in &assembled.participles {
-                let morph = format!("{:?} {:?} Participle", participle.tense, participle.voice);
+                let tense_str = participle.tense.to_greek();
+                let voice_str = participle.voice.to_greek();
+                let morph = format!("{} {} Μετοχή", tense_str, voice_str);
                 table.add_row(vec![
-                    "Participle (Lambda)",
+                    "Μετοχή (Participle)",
                     &participle.original,
                     &morph,
                     &participle.verb_lemma,
@@ -125,11 +127,18 @@ impl Oracle {
 
             for literal in &assembled.literals {
                 let (val, type_name) = match literal {
-                    Literal::String(s) => (format!("«{}»", s), "String"),
-                    Literal::Number(n) => (n.to_string(), "Number"),
-                    Literal::Boolean(b) => (b.to_string(), "Boolean"),
+                    Literal::String(s) => (format!("«{}»", s), "ὄνομα (String)"),
+                    Literal::Number(n) => (n.to_string(), "ἀριθμός (Number)"),
+                    Literal::Boolean(b) => (
+                        if *b {
+                            "ἀληθές".to_string()
+                        } else {
+                            "ψεῦδος".to_string()
+                        },
+                        "ἀληθές (Boolean)",
+                    ),
                 };
-                table.add_row(vec!["Literal Value", &val, type_name, &val]);
+                table.add_row(vec!["Τιμή (Literal)", &val, type_name, &val]);
             }
 
             report.push_str(&table.to_string());
@@ -194,11 +203,11 @@ mod tests {
 
         println!("{}", explanation);
 
-        assert!(explanation.contains("Subject (Agent)"));
+        assert!(explanation.contains("Ὑποκείμενον (Subject)"));
         assert!(explanation.contains("ἄνθρωπος"));
-        assert!(explanation.contains("Object (Patient)"));
+        assert!(explanation.contains("Ἀντικείμενον (Object)"));
         assert!(explanation.contains("ἀρχήν"));
-        assert!(explanation.contains("Verb (Action)"));
+        assert!(explanation.contains("Ῥῆμα (Verb)"));
         assert!(explanation.contains("λέγει"));
     }
 
@@ -216,10 +225,10 @@ mod tests {
         let source = "«χαῖρε» 42 ἀληθές λέγε.";
         let explanation = oracle.explain(source).unwrap();
 
-        assert!(explanation.contains("Literal Value"));
+        assert!(explanation.contains("Τιμή (Literal)"));
         assert!(explanation.contains("«χαῖρε»"));
         assert!(explanation.contains("42"));
-        assert!(explanation.contains("true")); // boolean true prints as true
+        assert!(explanation.contains("ἀληθές"));
     }
 
     #[test]
@@ -229,7 +238,7 @@ mod tests {
         let source = "διπλασιαζόμενα λέγε.";
         let explanation = oracle.explain(source).unwrap();
 
-        assert!(explanation.contains("Participle (Lambda)"));
+        assert!(explanation.contains("Μετοχή (Participle)"));
         assert!(explanation.contains("διπλασιαζόμενα"));
         assert!(explanation.contains("lambda"));
     }
@@ -241,7 +250,7 @@ mod tests {
         let source = "τῷ ἀνθρώπῳ δίδωμι.";
         let explanation = oracle.explain(source).unwrap();
 
-        assert!(explanation.contains("Indirect Object"));
+        assert!(explanation.contains("Ἔμμεσον (Indirect)"));
         assert!(explanation.contains("ἀνθρώπῳ"));
     }
 
@@ -275,7 +284,7 @@ mod tests {
         let source = "ὁ ἄνθρωπος θεός ἐστιν.";
         let explanation = oracle.explain(source).unwrap();
 
-        assert!(explanation.contains("Subject (Agent)"));
-        assert!(explanation.contains("Nominative (Secondary)"));
+        assert!(explanation.contains("Ὑποκείμενον (Subject)"));
+        assert!(explanation.contains("Κατηγορούμενον (Predicate)"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -402,7 +402,7 @@ fn print_env(context: &ReplContext) {
         for (name, binding) in bindings {
             table.add_row(vec![
                 Cell::new(name).fg(Color::Green),
-                Cell::new(format!("{:?}", binding.glossa_type)),
+                Cell::new(binding.glossa_type.to_greek()),
                 if binding.mutable {
                     Cell::new("Ναί (Yes)").fg(Color::Yellow)
                 } else {

--- a/src/morphology/case.rs
+++ b/src/morphology/case.rs
@@ -31,6 +31,17 @@ impl Case {
             Case::Vocative => "",   // No ownership semantic
         }
     }
+
+    /// Get the Greek name for the case
+    pub fn to_greek(&self) -> &'static str {
+        match self {
+            Case::Nominative => "Ὀνομαστική",
+            Case::Genitive => "Γενική",
+            Case::Dative => "Δοτική",
+            Case::Accusative => "Αἰτιατική",
+            Case::Vocative => "Κλητική",
+        }
+    }
 }
 
 /// Grammatical number
@@ -41,6 +52,16 @@ pub enum Number {
     // Dual omitted for MVP
 }
 
+impl Number {
+    /// Get the Greek name for the number
+    pub fn to_greek(&self) -> &'static str {
+        match self {
+            Number::Singular => "Ἑνικός",
+            Number::Plural => "Πληθυντικός",
+        }
+    }
+}
+
 /// Grammatical gender
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Gender {
@@ -49,12 +70,34 @@ pub enum Gender {
     Neuter,
 }
 
+impl Gender {
+    /// Get the Greek name for the gender
+    pub fn to_greek(&self) -> &'static str {
+        match self {
+            Gender::Masculine => "Ἀρσενικόν",
+            Gender::Feminine => "Θηλυκόν",
+            Gender::Neuter => "Οὐδέτερον",
+        }
+    }
+}
+
 /// Person (for verbs)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Person {
     First,
     Second,
     Third,
+}
+
+impl Person {
+    /// Get the Greek name for the person
+    pub fn to_greek(&self) -> &'static str {
+        match self {
+            Person::First => "Πρῶτον",
+            Person::Second => "Δεύτερον",
+            Person::Third => "Τρίτον",
+        }
+    }
 }
 
 /// Tense - encodes aspect/time
@@ -72,6 +115,20 @@ pub enum Tense {
     Aorist,
     Perfect,
     Pluperfect,
+}
+
+impl Tense {
+    /// Get the Greek name for the tense
+    pub fn to_greek(&self) -> &'static str {
+        match self {
+            Tense::Present => "Ἐνεστώς",
+            Tense::Imperfect => "Παρατατικός",
+            Tense::Future => "Μέλλων",
+            Tense::Aorist => "Ἀόριστος",
+            Tense::Perfect => "Παρακείμενος",
+            Tense::Pluperfect => "Ὑπερσυντέλικος",
+        }
+    }
 }
 
 /// Mood - encodes modality
@@ -93,6 +150,20 @@ pub enum Mood {
     Participle,
 }
 
+impl Mood {
+    /// Get the Greek name for the mood
+    pub fn to_greek(&self) -> &'static str {
+        match self {
+            Mood::Indicative => "Ὁριστική",
+            Mood::Imperative => "Προστακτική",
+            Mood::Subjunctive => "Ὑποτακτική",
+            Mood::Optative => "Εὐκτική",
+            Mood::Infinitive => "Ἀπαρέμφατον",
+            Mood::Participle => "Μετοχή",
+        }
+    }
+}
+
 /// Voice - active, middle, passive
 ///
 /// In ΓΛΩΣΣΑ:
@@ -106,6 +177,17 @@ pub enum Voice {
     Passive,
 }
 
+impl Voice {
+    /// Get the Greek name for the voice
+    pub fn to_greek(&self) -> &'static str {
+        match self {
+            Voice::Active => "Ἐνεργητική",
+            Voice::Middle => "Μέση",
+            Voice::Passive => "Παθητική",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,5 +197,16 @@ mod tests {
         assert_eq!(Case::Genitive.to_rust_ownership(), "&");
         assert_eq!(Case::Dative.to_rust_ownership(), "&mut");
         assert_eq!(Case::Accusative.to_rust_ownership(), "");
+    }
+
+    #[test]
+    fn test_greek_names() {
+        assert_eq!(Case::Nominative.to_greek(), "Ὀνομαστική");
+        assert_eq!(Number::Singular.to_greek(), "Ἑνικός");
+        assert_eq!(Gender::Neuter.to_greek(), "Οὐδέτερον");
+        assert_eq!(Person::Third.to_greek(), "Τρίτον");
+        assert_eq!(Tense::Present.to_greek(), "Ἐνεστώς");
+        assert_eq!(Mood::Imperative.to_greek(), "Προστακτική");
+        assert_eq!(Voice::Active.to_greek(), "Ἐνεργητική");
     }
 }

--- a/src/morphology/case.rs
+++ b/src/morphology/case.rs
@@ -200,13 +200,58 @@ mod tests {
     }
 
     #[test]
-    fn test_greek_names() {
+    fn test_greek_names_case() {
         assert_eq!(Case::Nominative.to_greek(), "Ὀνομαστική");
+        assert_eq!(Case::Genitive.to_greek(), "Γενική");
+        assert_eq!(Case::Dative.to_greek(), "Δοτική");
+        assert_eq!(Case::Accusative.to_greek(), "Αἰτιατική");
+        assert_eq!(Case::Vocative.to_greek(), "Κλητική");
+    }
+
+    #[test]
+    fn test_greek_names_number() {
         assert_eq!(Number::Singular.to_greek(), "Ἑνικός");
+        assert_eq!(Number::Plural.to_greek(), "Πληθυντικός");
+    }
+
+    #[test]
+    fn test_greek_names_gender() {
+        assert_eq!(Gender::Masculine.to_greek(), "Ἀρσενικόν");
+        assert_eq!(Gender::Feminine.to_greek(), "Θηλυκόν");
         assert_eq!(Gender::Neuter.to_greek(), "Οὐδέτερον");
+    }
+
+    #[test]
+    fn test_greek_names_person() {
+        assert_eq!(Person::First.to_greek(), "Πρῶτον");
+        assert_eq!(Person::Second.to_greek(), "Δεύτερον");
         assert_eq!(Person::Third.to_greek(), "Τρίτον");
+    }
+
+    #[test]
+    fn test_greek_names_tense() {
         assert_eq!(Tense::Present.to_greek(), "Ἐνεστώς");
+        assert_eq!(Tense::Imperfect.to_greek(), "Παρατατικός");
+        assert_eq!(Tense::Future.to_greek(), "Μέλλων");
+        assert_eq!(Tense::Aorist.to_greek(), "Ἀόριστος");
+        assert_eq!(Tense::Perfect.to_greek(), "Παρακείμενος");
+        assert_eq!(Tense::Pluperfect.to_greek(), "Ὑπερσυντέλικος");
+    }
+
+    #[test]
+    fn test_greek_names_mood() {
+        assert_eq!(Mood::Indicative.to_greek(), "Ὁριστική");
         assert_eq!(Mood::Imperative.to_greek(), "Προστακτική");
+        assert_eq!(Mood::Subjunctive.to_greek(), "Ὑποτακτική");
+        assert_eq!(Mood::Optative.to_greek(), "Εὐκτική");
+        assert_eq!(Mood::Infinitive.to_greek(), "Ἀπαρέμφατον");
+        assert_eq!(Mood::Participle.to_greek(), "Μετοχή");
+    }
+
+    #[test]
+    fn test_greek_names_voice() {
         assert_eq!(Voice::Active.to_greek(), "Ἐνεργητική");
+        assert_eq!(Voice::Middle.to_greek(), "Μέση");
+        assert_eq!(Voice::Passive.to_greek(), "Παθητική");
     }
 }


### PR DESCRIPTION
This PR polishes the "Human Interface" of the Glossa CLI, specifically the REPL and the Oracle tool.

**Changes:**
1.  **Morphology Localization:** Added `to_greek()` methods to `Case`, `Number`, `Gender`, `Person`, `Tense`, `Mood`, and `Voice` enums in `src/morphology/case.rs`.
2.  **REPL `.env` Command:** The `.env` / `.περιβάλλον` command now displays variable types in Greek (e.g., `ἀριθμός` instead of `Number`), improving immersion.
3.  **Oracle Polish:** The `explain` command (powered by `Oracle`) now produces a beautiful table with:
    *   Bilingual headers (e.g., `Ῥόλος (Role)`).
    *   Localized content (e.g., `Ὀνομαστική (Nominative)`).
    *   Localized literal types and values (e.g., `ἀληθές (Boolean)`).

**Visuals:**
*   **Before:** `.env` showed `Number`, `String`. Oracle tables had English headers and mixed content.
*   **After:** `.env` shows `ἀριθμός`, `ὄνομα`. Oracle tables use Greek terms consistent with the language philosophy.

**Verification:**
*   Added unit tests for `to_greek()` methods.
*   Updated Oracle tests to match new localized output strings.
*   Ran all tests to ensure no regressions.


---
*PR created automatically by Jules for task [9868141682187316112](https://jules.google.com/task/9868141682187316112) started by @madmax983*