### PR TITLE
🎨 Mosaic: UI Polish for REPL output

### DIFF
--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -200,6 +200,11 @@ pub fn generate_rust_file(program: &AnalyzedProgram) -> String {
     )
 }
 
+/// Generate Rust code for a single analyzed statement
+pub fn generate_statement_code(stmt: &AnalyzedStatement) -> String {
+    generate_statement(stmt).to_string()
+}
+
 fn generate_statement(stmt: &AnalyzedStatement) -> TokenStream {
     match &stmt.kind {
         StatementKind::Binding { name, mutable, .. } => {

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -999,4 +999,14 @@ mod tests {
         assert!(code.contains("let x = 5"), "Expected binding in: {}", code);
         assert!(code.contains("println"), "Expected println in: {}", code);
     }
+
+    #[test]
+    fn test_generate_statement_code() {
+        let ast = parse("«χαῖρε» λέγε.").unwrap();
+        let analyzed = analyze_program(&ast).unwrap();
+        let stmt = &analyzed.statements[0];
+        let code = generate_statement_code(stmt);
+        assert!(code.contains("println"));
+        assert!(code.contains("χαῖρε"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::SystemTime;
 
-use glossa::codegen::{generate_rust, generate_rust_file};
+use glossa::codegen::{generate_rust_file, generate_statement_code};
 use glossa::errors::GlossaError;
 use glossa::parser::parse;
-use glossa::semantic::{Scope, analyze_program, oracle::Oracle};
+use glossa::semantic::{GlossaType, Scope, StatementKind, analyze_program, oracle::Oracle};
 
 #[derive(Parser)]
 #[command(name = "glossa")]
@@ -318,9 +318,8 @@ fn run_repl() -> Result<()> {
 
         match context.execute(input) {
             Ok(output) => {
-                if !output.is_empty() {
-                    println!("{}", output);
-                }
+                // Display handles formatting (empty if None)
+                print!("{}", output);
             }
             Err(e) => {
                 // Use default error formatting but ensure it's visible
@@ -415,6 +414,55 @@ fn print_env(context: &ReplContext) {
     }
 }
 
+/// REPL Output variants
+#[derive(Debug)]
+pub enum ReplOutput {
+    /// A new variable binding
+    Binding {
+        name: String,
+        type_: GlossaType,
+        mutable: bool,
+    },
+    /// Code execution (compilation)
+    Statement { code: String },
+    /// No output (e.g. empty line)
+    None,
+}
+
+impl std::fmt::Display for ReplOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReplOutput::Binding {
+                name,
+                type_,
+                mutable,
+            } => {
+                write!(
+                    f,
+                    "{} {}: {:?}{}",
+                    "✓".green(),
+                    name.as_str().cyan().bold(),
+                    type_,
+                    if *mutable {
+                        " (mutable)".yellow().to_string()
+                    } else {
+                        "".to_string()
+                    }
+                )?;
+                writeln!(f)
+            }
+            ReplOutput::Statement { code } => {
+                writeln!(f, "{}", "✓ Ἐκτελέσθη (Executed)".green())?;
+                if !code.is_empty() {
+                    writeln!(f, "  {}", code.as_str().dim())?;
+                }
+                Ok(())
+            }
+            ReplOutput::None => Ok(()),
+        }
+    }
+}
+
 /// Maximum number of bindings to track in REPL history
 const MAX_REPL_BINDINGS: usize = 50;
 /// Maximum total source size for REPL history
@@ -423,6 +471,7 @@ const MAX_REPL_SOURCE_LEN: usize = 50_000;
 struct ReplContext {
     bindings: Vec<String>,
     last_scope: Option<Scope>,
+    statement_count: usize,
 }
 
 impl ReplContext {
@@ -430,10 +479,11 @@ impl ReplContext {
         ReplContext {
             bindings: Vec::new(),
             last_scope: None,
+            statement_count: 0,
         }
     }
 
-    fn execute(&mut self, input: &str) -> std::result::Result<String, GlossaError> {
+    fn execute(&mut self, input: &str) -> std::result::Result<ReplOutput, GlossaError> {
         // Check binding count limit
         if self.bindings.len() > MAX_REPL_BINDINGS {
             return Err(GlossaError::semantic(
@@ -459,26 +509,52 @@ impl ReplContext {
         let ast = parse(&full_source)?;
         let analyzed = analyze_program(&ast)?;
 
-        // Update scope
-        self.last_scope = Some(analyzed.scope.clone());
-
-        // Check if input contains a binding
-        if input.contains("ἔστω") || input.contains("εστω") {
-            self.bindings.push(input.to_string());
+        let new_count = analyzed.statements.len();
+        if new_count <= self.statement_count {
+            return Ok(ReplOutput::None);
         }
 
-        // Generate and return the code (for now, just show the Rust)
-        let rust_code = generate_rust(&analyzed);
-        Ok(format!(
-            "{} {}",
-            "→".blue(),
-            rust_code
-                .lines()
-                .skip(1)
-                .take(5)
-                .collect::<Vec<_>>()
-                .join("\n")
-        ))
+        // Update scope and count
+        self.last_scope = Some(analyzed.scope.clone());
+        self.statement_count = new_count;
+
+        // Analyze what happened in the last statement
+        // We know it exists because new_count > old_count >= 0
+        let last_stmt = analyzed.statements.last().unwrap();
+        match &last_stmt.kind {
+            StatementKind::Binding {
+                name,
+                value_type,
+                mutable,
+            } => {
+                // Add to bindings list so it persists
+                self.bindings.push(input.to_string());
+
+                Ok(ReplOutput::Binding {
+                    name: name.to_string(),
+                    type_: value_type.clone(),
+                    mutable: *mutable,
+                })
+            }
+            _ => {
+                // For non-binding statements, we don't save them to bindings list
+                // because we don't want to re-execute side effects (print) every time.
+                // BUT: If the user defines a function or type, we SHOULD save it.
+                if matches!(
+                    last_stmt.kind,
+                    StatementKind::FunctionDef { .. }
+                        | StatementKind::TypeDefinition { .. }
+                        | StatementKind::TraitDefinition { .. }
+                        | StatementKind::TraitImplementation { .. }
+                ) {
+                    self.bindings.push(input.to_string());
+                }
+
+                Ok(ReplOutput::Statement {
+                    code: generate_statement_code(last_stmt),
+                })
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -748,4 +748,82 @@ mod tests {
         let result = explain_file(&file_path);
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_repl_execute_variants() {
+        let mut context = ReplContext::new();
+
+        // Test Binding execution
+        let output = context.execute("ξ πέντε ἔστω.").unwrap();
+        if let ReplOutput::Binding {
+            name,
+            type_,
+            mutable,
+        } = output
+        {
+            assert_eq!(name, "ξ");
+            assert_eq!(type_, GlossaType::Number);
+            assert_eq!(mutable, false);
+        } else {
+            panic!("Expected Binding, got {:?}", output);
+        }
+
+        // Test Statement execution
+        let output = context.execute("ξ λέγε.").unwrap();
+        if let ReplOutput::Statement { code } = output {
+            assert!(code.contains("println"));
+        } else {
+            panic!("Expected Statement, got {:?}", output);
+        }
+
+        // Test None execution (no new statement, e.g. comment or empty)
+        // Comments are stripped by parser usually, but let's try an empty input or just re-running without change
+        // Actually, execute appends input.
+        // Let's try an input that parses but produces no statements (e.g. just whitespace)
+        // But parse likely fails on empty.
+        // Let's try a comment if parser supports it.
+        // "Using strict parser..."
+        // If we can't easily generate 0 statements from valid input, we can check that
+        // the statement count logic works by manually manipulating if possible,
+        // but since we can't, let's trust the logic if we can verify state updates.
+        // Let's rely on the logic that if we add a statement, count increases.
+        assert_eq!(context.statement_count, 2);
+    }
+
+    #[test]
+    fn test_repl_output_display() {
+        // Test Binding display
+        let binding = ReplOutput::Binding {
+            name: "x".to_string(),
+            type_: GlossaType::Number,
+            mutable: false,
+        };
+        let output = binding.to_string();
+        // Check content without worrying about specific color codes
+        assert!(output.contains("x"));
+        assert!(output.contains("Number"));
+        assert!(!output.contains("mutable")); // Not mutable
+
+        let binding_mut = ReplOutput::Binding {
+            name: "y".to_string(),
+            type_: GlossaType::String,
+            mutable: true,
+        };
+        let output_mut = binding_mut.to_string();
+        assert!(output_mut.contains("y"));
+        assert!(output_mut.contains("String"));
+        assert!(output_mut.contains("mutable"));
+
+        // Test Statement display
+        let stmt = ReplOutput::Statement {
+            code: "println!(\"hello\")".to_string(),
+        };
+        let output_stmt = stmt.to_string();
+        assert!(output_stmt.contains("Ἐκτελέσθη"));
+        assert!(output_stmt.contains("println"));
+
+        // Test None display
+        let none = ReplOutput::None;
+        assert_eq!(none.to_string(), "");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -763,7 +763,7 @@ mod tests {
         {
             assert_eq!(name, "ξ");
             assert_eq!(type_, GlossaType::Number);
-            assert_eq!(mutable, false);
+            assert!(!mutable);
         } else {
             panic!("Expected Binding, got {:?}", output);
         }


### PR DESCRIPTION
- **Refactor `ReplContext::execute`**: Return `ReplOutput` enum instead of `String`.
- **Add `ReplOutput` Enum**: Variants for `Binding` (with name, type, mutability) and `Statement` (with generated code).
- **Implement `Display` for `ReplOutput`**: Use `crossterm` for colored output.
- **Update `codegen/rust.rs`**: Publicly expose `generate_statement_code` for single statement generation.
- **Update `run_repl`**: Use the new `ReplOutput` for printing.
- **Add `statement_count` to `ReplContext`**: Track statement count to ensure only new statements trigger output.

---
*PR created automatically by Jules for task [7948862050786793407](https://jules.google.com/task/7948862050786793407) started by @madmax983*