### PR TITLE
🗺️ Atlas: Decouple errors/parser

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -44,3 +44,10 @@
 2. Refactored `Oracle` to use `assemble_statement` instead of manually driving the assembler loop.
 3. Changed `src/semantic/expressions.rs` visibility to `pub(crate)` to enforce internal-only use.
 **Stability:** Enforces clear module boundaries. `semantic` now provides a stable public API for assembly, and internal expression logic is hidden from external consumers.
+
+## [Breaking The Knot: Parser-Errors Cycle]
+**Tangle:** The `errors` module imported `parser::ParseError` to implement the `From` trait for `GlossaError`, while the `parser` module imported `GlossaError` as its return type. This created a circular dependency `errors <-> parser`.
+**Blueprint:**
+1. Moved the `impl From<ParseError> for GlossaError` block from `src/errors/mod.rs` to `src/parser/mod.rs`.
+2. Removed the dependency on `crate::parser` from `src/errors/mod.rs`.
+**Stability:** `errors` is now a lower-level module that does not depend on `parser`. The dependency graph is strictly `parser -> errors`.

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -138,13 +138,6 @@ impl GlossaError {
 /// Result type for ΓΛΩΣΣΑ operations
 pub type GlossaResult<T> = Result<T, GlossaError>;
 
-// Conversion from Parser errors
-impl From<crate::parser::ParseError> for GlossaError {
-    fn from(err: crate::parser::ParseError) -> Self {
-        GlossaError::parse(err.to_string())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -787,5 +787,4 @@ mod tests {
         assert_eq!(ast.statements.len(), 1);
         assert_eq!(ast.statements[0].clauses().len(), 2); // Two clauses separated by comma
     }
-
 }

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -787,4 +787,5 @@ mod tests {
         assert_eq!(ast.statements.len(), 1);
         assert_eq!(ast.statements[0].clauses().len(), 2); // Two clauses separated by comma
     }
+
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -29,6 +29,12 @@ use crate::errors::GlossaError;
 
 pub use builder::ParseError;
 
+impl From<ParseError> for GlossaError {
+    fn from(err: ParseError) -> Self {
+        GlossaError::parse(err.to_string())
+    }
+}
+
 /// Parse a ΓΛΩΣΣΑ source string into an AST
 ///
 /// This is the main entry point for the parsing phase.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -49,5 +49,5 @@ impl From<ParseError> for GlossaError {
 /// assert_eq!(program.statements.len(), 1);
 /// ```
 pub fn parse(source: &str) -> Result<Program, GlossaError> {
-    builder::parse_source(source).map_err(|e| GlossaError::parse(e.to_string()))
+    builder::parse_source(source).map_err(GlossaError::from)
 }


### PR DESCRIPTION
🕸️ Tangle: The `errors` module imported `parser` to implement `From<ParseError>`, while `parser` imported `errors` for its return type `GlossaError`. This created a circular dependency `errors <-> parser`.\n📐 Blueprint: Moved the `impl From<ParseError> for GlossaError` to `src/parser/mod.rs`.\n🧱 Stability: Decouples error definitions from parser implementation details. `errors` is now a leaf node relative to `parser`.\n🔬 Verification: `cargo check` passes. No functional changes.

---
*PR created automatically by Jules for task [7063885333955080683](https://jules.google.com/task/7063885333955080683) started by @madmax983*