### PR TITLE
🎻 Bard: Enhance documentation with examples and lore

### DIFF
--- a/src/errors/messages.rs
+++ b/src/errors/messages.rs
@@ -16,21 +16,48 @@ use crate::morphology::{Case, Gender, Number};
 
 /// Get a Greek message for a type mismatch
 ///
-/// "I expected to find {expected}, but I found {got}"
+/// Returns: "Ἐδόκει {expected} εὑρεῖν, ἀλλ' εὗρον {got}"
+///
+/// # Examples
+///
+/// ```
+/// use glossa::errors::type_mismatch;
+///
+/// let msg = type_mismatch("ἀριθμόν", "ὄνομα");
+/// assert_eq!(msg, "Ἐδόκει ἀριθμόν εὑρεῖν, ἀλλ' εὗρον ὄνομα");
+/// ```
 pub fn type_mismatch(expected: &str, got: &str) -> String {
     format!("Ἐδόκει {} εὑρεῖν, ἀλλ' εὗρον {}", expected, got)
 }
 
 /// Get a Greek message for an undefined variable
 ///
-/// "I do not know the name {name}"
+/// Returns: "Οὐκ οἶδα τὸ ὄνομα «{name}»"
+///
+/// # Examples
+///
+/// ```
+/// use glossa::errors::undefined_variable;
+///
+/// let msg = undefined_variable("ξ");
+/// assert_eq!(msg, "Οὐκ οἶδα τὸ ὄνομα «ξ»");
+/// ```
 pub fn undefined_variable(name: &str) -> String {
     format!("Οὐκ οἶδα τὸ ὄνομα «{}»", name)
 }
 
 /// Get a Greek message for assignment to immutable variable
 ///
-/// "The {name} is immutable — use 'meta' before the definition"
+/// Returns: "Τὸ «{name}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ"
+///
+/// # Examples
+///
+/// ```
+/// use glossa::errors::immutable_assignment;
+///
+/// let msg = immutable_assignment("π");
+/// assert!(msg.contains("ἀμετάβλητόν ἐστιν"));
+/// ```
 pub fn immutable_assignment(name: &str) -> String {
     format!(
         "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
@@ -40,7 +67,17 @@ pub fn immutable_assignment(name: &str) -> String {
 
 /// Get a Greek message for gender mismatch
 ///
-/// "The {word1} ({gender1}) does not agree with the {word2} ({gender2})"
+/// Returns: "Τὸ «{word1}» ({gender1}) οὐ συμφωνεῖ τῷ «{word2}» ({gender2})"
+///
+/// # Examples
+///
+/// ```
+/// use glossa::errors::gender_mismatch;
+/// use glossa::morphology::Gender;
+///
+/// let msg = gender_mismatch("καλός", Gender::Masculine, "γυνή", Gender::Feminine);
+/// assert!(msg.contains("οὐ συμφωνεῖ"));
+/// ```
 pub fn gender_mismatch(word1: &str, gender1: Gender, word2: &str, gender2: Gender) -> String {
     format!(
         "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
@@ -53,7 +90,17 @@ pub fn gender_mismatch(word1: &str, gender1: Gender, word2: &str, gender2: Gende
 
 /// Get a Greek message for number mismatch
 ///
-/// "The {word1} ({num1}) does not agree with the {word2} ({num2})"
+/// Returns: "Τὸ «{word1}» ({num1}) οὐ συμφωνεῖ τῷ «{word2}» ({num2})"
+///
+/// # Examples
+///
+/// ```
+/// use glossa::errors::number_mismatch;
+/// use glossa::morphology::Number;
+///
+/// let msg = number_mismatch("ἄνθρωπος", Number::Singular, "λέγουσι", Number::Plural);
+/// assert!(msg.contains("οὐ συμφωνεῖ"));
+/// ```
 pub fn number_mismatch(word1: &str, num1: Number, word2: &str, num2: Number) -> String {
     format!(
         "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
@@ -66,7 +113,17 @@ pub fn number_mismatch(word1: &str, num1: Number, word2: &str, num2: Number) -> 
 
 /// Get a Greek message for case mismatch
 ///
-/// "The {word1} ({case1}) does not agree with the {word2} ({case2})"
+/// Returns: "Τὸ «{word1}» ({case1}) οὐ συμφωνεῖ τῷ «{word2}» ({case2})"
+///
+/// # Examples
+///
+/// ```
+/// use glossa::errors::case_mismatch;
+/// use glossa::morphology::Case;
+///
+/// let msg = case_mismatch("ἄνθρωπος", Case::Nominative, "λόγον", Case::Accusative);
+/// assert!(msg.contains("οὐ συμφωνεῖ"));
+/// ```
 pub fn case_mismatch(word1: &str, case1: Case, word2: &str, case2: Case) -> String {
     format!(
         "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -1,6 +1,14 @@
 //! AST Builder
 //!
-//! Converts Pest pairs into AST nodes.
+//! This module is responsible for converting the raw Concrete Syntax Tree (CST)
+//! produced by the Pest parser into a strongly-typed Abstract Syntax Tree (AST).
+//!
+//! # Safety: Recursion Depth
+//!
+//! ΓΛΩΣΣΑ implements a strict recursion depth check ([`check_recursion_depth`])
+//! before parsing begins. This linear scan of the source code ensures that deep
+//! nesting (e.g., `((((...))))`) does not cause a stack overflow during the
+//! recursive descent parsing phase.
 
 use crate::ast::*;
 use crate::grammar::{Rule, parse};
@@ -602,6 +610,10 @@ pub enum ParseError {
 }
 
 /// Check recursion depth to prevent stack overflows
+///
+/// This function performs a fast linear scan of the source code to ensure that
+/// parentheses, braces, and brackets are not nested deeper than `MAX_DEPTH` (500).
+/// This prevents stack overflows during the recursive parsing phase.
 fn check_recursion_depth(source: &str) -> Result<(), ParseError> {
     const MAX_DEPTH: usize = 500;
     let mut depth = 0;

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -111,31 +111,37 @@ use smol_str::SmolStr;
 pub struct AssembledStatement {
     /// The subject (nominative) - the agent/doer
     ///
+    /// Fills the **Nominative** slot.
     /// Example: **ὁ ἄνθρωπος** λέγει (The **man** speaks)
     pub subject: Option<Constituent>,
 
     /// Additional nominatives (for function names, etc.)
     ///
     /// Used in patterns where multiple nominatives appear, such as
-    /// function calls or predicate nominatives.
+    /// function calls (`add x y`) or predicate nominatives (`x is y`).
     pub nominatives: Vec<Constituent>,
 
     /// The verb - the action
     ///
+    /// Fills the **Verb** slot.
     /// Example: ὁ ἄνθρωπος **λέγει** (The man **speaks**)
     pub verb: Option<VerbConstituent>,
 
     /// The direct object (accusative) - receives the action
     ///
+    /// Fills the **Accusative** slot.
     /// Example: βλέπω **τὸν ἄνθρωπον** (I see **the man**)
     pub object: Option<Constituent>,
+
     /// The indirect object (dative) - recipient/beneficiary
     ///
+    /// Fills the **Dative** slot.
     /// Example: δίδωμι **τῷ ἀνθρώπῳ** (I give **to the man**)
     pub indirect: Option<Constituent>,
 
     /// Possessors/sources (genitive) - attached to other constituents
     ///
+    /// Fills the **Genitive** slot.
     /// Example: τὸ τοῦ **ἀνθρώπου** βιβλίον (The **man's** book)
     pub genitives: Vec<Constituent>,
 
@@ -209,6 +215,23 @@ pub struct AssembledStatement {
 ///
 /// This represents a word that fills a nominal slot (Subject, Object, etc.).
 /// It carries both its original surface form and its normalized lemma.
+///
+/// # Examples
+///
+/// ```
+/// use glossa::semantic::Constituent;
+/// use glossa::morphology::{Case, Number, Gender};
+/// use smol_str::SmolStr;
+///
+/// let man = Constituent {
+///     lemma: SmolStr::new("ανθρωπος"),
+///     original: SmolStr::new("ἄνθρωπος"),
+///     case: Case::Nominative,
+///     number: Some(Number::Singular),
+///     gender: Some(Gender::Masculine),
+///     person: None,
+/// };
+/// ```
 #[derive(Debug, Clone)]
 pub struct Constituent {
     /// The dictionary form

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -171,6 +171,17 @@ impl Ownership {
 }
 
 /// Infer type from a Greek word (by looking at lexicon or morphology)
+///
+/// # Examples
+///
+/// ```
+/// use glossa::semantic::{infer_type, GlossaType};
+///
+/// assert_eq!(infer_type("πέντε"), GlossaType::Number);
+/// assert_eq!(infer_type("ἀριθμός"), GlossaType::Number);
+/// assert_eq!(infer_type("ὄνομα"), GlossaType::String);
+/// assert_eq!(infer_type("ἄγνωστον"), GlossaType::Unknown);
+/// ```
 pub fn infer_type(word: &str) -> GlossaType {
     let normalized = crate::text::normalize_greek(word);
 
@@ -194,6 +205,19 @@ pub fn infer_type(word: &str) -> GlossaType {
 }
 
 /// Detect built-in collection types (HashSet, HashMap)
+///
+/// Returns a tuple of (Rust collection name, GlossaType).
+///
+/// # Examples
+///
+/// ```
+/// use glossa::semantic::detect_collection_type;
+/// use glossa::semantic::GlossaType;
+///
+/// let (name, ty) = detect_collection_type("χαρτης").unwrap();
+/// assert_eq!(name, "HashMap");
+/// assert!(matches!(ty, GlossaType::Map(..)));
+/// ```
 pub fn detect_collection_type(type_name: &str) -> Option<(&'static str, GlossaType)> {
     match type_name {
         "συνολον" => Some(("HashSet", GlossaType::Set(Box::new(GlossaType::Unknown)))),


### PR DESCRIPTION
This PR enhances the documentation across key modules of the compiler to align with the 'Bard' persona's philosophy: code is a medium for human communication.

Key improvements:
1.  **"Dialogue" in Errors**: `src/errors/messages.rs` now features executable doctests showing the actual Ancient Greek output strings, reinforcing the immersive nature of error reporting.
2.  **Architectural Clarity**: `src/parser/builder.rs` now explains *why* it exists (bridging Pest CST to internal AST) and *how* it prevents stack overflows (recursion depth check).
3.  **Semantic Storytelling**: `src/semantic/assembler.rs` now has "Hero's Journey" style examples showing how raw words like "ἄνθρωπος" become semantic `Constituent`s filling grammatical slots.
4.  **Type System Examples**: `src/semantic/types.rs` now includes practical examples for type inference and collection detection.

All doctests are verified to compile and pass.

---
*PR created automatically by Jules for task [9189449724495118663](https://jules.google.com/task/9189449724495118663) started by @madmax983*