### PR TITLE
Fix Assembler DoS via nested phrases

### DIFF
--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -588,7 +588,10 @@ impl Assembler {
     /// let mut asm = Assembler::new();
     /// asm.feed_block(vec![]).unwrap(); // Empty block
     /// ```
-    pub fn feed_block(&mut self, statements: Vec<crate::ast::Statement>) -> Result<(), AssemblyError> {
+    pub fn feed_block(
+        &mut self,
+        statements: Vec<crate::ast::Statement>,
+    ) -> Result<(), AssemblyError> {
         self.check_token_limit()?;
         self.pending_blocks.push(statements);
         Ok(())

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -476,14 +476,7 @@ impl Assembler {
     /// asm.feed(&obj, "λόγον").unwrap();
     /// ```
     pub fn feed(&mut self, analysis: &MorphAnalysis, original: &str) -> Result<(), AssemblyError> {
-        // Enforce token limit
-        self.token_count += 1;
-        if self.token_count > MAX_TOKENS {
-            return Err(AssemblyError::StatementTooLong {
-                count: self.token_count,
-                limit: MAX_TOKENS,
-            });
-        }
+        self.check_token_limit()?;
 
         let normalized = normalize_greek(original);
 
@@ -527,10 +520,12 @@ impl Assembler {
     /// use glossa::semantic::Assembler;
     ///
     /// let mut asm = Assembler::new();
-    /// asm.feed_string("χαῖρε".to_string());
+    /// asm.feed_string("χαῖρε".to_string()).unwrap();
     /// ```
-    pub fn feed_string(&mut self, value: String) {
+    pub fn feed_string(&mut self, value: String) -> Result<(), AssemblyError> {
+        self.check_token_limit()?;
         self.pending_literals.push(Literal::String(value));
+        Ok(())
     }
 
     /// Feed a number literal
@@ -541,10 +536,12 @@ impl Assembler {
     /// use glossa::semantic::Assembler;
     ///
     /// let mut asm = Assembler::new();
-    /// asm.feed_number(42);
+    /// asm.feed_number(42).unwrap();
     /// ```
-    pub fn feed_number(&mut self, value: i64) {
+    pub fn feed_number(&mut self, value: i64) -> Result<(), AssemblyError> {
+        self.check_token_limit()?;
         self.pending_literals.push(Literal::Number(value));
+        Ok(())
     }
 
     /// Feed a boolean literal
@@ -555,10 +552,12 @@ impl Assembler {
     /// use glossa::semantic::Assembler;
     ///
     /// let mut asm = Assembler::new();
-    /// asm.feed_boolean(true);
+    /// asm.feed_boolean(true).unwrap();
     /// ```
-    pub fn feed_boolean(&mut self, value: bool) {
+    pub fn feed_boolean(&mut self, value: bool) -> Result<(), AssemblyError> {
+        self.check_token_limit()?;
         self.pending_literals.push(Literal::Boolean(value));
+        Ok(())
     }
 
     /// Feed an array literal
@@ -571,10 +570,12 @@ impl Assembler {
     ///
     /// let mut asm = Assembler::new();
     /// let elements = vec![Expr::NumberLiteral(1), Expr::NumberLiteral(2)];
-    /// asm.feed_array(elements);
+    /// asm.feed_array(elements).unwrap();
     /// ```
-    pub fn feed_array(&mut self, elements: Vec<Expr>) {
+    pub fn feed_array(&mut self, elements: Vec<Expr>) -> Result<(), AssemblyError> {
+        self.check_token_limit()?;
         self.pending_arrays.push(elements);
+        Ok(())
     }
 
     /// Feed a parenthesized block (nested expression)
@@ -585,10 +586,12 @@ impl Assembler {
     /// use glossa::semantic::Assembler;
     ///
     /// let mut asm = Assembler::new();
-    /// asm.feed_block(vec![]); // Empty block
+    /// asm.feed_block(vec![]).unwrap(); // Empty block
     /// ```
-    pub fn feed_block(&mut self, statements: Vec<crate::ast::Statement>) {
+    pub fn feed_block(&mut self, statements: Vec<crate::ast::Statement>) -> Result<(), AssemblyError> {
+        self.check_token_limit()?;
         self.pending_blocks.push(statements);
+        Ok(())
     }
 
     /// Feed a nested phrase (parenthesized function call)
@@ -600,10 +603,12 @@ impl Assembler {
     /// use glossa::ast::Expr;
     ///
     /// let mut asm = Assembler::new();
-    /// asm.feed_nested_phrase(vec![Expr::NumberLiteral(1)]);
+    /// asm.feed_nested_phrase(vec![Expr::NumberLiteral(1)]).unwrap();
     /// ```
-    pub fn feed_nested_phrase(&mut self, terms: Vec<Expr>) {
+    pub fn feed_nested_phrase(&mut self, terms: Vec<Expr>) -> Result<(), AssemblyError> {
+        self.check_token_limit()?;
         self.pending_nested_phrases.push(terms);
+        Ok(())
     }
 
     /// Feed an index access (`array[index]`)
@@ -620,10 +625,12 @@ impl Assembler {
     ///     normalized: "πιναξ".into(),
     /// });
     /// let index = Expr::NumberLiteral(0);
-    /// asm.feed_index_access(array, index);
+    /// asm.feed_index_access(array, index).unwrap();
     /// ```
-    pub fn feed_index_access(&mut self, array: Expr, index: Expr) {
+    pub fn feed_index_access(&mut self, array: Expr, index: Expr) -> Result<(), AssemblyError> {
+        self.check_token_limit()?;
         self.pending_index_accesses.push((array, index));
+        Ok(())
     }
 
     /// Feed an unwrap expression (expr!)
@@ -639,10 +646,12 @@ impl Assembler {
     ///     original: "τιμή".into(),
     ///     normalized: "τιμη".into(),
     /// });
-    /// asm.feed_unwrap(expr);
+    /// asm.feed_unwrap(expr).unwrap();
     /// ```
-    pub fn feed_unwrap(&mut self, expr: Expr) {
+    pub fn feed_unwrap(&mut self, expr: Expr) -> Result<(), AssemblyError> {
+        self.check_token_limit()?;
         self.pending_unwraps.push(expr);
+        Ok(())
     }
 
     /// Feed a participle (for lambda construction)
@@ -663,13 +672,14 @@ impl Assembler {
     ///     number: Number::Plural,
     ///     confidence: 1.0,
     /// };
-    /// asm.feed_participle(&analysis, "διπλασιαζόμενα");
+    /// asm.feed_participle(&analysis, "διπλασιαζόμενα").unwrap();
     /// ```
     pub fn feed_participle(
         &mut self,
         analysis: &crate::morphology::ParticipleAnalysis,
         original: &str,
-    ) {
+    ) -> Result<(), AssemblyError> {
+        self.check_token_limit()?;
         let constituent = ParticipleConstituent {
             verb_lemma: analysis.verb_lemma(),
             original: original.to_string(),
@@ -680,6 +690,19 @@ impl Assembler {
             number: analysis.number,
         };
         self.pending_participles.push(constituent);
+        Ok(())
+    }
+
+    /// Check if token limit is exceeded
+    fn check_token_limit(&mut self) -> Result<(), AssemblyError> {
+        self.token_count += 1;
+        if self.token_count > MAX_TOKENS {
+            return Err(AssemblyError::StatementTooLong {
+                count: self.token_count,
+                limit: MAX_TOKENS,
+            });
+        }
+        Ok(())
     }
 
     /// Handle a noun/pronoun/adjective - route to slot by case
@@ -1098,14 +1121,14 @@ mod tests {
         let mut asm = Assembler::new();
 
         // Feed true (boolean literal - handled by parser, goes to feed_boolean)
-        asm.feed_boolean(true);
+        asm.feed_boolean(true).unwrap();
 
         // Feed ἤ (OR operator)
         let or_particle = analyze("η");
         asm.feed(&or_particle, "ἤ").unwrap();
 
         // Feed false (boolean literal)
-        asm.feed_boolean(false);
+        asm.feed_boolean(false).unwrap();
 
         // Feed λέγε (print verb)
         let verb = analyze("λεγε");
@@ -1206,7 +1229,7 @@ mod tests {
     fn test_literals() {
         let mut asm = Assembler::new();
 
-        asm.feed_string("χαῖρε κόσμε".to_string());
+        asm.feed_string("χαῖρε κόσμε".to_string()).unwrap();
 
         let verb = analyze("λεγε");
         asm.feed(&verb, "λέγε").unwrap();
@@ -1499,7 +1522,7 @@ mod tests {
         asm.feed(&marker_analysis, "κατά").unwrap();
 
         // 3. Delimiter Literal: ","
-        asm.feed_string(",".to_string());
+        asm.feed_string(",".to_string()).unwrap();
 
         // 4. Split Verb: "σχίζεται" (is split)
         let split_verb = MorphAnalysis {

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -274,13 +274,13 @@ fn feed_expr_recursive(
 
     match expr {
         Expr::StringLiteral(s) => {
-            asm.feed_string(s.clone());
+            asm.feed_string(s.clone())?;
         }
         Expr::NumberLiteral(n) => {
-            asm.feed_number(*n);
+            asm.feed_number(*n)?;
         }
         Expr::BooleanLiteral(b) => {
-            asm.feed_boolean(*b);
+            asm.feed_boolean(*b)?;
         }
         Expr::Word(w) => {
             // Check if this is an article using ORIGINAL form (preserves diacritics)
@@ -301,7 +301,7 @@ fn feed_expr_recursive(
             if !in_lexicon && !is_numeral {
                 let participle_check = morphology::analyze_participle(&w.normalized);
                 if let Some(participle_analysis) = participle_check {
-                    asm.feed_participle(&participle_analysis, &w.original);
+                    asm.feed_participle(&participle_analysis, &w.original)?;
                     return Ok(());
                 }
             }
@@ -328,7 +328,7 @@ fn feed_expr_recursive(
                     // This is a nested phrase (parenthesized expression)
                     // Store it for later analysis instead of flattening
                     if let Expr::Phrase(nested_terms) = term {
-                        asm.feed_nested_phrase(nested_terms.clone());
+                        asm.feed_nested_phrase(nested_terms.clone())?;
                     }
                 } else {
                     feed_expr_recursive(asm, term, context, depth + 1)?;
@@ -376,7 +376,7 @@ fn feed_expr_recursive(
             // Handle unwrap operator specially - it's a postfix operator that doesn't need word-order handling
             if matches!(op, crate::ast::UnaryOperator::Unwrap) {
                 // Store the unwrap expression for special handling
-                asm.feed_unwrap(operand.as_ref().clone());
+                asm.feed_unwrap(operand.as_ref().clone())?;
             } else {
                 // TODO: Implement other unary operations (Not, Neg)
                 feed_expr_recursive(asm, operand, context, depth + 1)?;
@@ -385,15 +385,15 @@ fn feed_expr_recursive(
         Expr::Block(statements) => {
             // Parenthesized expressions are stored as blocks for later analysis
             // Don't feed their contents to the main assembler - they'll be analyzed separately
-            asm.feed_block(statements.clone());
+            asm.feed_block(statements.clone())?;
         }
         Expr::ArrayLiteral(elements) => {
             // Feed array literal to assembler
-            asm.feed_array(elements.clone());
+            asm.feed_array(elements.clone())?;
         }
         Expr::IndexAccess { array, index } => {
             // Feed index access to assembler
-            asm.feed_index_access(array.as_ref().clone(), index.as_ref().clone());
+            asm.feed_index_access(array.as_ref().clone(), index.as_ref().clone())?;
         }
     }
     Ok(())

--- a/tests/havoc_assembler_bypass.rs
+++ b/tests/havoc_assembler_bypass.rs
@@ -3,7 +3,6 @@ use proptest::prelude::*;
 
 proptest! {
     #[test]
-    #[should_panic(expected = "Invariant violated")]
     fn test_bypass_token_limit_invariant(
         // Generate a vector of strings with length 1001..2000
         // This ensures we always try to exceed the limit
@@ -12,19 +11,15 @@ proptest! {
         let mut asm = Assembler::new();
 
         // Feed all strings
-        // In a correct system, this should either error or stop accepting input after 1000.
-        // But Assembler::feed_string returns (), so we can't check for error there.
+        // The Assembler should stop accepting input after limit is reached
         for s in strings {
-            asm.feed_string(s);
+            let _ = asm.feed_string(s);
         }
 
         let stmt = asm.finalize().expect("Finalize failed unexpectedly");
 
         // ASSERT INVARIANT:
         // The number of literals should not exceed the MAX_TOKENS limit (1000).
-        // Since the bug exists, this assertion will FAIL (panic).
-        // We marked the test as #[should_panic] to indicate this is a known vulnerability
-        // that we have reproduced but not yet fixed (Chaos Engineering "Red Phase").
         prop_assert!(stmt.literals.len() <= 1000,
             "Invariant violated: Assembler accepted {} literals, exceeding limit of 1000",
             stmt.literals.len());

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -29,5 +29,9 @@ fn test_dos_max_tokens_bypass() {
 
     // Verify it is indeed the token limit error
     // Error message: "Πρότασις λίαν μακρά! ({count} > {limit})"
-    assert!(err.to_string().contains("Πρότασις λίαν μακρά"), "Error should be 'Statement too long' (in Greek), got: {}", err);
+    assert!(
+        err.to_string().contains("Πρότασις λίαν μακρά"),
+        "Error should be 'Statement too long' (in Greek), got: {}",
+        err
+    );
 }

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -1,0 +1,33 @@
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_dos_max_tokens_bypass() {
+    // Generate a huge statement with nested phrases
+    // (a b) (a b) ... repeated 2000 times
+    // This creates 2000 nested phrases.
+    // MAX_TOKENS is 1000.
+
+    let mut source = String::new();
+    for _ in 0..2000 {
+        source.push_str("(α β) ");
+    }
+    source.push_str("λέγε."); // End with a verb to make it a valid statement
+
+    // Parse
+    let ast = parse(&source).expect("Parsing should succeed");
+
+    // Analyze - this should fail with StatementTooLong
+    let result = analyze_program(&ast);
+
+    if result.is_ok() {
+        panic!("DoS EXPLOIT SUCCESSFUL: Managed to feed 2000+ tokens bypassing MAX_TOKENS limit!");
+    }
+
+    let err = result.err().unwrap();
+    println!("Got error: {}", err);
+
+    // Verify it is indeed the token limit error
+    // Error message: "Πρότασις λίαν μακρά! ({count} > {limit})"
+    assert!(err.to_string().contains("Πρότασις λίαν μακρά"), "Error should be 'Statement too long' (in Greek), got: {}", err);
+}

--- a/tests/semantic_assembler_edge_cases.rs
+++ b/tests/semantic_assembler_edge_cases.rs
@@ -10,7 +10,7 @@ fn test_split_verb_consumes_literal_without_subject() {
     asm.feed(&kata, "κατά").unwrap();
 
     // 2. Feed string literal " "
-    asm.feed_string(" ".to_string());
+    asm.feed_string(" ".to_string()).unwrap();
 
     // 3. Feed "σχίζεται" (split verb)
     // This triggers check_method_verbs
@@ -130,7 +130,7 @@ fn test_length_property_not_ignored_without_subject() {
     asm.feed(&is_verb, "ἐστί").unwrap();
 
     // Feed "5"
-    asm.feed_number(5);
+    asm.feed_number(5).unwrap();
 
     let stmt = asm.finalize().unwrap();
 


### PR DESCRIPTION
The Assembler previously checked MAX_TOKENS only in the main `feed` loop but not in auxiliary methods like `feed_nested_phrase`. This allowed an attacker to bypass the limit using deeply nested phrases. This patch centralizes the check in `check_token_limit` and updates all feed methods to return `Result<(), AssemblyError>` and propagate errors.

---
*PR created automatically by Jules for task [13612352535211520021](https://jules.google.com/task/13612352535211520021) started by @madmax983*