### PR TITLE
🔒 Warden: Fix keyword collision & namespace pollution

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -49,3 +49,15 @@
 **Defense:** Removed special single-letter mapping in `sanitize_name` and enforced strict transliteration in `transliterate`. `σ` now maps to `s`, while `σίγμα` maps to `sigma`. `ψ` maps to `_u3c8_` (hex encoded) to avoid collision with `ps`.
 
 **Severity:** Medium (Logic Bug).
+
+## 2026-06-03 - Rust Keyword Collision & Namespace Pollution
+
+**Threat:**
+1. **Keyword Collision:** User identifiers like `if` or `fn` (valid in Glossa/ASCII) transliterated directly to Rust keywords, causing compilation errors.
+2. **Namespace Pollution:** User methods named `len` or `push` could shadow standard library methods, breaking generated code for standard types like `Vec`.
+
+**Defense:**
+1. **Namespace Isolation:** Modified `sanitize_name` to prefix ALL user-defined identifiers with `g_`.
+2. **Std Lib Preservation:** Implemented `is_std_method` and `is_std_type` allowlists in code generation to detect calls to standard library methods and preserve their original names (e.g. `len`) instead of prefixing them.
+
+**Severity:** Medium (Logic Bug / Compilation Failure).

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -1052,7 +1052,11 @@ mod tests {
     fn test_generate_full_program() {
         let code = compile("ξ πέντε ἔστω. ξ λέγε.");
         // Variables are now prefixed with g_
-        assert!(code.contains("let g_x = 5"), "Expected binding in: {}", code);
+        assert!(
+            code.contains("let g_x = 5"),
+            "Expected binding in: {}",
+            code
+        );
         assert!(code.contains("println"), "Expected println in: {}", code);
     }
 

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -700,7 +700,16 @@ fn generate_expr(expr: &AnalyzedExpr) -> TokenStream {
             args,
         } => {
             let recv = generate_expr(receiver);
-            let method_ident = format_ident!("{}", sanitize_name(method));
+
+            // Check if this is a standard library method call on a standard type
+            let method_ident = if is_std_method(method) && is_std_type(&receiver.glossa_type) {
+                // Use the raw method name (e.g., "len", "push")
+                format_ident!("{}", method.as_str())
+            } else {
+                // Sanitize (prefix with g_) for user-defined methods
+                format_ident!("{}", sanitize_name(method))
+            };
+
             let arg_tokens: Vec<TokenStream> = args.iter().map(generate_expr).collect();
             quote! { #recv.#method_ident(#(#arg_tokens),*) }
         }
@@ -955,6 +964,55 @@ fn is_self_parameter(param_name: &str, idx: usize) -> bool {
         || param_name.contains("self")
 }
 
+/// Check if a method name belongs to the Rust standard library allowlist
+fn is_std_method(name: &str) -> bool {
+    matches!(
+        name,
+        "len"
+            | "push"
+            | "unwrap"
+            | "to_string"
+            | "clone"
+            | "default"
+            | "into"
+            | "from"
+            | "eq"
+            | "insert"
+            | "contains"
+            | "contains_key"
+            | "get"
+            | "remove"
+            | "iter"
+            | "map"
+            | "filter"
+            | "collect"
+            | "any"
+            | "all"
+            | "fold"
+            | "find"
+            | "as_str"
+            | "chars"
+            | "lines"
+            | "is_empty"
+    )
+}
+
+/// Check if a Glossa type maps to a standard Rust type (Vec, String, etc.)
+fn is_std_type(ty: &GlossaType) -> bool {
+    matches!(
+        ty,
+        GlossaType::Number
+            | GlossaType::String
+            | GlossaType::Boolean
+            | GlossaType::List(_)
+            | GlossaType::Set(_)
+            | GlossaType::Map(_, _)
+            | GlossaType::Option(_)
+            | GlossaType::Result(_, _)
+            | GlossaType::Unit
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -978,7 +1036,8 @@ mod tests {
     #[test]
     fn test_generate_binding() {
         let code = compile("ξ πέντε ἔστω.");
-        assert!(code.contains("let x"));
+        // Variables are now prefixed with g_
+        assert!(code.contains("let g_x"));
         assert!(code.contains("5"));
     }
 
@@ -992,7 +1051,8 @@ mod tests {
     #[test]
     fn test_generate_full_program() {
         let code = compile("ξ πέντε ἔστω. ξ λέγε.");
-        assert!(code.contains("let x = 5"), "Expected binding in: {}", code);
+        // Variables are now prefixed with g_
+        assert!(code.contains("let g_x = 5"), "Expected binding in: {}", code);
         assert!(code.contains("println"), "Expected println in: {}", code);
     }
 

--- a/src/codegen/types.rs
+++ b/src/codegen/types.rs
@@ -90,13 +90,9 @@ mod tests {
             gender: crate::morphology::Gender::Masculine,
             fields: vec![],
         };
-        // Sanitize: χρηστης -> _u3c7_rhsths (Chi hex encoded, Eta -> h)
-        // Capitalize: _u3c7_rhsths (underscore remains underscore? No, capitalize capitalizes first char)
-        // _u... starts with _. _ is not uppercasable.
-        // Wait, capitalize logic:
-        // match chars.next() { Some(first) => first.to_uppercase() ... }
-        // '_' to_uppercase is '_'.
-        assert_eq!(to_rust_type(&ty), "_u3c7_rhsths");
+        // Sanitize: χρηστης -> g__u3c7_rhsths
+        // Capitalize: g__u3c7_rhsths -> G__u3c7_rhsths
+        assert_eq!(to_rust_type(&ty), "G__u3c7_rhsths");
     }
 
     #[test]

--- a/src/codegen/utils.rs
+++ b/src/codegen/utils.rs
@@ -33,7 +33,8 @@ pub(crate) fn sanitize_name(name: &str) -> String {
     // Directly transliterate without special casing single letters
     // This prevents collisions between single letters and their full names
     // e.g. "σ" (sigma) vs "σίγμα" (sigma)
-    transliterate(name)
+    // Prefix with "g_" to namespace all user-defined identifiers and avoid collisions with Rust keywords
+    format!("g_{}", transliterate(name))
 }
 
 /// Transliterate Greek to Latin characters
@@ -103,9 +104,9 @@ mod tests {
 
     #[test]
     fn test_sanitize_greek_letter() {
-        assert_eq!(sanitize_name("ξ"), "x");
-        assert_eq!(sanitize_name("α"), "a");
-        assert_eq!(sanitize_name("ω"), "w");
+        assert_eq!(sanitize_name("ξ"), "g_x");
+        assert_eq!(sanitize_name("α"), "g_a");
+        assert_eq!(sanitize_name("ω"), "g_w");
     }
 
     #[test]
@@ -150,5 +151,18 @@ mod tests {
         assert_eq!(capitalize("Hello"), "Hello");
         assert_eq!(capitalize(""), "");
         assert_eq!(capitalize("x"), "X");
+    }
+
+    #[test]
+    fn test_sanitize_keywords_and_prefix() {
+        // Test that keywords are safe (by prefixing)
+        // If "if" stays "if", it's invalid Rust
+        assert_eq!(sanitize_name("if"), "g_if");
+        assert_eq!(sanitize_name("fn"), "g_fn");
+
+        // Test that regular identifiers are prefixed
+        // This ensures a unique namespace for user variables
+        assert_eq!(sanitize_name("x"), "g_x");
+        assert_eq!(sanitize_name("foo"), "g_foo");
     }
 }

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -21,16 +21,16 @@ fn test_hello_cosmos() {
 #[test]
 fn test_variable_binding() {
     let code = compile("ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let x"));
+    assert!(code.contains("let g_x"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_variable_binding_and_use() {
     let code = compile("ξ πέντε ἔστω. ξ λέγε.").unwrap();
-    assert!(code.contains("let x = 5"));
+    assert!(code.contains("let g_x = 5"));
     assert!(code.contains("println"));
-    assert!(code.contains("x"));
+    assert!(code.contains("g_x"));
 }
 
 #[test]
@@ -42,8 +42,8 @@ fn test_number_literal() {
 #[test]
 fn test_multiple_statements() {
     let code = compile("α πέντε ἔστω. β δέκα ἔστω. α λέγε.").unwrap();
-    assert!(code.contains("let a = 5"));
-    assert!(code.contains("let b = 10"));
+    assert!(code.contains("let g_a = 5"));
+    assert!(code.contains("let g_b = 10"));
 }
 
 #[test]
@@ -61,15 +61,15 @@ fn test_preserves_greek_in_strings() {
 #[test]
 fn test_mutable_binding() {
     let code = compile("μετά ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let mut x"));
+    assert!(code.contains("let mut g_x"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_assignment_codegen() {
     let code = compile("μετά ξ πέντε ἔστω. ξ δέκα γίγνεται.").unwrap();
-    assert!(code.contains("let mut x = 5"));
-    assert!(code.contains("x = 10"));
+    assert!(code.contains("let mut g_x = 5"));
+    assert!(code.contains("g_x = 10"));
 }
 
 #[test]
@@ -89,8 +89,8 @@ fn test_undefined_assignment_error() {
 #[test]
 fn test_mutable_binding_and_reassignment() {
     let code = compile("μετά ξ πέντε ἔστω. ξ λέγε. ξ δέκα γίγνεται. ξ λέγε.").unwrap();
-    assert!(code.contains("let mut x = 5"));
-    assert!(code.contains("x = 10"));
+    assert!(code.contains("let mut g_x = 5"));
+    assert!(code.contains("g_x = 10"));
     assert!(code.matches("println").count() >= 2);
 }
 

--- a/tests/function_tests.rs
+++ b/tests/function_tests.rs
@@ -39,8 +39,8 @@ fn test_function_with_two_params() {
     let code = compile("προσθεσις ὁρίζειν τῷ ξ τῷ ψ· δός ξ ψ ἄθροισμα.");
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("fn"));
-    // ξ -> x, ψ -> _u3c8_
-    assert!(code.contains("x") && code.contains("_u3c8_"));
+    // ξ -> g_x, ψ -> g__u3c8_
+    assert!(code.contains("g_x") && code.contains("g__u3c8_"));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_simple_return() {
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("return"));
     // Should return x * 2, not just a literal
-    assert!(code.contains("x") || code.contains("*") || code.contains("2"));
+    assert!(code.contains("g_x") || code.contains("*") || code.contains("2"));
 }
 
 #[test]
@@ -82,10 +82,10 @@ fn test_function_call() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
-    // πρόσθεσις -> pros_u3b8_esis
+    // πρόσθεσις -> g_pros_u3b8_esis
     assert!(
-        code.contains("pros_u3b8_esis")
-            && (code.contains("pros_u3b8_esis(") || code.contains("pros_u3b8_esis ("))
+        code.contains("g_pros_u3b8_esis")
+            && (code.contains("g_pros_u3b8_esis(") || code.contains("g_pros_u3b8_esis ("))
     );
 }
 
@@ -100,7 +100,7 @@ fn test_nested_calls() {
     eprintln!("Generated code:\n{}", code);
     // Check for nested diplasiasmos calls (allowing for whitespace)
     assert!(
-        code.matches("diplasiasmos").count() >= 3,
+        code.matches("g_diplasiasmos").count() >= 3,
         "Expected at least 3 occurrences of diplasiasmos (fn def + 2 calls)"
     );
     assert!(code.contains("5i64"), "Expected literal 5 as argument");
@@ -120,7 +120,7 @@ fn test_function_local_variables() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
-    assert!(code.contains("let topikon"));
+    assert!(code.contains("let g_topikon"));
 }
 
 #[test]

--- a/tests/trait_tests.rs
+++ b/tests/trait_tests.rs
@@ -437,13 +437,13 @@ fn test_codegen_trait_definition() {
     let source = "χαρακτήρ Showable ὁρίζειν { δεῖ show τῷ self. }.";
     let code = compile(source);
     assert!(
-        code.contains("trait Showable"),
+        code.contains("trait G_showable"),
         "Should generate trait keyword: {}",
         code
     );
     // quote! adds spaces, so check for "& self" with possible spaces
     assert!(
-        code.contains("fn show") && code.contains("& self"),
+        code.contains("fn g_show") && code.contains("& self"),
         "Should generate method signature: {}",
         code
     );
@@ -460,12 +460,12 @@ fn test_codegen_trait_impl() {
     "#;
     let code = compile(source);
     assert!(
-        code.contains("impl Showable for Point"),
+        code.contains("impl G_showable for G_point"),
         "Should generate impl block: {}",
         code
     );
     assert!(
-        code.contains("fn show") && code.contains("& self"),
+        code.contains("fn g_show") && code.contains("& self"),
         "Should generate impl method: {}",
         code
     );
@@ -481,23 +481,23 @@ fn test_codegen_trait_with_default() {
     "#;
     let code = compile(source);
     assert!(
-        code.contains("trait Math"),
+        code.contains("trait G_math"),
         "Should generate trait: {}",
         code
     );
     assert!(
-        code.contains("fn value") && code.contains("& self"),
+        code.contains("fn g_value") && code.contains("& self"),
         "Should have required method: {}",
         code
     );
     assert!(
-        code.contains("fn double") && code.contains("& self"),
+        code.contains("fn g_double") && code.contains("& self"),
         "Should have default method: {}",
         code
     );
     // Default method should have a body
     assert!(
-        code.contains("double") && code.contains("& self") && code.contains("{"),
+        code.contains("g_double") && code.contains("& self") && code.contains("{"),
         "Default method should have body: {}",
         code
     );
@@ -519,12 +519,12 @@ fn test_codegen_trait_method_call_genitive() {
     // Using genitive pattern (που), this creates a property access which becomes a method call
     // The print statement should show the method call
     assert!(
-        code.contains("trait Showable"),
+        code.contains("trait G_showable"),
         "Should have trait: {}",
         code
     );
     assert!(
-        code.contains("impl Showable for Point"),
+        code.contains("impl G_showable for G_point"),
         "Should have impl: {}",
         code
     );
@@ -546,19 +546,19 @@ fn test_codegen_full_example() {
 
     // Check for trait definition
     assert!(
-        code.contains("trait Showable"),
+        code.contains("trait G_showable"),
         "Missing trait definition: {}",
         code
     );
     // Check for struct definition
     assert!(
-        code.contains("struct Point"),
+        code.contains("struct G_point"),
         "Missing struct definition: {}",
         code
     );
     // Check for impl block
     assert!(
-        code.contains("impl Showable for Point"),
+        code.contains("impl G_showable for G_point"),
         "Missing impl block: {}",
         code
     );
@@ -582,7 +582,7 @@ fn test_standalone_method_call() {
     let code = compile(source);
 
     // Should contain the method call
-    assert!(code.contains("p . show") || code.contains("p.show"));
+    assert!(code.contains("g_p . g_show") || code.contains("g_p.g_show"));
 }
 
 // ============================================================================
@@ -606,8 +606,8 @@ fn test_type_implements_multiple_traits() {
 
     let code = compile(source);
     // Should have impl blocks for both traits
-    assert!(code.contains("impl Showable for Point"));
-    assert!(code.contains("impl Printable for Point"));
+    assert!(code.contains("impl G_showable for G_point"));
+    assert!(code.contains("impl G_printable for G_point"));
 }
 
 #[test]
@@ -625,7 +625,7 @@ fn test_override_default_method() {
 
     let code = compile(source);
     // The impl should contain the overridden method
-    assert!(code.contains("impl Describable for Thing"));
+    assert!(code.contains("impl G_describable for G_thing"));
     // The impl body should have the custom implementation
     assert!(code.contains("custom") || code.contains("\"custom\""));
 }
@@ -650,7 +650,7 @@ fn test_call_both_trait_methods_on_same_type() {
 
     let code = compile(source);
     // Should have calls to both methods
-    assert!(code.contains("alpha") && code.contains("beta"));
+    assert!(code.contains("g_alpha") && code.contains("g_beta"));
 }
 
 #[test]
@@ -670,8 +670,8 @@ fn test_multiple_types_implement_same_trait() {
 
     let code = compile(source);
     // Should have impl blocks for both types
-    assert!(code.contains("impl Countable for Foo"));
-    assert!(code.contains("impl Countable for Bar"));
+    assert!(code.contains("impl G_countable for G_foo"));
+    assert!(code.contains("impl G_countable for G_bar"));
 }
 
 #[test]

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -43,8 +43,8 @@ fn test_instantiation() {
         π νέον σημεῖον πέντε ἔστω.
     "#;
     let code = compile(source);
-    // σημεῖον -> Shmeion (η -> h)
-    assert!(code.contains("Shmeion") || code.contains("shmeion"));
+    // σημεῖον -> G_shmeion
+    assert!(code.contains("G_shmeion"));
     assert!(code.contains("5"));
 }
 
@@ -55,7 +55,7 @@ fn test_instantiation_multiple_fields() {
         π νέον σημεῖον πέντε τρία ἔστω.
     "#;
     let code = compile(source);
-    assert!(code.contains("Shmeion") || code.contains("shmeion"));
+    assert!(code.contains("G_shmeion"));
 }
 
 // Cycle 5: Field Access
@@ -68,8 +68,8 @@ fn test_field_access() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    // ξ -> x
-    assert!(code.contains(".x") || code.contains(". x"));
+    // ξ -> g_x
+    assert!(code.contains(".g_x") || code.contains(". g_x"));
 }
 
 #[test]
@@ -82,10 +82,10 @@ fn test_field_access_multiple_fields() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    // ξ -> x
-    assert!(code.contains(". x") || code.contains(".x"));
-    // ψ -> _u3c8_
-    assert!(code.contains(". _u3c8_") || code.contains("._u3c8_"));
+    // ξ -> g_x
+    assert!(code.contains(". g_x") || code.contains(".g_x"));
+    // ψ -> g__u3c8_
+    assert!(code.contains(". g__u3c8_") || code.contains(".g__u3c8_"));
 }
 
 #[test]
@@ -97,9 +97,9 @@ fn test_instantiation_with_literals() {
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
     // It should generate struct instantiation, not string assignment
-    // Χρήστης -> _u3c7_rhsths (chi -> _u3c7_, eta -> h)
-    assert!(code.contains("struct _u3c7_rhsths"));
-    assert!(code.contains("let _u3c7_rhsths = _u3c7_rhsths"));
+    // Χρήστης -> G__u3c7_rhsths
+    assert!(code.contains("struct G__u3c7_rhsths"));
+    assert!(code.contains("let g__u3c7_rhsths = G__u3c7_rhsths"));
     assert!(code.contains("Σωκράτης"));
     assert!(code.contains("70"));
 }

--- a/tests/word_order_tests.rs
+++ b/tests/word_order_tests.rs
@@ -23,7 +23,7 @@ fn test_binding_word_order_independence() {
     let sov = compile_to_rust("ξ πέντε ἔστω.");
 
     // These should all produce equivalent output
-    assert!(sov.contains("let x"));
+    assert!(sov.contains("let g_x"));
     assert!(sov.contains("5i64") || sov.contains("5 "));
 }
 
@@ -44,7 +44,7 @@ fn test_variable_binding_and_reference() {
     let output = compile_to_rust(source);
 
     // Should have binding
-    assert!(output.contains("let x"));
+    assert!(output.contains("let g_x"));
     // Should have print
     assert!(output.contains("println"));
 }
@@ -54,12 +54,12 @@ fn test_variable_binding_and_reference() {
 fn test_number_binding_variations() {
     // Arabic numeral
     let arabic = compile_to_rust("ξ 42 ἔστω.");
-    assert!(arabic.contains("let x"));
+    assert!(arabic.contains("let g_x"));
     assert!(arabic.contains("42"));
 
     // Greek numeral word
     let greek_word = compile_to_rust("ξ πέντε ἔστω.");
-    assert!(greek_word.contains("let x"));
+    assert!(greek_word.contains("let g_x"));
     assert!(greek_word.contains("5"));
 }
 
@@ -104,8 +104,8 @@ fn test_multiple_statement_scope() {
     let output = compile_to_rust(source);
 
     // Both bindings should exist
-    assert!(output.contains("let a"));
-    assert!(output.contains("let b"));
+    assert!(output.contains("let g_a"));
+    assert!(output.contains("let g_b"));
 }
 
 /// Test that queries produce output


### PR DESCRIPTION
**Threat:** User identifiers (ASCII or Greek) could collide with Rust keywords (e.g. `if`, `fn`) or standard library methods (e.g. `len`), causing compilation errors or shadowing.

**Defense:**
1.  Modified `sanitize_name` in `src/codegen/utils.rs` to prefix ALL user-defined identifiers with `g_` (e.g., `if` -> `g_if`, `x` -> `g_x`).
2.  Implemented `is_std_method` and `is_std_type` in `src/codegen/rust.rs` to detect standard library calls (like `Vec::len`).
3.  Updated `generate_expr` to check these allowlists: if a method is a standard method on a standard type, it uses the raw name (`len`); otherwise, it uses the sanitized name (`g_len`).
4.  Updated the test suite (`tests/`) to expect `g_` prefixes in generated Rust code.

**Verification:**
*   Added unit test `test_sanitize_keywords_and_prefix` in `src/codegen/utils.rs` (passed).
*   Verified standard library calls (`tests/collection_tests.rs`) work correctly (passed).
*   Verified variable bindings (`tests/compile_tests.rs`) use `g_` prefix (passed).
*   Verified struct/trait generation (`tests/trait_tests.rs`, `tests/type_tests.rs`) uses `G_` prefix (passed).

---
*PR created automatically by Jules for task [12295743121348935835](https://jules.google.com/task/12295743121348935835) started by @madmax983*