### PR TITLE
👺 Havoc: Silent Data Corruption in Return Statements

### DIFF
--- a/tests/havoc_repro.proptest-regressions
+++ b/tests/havoc_repro.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c687c6bac86377ea48b34f8cacf52546589db2ac17761a5155cfaad4f9337a9d # shrinks to val = 1

--- a/tests/havoc_repro.rs
+++ b/tests/havoc_repro.rs
@@ -1,7 +1,6 @@
-
+use glossa::codegen::generate_rust;
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
-use glossa::codegen::generate_rust;
 use proptest::prelude::*;
 
 proptest! {

--- a/tests/havoc_repro.rs
+++ b/tests/havoc_repro.rs
@@ -1,0 +1,33 @@
+
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+use glossa::codegen::generate_rust;
+use proptest::prelude::*;
+
+proptest! {
+    // This test expects that return values are correctly generated.
+    // However, due to a bug in `parse_return_expression`, complex expressions
+    // are silently ignored and `0` is returned instead.
+    // We expect this test to fail (panic) because the bug is present.
+    #[test]
+    #[should_panic(expected = "Bug detected!")]
+    fn havoc_return_complex_expression(val in 1i64..1000) {
+        // "δός <val> 0 ἄθροισμα." should return <val>.
+        // But due to the bug, it returns 0.
+        let source = format!("
+            λείτουργος ὁρίζειν · δός {} 0 ἄθροισμα.
+
+            // Main
+            λείτουργος λέγε.
+        ", val);
+
+        let ast = parse(&source).unwrap();
+        let analyzed = analyze_program(&ast).unwrap();
+        let rust_code = generate_rust(&analyzed);
+
+        // If the code returns 0, it means the bug is triggered (since val >= 1).
+        if rust_code.contains("return 0i64") || rust_code.contains("return 0 i64") {
+             panic!("Bug detected! Expected return {}, got 0", val);
+        }
+    }
+}


### PR DESCRIPTION
👺 **Havoc Report: Silent Data Corruption in Return Statements**

🧨 **The Trigger:**
Any function that attempts to return a complex expression (multi-word, e.g., `1 2 ἄθροισμα`).

📉 **The Impact:**
The compiler silently generates code that returns `0` (or default value) instead of the actual expression result. This is **silent data corruption**. No error is raised during compilation.

🧪 **Reproduction:**
Run `cargo test --test havoc_repro`.
The test uses `proptest` to generate random integer return values. It asserts that the generated Rust code contains the correct return statement. Currently, it panics (as expected by `#[should_panic]`) because the compiler generates `return 0i64`.

😈 **Comment:**
"You assumed the return value would be calculated. You were wrong. Your functions are returning void (or zero) into the void."


---
*PR created automatically by Jules for task [11060507115096381977](https://jules.google.com/task/11060507115096381977) started by @madmax983*