### PR TITLE
docs: Add ADR 007 and update architecture diagram

### DIFF
--- a/docs/adr/007-separate-declaration-analysis.md
+++ b/docs/adr/007-separate-declaration-analysis.md
@@ -1,0 +1,33 @@
+# 7. Separate Declaration Analysis from Statement Assembly
+
+Date: 2024-10-25
+
+## Status
+
+Accepted
+
+## Context
+
+The Semantic Analyzer originally processed all input through the `Assembler` pipeline, which is designed for the language's signature free word order. While this works well for imperative statements (like function calls, assignments, and prints), declarative structures (such as Type Definitions, Trait Definitions, and Test Declarations) often follow a more rigid structure or require specialized handling that doesn't benefit from the Assembler's flexibility.
+
+Attempting to force declarations through the Assembler led to:
+1.  **Complexity:** The Assembler had to handle disparate concerns (e.g., distinguishing between a function call and a type definition).
+2.  **Scattered Logic:** Type resolution and validation logic was dispersed across multiple modules.
+3.  **Performance:** Running fixed-structure declarations through the expensive word-order permutation logic of the Assembler was inefficient.
+
+## Decision
+
+We have decided to architecturally separate the analysis of Declarations from the analysis of Imperative Statements.
+
+1.  **Introduce `src/semantic/declarations.rs`:** A new module dedicated to analyzing Type Definitions, Trait Definitions, Trait Implementations, and Test Declarations.
+2.  **Dispatch in `analyze_program`:** The main entry point `analyze_program` now acts as a high-level dispatcher. It inspects the AST statement kind and routes:
+    -   **Declarations** -> `declarations.rs` (Direct analysis).
+    -   **Imperative Statements** -> `Assembler` + `Converter` (Word-order independent assembly).
+3.  **Centralize Type Resolution:** The logic for resolving type names (including Greek genitive mapping like `ἀριθμοῦ` → `Number`) is centralized in `declarations::resolve_type_name`.
+
+## Consequences
+
+*   **Separation of Concerns:** The `Assembler` is now focused solely on assembling imperative sentences, making it simpler and more robust.
+*   **Maintainability:** Declaration logic is isolated in a single module, making it easier to add new declaration types or modify existing ones.
+*   **Clarity:** The distinction between "defining structure" (Declarations) and "executing logic" (Statements) is explicit in the compiler pipeline.
+*   **Extensibility:** Future declarative features can be added to `declarations.rs` without touching the complex Assembler logic.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,7 @@ C4Component
     title Component Diagram for Semantic Analysis
 
     Container_Boundary(semantic, "Semantic Analysis") {
+        Component(declarations, "Declarations", "src/semantic/declarations.rs", "Analyzes Types, Traits, Functions, Tests")
         Component(assembler, "Assembler", "src/semantic/assembler.rs", "Routes words to slots based on Case (Nom, Acc, Dat)")
         Component(converter, "Converter", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs (Iterators, Structs)")
@@ -57,6 +58,7 @@ C4Component
 
     Container(morphology, "Morphology", "src/morphology", "Provides Case/Gender/Number analysis")
 
+    Rel(declarations, model, "Produces AnalyzedStatement")
     Rel(morphology, assembler, "Feeds MorphAnalysis")
     Rel(assembler, converter, "Produces AssembledStatement")
     Rel(converter, patterns, "Delegates complex patterns")


### PR DESCRIPTION
Documented the architectural decision to separate the analysis of Declarations (Types, Traits, Tests) from Imperative Statements in the Semantic Analyzer.

Key changes:
- Created ADR 007 (`docs/adr/007-separate-declaration-analysis.md`) explaining the context, decision, and consequences of extracting declaration logic into `src/semantic/declarations.rs`.
- Updated the Semantic Analysis Component Diagram in `docs/architecture.md` to visually represent the `Declarations` component and its role in the pipeline.

This ensures architectural transparency regarding the structure of the semantic analysis phase.

---
*PR created automatically by Jules for task [10343332963294757352](https://jules.google.com/task/10343332963294757352) started by @madmax983*