### PR TITLE
Refactor: Simplify Oracle, Scope, and Literals

### DIFF
--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -630,10 +630,6 @@ fn generate_expr(expr: &AnalyzedExpr) -> TokenStream {
             quote! { #n }
         }
 
-        AnalyzedExprKind::Literal(n) => {
-            quote! { #n }
-        }
-
         AnalyzedExprKind::BooleanLiteral(b) => {
             quote! { #b }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::time::SystemTime;
 use glossa::codegen::{generate_rust_file, generate_statement_code};
 use glossa::errors::GlossaError;
 use glossa::parser::parse;
-use glossa::semantic::{GlossaType, Scope, StatementKind, analyze_program, oracle::Oracle};
+use glossa::semantic::{GlossaType, Scope, StatementKind, analyze_program, oracle::explain};
 
 #[derive(Parser)]
 #[command(name = "glossa")]
@@ -259,10 +259,7 @@ fn explain_file(input: &Path) -> Result<()> {
     check_file_size(input)?;
 
     let source = fs::read_to_string(input).into_diagnostic()?;
-    let oracle = Oracle::new();
-    let explanation = oracle
-        .explain(&source)
-        .map_err(|e| miette::miette!("{}", e))?;
+    let explanation = explain(&source).map_err(|e| miette::miette!("{}", e))?;
 
     println!("{}", explanation);
 

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -442,7 +442,7 @@ impl Assembler {
     /// Clears all pending slots, preparing the assembler for the next sentence.
     /// This is typically called automatically by `finalize()`, but can be
     /// called manually to discard a partial statement.
-    pub fn reset(&mut self) {
+    fn reset(&mut self) {
         self.pending_subject = None;
         self.pending_nominatives.clear();
         self.pending_object = None;

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -16,7 +16,7 @@ pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr,
     analyze_argument_expr_recursive(expr, scope, 0)
 }
 
-const MAX_RECURSION_DEPTH: usize = 50;
+pub const MAX_RECURSION_DEPTH: usize = 50;
 
 fn analyze_argument_expr_recursive(
     expr: &Expr,
@@ -326,7 +326,7 @@ fn feed_expr_recursive(
     context: &mut DisambiguationContext,
     depth: usize,
 ) -> Result<(), GlossaError> {
-    if depth > 50 {
+    if depth > MAX_RECURSION_DEPTH {
         return Err(GlossaError::semantic(
             "Recursion limit exceeded in expression analysis",
         ));

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -217,8 +217,6 @@ pub enum AnalyzedExprKind {
         collection: Box<AnalyzedExpr>,
         ops: Vec<AnalyzedIteratorOp>,
     },
-    /// Literal value (used in iterator ops, different from specific literals above)
-    Literal(i64),
     /// Collection constructor (HashSet::new(), HashMap::new())
     CollectionNew {
         collection_type: String,

--- a/src/semantic/oracle.rs
+++ b/src/semantic/oracle.rs
@@ -5,179 +5,163 @@ use comfy_table::presets::UTF8_FULL;
 use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table};
 use crossterm::style::Stylize;
 
-/// The Oracle - A tool to explain the semantic analysis of Glossa code
-pub struct Oracle;
+/// Explain the given source code
+///
+/// This parses and assembles the code, then generates a human-readable report
+/// explaining how the morphological assembler interpreted each sentence.
+pub fn explain(source: &str) -> Result<String, GlossaError> {
+    let ast = parse(source)?;
+    let mut report = String::new();
 
-impl Oracle {
-    /// Create a new Oracle
-    pub fn new() -> Self {
-        Oracle
-    }
+    report.push_str(&format!(
+        "\n{}\n",
+        "🔮 Ὁ Μάντις (The Oracle) Speaks...".bold().magenta()
+    ));
 
-    /// Explain the given source code
-    ///
-    /// This parses and assembles the code, then generates a human-readable report
-    /// explaining how the morphological assembler interpreted each sentence.
-    pub fn explain(&self, source: &str) -> Result<String, GlossaError> {
-        let ast = parse(source)?;
-        let mut report = String::new();
-
+    for (i, stmt) in ast.statements.iter().enumerate() {
         report.push_str(&format!(
             "\n{}\n",
-            "🔮 Ὁ Μάντις (The Oracle) Speaks...".bold().magenta()
+            format!("📜 Statement #{}", i + 1).yellow().underlined()
         ));
 
-        for (i, stmt) in ast.statements.iter().enumerate() {
-            report.push_str(&format!(
-                "\n{}\n",
-                format!("📜 Statement #{}", i + 1).yellow().underlined()
-            ));
-
-            // Check for non-assembler patterns first (like Type Definitions)
-            if matches!(stmt, crate::ast::Statement::TypeDefinition(_)) {
-                report.push_str(&format!("{}\n", "Type Definition detected.".blue()));
-                continue;
-            }
-
-            // Re-assemble to inspect slots
-            let assembled = assemble_statement(stmt)?;
-
-            // Build Table
-            let mut table = Table::new();
-            table
-                .load_preset(UTF8_FULL)
-                .set_content_arrangement(ContentArrangement::Dynamic)
-                .set_header(vec![
-                    Cell::new("Role")
-                        .add_attribute(Attribute::Bold)
-                        .fg(Color::Cyan),
-                    Cell::new("Greek Word").add_attribute(Attribute::Bold),
-                    Cell::new("Morphology")
-                        .add_attribute(Attribute::Bold)
-                        .fg(Color::Green),
-                    Cell::new("Lemma/Value").add_attribute(Attribute::Bold),
-                ]);
-
-            if let Some(subject) = &assembled.subject {
-                table.add_row(vec![
-                    "Subject (Agent)",
-                    &subject.original,
-                    "Nominative Case",
-                    subject.lemma.as_ref(),
-                ]);
-            }
-
-            for nom in &assembled.nominatives {
-                table.add_row(vec![
-                    "Nominative (Secondary)",
-                    &nom.original,
-                    "Nominative Case",
-                    nom.lemma.as_ref(),
-                ]);
-            }
-
-            if let Some(verb) = &assembled.verb {
-                let tense_str = verb
-                    .tense
-                    .map(|t| format!("{:?}", t))
-                    .unwrap_or_else(|| "Unknown".to_string());
-                let voice_str = verb
-                    .voice
-                    .map(|v| format!("{:?}", v))
-                    .unwrap_or_else(|| "Unknown".to_string());
-                let morph = format!("{} {}", tense_str, voice_str);
-
-                table.add_row(vec![
-                    "Verb (Action)",
-                    &verb.original,
-                    &morph,
-                    verb.lemma.as_ref(),
-                ]);
-            }
-
-            if let Some(object) = &assembled.object {
-                table.add_row(vec![
-                    "Object (Patient)",
-                    &object.original,
-                    "Accusative Case",
-                    object.lemma.as_ref(),
-                ]);
-            }
-
-            if let Some(indirect) = &assembled.indirect {
-                table.add_row(vec![
-                    "Indirect Object",
-                    &indirect.original,
-                    "Dative Case",
-                    indirect.lemma.as_ref(),
-                ]);
-            }
-
-            for participle in &assembled.participles {
-                let morph = format!("{:?} {:?} Participle", participle.tense, participle.voice);
-                table.add_row(vec![
-                    "Participle (Lambda)",
-                    &participle.original,
-                    &morph,
-                    &participle.verb_lemma,
-                ]);
-            }
-
-            for literal in &assembled.literals {
-                let (val, type_name) = match literal {
-                    Literal::String(s) => (format!("«{}»", s), "String"),
-                    Literal::Number(n) => (n.to_string(), "Number"),
-                    Literal::Boolean(b) => (b.to_string(), "Boolean"),
-                };
-                table.add_row(vec!["Literal Value", &val, type_name, &val]);
-            }
-
-            report.push_str(&table.to_string());
-            report.push('\n');
-
-            // Interpretation
-            report.push_str(&format!("\n{}\n", "👁️ Interpretation:".bold()));
-            if assembled.verb.is_some() {
-                if let Some(s) = &assembled.subject {
-                    if let Some(o) = &assembled.object {
-                        report.push_str(&format!(
-                            "The subject '{}' acts upon '{}'.",
-                            s.original, o.original
-                        ));
-                    } else {
-                        report
-                            .push_str(&format!("The subject '{}' performs an action.", s.original));
-                    }
-                } else if let Some(o) = &assembled.object {
-                    report.push_str(&format!("An action is performed on '{}'.", o.original));
-                } else {
-                    report.push_str("An action occurs.");
-                }
-            } else if !assembled.literals.is_empty() {
-                report.push_str("A value is being expressed.");
-            } else if !assembled.participles.is_empty() {
-                report.push_str("A functional operation (lambda) is being defined.");
-            } else {
-                report.push_str(
-                    "This statement contains no main verb (possibly a definition or fragment).",
-                );
-            }
-
-            if assembled.verb.is_some() && !assembled.participles.is_empty() {
-                report.push_str(" A functional operation (lambda) is also involved.");
-            }
-
-            report.push('\n');
+        // Check for non-assembler patterns first (like Type Definitions)
+        if matches!(stmt, crate::ast::Statement::TypeDefinition(_)) {
+            report.push_str(&format!("{}\n", "Type Definition detected.".blue()));
+            continue;
         }
 
-        Ok(report)
-    }
-}
+        // Re-assemble to inspect slots
+        let assembled = assemble_statement(stmt)?;
 
-impl Default for Oracle {
-    fn default() -> Self {
-        Self::new()
+        // Build Table
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_header(vec![
+                Cell::new("Role")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Cyan),
+                Cell::new("Greek Word").add_attribute(Attribute::Bold),
+                Cell::new("Morphology")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Green),
+                Cell::new("Lemma/Value").add_attribute(Attribute::Bold),
+            ]);
+
+        if let Some(subject) = &assembled.subject {
+            table.add_row(vec![
+                "Subject (Agent)",
+                &subject.original,
+                "Nominative Case",
+                subject.lemma.as_ref(),
+            ]);
+        }
+
+        for nom in &assembled.nominatives {
+            table.add_row(vec![
+                "Nominative (Secondary)",
+                &nom.original,
+                "Nominative Case",
+                nom.lemma.as_ref(),
+            ]);
+        }
+
+        if let Some(verb) = &assembled.verb {
+            let tense_str = verb
+                .tense
+                .map(|t| format!("{:?}", t))
+                .unwrap_or_else(|| "Unknown".to_string());
+            let voice_str = verb
+                .voice
+                .map(|v| format!("{:?}", v))
+                .unwrap_or_else(|| "Unknown".to_string());
+            let morph = format!("{} {}", tense_str, voice_str);
+
+            table.add_row(vec![
+                "Verb (Action)",
+                &verb.original,
+                &morph,
+                verb.lemma.as_ref(),
+            ]);
+        }
+
+        if let Some(object) = &assembled.object {
+            table.add_row(vec![
+                "Object (Patient)",
+                &object.original,
+                "Accusative Case",
+                object.lemma.as_ref(),
+            ]);
+        }
+
+        if let Some(indirect) = &assembled.indirect {
+            table.add_row(vec![
+                "Indirect Object",
+                &indirect.original,
+                "Dative Case",
+                indirect.lemma.as_ref(),
+            ]);
+        }
+
+        for participle in &assembled.participles {
+            let morph = format!("{:?} {:?} Participle", participle.tense, participle.voice);
+            table.add_row(vec![
+                "Participle (Lambda)",
+                &participle.original,
+                &morph,
+                &participle.verb_lemma,
+            ]);
+        }
+
+        for literal in &assembled.literals {
+            let (val, type_name) = match literal {
+                Literal::String(s) => (format!("«{}»", s), "String"),
+                Literal::Number(n) => (n.to_string(), "Number"),
+                Literal::Boolean(b) => (b.to_string(), "Boolean"),
+            };
+            table.add_row(vec!["Literal Value", &val, type_name, &val]);
+        }
+
+        report.push_str(&table.to_string());
+        report.push('\n');
+
+        // Interpretation
+        report.push_str(&format!("\n{}\n", "👁️ Interpretation:".bold()));
+        if assembled.verb.is_some() {
+            if let Some(s) = &assembled.subject {
+                if let Some(o) = &assembled.object {
+                    report.push_str(&format!(
+                        "The subject '{}' acts upon '{}'.",
+                        s.original, o.original
+                    ));
+                } else {
+                    report
+                        .push_str(&format!("The subject '{}' performs an action.", s.original));
+                }
+            } else if let Some(o) = &assembled.object {
+                report.push_str(&format!("An action is performed on '{}'.", o.original));
+            } else {
+                report.push_str("An action occurs.");
+            }
+        } else if !assembled.literals.is_empty() {
+            report.push_str("A value is being expressed.");
+        } else if !assembled.participles.is_empty() {
+            report.push_str("A functional operation (lambda) is being defined.");
+        } else {
+            report.push_str(
+                "This statement contains no main verb (possibly a definition or fragment).",
+            );
+        }
+
+        if assembled.verb.is_some() && !assembled.participles.is_empty() {
+            report.push_str(" A functional operation (lambda) is also involved.");
+        }
+
+        report.push('\n');
     }
+
+    Ok(report)
 }
 
 #[cfg(test)]
@@ -185,12 +169,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_oracle_explains_basic_sentence() {
-        let oracle = Oracle::new();
+    fn test_explain_basic_sentence() {
         // Use ἀρχήν (beginning/origin) which ends in -ην to avoid misidentification as participle (-ον)
         let source = "ὁ ἄνθρωπος τὴν ἀρχήν λέγει.";
 
-        let explanation = oracle.explain(source).unwrap();
+        let explanation = explain(source).unwrap();
 
         println!("{}", explanation);
 
@@ -203,18 +186,16 @@ mod tests {
     }
 
     #[test]
-    fn test_oracle_type_definition() {
-        let oracle = Oracle::new();
+    fn test_type_definition() {
         let source = "εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. }.";
-        let explanation = oracle.explain(source).unwrap();
+        let explanation = explain(source).unwrap();
         assert!(explanation.contains("Type Definition detected"));
     }
 
     #[test]
-    fn test_oracle_literals() {
-        let oracle = Oracle::new();
+    fn test_literals() {
         let source = "«χαῖρε» 42 ἀληθές λέγε.";
-        let explanation = oracle.explain(source).unwrap();
+        let explanation = explain(source).unwrap();
 
         assert!(explanation.contains("Literal Value"));
         assert!(explanation.contains("«χαῖρε»"));
@@ -223,11 +204,10 @@ mod tests {
     }
 
     #[test]
-    fn test_oracle_participle() {
-        let oracle = Oracle::new();
+    fn test_participle() {
         // Use a participle form
         let source = "διπλασιαζόμενα λέγε.";
-        let explanation = oracle.explain(source).unwrap();
+        let explanation = explain(source).unwrap();
 
         assert!(explanation.contains("Participle (Lambda)"));
         assert!(explanation.contains("διπλασιαζόμενα"));
@@ -235,45 +215,41 @@ mod tests {
     }
 
     #[test]
-    fn test_oracle_indirect_object() {
-        let oracle = Oracle::new();
+    fn test_indirect_object() {
         // Dative case: τῷ ἀνθρώπῳ (to the man)
         let source = "τῷ ἀνθρώπῳ δίδωμι.";
-        let explanation = oracle.explain(source).unwrap();
+        let explanation = explain(source).unwrap();
 
         assert!(explanation.contains("Indirect Object"));
         assert!(explanation.contains("ἀνθρώπῳ"));
     }
 
     #[test]
-    fn test_oracle_verbless() {
-        let oracle = Oracle::new();
+    fn test_verbless() {
         // Just a literal, no verb
         let source = "42.";
-        let explanation = oracle.explain(source).unwrap();
+        let explanation = explain(source).unwrap();
 
         assert!(explanation.contains("A value is being expressed"));
     }
 
     #[test]
-    fn test_oracle_empty_or_fragment() {
-        let oracle = Oracle::new();
+    fn test_empty_or_fragment() {
         // Empty statement (just a period, though parser might reject, let's try a variable decl without verb if possible, or just check the fallback path)
         // Actually, "User." is valid syntax for a variable reference statement
         let source = "User.";
-        let explanation = oracle.explain(source).unwrap();
+        let explanation = explain(source).unwrap();
 
         assert!(explanation.contains("This statement contains no main verb"));
     }
 
     #[test]
-    fn test_oracle_secondary_nominative() {
-        let oracle = Oracle::new();
+    fn test_secondary_nominative() {
         // "Subject Predicate is." - "User God is."
         // We need a sentence that Assembler treats as having multiple nominatives.
         // Usually, function calls or 'is' sentences do this.
         let source = "ὁ ἄνθρωπος θεός ἐστιν.";
-        let explanation = oracle.explain(source).unwrap();
+        let explanation = explain(source).unwrap();
 
         assert!(explanation.contains("Subject (Agent)"));
         assert!(explanation.contains("Nominative (Secondary)"));

--- a/src/semantic/oracle.rs
+++ b/src/semantic/oracle.rs
@@ -136,8 +136,7 @@ pub fn explain(source: &str) -> Result<String, GlossaError> {
                         s.original, o.original
                     ));
                 } else {
-                    report
-                        .push_str(&format!("The subject '{}' performs an action.", s.original));
+                    report.push_str(&format!("The subject '{}' performs an action.", s.original));
                 }
             } else if let Some(o) = &assembled.object {
                 report.push_str(&format!("An action is performed on '{}'.", o.original));

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -628,7 +628,7 @@ fn process_participles(asm_stmt: &AssembledStatement, iterator_ops: &mut Vec<Ana
                             glossa_type: GlossaType::Number,
                         }),
                         right: Box::new(AnalyzedExpr {
-                            expr: AnalyzedExprKind::Literal(2),
+                            expr: AnalyzedExprKind::NumberLiteral(2),
                             glossa_type: GlossaType::Number,
                         }),
                     },

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -90,7 +90,7 @@ impl Scope {
     }
 
     /// Enter a new scope level
-    pub fn enter(&mut self) {
+    fn enter(&mut self) {
         self.levels.push(ScopeLevel::new());
     }
 
@@ -101,17 +101,10 @@ impl Scope {
     }
 
     /// Exit the current scope level
-    pub fn exit(&mut self) {
+    fn exit(&mut self) {
         if self.levels.len() > 1 {
             self.levels.pop();
         }
-    }
-
-    /// Create a child scope with this scope as parent
-    pub fn child(&self) -> Self {
-        let mut new_scope = self.clone();
-        new_scope.enter();
-        new_scope
     }
 
     fn current_level(&mut self) -> &mut ScopeLevel {
@@ -343,7 +336,7 @@ mod tests {
         let mut parent = Scope::new();
         parent.define("ξ".to_string(), GlossaType::Number);
 
-        let child = parent.child();
+        let child = parent.enter_scope();
         assert!(child.is_defined("ξ"));
         assert_eq!(child.lookup("ξ"), Some(&GlossaType::Number));
     }
@@ -353,7 +346,7 @@ mod tests {
         let mut parent = Scope::new();
         parent.define("ξ".to_string(), GlossaType::Number);
 
-        let mut child = parent.child();
+        let mut child = parent.enter_scope();
         child.define("ξ".to_string(), GlossaType::String);
 
         assert_eq!(child.lookup("ξ"), Some(&GlossaType::String));
@@ -450,7 +443,7 @@ mod tests {
         let mut parent = Scope::new();
         parent.define_mut("π".to_string(), GlossaType::Number);
 
-        let child = parent.child();
+        let child = parent.enter_scope();
         let binding = child.lookup_binding("π").unwrap();
         assert_eq!(binding.name, "π");
         assert!(binding.mutable);


### PR DESCRIPTION
This PR applies "Razor's" philosophy to simplify the codebase by removing unnecessary abstractions and dead code. Key changes include converting the stateless `Oracle` struct into a function, cleaning up the `Scope` API by removing unused methods, unifying literal representation in the semantic model, and enforcing stricter visibility for internal methods like `Assembler::reset`. All changes have been verified with existing tests.

---
*PR created automatically by Jules for task [5474016361362236537](https://jules.google.com/task/5474016361362236537) started by @madmax983*