### PR TITLE
Refactor semantic model to remove redundant abstractions

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -208,19 +208,6 @@ pub enum Expr {
     Block(Vec<Statement>),
 }
 
-/// Capture mode for closures
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CaptureMode {
-    /// Borrow captured variables (default for present participles)
-    Borrow,
-
-    /// Move captured variables (for aorist participles)
-    Move,
-
-    /// Memoize result (for perfect participles)
-    Memoize,
-}
-
 /// Binary operators in GLOSSA
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinOperator {

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -51,8 +51,8 @@ use crate::codegen::types::to_rust_type;
 use crate::codegen::utils::{capitalize, sanitize_name};
 use crate::morphology::lexicon::{BinaryOp, UnaryOp};
 use crate::semantic::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedIteratorOp, AnalyzedMethod, AnalyzedProgram,
-    AnalyzedStatement, GlossaType, StatementKind,
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedMethod, AnalyzedProgram, AnalyzedStatement,
+    CaptureMode, GlossaType, StatementKind,
 };
 use crate::text::normalize_greek;
 use proc_macro2::TokenStream;
@@ -172,9 +172,7 @@ fn statement_uses_collections(stmt: &AnalyzedStatement) -> bool {
 /// Check if an expression uses collection types
 fn expr_uses_collections(expr: &AnalyzedExpr) -> bool {
     match &expr.expr {
-        AnalyzedExprKind::CollectionNew { .. } | AnalyzedExprKind::CollectionContains { .. } => {
-            true
-        }
+        AnalyzedExprKind::CollectionNew { .. } => true,
         AnalyzedExprKind::MethodCall { receiver, args, .. } => {
             expr_uses_collections(receiver) || args.iter().any(expr_uses_collections)
         }
@@ -738,6 +736,10 @@ fn generate_expr(expr: &AnalyzedExpr) -> TokenStream {
                     let operand_tokens = generate_expr(operand);
                     quote! { -#operand_tokens }
                 }
+                UnaryOp::Ref => {
+                    let operand_tokens = generate_expr(operand);
+                    quote! { &#operand_tokens }
+                }
             }
         }
 
@@ -767,42 +769,10 @@ fn generate_expr(expr: &AnalyzedExpr) -> TokenStream {
             capture_mode,
         } => generate_closure(params, body, capture_mode),
 
-        AnalyzedExprKind::IteratorChain { collection, ops } => {
-            generate_iterator_chain(collection, ops)
-        }
-
         AnalyzedExprKind::CollectionNew { collection_type } => {
             // Generate HashSet::new() or HashMap::new()
             let type_ident = format_ident!("{}", collection_type);
             quote! { #type_ident::new() }
-        }
-
-        AnalyzedExprKind::CollectionContains {
-            collection,
-            element,
-            is_map,
-        } => {
-            let coll = generate_expr(collection);
-            let elem = generate_expr(element);
-            if *is_map {
-                // HashMap uses .contains_key(&key)
-                quote! { #coll.contains_key(&#elem) }
-            } else {
-                match &element.expr {
-                    // When the element is a string literal, `generate_expr`
-                    // already yields a `&str`, so we call `.contains(elem)`
-                    // without adding another `&`.
-                    AnalyzedExprKind::StringLiteral(_) => {
-                        quote! { #coll.contains(#elem) }
-                    }
-                    // In all other cases, keep the existing behavior and
-                    // pass a reference to the element.
-                    _ => {
-                        // HashSet uses .contains(&element)
-                        quote! { #coll.contains(&#elem) }
-                    }
-                }
-            }
         }
 
         AnalyzedExprKind::Assert { condition } => {
@@ -864,10 +834,8 @@ fn generate_struct_lit(
 fn generate_closure(
     params: &[smol_str::SmolStr],
     body: &AnalyzedExpr,
-    capture_mode: &crate::ast::CaptureMode,
+    capture_mode: &CaptureMode,
 ) -> TokenStream {
-    use crate::ast::CaptureMode;
-
     let body_tokens = generate_expr(body);
     let params_idents: Vec<_> = params
         .iter()
@@ -898,48 +866,6 @@ fn generate_closure(
             }
         }
     }
-}
-
-fn generate_iterator_chain(collection: &AnalyzedExpr, ops: &[AnalyzedIteratorOp]) -> TokenStream {
-    let mut current = generate_expr(collection);
-
-    for op in ops {
-        current = match op {
-            AnalyzedIteratorOp::Iter => {
-                quote! { #current.iter() }
-            }
-            AnalyzedIteratorOp::Map(closure) => {
-                let closure_tokens = generate_expr(closure);
-                quote! { #current.map(#closure_tokens) }
-            }
-            AnalyzedIteratorOp::Filter(closure) => {
-                let closure_tokens = generate_expr(closure);
-                quote! { #current.filter(#closure_tokens) }
-            }
-            AnalyzedIteratorOp::Find(closure) => {
-                let closure_tokens = generate_expr(closure);
-                quote! { #current.find(#closure_tokens) }
-            }
-            AnalyzedIteratorOp::Fold { init, closure } => {
-                let init_tokens = generate_expr(init);
-                let closure_tokens = generate_expr(closure);
-                quote! { #current.fold(#init_tokens, #closure_tokens) }
-            }
-            AnalyzedIteratorOp::Any(closure) => {
-                let closure_tokens = generate_expr(closure);
-                quote! { #current.any(#closure_tokens) }
-            }
-            AnalyzedIteratorOp::All(closure) => {
-                let closure_tokens = generate_expr(closure);
-                quote! { #current.all(#closure_tokens) }
-            }
-            AnalyzedIteratorOp::Collect => {
-                quote! { #current.collect() }
-            }
-        };
-    }
-
-    current
 }
 
 /// Check if a parameter represents the self parameter in a trait method

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -2226,6 +2226,7 @@ impl BinaryOp {}
 pub enum UnaryOp {
     Not, // οὐ/οὐκ
     Neg, // arithmetic negation
+    Ref, // &
 }
 
 impl UnaryOp {}

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -614,15 +614,29 @@ fn classify_assertion(
                 };
 
                 let is_map = matches!(collection_type, GlossaType::Map(_, _));
+                let method = if is_map { "contains_key" } else { "contains" };
+
+                // Handle referencing argument if not a string literal
+                let arg_expr = if matches!(element.expr, AnalyzedExprKind::StringLiteral(_)) {
+                    element
+                } else {
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::UnaryOp {
+                            op: crate::morphology::lexicon::UnaryOp::Ref,
+                            operand: Box::new(element),
+                        },
+                        glossa_type: GlossaType::Unknown,
+                    }
+                };
 
                 let contains_expr = AnalyzedExpr {
-                    expr: AnalyzedExprKind::CollectionContains {
-                        collection: Box::new(AnalyzedExpr {
+                    expr: AnalyzedExprKind::MethodCall {
+                        receiver: Box::new(AnalyzedExpr {
                             expr: AnalyzedExprKind::Variable(subj_name.clone()),
                             glossa_type: collection_type.clone(),
                         }),
-                        element: Box::new(element),
-                        is_map,
+                        method: method.into(),
+                        args: vec![arg_expr],
                     },
                     glossa_type: GlossaType::Boolean,
                 };
@@ -846,12 +860,26 @@ fn classify_query(
             };
 
             let is_map = matches!(subj_type, GlossaType::Map(_, _));
+            let method = if is_map { "contains_key" } else { "contains" };
+
+            // Handle referencing argument if not a string literal
+            let arg_expr = if matches!(element.expr, AnalyzedExprKind::StringLiteral(_)) {
+                element
+            } else {
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::UnaryOp {
+                        op: crate::morphology::lexicon::UnaryOp::Ref,
+                        operand: Box::new(element),
+                    },
+                    glossa_type: GlossaType::Unknown,
+                }
+            };
 
             let contains_expr = AnalyzedExpr {
-                expr: AnalyzedExprKind::CollectionContains {
-                    collection: Box::new(collection),
-                    element: Box::new(element),
-                    is_map,
+                expr: AnalyzedExprKind::MethodCall {
+                    receiver: Box::new(collection),
+                    method: method.into(),
+                    args: vec![arg_expr],
                 },
                 glossa_type: GlossaType::Boolean,
             };

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -550,7 +550,7 @@ pub fn build_binary_expr(
     op: crate::morphology::lexicon::BinaryOp,
     right: AnalyzedExpr,
 ) -> AnalyzedExpr {
-    let result_type = infer_binop_type(&left.glossa_type, &op, &right.glossa_type);
+    let result_type = infer_binop_type(&op);
     AnalyzedExpr {
         expr: AnalyzedExprKind::BinOp {
             left: Box::new(left),
@@ -585,7 +585,7 @@ pub fn build_expressions_from_literals_and_ops(
     for (i, op) in operators.iter().enumerate() {
         if i + 1 < literals.len() {
             let right = literal_to_analyzed_expr(&literals[i + 1]);
-            let result_type = infer_binop_type(&result.glossa_type, op, &right.glossa_type);
+            let result_type = infer_binop_type(op);
             result = AnalyzedExpr {
                 expr: AnalyzedExprKind::BinOp {
                     left: Box::new(result),
@@ -601,11 +601,7 @@ pub fn build_expressions_from_literals_and_ops(
 }
 
 /// Infer the result type of a binary operation
-pub fn infer_binop_type(
-    _left: &GlossaType,
-    op: &crate::morphology::lexicon::BinaryOp,
-    _right: &GlossaType,
-) -> GlossaType {
+pub fn infer_binop_type(op: &crate::morphology::lexicon::BinaryOp) -> GlossaType {
     use crate::morphology::lexicon::BinaryOp;
 
     match op {

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -100,30 +100,6 @@ pub struct AnalyzedMethod {
     pub return_type: Option<GlossaType>,
 }
 
-/// Iterator operation for AnalyzedExpr
-#[derive(Debug, Clone)]
-pub enum AnalyzedIteratorOp {
-    /// .iter() - create iterator
-    Iter,
-    /// .map(closure) - transform elements
-    Map(Box<AnalyzedExpr>),
-    /// .filter(closure) - select elements
-    Filter(Box<AnalyzedExpr>),
-    /// .find(closure) - find first matching element
-    Find(Box<AnalyzedExpr>),
-    /// .fold(init, closure) - reduce to single value
-    Fold {
-        init: Box<AnalyzedExpr>,
-        closure: Box<AnalyzedExpr>,
-    },
-    /// .any(closure) - test if any element matches
-    Any(Box<AnalyzedExpr>),
-    /// .all(closure) - test if all elements match
-    All(Box<AnalyzedExpr>),
-    /// .collect() - collect into collection
-    Collect,
-}
-
 /// Analyzed expression with type information
 #[derive(Debug, Clone)]
 pub struct AnalyzedExpr {
@@ -210,22 +186,11 @@ pub enum AnalyzedExprKind {
     Lambda {
         params: Vec<SmolStr>,
         body: Box<AnalyzedExpr>,
-        capture_mode: crate::ast::CaptureMode,
-    },
-    /// Iterator chain collection.iter().map(...).filter(...)
-    IteratorChain {
-        collection: Box<AnalyzedExpr>,
-        ops: Vec<AnalyzedIteratorOp>,
+        capture_mode: CaptureMode,
     },
     /// Collection constructor (HashSet::new(), HashMap::new())
     CollectionNew {
         collection_type: String,
-    },
-    /// Collection contains check (set.contains(&x), map.contains_key(&k))
-    CollectionContains {
-        collection: Box<AnalyzedExpr>,
-        element: Box<AnalyzedExpr>,
-        is_map: bool,
     },
     /// Boolean assertion: δεῖ (condition must be true)
     Assert {
@@ -236,6 +201,19 @@ pub enum AnalyzedExprKind {
         left: Box<AnalyzedExpr>,
         right: Box<AnalyzedExpr>,
     },
+}
+
+/// Capture mode for closures
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureMode {
+    /// Borrow captured variables (default for present participles)
+    Borrow,
+
+    /// Move captured variables (for aorist participles)
+    Move,
+
+    /// Memoize result (for perfect participles)
+    Memoize,
 }
 
 // --- Trait and Type Definitions (moved from types.rs) ---

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -38,8 +38,8 @@
 //! into the corresponding Rust iterator chain.
 
 use super::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedIteratorOp, AnalyzedStatement, AssembledStatement,
-    GlossaType, Scope, StatementKind,
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, AssembledStatement, CaptureMode, GlossaType,
+    Scope, StatementKind,
 };
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
@@ -384,36 +384,77 @@ pub fn detect_iterator_pattern(
     }
 
     // Get the collection - prefer array literals, then subject
-    let Some(collection_expr) = extract_collection(asm_stmt) else {
-        return Ok(None);
+    let collection_expr = match extract_collection(asm_stmt) {
+        Some(c) => c,
+        None => return Ok(None),
     };
 
     // Determine flags for any/all quantification
     let flags = QuantifierFlags::from(asm_stmt);
 
-    // Start with the collection variable
-    let mut iterator_ops = vec![AnalyzedIteratorOp::Iter];
+    // Start with .iter()
+    // chain: collection.iter()
+    let mut current_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::MethodCall {
+            receiver: Box::new(collection_expr),
+            method: "iter".into(),
+            args: vec![],
+        },
+        glossa_type: GlossaType::Unknown, // Iterator type
+    };
+
+    // Keep track if we performed any operations, to avoid collecting empty iterator if not needed
+    let mut has_ops = false;
 
     // Process adjectives (filter, any, all)
-    process_adjectives(asm_stmt, &flags, &mut iterator_ops);
+    if process_adjectives(asm_stmt, &flags, &mut current_expr) {
+        has_ops = true;
+    }
 
     // Process participles (map, fold)
-    process_participles(asm_stmt, &mut iterator_ops);
+    let (participle_ops, is_fold_result) = process_participles(asm_stmt, &mut current_expr);
+    if participle_ops {
+        has_ops = true;
+    }
 
     // Handle any/all operations with explicit operators (comparatives stored as operators)
-    if let Some(chain) =
-        process_explicit_quantifiers(asm_stmt, &flags, &collection_expr, &mut iterator_ops)
-    {
-        return Ok(Some(chain));
+    let is_any_all =
+        process_explicit_quantifiers(asm_stmt, &flags, &mut current_expr);
+    if is_any_all {
+        return Ok(Some(current_expr));
     }
 
     // Handle find operations
     if is_find {
-        return process_find(asm_stmt, collection_expr, iterator_ops);
+        process_find(asm_stmt, &mut current_expr);
+        // Find returns Option/Result, not an iterator, so we are done
+        // We assume .find() was called on current_expr
+        // But wait, find returns Option<T>, so we might want to unwrap or treat as Number?
+        // Current logic says: glossa_type: GlossaType::Number
+        // Let's set the type properly
+        current_expr.glossa_type = GlossaType::Number;
+        return Ok(Some(current_expr));
+    }
+
+    // If we have a fold, we are done
+    if is_fold_result {
+        return Ok(Some(current_expr));
+    }
+
+    // If we have any/all result from adjectives, we are done
+    // Check if the current expression type is Boolean (any/all returns bool)
+    if matches!(current_expr.glossa_type, GlossaType::Boolean) {
+        return Ok(Some(current_expr));
     }
 
     // Finalize the iterator chain (add .collect() if needed)
-    finalize_iterator_chain(collection_expr, iterator_ops)
+    // Only if we actually added operations
+    if has_ops {
+        finalize_iterator_chain(&mut current_expr);
+        Ok(Some(current_expr))
+    } else {
+        Ok(None)
+    }
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -493,16 +534,19 @@ impl QuantifierFlags {
 }
 
 /// Helper: Process adjectives for filter/any/all patterns
+/// Returns true if any operation was added
 fn process_adjectives(
     asm_stmt: &AssembledStatement,
     flags: &QuantifierFlags,
-    iterator_ops: &mut Vec<AnalyzedIteratorOp>,
-) {
+    current_expr: &mut AnalyzedExpr,
+) -> bool {
     // Check for comparative adjective filter/any/all pattern
     // Pattern: collection + number + comparative_adj → filter/any/all
     if asm_stmt.adjectives.is_empty() {
-        return;
+        return false;
     }
+
+    let mut added = false;
 
     for adj in &asm_stmt.adjectives {
         // Look up adjective in lexicon to check if it's comparative
@@ -525,25 +569,48 @@ fn process_adjectives(
             // Create the filter predicate: |x| x > value
             let filter_closure = create_comparison_predicate(bin_op, comparison_expr);
 
-            // Determine which operation to use based on quantifier
-            if flags.is_any {
-                iterator_ops.push(AnalyzedIteratorOp::Any(Box::new(filter_closure)));
+            // Determine which method to call based on quantifier
+            let method = if flags.is_any {
+                "any"
             } else if flags.is_all {
-                iterator_ops.push(AnalyzedIteratorOp::All(Box::new(filter_closure)));
+                "all"
             } else {
-                iterator_ops.push(AnalyzedIteratorOp::Filter(Box::new(filter_closure)));
-            }
+                "filter"
+            };
+
+            // Wrap current expr
+            let new_expr = AnalyzedExpr {
+                expr: AnalyzedExprKind::MethodCall {
+                    receiver: Box::new(current_expr.clone()),
+                    method: method.into(),
+                    args: vec![filter_closure],
+                },
+                glossa_type: if flags.is_any || flags.is_all {
+                    GlossaType::Boolean
+                } else {
+                    GlossaType::Unknown
+                },
+            };
+            *current_expr = new_expr;
+            added = true;
         }
     }
+    added
 }
 
 /// Helper: Process participles for map/fold patterns
-fn process_participles(asm_stmt: &AssembledStatement, iterator_ops: &mut Vec<AnalyzedIteratorOp>) {
+/// Returns (bool, bool) -> (added_ops, is_fold_result)
+fn process_participles(
+    asm_stmt: &AssembledStatement,
+    current_expr: &mut AnalyzedExpr,
+) -> (bool, bool) {
+    let mut added = false;
+    let mut is_fold = false;
+
     for participle in &asm_stmt.participles {
         let verb_stem = normalize_greek(&participle.verb_lemma);
 
         // Check for fold pattern: συλλεγόμενα εἰς [target]
-        let mut is_fold = false;
         if verb_stem.contains("συλλεγ") {
             // Look for target operator (Add for sum, Mul for product)
             for &bin_op in &asm_stmt.operators {
@@ -561,9 +628,9 @@ fn process_participles(asm_stmt: &AssembledStatement, iterator_ops: &mut Vec<Ana
 
                     // Determine capture mode based on participle tense
                     let capture_mode = match participle.tense {
-                        crate::morphology::Tense::Aorist => crate::ast::CaptureMode::Move,
-                        crate::morphology::Tense::Perfect => crate::ast::CaptureMode::Memoize,
-                        _ => crate::ast::CaptureMode::Borrow,
+                        crate::morphology::Tense::Aorist => CaptureMode::Move,
+                        crate::morphology::Tense::Perfect => CaptureMode::Memoize,
+                        _ => CaptureMode::Borrow,
                     };
 
                     // Create fold closure: |acc, x| acc + x (or acc * x)
@@ -599,12 +666,18 @@ fn process_participles(asm_stmt: &AssembledStatement, iterator_ops: &mut Vec<Ana
                         glossa_type: GlossaType::Number,
                     };
 
-                    iterator_ops.push(AnalyzedIteratorOp::Fold {
-                        init: Box::new(init_expr),
-                        closure: Box::new(fold_closure),
-                    });
+                    let new_expr = AnalyzedExpr {
+                        expr: AnalyzedExprKind::MethodCall {
+                            receiver: Box::new(current_expr.clone()),
+                            method: "fold".into(),
+                            args: vec![init_expr, fold_closure],
+                        },
+                        glossa_type: GlossaType::Number,
+                    };
+                    *current_expr = new_expr;
 
                     is_fold = true;
+                    added = true;
                     break; // Exit operators loop
                 }
             }
@@ -643,9 +716,9 @@ fn process_participles(asm_stmt: &AssembledStatement, iterator_ops: &mut Vec<Ana
             };
 
             let capture_mode = match participle.tense {
-                crate::morphology::Tense::Aorist => crate::ast::CaptureMode::Move,
-                crate::morphology::Tense::Perfect => crate::ast::CaptureMode::Memoize,
-                _ => crate::ast::CaptureMode::Borrow,
+                crate::morphology::Tense::Aorist => CaptureMode::Move,
+                crate::morphology::Tense::Perfect => CaptureMode::Memoize,
+                _ => CaptureMode::Borrow,
             };
 
             let closure = AnalyzedExpr {
@@ -660,20 +733,30 @@ fn process_participles(asm_stmt: &AssembledStatement, iterator_ops: &mut Vec<Ana
                 },
             };
 
-            iterator_ops.push(AnalyzedIteratorOp::Map(Box::new(closure)));
+            let new_expr = AnalyzedExpr {
+                expr: AnalyzedExprKind::MethodCall {
+                    receiver: Box::new(current_expr.clone()),
+                    method: "map".into(),
+                    args: vec![closure],
+                },
+                glossa_type: GlossaType::Unknown,
+            };
+            *current_expr = new_expr;
+            added = true;
         }
     }
+    (added, is_fold)
 }
 
 /// Helper: Process explicit quantifier operators (any/all via >/<)
+/// Returns true if an any/all operation was added
 fn process_explicit_quantifiers(
     asm_stmt: &AssembledStatement,
     flags: &QuantifierFlags,
-    collection_expr: &AnalyzedExpr,
-    iterator_ops: &mut Vec<AnalyzedIteratorOp>,
-) -> Option<AnalyzedExpr> {
+    current_expr: &mut AnalyzedExpr,
+) -> bool {
     if (!flags.is_any && !flags.is_all) || asm_stmt.operators.is_empty() {
-        return None;
+        return false;
     }
 
     // Get the comparison operator (Gt or Lt)
@@ -685,32 +768,31 @@ fn process_explicit_quantifiers(
             let comparison_expr = extract_comparison_value(asm_stmt);
             let any_all_closure = create_comparison_predicate(bin_op, comparison_expr);
 
-            if flags.is_any {
-                iterator_ops.push(AnalyzedIteratorOp::Any(Box::new(any_all_closure)));
-            } else {
-                iterator_ops.push(AnalyzedIteratorOp::All(Box::new(any_all_closure)));
-            }
+            let method = if flags.is_any { "any" } else { "all" };
 
-            // Build the iterator chain for any/all (returns boolean)
-            return Some(AnalyzedExpr {
-                expr: AnalyzedExprKind::IteratorChain {
-                    collection: Box::new(collection_expr.clone()),
-                    ops: iterator_ops.clone(),
+            let new_expr = AnalyzedExpr {
+                expr: AnalyzedExprKind::MethodCall {
+                    receiver: Box::new(current_expr.clone()),
+                    method: method.into(),
+                    args: vec![any_all_closure],
                 },
                 glossa_type: GlossaType::Boolean,
-            });
+            };
+            *current_expr = new_expr;
+            return true;
         }
     }
-    None
+    false
 }
 
 /// Helper: Process find operations
 fn process_find(
     asm_stmt: &AssembledStatement,
-    collection_expr: AnalyzedExpr,
-    mut iterator_ops: Vec<AnalyzedIteratorOp>,
-) -> Result<Option<AnalyzedExpr>, GlossaError> {
+    current_expr: &mut AnalyzedExpr,
+) {
     // Find operation: .iter().find(predicate)
+    let mut found_predicate = false;
+
     if !asm_stmt.operators.is_empty() {
         // Get the comparison operator (Gt or Lt)
         for &bin_op in &asm_stmt.operators {
@@ -721,14 +803,23 @@ fn process_find(
                 let comparison_expr = extract_comparison_value(asm_stmt);
                 let find_closure = create_comparison_predicate(bin_op, comparison_expr);
 
-                iterator_ops.push(AnalyzedIteratorOp::Find(Box::new(find_closure)));
+                let new_expr = AnalyzedExpr {
+                    expr: AnalyzedExprKind::MethodCall {
+                        receiver: Box::new(current_expr.clone()),
+                        method: "find".into(),
+                        args: vec![find_closure],
+                    },
+                    glossa_type: GlossaType::Number,
+                };
+                *current_expr = new_expr;
+                found_predicate = true;
                 break;
             }
         }
     }
 
     // If no predicate was added, just find the first element (essentially .next())
-    if iterator_ops.len() <= 1 {
+    if !found_predicate {
         // No predicate specified, so find the first element
         // Create a trivial predicate that always returns true: |_| true
         let always_true_body = AnalyzedExpr {
@@ -740,7 +831,7 @@ fn process_find(
             expr: AnalyzedExprKind::Lambda {
                 params: vec!["_".into()],
                 body: Box::new(always_true_body),
-                capture_mode: crate::ast::CaptureMode::Borrow,
+                capture_mode: CaptureMode::Borrow,
             },
             glossa_type: GlossaType::Function {
                 params: vec![GlossaType::Number],
@@ -748,74 +839,30 @@ fn process_find(
             },
         };
 
-        iterator_ops.push(AnalyzedIteratorOp::Find(Box::new(find_first_closure)));
+        let new_expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::MethodCall {
+                receiver: Box::new(current_expr.clone()),
+                method: "find".into(),
+                args: vec![find_first_closure],
+            },
+            glossa_type: GlossaType::Number,
+        };
+        *current_expr = new_expr;
     }
-
-    // Build the iterator chain for find (no .collect())
-    Ok(Some(AnalyzedExpr {
-        expr: AnalyzedExprKind::IteratorChain {
-            collection: Box::new(collection_expr),
-            ops: iterator_ops,
-        },
-        glossa_type: GlossaType::Number, // find returns Option<T>, but we'll unwrap for now
-    }))
 }
 
 /// Helper: Finalize iterator chain with optional collect
-fn finalize_iterator_chain(
-    collection_expr: AnalyzedExpr,
-    mut iterator_ops: Vec<AnalyzedIteratorOp>,
-) -> Result<Option<AnalyzedExpr>, GlossaError> {
-    // Print operation: only proceed if we have actual operations
-    if iterator_ops.len() <= 1 {
-        // No filter/map operations were added, so this isn't an iterator pattern
-        return Ok(None);
-    }
-
-    // Check if this is a fold/any/all operation (returns single value, not a collection)
-    let has_fold = iterator_ops
-        .iter()
-        .any(|op| matches!(op, AnalyzedIteratorOp::Fold { .. }));
-    let has_any = iterator_ops
-        .iter()
-        .any(|op| matches!(op, AnalyzedIteratorOp::Any(_)));
-    let has_all = iterator_ops
-        .iter()
-        .any(|op| matches!(op, AnalyzedIteratorOp::All(_)));
-
-    if has_fold {
-        // Fold returns a single value, no .collect() needed
-        return Ok(Some(AnalyzedExpr {
-            expr: AnalyzedExprKind::IteratorChain {
-                collection: Box::new(collection_expr),
-                ops: iterator_ops,
-            },
-            glossa_type: GlossaType::Number, // fold returns a single number
-        }));
-    }
-
-    if has_any || has_all {
-        // Any/all return a boolean, no .collect() needed
-        return Ok(Some(AnalyzedExpr {
-            expr: AnalyzedExprKind::IteratorChain {
-                collection: Box::new(collection_expr),
-                ops: iterator_ops,
-            },
-            glossa_type: GlossaType::Boolean,
-        }));
-    }
-
-    // Add .collect() at the end for map/filter operations
-    iterator_ops.push(AnalyzedIteratorOp::Collect);
-
-    // Build the iterator chain expression
-    Ok(Some(AnalyzedExpr {
-        expr: AnalyzedExprKind::IteratorChain {
-            collection: Box::new(collection_expr),
-            ops: iterator_ops,
+fn finalize_iterator_chain(current_expr: &mut AnalyzedExpr) {
+    // Add .collect() at the end
+    let new_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::MethodCall {
+            receiver: Box::new(current_expr.clone()),
+            method: "collect".into(),
+            args: vec![],
         },
         glossa_type: GlossaType::List(Box::new(GlossaType::Number)),
-    }))
+    };
+    *current_expr = new_expr;
 }
 
 /// Helper: Extract comparison value for filter/find/any/all
@@ -881,7 +928,7 @@ fn create_comparison_predicate(
         expr: AnalyzedExprKind::Lambda {
             params: vec!["x".into()],
             body: Box::new(predicate_body),
-            capture_mode: crate::ast::CaptureMode::Borrow,
+            capture_mode: CaptureMode::Borrow,
         },
         glossa_type: GlossaType::Function {
             params: vec![GlossaType::Number],

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -418,8 +418,7 @@ pub fn detect_iterator_pattern(
     }
 
     // Handle any/all operations with explicit operators (comparatives stored as operators)
-    let is_any_all =
-        process_explicit_quantifiers(asm_stmt, &flags, &mut current_expr);
+    let is_any_all = process_explicit_quantifiers(asm_stmt, &flags, &mut current_expr);
     if is_any_all {
         return Ok(Some(current_expr));
     }
@@ -786,10 +785,7 @@ fn process_explicit_quantifiers(
 }
 
 /// Helper: Process find operations
-fn process_find(
-    asm_stmt: &AssembledStatement,
-    current_expr: &mut AnalyzedExpr,
-) {
+fn process_find(asm_stmt: &AssembledStatement, current_expr: &mut AnalyzedExpr) {
     // Find operation: .iter().find(predicate)
     let mut found_predicate = false;
 


### PR DESCRIPTION
This PR simplifies the semantic model by removing redundant abstractions.

- **`IteratorChain` Removal**: The `IteratorChain` expression kind and its associated `AnalyzedIteratorOp` enum were a mini-DSL for iterator operations. This has been replaced by standard nested `MethodCall` expressions (e.g., `vec.iter().map(...)`), which simplifies both the semantic model and the code generator.
- **`CollectionContains` Removal**: The `CollectionContains` expression kind was a special case for `contains`/`contains_key`. This logic has been moved to the semantic analysis phase (`conversion.rs`), which now generates standard `MethodCall`s. To support this, a `UnaryOp::Ref` variant was added to represent explicit borrowing (`&x`), which is handled in the code generator.
- **`CaptureMode` Move**: `CaptureMode` was defined in `ast/nodes.rs` but only used for semantic analysis and codegen. It has been moved to `semantic/model.rs` to keep the AST pure.
- **Simplification**: `infer_binop_type` was simplified to remove unused arguments.

These changes reduce the number of concepts in the compiler backend without changing the language behavior.

---
*PR created automatically by Jules for task [5651741927102089956](https://jules.google.com/task/5651741927102089956) started by @madmax983*