### PR TITLE
🔒 Warden: Fix nested expression truncation vulnerability

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -49,3 +49,16 @@
 **Defense:** Removed special single-letter mapping in `sanitize_name` and enforced strict transliteration in `transliterate`. `σ` now maps to `s`, while `σίγμα` maps to `sigma`. `ψ` maps to `_u3c8_` (hex encoded) to avoid collision with `ps`.
 
 **Severity:** Medium (Logic Bug).
+
+## 2026-06-03 - Nested Expression Truncation
+
+**Threat:** Logic bug in `src/semantic/expressions.rs` and `src/semantic/conversion.rs`.
+1. `analyze_argument_expr` silently truncated nested phrases (e.g., `(1 2 sum)`) to their first term (`1`), ignoring subsequent terms and operators. This could allow logic errors or assertion bypasses.
+2. `extract_value` ignored nested phrases entirely, causing bindings like `x = (1 + 2)` to default to `0` (silent data loss).
+
+**Defense:**
+1. Updated `analyze_argument_expr` to use a fresh `Assembler` to correctly analyze the full nested phrase, preserving operator order and terms.
+2. Updated `extract_value` to correctly extract and analyze nested phrases.
+3. Used `scope.child()` for nested analysis to prevent variable leakage.
+
+**Severity:** High (Logic Bug / Silent Data Loss).

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -1010,6 +1010,11 @@ pub fn extract_value(
     // Check nested phrases (parenthesized expressions) which should be treated as values
     // This allows constructs like "x = (1 + 2)"
     if let Some(nested) = asm_stmt.nested_phrases.first() {
+        if asm_stmt.nested_phrases.len() > 1 {
+            return Err(GlossaError::semantic(
+                "Multiple nested phrases in value position are ambiguous",
+            ));
+        }
         let phrase_expr = Expr::Phrase(nested.clone());
         let analyzed = analyze_argument_expr(&phrase_expr, scope)?;
         let ty = analyzed.glossa_type.clone();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -1007,6 +1007,15 @@ pub fn extract_value(
         ));
     }
 
+    // Check nested phrases (parenthesized expressions) which should be treated as values
+    // This allows constructs like "x = (1 + 2)"
+    if let Some(nested) = asm_stmt.nested_phrases.first() {
+        let phrase_expr = Expr::Phrase(nested.clone());
+        let analyzed = analyze_argument_expr(&phrase_expr, scope)?;
+        let ty = analyzed.glossa_type.clone();
+        return Ok((analyzed, ty));
+    }
+
     // Check subject for Option/Result words
     if let Some(ref subj) = asm_stmt.subject
         && let Some(result) = detect_enum_variant(subj, &asm_stmt.literals)

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -1,9 +1,12 @@
 //! Expression analysis and helpers
 
-use super::{AnalyzedExpr, AnalyzedExprKind, Assembler, GlossaType, Literal, Scope};
+use super::conversion::classify_assembled_statement;
+use super::{
+    AnalyzedExpr, AnalyzedExprKind, Assembler, GlossaType, Literal, Scope, StatementKind,
+};
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
-use crate::morphology::{self, DisambiguationContext, analyze_article, resolve_best};
+use crate::morphology::{self, analyze_article, resolve_best, DisambiguationContext};
 use crate::text::normalize_greek;
 
 /// Analyze an argument expression (could be literal, variable, or nested call)
@@ -131,9 +134,35 @@ fn analyze_argument_expr_recursive(
                 }
             }
 
-            // Not a function call - could be a complex expression
-            // For now, just analyze the first term
-            analyze_argument_expr_recursive(&terms[0], scope, depth + 1)
+            // Not a function call - could be a complex expression (e.g. "1 2 +")
+            // Use Assembler to analyze the phrase properly
+            let mut asm = Assembler::new();
+            let mut context = DisambiguationContext::new();
+
+            for term in terms {
+                feed_expr_recursive(&mut asm, term, &mut context, depth + 1)?;
+            }
+
+            let asm_stmt = asm.finalize()?;
+            // Use a child scope to prevent side effects from leaking out (e.g. bindings in expressions)
+            let mut inner_scope = scope.child();
+            let (kind, mut exprs) = classify_assembled_statement(&asm_stmt, &mut inner_scope)?;
+
+            // Expecting an Expression statement that yielded a result
+            if matches!(kind, StatementKind::Expression) || matches!(kind, StatementKind::Print) {
+                if exprs.len() == 1 {
+                    return Ok(exprs.remove(0));
+                } else if exprs.is_empty() {
+                    return Err(GlossaError::semantic("Expression evaluated to nothing"));
+                } else {
+                    // Return the last expression (block style)
+                    return Ok(exprs.pop().unwrap());
+                }
+            }
+
+            Err(GlossaError::semantic(
+                "Nested phrase must evaluate to an expression",
+            ))
         }
 
         Expr::Block(statements) => {

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -1,12 +1,10 @@
 //! Expression analysis and helpers
 
 use super::conversion::classify_assembled_statement;
-use super::{
-    AnalyzedExpr, AnalyzedExprKind, Assembler, GlossaType, Literal, Scope, StatementKind,
-};
+use super::{AnalyzedExpr, AnalyzedExprKind, Assembler, GlossaType, Literal, Scope, StatementKind};
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
-use crate::morphology::{self, analyze_article, resolve_best, DisambiguationContext};
+use crate::morphology::{self, DisambiguationContext, analyze_article, resolve_best};
 use crate::text::normalize_greek;
 
 /// Analyze an argument expression (could be literal, variable, or nested call)

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -155,8 +155,9 @@ fn analyze_argument_expr_recursive(
                 } else if exprs.is_empty() {
                     return Err(GlossaError::semantic("Expression evaluated to nothing"));
                 } else {
-                    // Return the last expression (block style)
-                    return Ok(exprs.pop().unwrap());
+                    return Err(GlossaError::semantic(
+                        "Ambiguous nested phrase: multiple expressions found",
+                    ));
                 }
             }
 

--- a/tests/warden_coverage.rs
+++ b/tests/warden_coverage.rs
@@ -14,7 +14,12 @@ fn compile_error(source: &str, expected_error: &str) {
         Ok(_) => panic!("Expected error: {}", expected_error),
         Err(e) => {
             let msg = e.to_string();
-            assert!(msg.contains(expected_error), "Expected '{}', got '{}'", expected_error, msg);
+            assert!(
+                msg.contains(expected_error),
+                "Expected '{}', got '{}'",
+                expected_error,
+                msg
+            );
         }
     }
 }
@@ -56,7 +61,10 @@ fn test_coverage_nested_phrase_multiple_error() {
     // This is parsed as multiple terms, fed to assembler as separate nested phrases.
     // Single terms like (1) are flattened by parser to just 1, so we need multiple terms.
     let source = "ξ (1 2) (3 4) ἔστω.";
-    compile_error(source, "Multiple nested phrases in value position are ambiguous");
+    compile_error(
+        source,
+        "Multiple nested phrases in value position are ambiguous",
+    );
 }
 
 #[test]

--- a/tests/warden_coverage.rs
+++ b/tests/warden_coverage.rs
@@ -8,6 +8,57 @@ fn compile(source: &str) {
     let _ = generate_rust(&analyzed);
 }
 
+fn compile_error(source: &str, expected_error: &str) {
+    let ast = parse(source).unwrap();
+    match analyze_program(&ast) {
+        Ok(_) => panic!("Expected error: {}", expected_error),
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(msg.contains(expected_error), "Expected '{}', got '{}'", expected_error, msg);
+        }
+    }
+}
+
+#[test]
+fn test_coverage_nested_phrase_ambiguous_error() {
+    // Should error because multiple expressions are found
+    // Code path: exprs.len() > 1 -> Err("Ambiguous nested phrase...")
+    let source = "ξ (1 2) ἔστω.";
+    compile_error(source, "Ambiguous nested phrase");
+}
+
+#[test]
+fn test_coverage_nested_phrase_binding_error() {
+    // Nested phrase containing a statement (binding) -> Error
+    // Code path: kind is Binding -> Err("Nested phrase must evaluate to an expression")
+    let source = "ξ (ψ 1 ἔστω) ἔστω.";
+    compile_error(source, "Nested phrase must evaluate to an expression");
+}
+
+#[test]
+fn test_coverage_nested_phrase_empty_error() {
+    // Nested phrase evaluating to nothing (e.g. just article)
+    // Code path: exprs.is_empty() -> Err("Expression evaluated to nothing")
+    // "ὁ" is an article, ignored by assembler.
+    // We use "ὁ ὁ" to ensure it parses as a Phrase (multiple terms) rather than a single Word,
+    // which forces it to go through the nested phrase path.
+    let source = "ξ (ὁ ὁ) ἔστω.";
+    compile_error(source, "Expression evaluated to nothing");
+}
+
+#[test]
+fn test_coverage_nested_phrase_multiple_error() {
+    // Multiple nested phrases in binding -> Error
+    // Code path: nested_phrases.len() > 1 -> Err("Multiple nested phrases...")
+    // "ξ (1 2) (3 4) ἔστω."
+    // (1 2) -> nested phrase [1, 2]
+    // (3 4) -> nested phrase [3, 4]
+    // This is parsed as multiple terms, fed to assembler as separate nested phrases.
+    // Single terms like (1) are flattened by parser to just 1, so we need multiple terms.
+    let source = "ξ (1 2) (3 4) ἔστω.";
+    compile_error(source, "Multiple nested phrases in value position are ambiguous");
+}
+
 #[test]
 fn test_coverage_filter_patterns() {
     // 1. Suffix "ου" (e.g. θ -> θου)

--- a/tests/warden_exploit.rs
+++ b/tests/warden_exploit.rs
@@ -35,3 +35,29 @@ fn test_exploit_unicode_panic() {
         rust
     );
 }
+
+#[test]
+fn test_exploit_nested_expression_truncation() {
+    // Vulnerability: analyze_argument_expr used to only take the first term of a phrase
+    // if it wasn't a function call.
+    // Source: (1 2 ἄθροισμα) -> should be 1 + 2 = 3.
+    // Exploit: If truncated, it becomes 1.
+
+    let source = "ξ (1 2 ἄθροισμα) ἔστω. ξ λέγε.";
+    let ast = parse(source).expect("Parsing failed");
+    let analyzed = analyze_program(&ast).expect("Analysis failed");
+    let rust = generate_rust(&analyzed);
+
+    // Check that it generates a binary operation (1 + 2) or the result 3 (if constant folded, but we don't constant fold yet)
+    // It should definitely NOT just be "let x = 1;" or "let x = 0;"
+    // The output might look like "let x = (1i64 + 2i64)" due to Rust codegen specifics
+    assert!(rust.contains("+") || rust.contains("3"), "Code should contain addition or result 3. Got: {}", rust);
+
+    // Also check for the absence of silent truncation/defaulting
+    if rust.contains("let x = 1") && !rust.contains("+") {
+         panic!("Vulnerability confirmed: Expression was truncated to first term!");
+    }
+    if rust.contains("let x = 0") && !rust.contains("+") {
+        panic!("Vulnerability confirmed: Expression defaulted to 0 (ignored nested phrase)!");
+    }
+}

--- a/tests/warden_exploit.rs
+++ b/tests/warden_exploit.rs
@@ -51,11 +51,15 @@ fn test_exploit_nested_expression_truncation() {
     // Check that it generates a binary operation (1 + 2) or the result 3 (if constant folded, but we don't constant fold yet)
     // It should definitely NOT just be "let x = 1;" or "let x = 0;"
     // The output might look like "let x = (1i64 + 2i64)" due to Rust codegen specifics
-    assert!(rust.contains("+") || rust.contains("3"), "Code should contain addition or result 3. Got: {}", rust);
+    assert!(
+        rust.contains("+") || rust.contains("3"),
+        "Code should contain addition or result 3. Got: {}",
+        rust
+    );
 
     // Also check for the absence of silent truncation/defaulting
     if rust.contains("let x = 1") && !rust.contains("+") {
-         panic!("Vulnerability confirmed: Expression was truncated to first term!");
+        panic!("Vulnerability confirmed: Expression was truncated to first term!");
     }
     if rust.contains("let x = 0") && !rust.contains("+") {
         panic!("Vulnerability confirmed: Expression defaulted to 0 (ignored nested phrase)!");


### PR DESCRIPTION
Fixed a critical logic bug where nested expressions were truncated or ignored, leading to incorrect program behavior and potential security bypasses. Added regression tests to prevent recurrence.

---
*PR created automatically by Jules for task [11336623443218142654](https://jules.google.com/task/11336623443218142654) started by @madmax983*