### PR TITLE
🎨 Mosaic: UI Polish for Parse Errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -322,8 +322,16 @@ fn run_repl() -> Result<()> {
                 print!("{}", output);
             }
             Err(e) => {
-                // Use default error formatting but ensure it's visible
-                eprintln!("{}", format!("× Σφάλμα: {}", e).red());
+                let mut out = String::new();
+                if miette::GraphicalReportHandler::new()
+                    .with_theme(miette::GraphicalTheme::unicode())
+                    .render_report(&mut out, &e)
+                    .is_err()
+                {
+                    eprintln!("{}", e);
+                } else {
+                    eprintln!("{}", out);
+                }
             }
         }
     }

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -19,7 +19,7 @@ pub fn parse_source(source: &str) -> Result<Program, ParseError> {
     // Check recursion depth before parsing to prevent stack overflow
     check_recursion_depth(source)?;
 
-    let pairs = parse(source).map_err(|e| ParseError::PestError(e.to_string()))?;
+    let pairs = parse(source).map_err(|e| ParseError::PestError(Box::new(e)))?;
 
     let mut statements = Vec::new();
 
@@ -593,8 +593,8 @@ fn build_array_element(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
 /// Errors that can occur during AST construction
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ParseError {
-    #[error("Parse error: {0}")]
-    PestError(String),
+    #[error("{0}")]
+    PestError(Box<pest::error::Error<Rule>>),
 
     #[error("Empty term in expression")]
     EmptyTerm,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -52,10 +52,8 @@ pub fn parse(source: &str) -> Result<Program, GlossaError> {
                     if positives.is_empty() {
                         "Unexpected token".to_string()
                     } else {
-                        let expected: Vec<String> = positives
-                            .iter()
-                            .map(|r| format!("{:?}", r))
-                            .collect();
+                        let expected: Vec<String> =
+                            positives.iter().map(|r| format!("{:?}", r)).collect();
                         format!("Expected one of: {}", expected.join(", "))
                     }
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -26,6 +26,7 @@ pub mod builder;
 
 use crate::ast::Program;
 use crate::errors::GlossaError;
+use pest::error::{ErrorVariant, InputLocation};
 
 pub use builder::ParseError;
 
@@ -43,5 +44,30 @@ pub use builder::ParseError;
 /// assert_eq!(program.statements.len(), 1);
 /// ```
 pub fn parse(source: &str) -> Result<Program, GlossaError> {
-    builder::parse_source(source).map_err(|e| GlossaError::parse(e.to_string()))
+    builder::parse_source(source).map_err(|e| match e {
+        ParseError::PestError(pest_err) => {
+            let message = match &pest_err.variant {
+                ErrorVariant::CustomError { message } => message.clone(),
+                ErrorVariant::ParsingError { positives, .. } => {
+                    if positives.is_empty() {
+                        "Unexpected token".to_string()
+                    } else {
+                        let expected: Vec<String> = positives
+                            .iter()
+                            .map(|r| format!("{:?}", r))
+                            .collect();
+                        format!("Expected one of: {}", expected.join(", "))
+                    }
+                }
+            };
+
+            let span = match pest_err.location {
+                InputLocation::Pos(pos) => (pos, 1).into(),
+                InputLocation::Span((start, end)) => (start, end - start).into(),
+            };
+
+            GlossaError::parse_with_source(message, source, span)
+        }
+        _ => GlossaError::parse(e.to_string()),
+    })
 }

--- a/tests/error_formatting.rs
+++ b/tests/error_formatting.rs
@@ -1,0 +1,25 @@
+use glossa::parser::parse;
+use miette::Diagnostic;
+
+#[test]
+fn test_parse_error_span() {
+    let source = "«χαῖρε» @ λέγε.";
+    let err = parse(source).unwrap_err();
+
+    // Check it's a parse error
+    assert_eq!(err.category_greek(), "Σύνταξις");
+
+    // Check labels (spans)
+    // labels() returns Option<Box<dyn Iterator...>>
+    let labels: Vec<_> = err.labels().expect("Should have labels").collect();
+    assert_eq!(labels.len(), 1, "Should have exactly one label");
+
+    let label = &labels[0];
+    let offset = label.offset();
+    let len = label.len();
+
+    // "«χαῖρε» " is 15 + 1 = 16 bytes.
+    // @ is at byte 16.
+    assert_eq!(offset, 16, "Offset should point to @");
+    assert_eq!(len, 1, "Length should be 1 (@)");
+}

--- a/tests/parser_coverage.rs
+++ b/tests/parser_coverage.rs
@@ -1,0 +1,33 @@
+use glossa::parser::parse;
+use miette::Diagnostic;
+
+#[test]
+fn test_unexpected_token_has_labels() {
+    let source = "«χαῖρε» @";
+    let err = parse(source).unwrap_err();
+
+    // Check that we got the span correctly
+    assert!(err.labels().is_some());
+    let labels: Vec<_> = err.labels().unwrap().collect();
+    assert!(!labels.is_empty());
+
+    // Check that we got an expected message
+    // "Expected one of: ..."
+    let msg = err.to_string();
+    // In miette, `to_string` on the error might not include the full report if it just uses Display,
+    // but GlossaError uses `#[error("Σφάλμα συντάξεως: {message}")]` so it should be visible.
+    // However, the `ParseError` conversion logic I added constructs a message that says "Expected one of: ..."
+    // Let's verify that message is present.
+    // Wait, `GlossaError::parse_with_source` takes a message.
+    // The message is "Expected one of: ...".
+    // So `err.to_string()` will be "Σφάλμα συντάξεως: Expected one of: ..."
+    assert!(msg.contains("Expected one of:"));
+}
+
+#[test]
+fn test_unexpected_eof() {
+    let source = "«χαῖρε"; // Unclosed string
+    let err = parse(source).unwrap_err();
+
+    assert!(err.labels().is_some());
+}

--- a/verify_error.rs
+++ b/verify_error.rs
@@ -1,0 +1,19 @@
+use glossa::parser::parse;
+use miette::GraphicalReportHandler;
+
+fn main() {
+    let source = "«χαῖρε»"; // Missing verb
+    let result = parse(source);
+
+    if let Err(e) = result {
+        println!("--- MIETTE ERROR ---");
+        let mut out = String::new();
+        GraphicalReportHandler::new()
+            .render_report(&mut out, &e)
+            .unwrap();
+        println!("{}", out);
+        println!("--------------------");
+    } else {
+        println!("Unexpected success");
+    }
+}


### PR DESCRIPTION
This PR enhances the error reporting for parsing errors in the ΓΛΩΣΣΑ compiler.

Previously, parse errors were eagerly converted to strings, losing location information and resulting in "Ugly" error messages in the CLI and REPL.

This change:
1.  Updates `ParseError` in `src/parser/builder.rs` to hold the full `pest` error.
2.  Updates `src/parser/mod.rs` to convert this rich error into a `GlossaError` with a `miette::SourceSpan`.
3.  Updates the REPL in `src/main.rs` to use `miette::GraphicalReportHandler` to render these errors with colors, context, and arrows.

The result is a much more user-friendly experience where syntax errors are clearly highlighted in the source code.

---
*PR created automatically by Jules for task [4166508685853642176](https://jules.google.com/task/4166508685853642176) started by @madmax983*