### PR TITLE
🗺️ Atlas: Decouple Domain from CodeGen

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -33,5 +33,7 @@
 //! 2. **Code Generation**: [`generate_rust`] takes the program and produces a Rust source string.
 
 mod rust;
+pub mod types;
+pub(crate) mod utils;
 
 pub use rust::*;

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -48,6 +48,8 @@
 //! ```
 
 use crate::morphology::lexicon::{BinaryOp, UnaryOp};
+use crate::codegen::types::to_rust_type;
+use crate::codegen::utils::{capitalize, sanitize_name};
 use crate::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedIteratorOp, AnalyzedMethod, AnalyzedProgram,
     AnalyzedStatement, GlossaType, StatementKind,
@@ -407,7 +409,7 @@ fn generate_fn_def(
         .map(|(param_name, param_type)| {
             let param_ident = format_ident!("{}", sanitize_name(param_name));
             if let Some(ty) = param_type {
-                let ty_str = type_to_rust_string(ty);
+                let ty_str = to_rust_type(ty);
                 let ty_ident = format_ident!("{}", ty_str);
                 quote! { #param_ident: #ty_ident }
             } else {
@@ -418,7 +420,7 @@ fn generate_fn_def(
 
     // Generate return type
     if let Some(ret_type) = return_type {
-        let ret_str = type_to_rust_string(ret_type);
+        let ret_str = to_rust_type(ret_type);
         let ret_ty = format_ident!("{}", ret_str);
         quote! {
             fn #fn_name(#(#param_tokens),*) -> #ret_ty {
@@ -443,7 +445,7 @@ fn generate_struct_def(name: &str, fields: &[(smol_str::SmolStr, GlossaType)]) -
         .iter()
         .map(|(field_name, field_type)| {
             let field_ident = format_ident!("{}", sanitize_name(field_name));
-            let type_str = type_to_rust_string(field_type);
+            let type_str = to_rust_type(field_type);
             let type_ident = format_ident!("{}", type_str);
             quote! { #field_ident: #type_ident }
         })
@@ -478,7 +480,7 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
                         quote! { &self }
                     } else {
                         let param_ident = format_ident!("{}", sanitize_name(param_name));
-                        let type_str = type_to_rust_string(param_type);
+                        let type_str = to_rust_type(param_type);
                         let ty = format_ident!("{}", type_str);
                         quote! { #param_ident: #ty }
                     }
@@ -487,7 +489,7 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
 
             // Generate return type
             if let Some(ret_type) = &method.return_type {
-                let ret_str = type_to_rust_string(ret_type);
+                let ret_str = to_rust_type(ret_type);
                 let ret_ty = format_ident!("{}", ret_str);
 
                 if let Some(body) = &method.body {
@@ -550,7 +552,7 @@ fn generate_trait_impl(
                         quote! { &self }
                     } else {
                         let param_ident = format_ident!("{}", sanitize_name(param_name));
-                        let type_str = type_to_rust_string(param_type);
+                        let type_str = to_rust_type(param_type);
                         let ty = format_ident!("{}", type_str);
                         quote! { #param_ident: #ty }
                     }
@@ -566,7 +568,7 @@ fn generate_trait_impl(
 
             // Generate return type
             if let Some(ret_type) = &method.return_type {
-                let ret_str = type_to_rust_string(ret_type);
+                let ret_str = to_rust_type(ret_type);
                 let ret_ty = format_ident!("{}", ret_str);
                 quote! {
                     fn #method_name(#(#param_tokens),*) -> #ret_ty {
@@ -939,15 +941,6 @@ fn generate_iterator_chain(collection: &AnalyzedExpr, ops: &[AnalyzedIteratorOp]
     current
 }
 
-/// Capitalize the first letter of a string (for Rust type/trait names)
-fn capitalize(s: &str) -> String {
-    let mut chars = s.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-    }
-}
-
 /// Check if a parameter represents the self parameter in a trait method
 fn is_self_parameter(param_name: &str, idx: usize) -> bool {
     if idx != 0 {
@@ -961,101 +954,6 @@ fn is_self_parameter(param_name: &str, idx: usize) -> bool {
         || param_name.contains("self")
 }
 
-/// Sanitize a Greek name for use as a Rust identifier
-///
-/// This function performs the critical step of converting Ancient Greek identifiers
-/// into valid ASCII Rust identifiers. It uses a combination of name mapping
-/// (for single letters like `α`) and transliteration (for words like `χρήστης`).
-///
-/// # Edge Cases
-///
-/// Characters that do not have a standard Latin mapping (like `ϟ` Koppa) are
-/// hex-encoded to ensure uniqueness and prevent collisions.
-///
-/// * `ϟ` -> `_u3df_`
-///
-/// # Examples
-///
-/// ```
-/// // These are internal functions, but here is how they behave:
-/// // sanitize_name("ξ") -> "xi"
-/// // sanitize_name("χρήστης") -> "chrestes"
-/// ```
-fn sanitize_name(name: &str) -> String {
-    // Directly transliterate without special casing single letters
-    // This prevents collisions between single letters and their full names
-    // e.g. "σ" (sigma) vs "σίγμα" (sigma)
-    transliterate(name)
-}
-
-/// Transliterate Greek to Latin characters
-fn transliterate(greek: &str) -> String {
-    let mut result = String::new();
-
-    for c in greek.chars() {
-        let trans = match c {
-            'α' => "a",
-            'β' => "b",
-            'γ' => "g",
-            'δ' => "d",
-            'ε' => "e",
-            'ζ' => "z",
-            'η' => "h", // Distinct from 'e' (epsilon)
-            'ι' => "i",
-            'κ' => "k",
-            'λ' => "l",
-            'μ' => "m",
-            'ν' => "n",
-            'ξ' => "x",
-            'ο' => "o",
-            'π' => "p",
-            'ρ' => "r",
-            'σ' | 'ς' => "s",
-            'τ' => "t",
-            'υ' => "u",
-            'ω' => "w", // Distinct from 'o' (omicron)
-            // Digraphs and other characters are hex-encoded to prevent collisions
-            // θ, φ, χ, ψ map to _u..._ because th, ph, ch, ps collide with sequences
-            _ => {
-                // Keep only ASCII alphanumeric characters and underscore
-                if c.is_ascii_alphanumeric() || c == '_' {
-                    result.push(c);
-                } else {
-                    // Replace invalid characters with unique hex code to prevent collisions
-                    // e.g. ϟ -> _u3df_
-                    use std::fmt::Write;
-                    write!(result, "_u{:x}_", c as u32).unwrap();
-                }
-                continue;
-            }
-        };
-        result.push_str(trans);
-    }
-
-    // Ensure it starts with a letter or underscore (valid Rust identifier)
-    if result.is_empty() {
-        return "_var_empty".to_string();
-    }
-
-    if result
-        .chars()
-        .next()
-        .map(|c| c.is_numeric())
-        .unwrap_or(false)
-    {
-        format!("_{}", result)
-    } else {
-        result
-    }
-}
-
-/// Helper to get Rust type string, working around GlossaType::to_rust issues
-fn type_to_rust_string(ty: &GlossaType) -> String {
-    match ty {
-        GlossaType::Struct { name, .. } => capitalize(&sanitize_name(name)),
-        _ => ty.to_rust(),
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -1091,48 +989,6 @@ mod tests {
         assert!(code.contains("42"));
     }
 
-    #[test]
-    fn test_sanitize_greek_letter() {
-        assert_eq!(sanitize_name("ξ"), "x");
-        assert_eq!(sanitize_name("α"), "a");
-        assert_eq!(sanitize_name("ω"), "w");
-    }
-
-    #[test]
-    fn test_transliterate() {
-        // χ (chi) -> hex, ρ -> r, η -> h, σ -> s, τ -> t, ο -> o, ς -> s
-        // χ is 0x3c7
-        assert_eq!(transliterate("χρηστος"), "_u3c7_rhstos");
-        assert_eq!(transliterate("λογος"), "logos");
-        // φ (phi) -> hex
-        // φ is 0x3c6
-        assert_eq!(transliterate("φιλοσοφια"), "_u3c6_iloso_u3c6_ia");
-    }
-
-    #[test]
-    fn test_transliterate_unique() {
-        // Test that different invalid characters produce different outputs
-        let koppa = "ϟ";
-        let stigma = "ϛ";
-
-        let t_koppa = transliterate(koppa);
-        let t_stigma = transliterate(stigma);
-
-        assert_ne!(
-            t_koppa, t_stigma,
-            "Different invalid chars should not collide"
-        );
-        assert!(t_koppa.contains("_u3df_")); // Koppa is 0x3DF
-        assert!(t_stigma.contains("_u3db_")); // Stigma is 0x3DB
-    }
-
-    #[test]
-    fn test_transliterate_mixed_valid_invalid() {
-        // Test mixing valid and invalid characters
-        let input = "αϟβ";
-        let output = transliterate(input);
-        assert_eq!(output, "a_u3df_b");
-    }
 
     #[test]
     fn test_generate_full_program() {

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -47,9 +47,9 @@
 //! }
 //! ```
 
-use crate::morphology::lexicon::{BinaryOp, UnaryOp};
 use crate::codegen::types::to_rust_type;
 use crate::codegen::utils::{capitalize, sanitize_name};
+use crate::morphology::lexicon::{BinaryOp, UnaryOp};
 use crate::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedIteratorOp, AnalyzedMethod, AnalyzedProgram,
     AnalyzedStatement, GlossaType, StatementKind,
@@ -954,7 +954,6 @@ fn is_self_parameter(param_name: &str, idx: usize) -> bool {
         || param_name.contains("self")
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -988,7 +987,6 @@ mod tests {
         assert!(code.contains("println"), "Expected println in: {}", code);
         assert!(code.contains("42"));
     }
-
 
     #[test]
     fn test_generate_full_program() {

--- a/src/codegen/types.rs
+++ b/src/codegen/types.rs
@@ -1,0 +1,109 @@
+//! Type generation for Rust
+//!
+//! Handles the conversion of semantic types to Rust types.
+
+use crate::codegen::utils::{capitalize, sanitize_name};
+use crate::semantic::{GlossaType, Ownership};
+
+/// Convert a Glossa type to its Rust equivalent string
+pub fn to_rust_type(ty: &GlossaType) -> String {
+    match ty {
+        GlossaType::Number => "i64".to_string(),
+        GlossaType::String => "String".to_string(),
+        GlossaType::Boolean => "bool".to_string(),
+        GlossaType::List(inner) => format!("Vec<{}>", to_rust_type(inner)),
+        GlossaType::Set(inner) => format!("HashSet<{}>", to_rust_type(inner)),
+        GlossaType::Map(key, value) => {
+            format!("HashMap<{}, {}>", to_rust_type(key), to_rust_type(value))
+        }
+        GlossaType::Option(inner) => format!("Option<{}>", to_rust_type(inner)),
+        GlossaType::Result(ok, err) => {
+            format!("Result<{}, {}>", to_rust_type(ok), to_rust_type(err))
+        }
+        GlossaType::Unit => "()".to_string(),
+        GlossaType::Struct { name, .. } => capitalize(&sanitize_name(name)),
+        // TODO: Better representation for function types if they appear in type signatures
+        GlossaType::Function { .. } => "fn".to_string(),
+        GlossaType::Unknown => "_".to_string(),
+    }
+}
+
+/// Convert ownership mode to Rust reference prefix
+pub fn to_rust_ownership(ownership: &Ownership) -> &'static str {
+    match ownership {
+        Ownership::Move => "",
+        Ownership::Borrow => "&",
+        Ownership::BorrowMut => "&mut ",
+        Ownership::Copy => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smol_str::SmolStr;
+
+    #[test]
+    fn test_basic_types() {
+        assert_eq!(to_rust_type(&GlossaType::Number), "i64");
+        assert_eq!(to_rust_type(&GlossaType::String), "String");
+        assert_eq!(to_rust_type(&GlossaType::Boolean), "bool");
+        assert_eq!(to_rust_type(&GlossaType::Unit), "()");
+        assert_eq!(to_rust_type(&GlossaType::Unknown), "_");
+    }
+
+    #[test]
+    fn test_container_types() {
+        assert_eq!(
+            to_rust_type(&GlossaType::List(Box::new(GlossaType::Number))),
+            "Vec<i64>"
+        );
+        assert_eq!(
+            to_rust_type(&GlossaType::Set(Box::new(GlossaType::String))),
+            "HashSet<String>"
+        );
+        assert_eq!(
+            to_rust_type(&GlossaType::Map(
+                Box::new(GlossaType::String),
+                Box::new(GlossaType::Number)
+            )),
+            "HashMap<String, i64>"
+        );
+        assert_eq!(
+            to_rust_type(&GlossaType::Option(Box::new(GlossaType::Number))),
+            "Option<i64>"
+        );
+        assert_eq!(
+            to_rust_type(&GlossaType::Result(
+                Box::new(GlossaType::Number),
+                Box::new(GlossaType::String)
+            )),
+            "Result<i64, String>"
+        );
+    }
+
+    #[test]
+    fn test_struct_type() {
+        // Use normalized name as per compiler convention
+        let ty = GlossaType::Struct {
+            name: SmolStr::new("χρηστης"),
+            gender: crate::morphology::Gender::Masculine,
+            fields: vec![],
+        };
+        // Sanitize: χρηστης -> _u3c7_rhsths (Chi hex encoded, Eta -> h)
+        // Capitalize: _u3c7_rhsths (underscore remains underscore? No, capitalize capitalizes first char)
+        // _u... starts with _. _ is not uppercasable.
+        // Wait, capitalize logic:
+        // match chars.next() { Some(first) => first.to_uppercase() ... }
+        // '_' to_uppercase is '_'.
+        assert_eq!(to_rust_type(&ty), "_u3c7_rhsths");
+    }
+
+    #[test]
+    fn test_ownership() {
+        assert_eq!(to_rust_ownership(&Ownership::Move), "");
+        assert_eq!(to_rust_ownership(&Ownership::Borrow), "&");
+        assert_eq!(to_rust_ownership(&Ownership::BorrowMut), "&mut ");
+        assert_eq!(to_rust_ownership(&Ownership::Copy), "");
+    }
+}

--- a/src/codegen/utils.rs
+++ b/src/codegen/utils.rs
@@ -1,0 +1,154 @@
+//! Utility functions for code generation
+
+/// Capitalize the first letter of a string (for Rust type/trait names)
+pub(crate) fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+/// Sanitize a Greek name for use as a Rust identifier
+///
+/// This function performs the critical step of converting Ancient Greek identifiers
+/// into valid ASCII Rust identifiers. It uses a combination of name mapping
+/// (for single letters like `α`) and transliteration (for words like `χρήστης`).
+///
+/// # Edge Cases
+///
+/// Characters that do not have a standard Latin mapping (like `ϟ` Koppa) are
+/// hex-encoded to ensure uniqueness and prevent collisions.
+///
+/// * `ϟ` -> `_u3df_`
+///
+/// # Examples
+///
+/// ```
+/// // These are internal functions, but here is how they behave:
+/// // sanitize_name("ξ") -> "xi"
+/// // sanitize_name("χρήστης") -> "chrestes"
+/// ```
+pub(crate) fn sanitize_name(name: &str) -> String {
+    // Directly transliterate without special casing single letters
+    // This prevents collisions between single letters and their full names
+    // e.g. "σ" (sigma) vs "σίγμα" (sigma)
+    transliterate(name)
+}
+
+/// Transliterate Greek to Latin characters
+pub(crate) fn transliterate(greek: &str) -> String {
+    let mut result = String::new();
+
+    for c in greek.chars() {
+        let trans = match c {
+            'α' => "a",
+            'β' => "b",
+            'γ' => "g",
+            'δ' => "d",
+            'ε' => "e",
+            'ζ' => "z",
+            'η' => "h", // Distinct from 'e' (epsilon)
+            'ι' => "i",
+            'κ' => "k",
+            'λ' => "l",
+            'μ' => "m",
+            'ν' => "n",
+            'ξ' => "x",
+            'ο' => "o",
+            'π' => "p",
+            'ρ' => "r",
+            'σ' | 'ς' => "s",
+            'τ' => "t",
+            'υ' => "u",
+            'ω' => "w", // Distinct from 'o' (omicron)
+            // Digraphs and other characters are hex-encoded to prevent collisions
+            // θ, φ, χ, ψ map to _u..._ because th, ph, ch, ps collide with sequences
+            _ => {
+                // Keep only ASCII alphanumeric characters and underscore
+                if c.is_ascii_alphanumeric() || c == '_' {
+                    result.push(c);
+                } else {
+                    // Replace invalid characters with unique hex code to prevent collisions
+                    // e.g. ϟ -> _u3df_
+                    use std::fmt::Write;
+                    write!(result, "_u{:x}_", c as u32).unwrap();
+                }
+                continue;
+            }
+        };
+        result.push_str(trans);
+    }
+
+    // Ensure it starts with a letter or underscore (valid Rust identifier)
+    if result.is_empty() {
+        return "_var_empty".to_string();
+    }
+
+    if result
+        .chars()
+        .next()
+        .map(|c| c.is_numeric())
+        .unwrap_or(false)
+    {
+        format!("_{}", result)
+    } else {
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_greek_letter() {
+        assert_eq!(sanitize_name("ξ"), "x");
+        assert_eq!(sanitize_name("α"), "a");
+        assert_eq!(sanitize_name("ω"), "w");
+    }
+
+    #[test]
+    fn test_transliterate() {
+        // χ (chi) -> hex, ρ -> r, η -> h, σ -> s, τ -> t, ο -> o, ς -> s
+        // χ is 0x3c7
+        assert_eq!(transliterate("χρηστος"), "_u3c7_rhstos");
+        assert_eq!(transliterate("λογος"), "logos");
+        // φ (phi) -> hex
+        // φ is 0x3c6
+        assert_eq!(transliterate("φιλοσοφια"), "_u3c6_iloso_u3c6_ia");
+    }
+
+    #[test]
+    fn test_transliterate_unique() {
+        // Test that different invalid characters produce different outputs
+        let koppa = "ϟ";
+        let stigma = "ϛ";
+
+        let t_koppa = transliterate(koppa);
+        let t_stigma = transliterate(stigma);
+
+        assert_ne!(
+            t_koppa, t_stigma,
+            "Different invalid chars should not collide"
+        );
+        assert!(t_koppa.contains("_u3df_")); // Koppa is 0x3DF
+        assert!(t_stigma.contains("_u3db_")); // Stigma is 0x3DB
+    }
+
+    #[test]
+    fn test_transliterate_mixed_valid_invalid() {
+        // Test mixing valid and invalid characters
+        let input = "αϟβ";
+        let output = transliterate(input);
+        assert_eq!(output, "a_u3df_b");
+    }
+
+    #[test]
+    fn test_capitalize() {
+        assert_eq!(capitalize("hello"), "Hello");
+        assert_eq!(capitalize("Hello"), "Hello");
+        assert_eq!(capitalize(""), "");
+        assert_eq!(capitalize("x"), "X");
+    }
+}

--- a/src/morphology/case.rs
+++ b/src/morphology/case.rs
@@ -20,7 +20,6 @@ pub enum Case {
     Vocative,
 }
 
-
 /// Grammatical number
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Number {
@@ -93,4 +92,3 @@ pub enum Voice {
     Middle,
     Passive,
 }
-

--- a/src/morphology/case.rs
+++ b/src/morphology/case.rs
@@ -20,18 +20,6 @@ pub enum Case {
     Vocative,
 }
 
-impl Case {
-    /// Convert case to its ownership/borrowing semantic
-    pub fn to_rust_ownership(&self) -> &'static str {
-        match self {
-            Case::Nominative => "", // Subject, just the value
-            Case::Genitive => "&",  // Borrow (of/from)
-            Case::Dative => "&mut", // Mutable borrow (to/for)
-            Case::Accusative => "", // Move (direct object)
-            Case::Vocative => "",   // No ownership semantic
-        }
-    }
-}
 
 /// Grammatical number
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -106,14 +94,3 @@ pub enum Voice {
     Passive,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_case_ownership() {
-        assert_eq!(Case::Genitive.to_rust_ownership(), "&");
-        assert_eq!(Case::Dative.to_rust_ownership(), "&mut");
-        assert_eq!(Case::Accusative.to_rust_ownership(), "");
-    }
-}

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -2183,8 +2183,7 @@ pub enum BinaryOp {
     Or,
 }
 
-impl BinaryOp {
-}
+impl BinaryOp {}
 
 /// Unary operator type for code generation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2193,8 +2192,7 @@ pub enum UnaryOp {
     Neg, // arithmetic negation
 }
 
-impl UnaryOp {
-}
+impl UnaryOp {}
 
 /// Check if a word is a comparison adjective and return the operator
 pub fn comparison_operator(normalized_word: &str) -> Option<BinaryOp> {

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -2184,24 +2184,6 @@ pub enum BinaryOp {
 }
 
 impl BinaryOp {
-    /// Get the Rust operator string
-    pub fn to_rust(&self) -> &'static str {
-        match self {
-            BinaryOp::Add => "+",
-            BinaryOp::Sub => "-",
-            BinaryOp::Mul => "*",
-            BinaryOp::Div => "/",
-            BinaryOp::Mod => "%",
-            BinaryOp::Eq => "==",
-            BinaryOp::Ne => "!=",
-            BinaryOp::Lt => "<",
-            BinaryOp::Le => "<=",
-            BinaryOp::Gt => ">",
-            BinaryOp::Ge => ">=",
-            BinaryOp::And => "&&",
-            BinaryOp::Or => "||",
-        }
-    }
 }
 
 /// Unary operator type for code generation
@@ -2212,13 +2194,6 @@ pub enum UnaryOp {
 }
 
 impl UnaryOp {
-    /// Get the Rust operator string
-    pub fn to_rust(&self) -> &'static str {
-        match self {
-            UnaryOp::Not => "!",
-            UnaryOp::Neg => "-",
-        }
-    }
 }
 
 /// Check if a word is a comparison adjective and return the operator
@@ -2504,14 +2479,6 @@ mod tests {
         assert_eq!(arithmetic_operator("γινομενον"), Some(BinaryOp::Mul));
         assert_eq!(arithmetic_operator("μερος"), Some(BinaryOp::Div));
         assert_eq!(arithmetic_operator("υπολοιπον"), Some(BinaryOp::Mod));
-    }
-
-    #[test]
-    fn test_operator_to_rust() {
-        assert_eq!(BinaryOp::Add.to_rust(), "+");
-        assert_eq!(BinaryOp::Gt.to_rust(), ">");
-        assert_eq!(BinaryOp::And.to_rust(), "&&");
-        assert_eq!(UnaryOp::Not.to_rust(), "!");
     }
 
     #[test]

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -138,7 +138,6 @@ impl Ownership {
             _ => Ownership::Copy,
         }
     }
-
 }
 
 /// Infer type from a Greek word (by looking at lexicon or morphology)

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -79,26 +79,6 @@ pub enum GlossaType {
 }
 
 impl GlossaType {
-    /// Get the Rust equivalent type
-    pub fn to_rust(&self) -> String {
-        match self {
-            GlossaType::Number => "i64".to_string(),
-            GlossaType::String => "String".to_string(),
-            GlossaType::Boolean => "bool".to_string(),
-            GlossaType::List(inner) => format!("Vec<{}>", inner.to_rust()),
-            GlossaType::Set(inner) => format!("HashSet<{}>", inner.to_rust()),
-            GlossaType::Map(key, value) => {
-                format!("HashMap<{}, {}>", key.to_rust(), value.to_rust())
-            }
-            GlossaType::Option(inner) => format!("Option<{}>", inner.to_rust()),
-            GlossaType::Result(ok, err) => format!("Result<{}, {}>", ok.to_rust(), err.to_rust()),
-            GlossaType::Unit => "()".to_string(),
-            GlossaType::Struct { .. } => "struct".to_string(),
-            GlossaType::Function { .. } => "fn".to_string(),
-            GlossaType::Unknown => "_".to_string(),
-        }
-    }
-
     /// Get the Greek name for this type
     pub fn to_greek(&self) -> &'static str {
         match self {
@@ -159,15 +139,6 @@ impl Ownership {
         }
     }
 
-    /// Get the Rust reference prefix
-    pub fn to_rust_prefix(&self) -> &'static str {
-        match self {
-            Ownership::Move => "",
-            Ownership::Borrow => "&",
-            Ownership::BorrowMut => "&mut ",
-            Ownership::Copy => "",
-        }
-    }
 }
 
 /// Infer type from a Greek word (by looking at lexicon or morphology)
@@ -210,13 +181,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_type_to_rust() {
-        assert_eq!(GlossaType::Number.to_rust(), "i64".to_string());
-        assert_eq!(GlossaType::String.to_rust(), "String".to_string());
-        assert_eq!(GlossaType::Boolean.to_rust(), "bool".to_string());
-    }
-
-    #[test]
     fn test_type_to_greek() {
         assert_eq!(GlossaType::Number.to_greek(), "ἀριθμός");
         assert_eq!(GlossaType::String.to_greek(), "ὄνομα");
@@ -227,13 +191,6 @@ mod tests {
         assert_eq!(Ownership::from_case(Case::Genitive), Ownership::Borrow);
         assert_eq!(Ownership::from_case(Case::Dative), Ownership::BorrowMut);
         assert_eq!(Ownership::from_case(Case::Accusative), Ownership::Move);
-    }
-
-    #[test]
-    fn test_ownership_prefix() {
-        assert_eq!(Ownership::Borrow.to_rust_prefix(), "&");
-        assert_eq!(Ownership::BorrowMut.to_rust_prefix(), "&mut ");
-        assert_eq!(Ownership::Move.to_rust_prefix(), "");
     }
 
     #[test]

--- a/tests/option_result_tests.rs
+++ b/tests/option_result_tests.rs
@@ -6,6 +6,7 @@
 /// - τί (ti) → Some
 /// - ἐπιτυχία (epitychia) → Ok
 /// - σφάλμα (sphalma) → Err
+use glossa::codegen::types::to_rust_type;
 use glossa::semantic::GlossaType;
 
 /// Helper to compile GLOSSA source to Rust code
@@ -38,13 +39,13 @@ fn test_result_type_exists() {
 #[test]
 fn test_option_to_rust() {
     let opt = GlossaType::Option(Box::new(GlossaType::Number));
-    assert_eq!(opt.to_rust(), "Option<i64>");
+    assert_eq!(to_rust_type(&opt), "Option<i64>");
 }
 
 #[test]
 fn test_result_to_rust() {
     let result = GlossaType::Result(Box::new(GlossaType::Number), Box::new(GlossaType::String));
-    assert_eq!(result.to_rust(), "Result<i64, String>");
+    assert_eq!(to_rust_type(&result), "Result<i64, String>");
 }
 
 #[test]
@@ -64,7 +65,7 @@ fn test_result_type_compatibility() {
 #[test]
 fn test_nested_option() {
     let nested = GlossaType::Option(Box::new(GlossaType::Option(Box::new(GlossaType::Number))));
-    assert_eq!(nested.to_rust(), "Option<Option<i64>>");
+    assert_eq!(to_rust_type(&nested), "Option<Option<i64>>");
 }
 
 // ============================================================================


### PR DESCRIPTION
🗺️ Atlas: Decoupling Domain from Code Generation

🕸️ Tangle: Domain entities (`GlossaType`, `Case`, `BinaryOp`, `UnaryOp`) had `to_rust()` methods, leaking code generation details into the domain model. This coupled the core logic to the specific target language (Rust) and created potential circular dependencies.

📐 Blueprint:
1.  Extracted code generation utilities (`sanitize_name`, `capitalize`) to `src/codegen/utils.rs`.
2.  Created `src/codegen/types.rs` to centralize type conversion logic (`to_rust_type`, `to_rust_ownership`).
3.  Updated `src/codegen/rust.rs` to use these new modules instead of calling methods on domain objects.
4.  Removed `to_rust()` methods from `GlossaType` (semantic), `BinaryOp`/`UnaryOp` (lexicon), and `Case` (morphology).

🧱 Stability:
-   Zero runtime behavior changes.
-   Code generation logic is now fully contained within the `codegen` module.
-   Domain modules (`semantic`, `morphology`) are now pure and target-agnostic.

🔬 Verification:
-   `cargo check` passes.
-   `cargo test` passes (236 tests).
-   `cargo clippy` passes.

---
*PR created automatically by Jules for task [7213054161699614979](https://jules.google.com/task/7213054161699614979) started by @madmax983*