### PR TITLE
Unify type resolution and fix genitive struct references

### DIFF
--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -10,6 +10,68 @@ use crate::text::normalize_greek;
 use smol_str::SmolStr;
 // Circular dependencies handled by crate structure
 
+/// Resolve a type name (nominative or genitive) to a GlossaType
+pub fn resolve_type_name(name: &str, scope: &Scope) -> GlossaType {
+    let normalized = normalize_greek(name);
+
+    // 1. Check hardcoded mappings (nominative and genitive)
+    match normalized.as_str() {
+        // Number
+        "αριθμος" | "αριθμου" => return GlossaType::Number,
+        // String
+        "ονομα" | "ονοματος" => return GlossaType::String,
+        // Boolean
+        "αληθες" | "ψευδος" => return GlossaType::Boolean,
+        // List (generic unknown)
+        "λιστη" | "λιστης" => return GlossaType::List(Box::new(GlossaType::Unknown)),
+        // Set
+        "συνολον" | "συνολου" => return GlossaType::Set(Box::new(GlossaType::Unknown)),
+        // Map
+        "χαρτης" | "χαρτου" => return GlossaType::Map(Box::new(GlossaType::Unknown), Box::new(GlossaType::Unknown)),
+        _ => {}
+    }
+
+    // 2. Check user-defined types (exact match)
+    if let Some(ty) = scope.lookup_type(&normalized) {
+        return ty.clone();
+    }
+
+    // 3. Check user-defined types (stripping genitive endings)
+    // Common endings: -ου, -ης, -ων, -ατος
+    let stems = [
+        normalized.strip_suffix("ου"),
+        normalized.strip_suffix("ης"),
+        normalized.strip_suffix("ων"),
+        normalized.strip_suffix("ατος"),
+        normalized.strip_suffix("εως"),
+    ];
+
+    for stem in stems.into_iter().flatten() {
+        // Try reconstructing nominative by appending common endings
+        let candidates = [
+            format!("{}ος", stem),
+            format!("{}ον", stem),
+            format!("{}η", stem),
+            format!("{}α", stem),
+            format!("{}ης", stem),
+            format!("{}ας", stem),
+        ];
+
+        for candidate in candidates {
+            if let Some(ty) = scope.lookup_type(&candidate) {
+                return ty.clone();
+            }
+        }
+
+        // Also try the stem itself
+        if let Some(ty) = scope.lookup_type(stem) {
+            return ty.clone();
+        }
+    }
+
+    GlossaType::Unknown
+}
+
 /// Analyze a type definition statement
 pub fn analyze_type_definition(
     type_def: &crate::ast::TypeDef,
@@ -25,7 +87,7 @@ pub fn analyze_type_definition(
         let type_name_gen = normalize_greek(&field.type_name.original);
 
         // Map genitive type names to GlossaType
-        let field_type = map_genitive_to_type(&type_name_gen, scope);
+        let field_type = resolve_type_name(&type_name_gen, scope);
         fields.push((field_name, field_type));
     }
 
@@ -233,26 +295,6 @@ pub fn analyze_trait_impl(
     })
 }
 
-/// Map a genitive type name to a GlossaType
-pub fn map_genitive_to_type(genitive_name: &str, scope: &Scope) -> GlossaType {
-    // ἀριθμοῦ (genitive of ἀριθμός) → Number
-    if genitive_name == "αριθμου" {
-        return GlossaType::Number;
-    }
-    // ὀνόματος (genitive of ὄνομα) → String
-    if genitive_name == "ονοματος" {
-        return GlossaType::String;
-    }
-    // Check for user-defined types
-    // Strip genitive ending and look up the nominative form
-    // For now, just try the name as-is
-    if let Some(ty) = scope.lookup_type(genitive_name) {
-        return ty.clone();
-    }
-
-    GlossaType::Unknown
-}
-
 /// Parse a function definition: name ὁρίζειν [params]· body
 pub fn parse_function_definition(
     stmt: &Statement,
@@ -280,7 +322,7 @@ pub fn parse_function_definition(
     let function_name = extract_function_name_from_expr(header_expr)?;
 
     // Extract parameters (dative words) from the header
-    let params = extract_parameters_from_expr(header_expr)?;
+    let params = extract_parameters_from_expr(header_expr, scope)?;
 
     // Use enter_scope() to create a child scope that inherits types/traits
     let mut body_statements = Vec::new();
@@ -362,6 +404,7 @@ fn extract_function_name_from_expr(expr: &Expr) -> Result<SmolStr, GlossaError> 
 /// Parameters are words after dative article τῷ, optionally followed by genitive type annotations
 fn extract_parameters_from_expr(
     expr: &Expr,
+    scope: &Scope,
 ) -> Result<Vec<(SmolStr, Option<GlossaType>)>, GlossaError> {
     let mut params = Vec::new();
 
@@ -402,7 +445,7 @@ fn extract_parameters_from_expr(
                     if next_analysis.case == Some(morphology::Case::Genitive) {
                         // Map genitive type to GlossaType
                         let type_name = normalize_greek(&next_word.original);
-                        param_type = Some(map_greek_type_to_glossa(&type_name));
+                        param_type = Some(resolve_type_name(&type_name, scope));
                         i += 1; // Skip the type annotation
                     }
                 }
@@ -433,16 +476,6 @@ fn collect_words_from_expr(expr: &Expr) -> Vec<&crate::ast::Word> {
     }
 
     words
-}
-
-/// Map Greek type names to GlossaType
-fn map_greek_type_to_glossa(type_name: &str) -> GlossaType {
-    match type_name {
-        "αριθμου" => GlossaType::Number,
-        "ονοματος" => GlossaType::String,
-        "λιστης" => GlossaType::List(Box::new(GlossaType::Unknown)),
-        _ => GlossaType::Unknown,
-    }
 }
 
 /// Infer the return type from the function body by examining return statements

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -25,9 +25,13 @@ pub fn resolve_type_name(name: &str, scope: &Scope) -> GlossaType {
         // List (generic unknown)
         "λιστη" | "λιστης" => return GlossaType::List(Box::new(GlossaType::Unknown)),
         // Set
-        "συνολον" | "συνολου" => return GlossaType::Set(Box::new(GlossaType::Unknown)),
+        "συνολον" | "συνολου" => {
+            return GlossaType::Set(Box::new(GlossaType::Unknown));
+        }
         // Map
-        "χαρτης" | "χαρτου" => return GlossaType::Map(Box::new(GlossaType::Unknown), Box::new(GlossaType::Unknown)),
+        "χαρτης" | "χαρτου" => {
+            return GlossaType::Map(Box::new(GlossaType::Unknown), Box::new(GlossaType::Unknown));
+        }
         _ => {}
     }
 

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -140,40 +140,6 @@ impl Ownership {
     }
 }
 
-/// Infer type from a Greek word (by looking at lexicon or morphology)
-///
-/// # Examples
-///
-/// ```
-/// use glossa::semantic::{infer_type, GlossaType};
-///
-/// assert_eq!(infer_type("πέντε"), GlossaType::Number);
-/// assert_eq!(infer_type("ἀριθμός"), GlossaType::Number);
-/// assert_eq!(infer_type("ὄνομα"), GlossaType::String);
-/// assert_eq!(infer_type("ἄγνωστον"), GlossaType::Unknown);
-/// ```
-pub fn infer_type(word: &str) -> GlossaType {
-    let normalized = crate::text::normalize_greek(word);
-
-    // Check lexicon first
-    if let Some(entry) = crate::morphology::lexicon::lookup(&normalized) {
-        match entry.rust_equiv {
-            Some("i64") => return GlossaType::Number,
-            Some("String") => return GlossaType::String,
-            Some("bool") | Some("true") | Some("false") => return GlossaType::Boolean,
-            Some("Vec") => return GlossaType::List(Box::new(GlossaType::Unknown)),
-            _ => {}
-        }
-    }
-
-    // Check for numeral
-    if crate::morphology::lexicon::numeral_value(&normalized).is_some() {
-        return GlossaType::Number;
-    }
-
-    GlossaType::Unknown
-}
-
 /// Detect built-in collection types (HashSet, HashMap)
 ///
 /// Returns a tuple of (Rust collection name, GlossaType).
@@ -214,12 +180,6 @@ mod tests {
         assert_eq!(Ownership::from_case(Case::Genitive), Ownership::Borrow);
         assert_eq!(Ownership::from_case(Case::Dative), Ownership::BorrowMut);
         assert_eq!(Ownership::from_case(Case::Accusative), Ownership::Move);
-    }
-
-    #[test]
-    fn test_infer_type_numeral() {
-        assert_eq!(infer_type("πέντε"), GlossaType::Number);
-        assert_eq!(infer_type("δέκα"), GlossaType::Number);
     }
 
     #[test]

--- a/tests/user_defined_types_tests.rs
+++ b/tests/user_defined_types_tests.rs
@@ -1,0 +1,42 @@
+use glossa::codegen::generate_rust;
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+/// Helper to compile GLOSSA source to Rust code
+fn compile(source: &str) -> String {
+    let ast = parse(source).unwrap();
+    let analyzed = analyze_program(&ast).unwrap();
+    generate_rust(&analyzed)
+}
+
+#[test]
+fn test_function_with_struct_parameter() {
+    let source = "
+    εἶδος Σημεῖον ὁρίζειν {
+        χ ἀριθμοῦ.
+        ψ ἀριθμοῦ.
+    }.
+
+    απόσταση ὁρίζειν τῷ σ Σημείου·
+        δός σ.χ
+    .
+    ";
+
+    let code = compile(source);
+    eprintln!("Generated code:\n{}", code);
+
+    // Should contain the struct definition
+    // Σημεῖον -> normalized "σημειον" -> sanitized "shmeion" -> capitalized "Shmeion"
+    assert!(code.contains("struct Shmeion"));
+
+    // Should contain the function definition with the correct type
+    // Σημείου (genitive) -> Σημεῖον (nominative)
+    // The parameter type should be the struct name
+
+    // Note: If type is unknown, it generates "_"
+    assert!(!code.contains("s: _"), "Generated 's: _' which means type was not resolved");
+
+    // We expect the struct name in the function signature
+    // Currently generated as value (move), e.g. "s: Shmeion"
+    assert!(code.contains("s : Shmeion") || code.contains("s: Shmeion"));
+}

--- a/tests/user_defined_types_tests.rs
+++ b/tests/user_defined_types_tests.rs
@@ -34,7 +34,10 @@ fn test_function_with_struct_parameter() {
     // The parameter type should be the struct name
 
     // Note: If type is unknown, it generates "_"
-    assert!(!code.contains("s: _"), "Generated 's: _' which means type was not resolved");
+    assert!(
+        !code.contains("s: _"),
+        "Generated 's: _' which means type was not resolved"
+    );
 
     // We expect the struct name in the function signature
     // Currently generated as value (move), e.g. "s: Shmeion"


### PR DESCRIPTION
Consolidated type name resolution logic into `resolve_type_name` in `src/semantic/declarations.rs`. This fixes an issue where user-defined types (structs) could not be resolved in function parameters when used with their genitive forms (e.g. `Σημείου` for `Σημεῖον`). Also removed dead code (`infer_type`, `map_genitive_to_type`, `map_greek_type_to_glossa`) adhering to Razor philosophy.

---
*PR created automatically by Jules for task [14305993618180426729](https://jules.google.com/task/14305993618180426729) started by @madmax983*