### PR TITLE
Refactor semantic analysis dispatch and fix scoping

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -42,3 +42,13 @@
 **Bloat:** `AnalyzedTraitMethod` and `AnalyzedImplMethod` in `src/semantic/model.rs`.
 **Cut:** Merged into a unified `AnalyzedMethod` struct. Removed redundant `is_default` field.
 **Saved:** Reduced code duplication in semantic model and codegen (~60 lines removed/simplified). Unified method representation.
+
+## [Reduction]
+**Bloat:** Duplicated "statement dispatch" logic in `analyze_program`, `analyze_trait_definition`, `analyze_trait_impl`, and `parse_function_definition`.
+**Cut:** Centralized in `analyze_statement` helper in `src/semantic/mod.rs`.
+**Saved:** Removed duplicate `if/else` chains (~40 lines). Enabled consistent block (`{...}`) support across all contexts.
+
+## [Fix]
+**Issue:** `parse_function_definition` used `Scope::new()` which created a detached scope, preventing access to global types/traits.
+**Fix:** Switched to `scope.enter_scope()`.
+**Saved:** Fixed bug where functions couldn't see global definitions. Corrected scope inheritance.

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -4,7 +4,7 @@
 
 use super::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, StatementKind,
-    assemble_statement, convert_assembled_to_analyzed,
+    analyze_statement,
 };
 use crate::ast::{Clause, Expr, Statement};
 use crate::errors::GlossaError;
@@ -13,6 +13,7 @@ use crate::text::normalize_greek;
 // Circular dependencies handled by crate structure
 use super::declarations::parse_function_definition;
 use super::expressions::{contains_function_definition_verb, get_first_word};
+use super::{assemble_statement, convert_assembled_to_analyzed};
 
 /// Check if a statement is a control flow construct and analyze it
 /// Returns Some(AnalyzedStatement) if it's control flow, None otherwise
@@ -112,17 +113,13 @@ fn parse_while_loop(
         is_propagate: false,
     };
 
-    let body_analyzed = if let Some(cf) = analyze_control_flow(&body_stmt, scope)? {
-        cf
-    } else {
-        let assembled = assemble_statement(&body_stmt)?;
-        convert_assembled_to_analyzed(&assembled, scope)?
-    };
+    // Analyze body using unified helper
+    let body_analyzed = analyze_statement(&body_stmt, scope)?;
 
     Ok(Some(AnalyzedStatement {
         kind: StatementKind::While {
             condition: Box::new(condition_expr),
-            body: vec![body_analyzed],
+            body: body_analyzed,
         },
         expressions: vec![],
     }))
@@ -141,8 +138,6 @@ fn parse_for_range_loop(
     }
 
     // Parse range specification from first clause
-    // Pattern: ἀπὸ start μέχρι/ἕως end
-    // Structure in clause.expressions[0].Phrase: [ἀπὸ, start, μέχρι/ἕως, end]
     let range_clause = &stmt.clauses()[0];
 
     if range_clause.expressions.is_empty() {
@@ -225,7 +220,6 @@ fn parse_for_range_loop(
     };
 
     // Parse body - all remaining clauses form the body
-    // Body might be a single clause or multiple clauses (e.g., if statement)
     let body_clauses = &stmt.clauses()[1..];
 
     if body_clauses.is_empty() {
@@ -249,32 +243,25 @@ fn parse_for_range_loop(
         "i".into()
     };
 
-    // Parse body as a multi-clause statement (handles if/else/etc)
     let body_stmt = Statement::Regular {
         clauses: body_clauses.to_vec(),
         is_query: false,
         is_propagate: false,
     };
 
-    // Add loop variable to scope temporarily while parsing body
-    scope.define(variable.clone(), GlossaType::Number);
+    // Use a scope guard to ensure the loop variable is removed after parsing
+    let body_analyzed = {
+        let mut loop_scope = scope.enter_scope();
+        loop_scope.define(variable.clone(), GlossaType::Number);
 
-    // Check if body is control flow, otherwise parse as regular statement
-    let body_analyzed = if let Some(cf) = analyze_control_flow(&body_stmt, scope)? {
-        cf
-    } else {
-        let assembled = assemble_statement(&body_stmt)?;
-        convert_assembled_to_analyzed(&assembled, scope)?
+        analyze_statement(&body_stmt, &mut loop_scope)?
     };
-
-    // Note: We don't remove the variable from scope since Scope doesn't support that
-    // In a real implementation, we'd use nested scopes
 
     Ok(Some(AnalyzedStatement {
         kind: StatementKind::For {
             variable,
             iterator: Box::new(iterator),
-            body: vec![body_analyzed],
+            body: body_analyzed,
         },
         expressions: vec![],
     }))
@@ -294,7 +281,6 @@ fn parse_for_iteration_loop(
     }
 
     // Extract collection name from first clause (διὰ + genitive noun)
-    // Pattern: διὰ στοιχείων -> extract "στοιχείων" as collection variable
     let collection_clause = &stmt.clauses()[0];
 
     if collection_clause.expressions.is_empty() {
@@ -316,7 +302,6 @@ fn parse_for_iteration_loop(
     };
 
     // Create a variable expression for the collection
-    // TODO: Look up the collection in scope to get its actual type
     let collection_type = scope
         .lookup(&collection_name)
         .cloned()
@@ -346,29 +331,26 @@ fn parse_for_iteration_loop(
         "x".into()
     };
 
-    // Parse body as multi-clause statement
     let body_stmt = Statement::Regular {
         clauses: body_clauses.to_vec(),
         is_query: false,
         is_propagate: false,
     };
 
-    // Add loop variable to scope temporarily
-    // TODO: Infer element type from collection type
-    scope.define(variable.clone(), GlossaType::String);
+    // Use scope guard for loop variable
+    let body_analyzed = {
+        let mut loop_scope = scope.enter_scope();
+        // TODO: Infer element type from collection type
+        loop_scope.define(variable.clone(), GlossaType::String);
 
-    let body_analyzed = if let Some(cf) = analyze_control_flow(&body_stmt, scope)? {
-        cf
-    } else {
-        let assembled = assemble_statement(&body_stmt)?;
-        convert_assembled_to_analyzed(&assembled, scope)?
+        analyze_statement(&body_stmt, &mut loop_scope)?
     };
 
     Ok(Some(AnalyzedStatement {
         kind: StatementKind::For {
             variable,
             iterator: Box::new(collection_expr),
-            body: vec![body_analyzed],
+            body: body_analyzed,
         },
         expressions: vec![],
     }))
@@ -401,8 +383,7 @@ fn parse_match_expression(
         if clause.expressions.len() > 1 {
             let pattern_expr = &clause.expressions[1];
 
-            // Extract pattern value (skip ᾖ subjunctive verb)
-            // Pattern is the first word(s) before ᾖ
+            // Extract pattern value
             let pattern = parse_match_pattern(pattern_expr, scope)?;
 
             // Get body from next clause, expression 0
@@ -419,9 +400,10 @@ fn parse_match_expression(
             let body_expr_clause = Clause {
                 expressions: vec![body_clause.expressions[0].clone()],
             };
-            let body_stmt = parse_clause_as_statement(&body_expr_clause, scope)?;
+            let body_stmt = parse_clause_as_mini_statement(&body_expr_clause)?;
+            let body_analyzed = analyze_statement(&body_stmt, scope)?;
 
-            arms.push((pattern, vec![body_stmt]));
+            arms.push((pattern, body_analyzed));
         }
     }
 
@@ -455,8 +437,7 @@ fn parse_return_statement(
 
     let clause = &stmt.clauses()[0];
 
-    // Try to parse return expression - for now, use a simple heuristic
-    // Full expression parsing will need a context-aware approach
+    // Try to parse return expression
     let return_expr = parse_return_expression(clause, scope)?;
 
     Ok(Some(AnalyzedStatement {
@@ -467,7 +448,7 @@ fn parse_return_statement(
     }))
 }
 
-/// Parse return expression in a simple way (avoiding assembler issues with scoped variables)
+/// Parse return expression in a simple way
 fn parse_return_expression(clause: &Clause, scope: &Scope) -> Result<AnalyzedExpr, GlossaError> {
     // For Cycle 3, we'll do simple expression parsing
     // The expression after δός could be:
@@ -544,10 +525,8 @@ fn parse_return_expression(clause: &Clause, scope: &Scope) -> Result<AnalyzedExp
 }
 
 /// Parse a match pattern expression
-/// Patterns can be: literals (μηδὲν, ἓν, δύο), or wildcard (ἄλλο)
 fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, GlossaError> {
     // Pattern is typically: value ᾖ
-    // We want to extract the value part
     if let Expr::Phrase(terms) = expr {
         if terms.is_empty() {
             return Err(GlossaError::semantic("Empty match pattern"));
@@ -559,8 +538,6 @@ fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, G
 
             // Check if it's ἄλλο (wildcard)
             if normalized == "αλλο" {
-                // Wildcard pattern - represented as a special marker
-                // We'll use a boolean literal true as a placeholder for wildcard
                 return Ok(AnalyzedExpr {
                     expr: AnalyzedExprKind::BooleanLiteral(true),
                     glossa_type: GlossaType::Boolean,
@@ -609,7 +586,6 @@ fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, G
 }
 
 /// Parse a conditional statement (εἰ/ἐάν)
-/// Structure: εἰ condition, body [, εἰ δὲ μή, else_body]
 fn parse_conditional(
     stmt: &Statement,
     scope: &mut Scope,
@@ -625,8 +601,6 @@ fn parse_conditional(
     let condition_expr = skip_first_word_and_parse(condition_clause, scope)?;
 
     // Parse then-body (second clause, first expression)
-    // Note: Clause 1 may have multiple expressions chained with middle dot (·)
-    // The first expression is the then-body, the second (if present) is the else marker
     let then_clause = &stmt.clauses()[1];
     let then_body = if then_clause.expressions.is_empty() {
         return Err(GlossaError::semantic("Empty then-body in conditional"));
@@ -635,25 +609,22 @@ fn parse_conditional(
         let first_expr_clause = Clause {
             expressions: vec![then_clause.expressions[0].clone()],
         };
-        parse_clause_as_statement(&first_expr_clause, scope)?
+        let stmt = parse_clause_as_mini_statement(&first_expr_clause)?;
+        analyze_statement(&stmt, scope)?
     };
 
     // Check for else/elif clause
-    // The second expression in clause 1 (if present) can be:
-    // 1. "εἰ δὲ μή" - else clause
-    // 2. "εἰ" - elif chain (nested if)
     let else_body = if then_clause.expressions.len() > 1 && stmt.clauses().len() >= 3 {
         let second_expr = &then_clause.expressions[1];
 
         // Check if it's "εἰ δὲ μή" (else)
         if check_else_pattern_in_expression(second_expr) {
-            Some(vec![parse_clause_as_statement(&stmt.clauses()[2], scope)?])
+            let stmt = parse_clause_as_mini_statement(&stmt.clauses()[2])?;
+            Some(analyze_statement(&stmt, scope)?)
         }
         // Check if it's "εἰ" or "ἐάν" (elif)
         else if check_conditional_start(second_expr) {
             // Build a new statement for the elif chain
-            // The elif condition is in clause 1, expression 1
-            // We need to restructure: make a new clause 0 with just that expression
             let mut elif_clauses = Vec::new();
 
             // New clause 0: just the elif condition (from clause 1, expr 1)
@@ -686,10 +657,10 @@ fn parse_conditional(
     Ok(Some(AnalyzedStatement {
         kind: StatementKind::If {
             condition: Box::new(condition_expr),
-            then_body: vec![then_body],
+            then_body,
             else_body,
         },
-        expressions: vec![], // Control flow doesn't use flat expression list
+        expressions: vec![],
     }))
 }
 
@@ -722,22 +693,6 @@ fn skip_first_word_and_parse(
     }
 }
 
-/// Parse a clause as a statement
-fn parse_clause_as_statement(
-    clause: &Clause,
-    scope: &mut Scope,
-) -> Result<AnalyzedStatement, GlossaError> {
-    let stmt = parse_clause_as_mini_statement(clause)?;
-
-    // Check if it's control flow first (break, continue, etc.)
-    if let Some(cf) = analyze_control_flow(&stmt, scope)? {
-        return Ok(cf);
-    }
-
-    let assembled = assemble_statement(&stmt)?;
-    convert_assembled_to_analyzed(&assembled, scope)
-}
-
 /// Convert a clause to a mini-statement for parsing
 fn parse_clause_as_mini_statement(clause: &Clause) -> Result<Statement, GlossaError> {
     Ok(Statement::Regular {
@@ -748,7 +703,6 @@ fn parse_clause_as_mini_statement(clause: &Clause) -> Result<Statement, GlossaEr
 }
 
 /// Check if a clause starts with "εἰ δὲ μή" (else pattern)
-/// Check if an expression matches "εἰ δὲ μή" (else pattern)
 fn check_else_pattern_in_expression(expr: &Expr) -> bool {
     // Extract first 3 words from the expression
     let words: Vec<String> = if let Expr::Phrase(terms) = expr {

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -1,8 +1,7 @@
 //! Declaration analysis (functions, types, traits)
 
 use super::{
-    AnalyzedMethod, AnalyzedStatement, GlossaType, Scope, StatementKind, assemble_statement,
-    convert_assembled_to_analyzed,
+    AnalyzedMethod, AnalyzedStatement, GlossaType, Scope, StatementKind, analyze_statement,
 };
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
@@ -10,8 +9,6 @@ use crate::morphology;
 use crate::text::normalize_greek;
 use smol_str::SmolStr;
 // Circular dependencies handled by crate structure
-use super::control_flow::analyze_control_flow;
-use super::patterns::{try_parse_struct_instantiation, try_parse_trait_method_call};
 
 /// Analyze a type definition statement
 pub fn analyze_type_definition(
@@ -93,23 +90,9 @@ pub fn analyze_trait_definition(
                     for (param_name, param_type) in &params {
                         scope.define(param_name.clone(), param_type.clone());
                     }
-                    // Properly analyze statements in the body
+                    // Properly analyze statements in the body using unified helper
                     for body_stmt in body_stmts {
-                        if let Some(control_flow) = analyze_control_flow(body_stmt, &mut scope)? {
-                            analyzed_body.push(control_flow);
-                        } else if let Some(struct_inst) =
-                            try_parse_struct_instantiation(body_stmt, &mut scope)?
-                        {
-                            analyzed_body.push(struct_inst);
-                        } else if let Some(method_call) =
-                            try_parse_trait_method_call(body_stmt, &mut scope)?
-                        {
-                            analyzed_body.push(method_call);
-                        } else {
-                            let assembled = assemble_statement(body_stmt)?;
-                            let analyzed = convert_assembled_to_analyzed(&assembled, &mut scope)?;
-                            analyzed_body.push(analyzed);
-                        }
+                        analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
                     }
                 }
                 Some(analyzed_body)
@@ -204,29 +187,9 @@ pub fn analyze_trait_impl(
                 scope.define(param_name.clone(), param_type.clone());
             }
 
-            // Analyze the method body
+            // Analyze the method body using unified helper
             for body_stmt in &method.body {
-                // Try control flow first
-                if let Some(control_flow) = analyze_control_flow(body_stmt, &mut scope)? {
-                    analyzed_body.push(control_flow);
-                }
-                // Try struct instantiation pattern
-                else if let Some(struct_inst) =
-                    try_parse_struct_instantiation(body_stmt, &mut scope)?
-                {
-                    analyzed_body.push(struct_inst);
-                }
-                // Try trait method call pattern
-                else if let Some(method_call) =
-                    try_parse_trait_method_call(body_stmt, &mut scope)?
-                {
-                    analyzed_body.push(method_call);
-                } else {
-                    // Use assembler for regular statements
-                    let assembled = assemble_statement(body_stmt)?;
-                    let analyzed = convert_assembled_to_analyzed(&assembled, &mut scope)?;
-                    analyzed_body.push(analyzed);
-                }
+                analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
             }
         }
 
@@ -293,7 +256,7 @@ pub fn map_genitive_to_type(genitive_name: &str, scope: &Scope) -> GlossaType {
 /// Parse a function definition: name ὁρίζειν [params]· body
 pub fn parse_function_definition(
     stmt: &Statement,
-    _scope: &mut Scope,
+    scope: &mut Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     // The middle dot (·) separates expressions within a clause
     // Structure: expr1 · expr2 where expr1 is "name ὁρίζειν [params]" and expr2 is the body
@@ -319,37 +282,33 @@ pub fn parse_function_definition(
     // Extract parameters (dative words) from the header
     let params = extract_parameters_from_expr(header_expr)?;
 
-    // Create a new scope for the function body and add parameters to it
-    let mut function_scope = Scope::new();
-    for (param_name, param_type) in &params {
-        let glossa_type = param_type.clone().unwrap_or(GlossaType::Unknown);
-        function_scope.define(param_name.clone(), glossa_type);
-    }
-
-    // Parse body (remaining expressions after middle dot)
-    let body_exprs = &clause.expressions[1..];
+    // Use enter_scope() to create a child scope that inherits types/traits
     let mut body_statements = Vec::new();
+    {
+        let mut function_scope = scope.enter_scope();
+        for (param_name, param_type) in &params {
+            let glossa_type = param_type.clone().unwrap_or(GlossaType::Unknown);
+            function_scope.define(param_name.clone(), glossa_type);
+        }
 
-    // Each expression in the body becomes a statement
-    for expr in body_exprs {
-        // Create a clause with this single expression
-        let body_clause = crate::ast::Clause {
-            expressions: vec![expr.clone()],
-        };
+        // Parse body (remaining expressions after middle dot)
+        let body_exprs = &clause.expressions[1..];
 
-        let clause_stmt = Statement::Regular {
-            clauses: vec![body_clause],
-            is_query: false,
-            is_propagate: false,
-        };
+        // Each expression in the body becomes a statement
+        for expr in body_exprs {
+            // Create a clause with this single expression
+            let body_clause = crate::ast::Clause {
+                expressions: vec![expr.clone()],
+            };
 
-        // Analyze each body expression as a statement with the function scope
-        if let Some(cf) = analyze_control_flow(&clause_stmt, &mut function_scope)? {
-            body_statements.push(cf);
-        } else {
-            let assembled = assemble_statement(&clause_stmt)?;
-            let analyzed = convert_assembled_to_analyzed(&assembled, &mut function_scope)?;
-            body_statements.push(analyzed);
+            let clause_stmt = Statement::Regular {
+                clauses: vec![body_clause],
+                is_query: false,
+                is_propagate: false,
+            };
+
+            // Analyze each body expression using unified helper
+            body_statements.extend(analyze_statement(&clause_stmt, &mut function_scope)?);
         }
     }
 
@@ -513,28 +472,7 @@ pub fn analyze_test_declaration(
         let mut test_scope = scope.enter_scope();
 
         for body_stmt in &test_decl.body {
-            // Handle control flow
-            if let Some(control_flow) = analyze_control_flow(body_stmt, &mut test_scope)? {
-                analyzed_body.push(control_flow);
-            }
-            // Handle struct instantiation
-            else if let Some(struct_inst) =
-                try_parse_struct_instantiation(body_stmt, &mut test_scope)?
-            {
-                analyzed_body.push(struct_inst);
-            }
-            // Handle trait method calls
-            else if let Some(method_call) =
-                try_parse_trait_method_call(body_stmt, &mut test_scope)?
-            {
-                analyzed_body.push(method_call);
-            }
-            // Regular statement analysis
-            else {
-                let assembled = assemble_statement(body_stmt)?;
-                let analyzed = convert_assembled_to_analyzed(&assembled, &mut test_scope)?;
-                analyzed_body.push(analyzed);
-            }
+             analyzed_body.extend(analyze_statement(body_stmt, &mut test_scope)?);
         }
     }
 

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -472,7 +472,7 @@ pub fn analyze_test_declaration(
         let mut test_scope = scope.enter_scope();
 
         for body_stmt in &test_decl.body {
-             analyzed_body.extend(analyze_statement(body_stmt, &mut test_scope)?);
+            analyzed_body.extend(analyze_statement(body_stmt, &mut test_scope)?);
         }
     }
 

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -50,7 +50,7 @@ pub use model::*;
 pub use resolver::*;
 pub use types::*;
 
-use crate::ast::{Program, Statement};
+use crate::ast::{Expr, Program, Statement};
 use crate::errors::GlossaError;
 
 use self::control_flow::analyze_control_flow;
@@ -92,46 +92,79 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
             continue;
         }
 
-        // Check if this is a control flow construct
-        if let Some(control_flow_stmt) = analyze_control_flow(stmt, &mut scope)? {
-            // If it's a function definition, register it in the scope
-            if let StatementKind::FunctionDef {
-                name,
-                params,
-                return_type,
-                ..
-            } = &control_flow_stmt.kind
-            {
-                let param_types: Vec<GlossaType> = params
-                    .iter()
-                    .map(|(_, ty)| ty.clone().unwrap_or(GlossaType::Unknown))
-                    .collect();
-                scope.define_function(name.clone(), param_types, return_type.clone());
-            }
-            analyzed_statements.push(control_flow_stmt);
-        } else {
-            // Check for struct instantiation pattern BEFORE assembler
-            // Pattern: var_name νέον TypeName args... ἔστω
-            if let Some(struct_inst) = try_parse_struct_instantiation(stmt, &mut scope)? {
-                analyzed_statements.push(struct_inst);
-            }
-            // Check for trait method call pattern BEFORE assembler
-            // Pattern: method_name receiver
-            else if let Some(method_call) = try_parse_trait_method_call(stmt, &mut scope)? {
-                analyzed_statements.push(method_call);
-            } else {
-                // Use the assembler-based approach for regular statements
-                let assembled = assemble_statement(stmt)?;
-                let analyzed = convert_assembled_to_analyzed(&assembled, &mut scope)?;
-                analyzed_statements.push(analyzed);
-            }
-        }
+        // Use the unified analyze_statement helper for all other statements
+        analyzed_statements.extend(analyze_statement(stmt, &mut scope)?);
     }
 
     Ok(AnalyzedProgram {
         statements: analyzed_statements,
         scope,
     })
+}
+
+/// Analyze a single statement (which might produce multiple analyzed statements if it's a block)
+pub fn analyze_statement(
+    stmt: &Statement,
+    scope: &mut Scope,
+) -> Result<Vec<AnalyzedStatement>, GlossaError> {
+    // Check for control flow (if, while, etc.)
+    if let Some(control_flow) = analyze_control_flow(stmt, scope)? {
+        // If it's a function definition, register it in the scope
+        if let StatementKind::FunctionDef {
+            name,
+            params,
+            return_type,
+            ..
+        } = &control_flow.kind
+        {
+            let param_types: Vec<GlossaType> = params
+                .iter()
+                .map(|(_, ty)| ty.clone().unwrap_or(GlossaType::Unknown))
+                .collect();
+            scope.define_function(name.clone(), param_types, return_type.clone());
+        }
+
+        return Ok(vec![control_flow]);
+    }
+
+    // Check for struct instantiation pattern
+    if let Some(struct_inst) = try_parse_struct_instantiation(stmt, scope)? {
+        return Ok(vec![struct_inst]);
+    }
+
+    // Check for trait method call pattern
+    if let Some(method_call) = try_parse_trait_method_call(stmt, scope)? {
+        return Ok(vec![method_call]);
+    }
+
+    // Check if it's a block statement (regular statement containing a single block expression)
+    if let Some(block_stmts) = extract_block_statements(stmt) {
+        let mut analyzed = Vec::new();
+        // Create a child scope for the block
+        // This ensures variables defined inside the block don't leak out
+        let mut block_scope = scope.enter_scope();
+        for s in block_stmts {
+            analyzed.extend(analyze_statement(s, &mut block_scope)?);
+        }
+        return Ok(analyzed);
+    }
+
+    // Use the assembler-based approach for regular statements
+    let assembled = assemble_statement(stmt)?;
+    let analyzed = convert_assembled_to_analyzed(&assembled, scope)?;
+    Ok(vec![analyzed])
+}
+
+fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
+    if let Statement::Regular { clauses, .. } = stmt
+        && clauses.len() == 1
+        && clauses[0].expressions.len() == 1
+        && let Expr::Block(stmts) = &clauses[0].expressions[0]
+    {
+        Some(stmts)
+    } else {
+        None
+    }
 }
 
 /// Analyze a single statement using the slot-based assembler

--- a/tests/control_flow_tests.rs
+++ b/tests/control_flow_tests.rs
@@ -267,3 +267,20 @@ fn test_lexicon_match_particle() {
         "κατά should be match particle"
     );
 }
+
+#[test]
+fn test_block_in_while_loop() {
+    // Regression test for multi-statement blocks in loops
+    let source = "
+    κ μετά 0 ἔστω.
+    ἕως κ 10 μεῖον ᾖ, {
+        κ 1 1 ἄθροισμα γίγνεται.
+        κ λέγε.
+    }.";
+    let output = compile_to_rust(source);
+
+    assert!(output.contains("while"), "Expected while loop");
+    // Ensure body contains both statements
+    assert!(output.contains("println"), "Expected print in loop body");
+    assert!(output.contains("+"), "Expected addition in loop body");
+}


### PR DESCRIPTION
This PR simplifies the semantic analysis logic by consolidating the dispatch mechanism for statements into a single `analyze_statement` function. This removes duplicated `if-else` chains across the codebase and enables consistent handling of statement blocks in control flow constructs.

Additionally, it fixes a bug where function definitions and loops were not correctly inheriting or managing scope, preventing access to global types or leaking loop variables.

**Changes:**
- `src/semantic/mod.rs`: Added `analyze_statement` helper.
- `src/semantic/control_flow.rs`: Refactored to use `analyze_statement` and proper scoping.
- `src/semantic/declarations.rs`: Refactored to use `analyze_statement` and proper scoping.
- `tests/control_flow_tests.rs`: Added regression test for blocks in loops.


---
*PR created automatically by Jules for task [4146129680318578394](https://jules.google.com/task/4146129680318578394) started by @madmax983*