### PR TITLE
🎨 Mosaic: UI Polish for REPL and Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +412,7 @@ name = "glossa"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "comfy-table",
  "crossterm",
  "dirs-next",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ quote = "1"
 proc-macro2 = "1"
 smol_str = "0.3"
 rustc-hash = "2"
+comfy-table = "7.2.2"
 
 [dev-dependencies]
 insta = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 //! A compiler for ΓΛΩΣΣΑ - where Ancient Greek morphology encodes programming semantics.
 
 use clap::{Parser, Subcommand};
-use comfy_table::{Table, presets, Cell, Color};
+use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
 use std::fs;
@@ -320,21 +320,20 @@ fn print_banner() {
 
 fn print_help() {
     let mut table = Table::new();
-    table
-        .load_preset(presets::UTF8_FULL)
-        .set_header(vec![
-            Cell::new("Ἐντολή (Command)").fg(Color::Cyan).add_attribute(comfy_table::Attribute::Bold),
-            Cell::new("Περιγραφή (Description)").fg(Color::Cyan).add_attribute(comfy_table::Attribute::Bold),
-        ]);
+    table.load_preset(presets::UTF8_FULL).set_header(vec![
+        Cell::new("Ἐντολή (Command)")
+            .fg(Color::Cyan)
+            .add_attribute(comfy_table::Attribute::Bold),
+        Cell::new("Περιγραφή (Description)")
+            .fg(Color::Cyan)
+            .add_attribute(comfy_table::Attribute::Bold),
+    ]);
 
     table.add_row(vec![
         ".βοήθεια / .help",
         "Δεῖξαι τήνδε τὴν βοήθειαν (Show this help)",
     ]);
-    table.add_row(vec![
-        ".ἔξοδος / .exit",
-        "Ἐξελθεῖν (Exit REPL)",
-    ]);
+    table.add_row(vec![".ἔξοδος / .exit", "Ἐξελθεῖν (Exit REPL)"]);
     table.add_row(vec![
         ".καθαρός / .clear",
         "Καθαρίσαι τὸ περιβάλλον (Clear history)",
@@ -363,13 +362,13 @@ fn print_env(context: &ReplContext) {
         }
 
         let mut table = Table::new();
-        table
-            .load_preset(presets::UTF8_FULL)
-            .set_header(vec![
-                Cell::new("Μεταβλητή (Var)").fg(Color::Magenta).add_attribute(comfy_table::Attribute::Bold),
-                Cell::new("Τύπος (Type)").add_attribute(comfy_table::Attribute::Bold),
-                Cell::new("Μεταβλητότης (Mut)").add_attribute(comfy_table::Attribute::Bold),
-            ]);
+        table.load_preset(presets::UTF8_FULL).set_header(vec![
+            Cell::new("Μεταβλητή (Var)")
+                .fg(Color::Magenta)
+                .add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Τύπος (Type)").add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Μεταβλητότης (Mut)").add_attribute(comfy_table::Attribute::Bold),
+        ]);
 
         for (name, binding) in bindings {
             let mut_str = if binding.mutable {
@@ -693,11 +692,14 @@ mod tests {
         let scope = context.last_scope.as_ref().unwrap();
         assert!(scope.lookup("ξ").is_some());
 
-        // 4. Run print_env to cover the table generation code
+        // 4. Add a mutable binding to cover that branch
+        let _ = context.execute("μετά ψ δέκα ἔστω.").unwrap();
+
+        // 5. Run print_env to cover the table generation code
         // We aren't capturing stdout, but this ensures the code runs without panicking
         print_env(&context);
 
-        // 5. Test clear simulation (new context)
+        // 6. Test clear simulation (new context)
         let context = ReplContext::new();
         assert!(context.last_scope.is_none());
         print_env(&context);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 //! A compiler for ΓΛΩΣΣΑ - where Ancient Greek morphology encodes programming semantics.
 
 use clap::{Parser, Subcommand};
+use comfy_table::{Table, presets, Cell, Color};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
 use std::fs;
@@ -318,29 +319,32 @@ fn print_banner() {
 }
 
 fn print_help() {
-    println!(
-        "{}",
-        "Ἐντολή (Command)          Περιγραφή (Description)"
-            .bold()
-            .cyan()
-    );
-    println!(
-        "{}",
-        "----------------------------------------------------".dim()
-    );
-    println!(
-        "{:<25} Δεῖξαι τήνδε τὴν βοήθειαν (Show this help)",
-        ".βοήθεια / .help"
-    );
-    println!("{:<25} Ἐξελθεῖν (Exit REPL)", ".ἔξοδος / .exit");
-    println!(
-        "{:<25} Καθαρίσαι τὸ περιβάλλον (Clear history)",
-        ".καθαρός / .clear"
-    );
-    println!(
-        "{:<25} Δεῖξαι τὰς μεταβλητάς (Show variables)",
-        ".περιβάλλον / .env"
-    );
+    let mut table = Table::new();
+    table
+        .load_preset(presets::UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Ἐντολή (Command)").fg(Color::Cyan).add_attribute(comfy_table::Attribute::Bold),
+            Cell::new("Περιγραφή (Description)").fg(Color::Cyan).add_attribute(comfy_table::Attribute::Bold),
+        ]);
+
+    table.add_row(vec![
+        ".βοήθεια / .help",
+        "Δεῖξαι τήνδε τὴν βοήθειαν (Show this help)",
+    ]);
+    table.add_row(vec![
+        ".ἔξοδος / .exit",
+        "Ἐξελθεῖν (Exit REPL)",
+    ]);
+    table.add_row(vec![
+        ".καθαρός / .clear",
+        "Καθαρίσαι τὸ περιβάλλον (Clear history)",
+    ]);
+    table.add_row(vec![
+        ".περιβάλλον / .env",
+        "Δεῖξαι τὰς μεταβλητάς (Show variables)",
+    ]);
+
+    println!("{table}");
 
     println!("\n{}", "Παραδείγματα:".bold().underlined());
     println!("  «χαῖρε κόσμε» λέγε.");
@@ -358,16 +362,14 @@ fn print_env(context: &ReplContext) {
             return;
         }
 
-        println!(
-            "{:<20} {:<30} {}",
-            "Μεταβλητή (Var)".magenta().bold(),
-            "Τύπος (Type)".bold(),
-            "Μεταβλητότης (Mut)".bold()
-        );
-        println!(
-            "{}",
-            "----------------------------------------------------------------".dim()
-        );
+        let mut table = Table::new();
+        table
+            .load_preset(presets::UTF8_FULL)
+            .set_header(vec![
+                Cell::new("Μεταβλητή (Var)").fg(Color::Magenta).add_attribute(comfy_table::Attribute::Bold),
+                Cell::new("Τύπος (Type)").add_attribute(comfy_table::Attribute::Bold),
+                Cell::new("Μεταβλητότης (Mut)").add_attribute(comfy_table::Attribute::Bold),
+            ]);
 
         for (name, binding) in bindings {
             let mut_str = if binding.mutable {
@@ -375,19 +377,21 @@ fn print_env(context: &ReplContext) {
             } else {
                 "Οὔ (No)"
             };
-            let mut_colored = if binding.mutable {
-                mut_str.yellow()
+
+            let mut_cell = Cell::new(mut_str);
+            let mut_cell = if binding.mutable {
+                mut_cell.fg(Color::Yellow)
             } else {
-                mut_str.dark_grey()
+                mut_cell.fg(Color::DarkGrey)
             };
 
-            println!(
-                "{:<20} {:<30} {}",
-                name.green(),
-                format!("{:?}", binding.glossa_type),
-                mut_colored
-            );
+            table.add_row(vec![
+                Cell::new(name).fg(Color::Green),
+                Cell::new(&binding.glossa_type),
+                mut_cell,
+            ]);
         }
+        println!("{table}");
     } else {
         println!("{}", "Οὐδεμία μεταβλητή (No variables defined).".yellow());
     }
@@ -418,7 +422,7 @@ impl std::fmt::Display for ReplOutput {
             } => {
                 write!(
                     f,
-                    "{} {}: {:?}{}",
+                    "{} {}: {}{}",
                     "✓".green(),
                     name.as_str().cyan().bold(),
                     type_,
@@ -770,7 +774,7 @@ mod tests {
         let output = binding.to_string();
         // Check content without worrying about specific color codes
         assert!(output.contains("x"));
-        assert!(output.contains("Number"));
+        assert!(output.contains("Ἀριθμός"));
         assert!(!output.contains("mutable")); // Not mutable
 
         let binding_mut = ReplOutput::Binding {
@@ -780,7 +784,7 @@ mod tests {
         };
         let output_mut = binding_mut.to_string();
         assert!(output_mut.contains("y"));
-        assert!(output_mut.contains("String"));
+        assert!(output_mut.contains("Ὄνομα"));
         assert!(output_mut.contains("mutable"));
 
         // Test Statement display

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -253,9 +253,14 @@ mod tests {
     fn test_display_formatting() {
         assert_eq!(format!("{}", GlossaType::Number), "Ἀριθμός");
         assert_eq!(format!("{}", GlossaType::String), "Ὄνομα");
+        assert_eq!(format!("{}", GlossaType::Boolean), "Ἀληθές/Ψεῦδος");
         assert_eq!(
             format!("{}", GlossaType::List(Box::new(GlossaType::Number))),
             "Λίστη<Ἀριθμός>"
+        );
+        assert_eq!(
+            format!("{}", GlossaType::Set(Box::new(GlossaType::Number))),
+            "Σύνολον<Ἀριθμός>"
         );
         assert_eq!(
             format!(
@@ -267,5 +272,35 @@ mod tests {
             ),
             "Χάρτης<Ὄνομα, Εὑρεθείη<Ἀριθμός>>"
         );
+        assert_eq!(
+            format!(
+                "{}",
+                GlossaType::Result(Box::new(GlossaType::Unit), Box::new(GlossaType::String))
+            ),
+            "Ἀποτέλεσμα<Οὐδέν, Ὄνομα>"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                GlossaType::Struct {
+                    name: "User".into(),
+                    gender: Gender::Masculine,
+                    fields: vec![]
+                }
+            ),
+            "Εἶδος User"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                GlossaType::Function {
+                    params: vec![GlossaType::Number, GlossaType::String],
+                    returns: Box::new(GlossaType::Boolean)
+                }
+            ),
+            "Ἔργον(Ἀριθμός, Ὄνομα) -> Ἀληθές/Ψεῦδος"
+        );
+        assert_eq!(format!("{}", GlossaType::Unit), "Οὐδέν");
+        assert_eq!(format!("{}", GlossaType::Unknown), "Ἄγνωστον");
     }
 }

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -109,6 +109,28 @@ pub enum GlossaType {
     Unknown,
 }
 
+impl std::fmt::Display for GlossaType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GlossaType::Number => write!(f, "Ἀριθμός"),
+            GlossaType::String => write!(f, "Ὄνομα"),
+            GlossaType::Boolean => write!(f, "Ἀληθές/Ψεῦδος"),
+            GlossaType::List(inner) => write!(f, "Λίστη<{}>", inner),
+            GlossaType::Set(inner) => write!(f, "Σύνολον<{}>", inner),
+            GlossaType::Map(k, v) => write!(f, "Χάρτης<{}, {}>", k, v),
+            GlossaType::Option(inner) => write!(f, "Εὑρεθείη<{}>", inner),
+            GlossaType::Result(ok, err) => write!(f, "Ἀποτέλεσμα<{}, {}>", ok, err),
+            GlossaType::Struct { name, .. } => write!(f, "Εἶδος {}", name),
+            GlossaType::Function { params, returns } => {
+                let params_str: Vec<String> = params.iter().map(|p| p.to_string()).collect();
+                write!(f, "Ἔργον({}) -> {}", params_str.join(", "), returns)
+            }
+            GlossaType::Unit => write!(f, "Οὐδέν"),
+            GlossaType::Unknown => write!(f, "Ἄγνωστον"),
+        }
+    }
+}
+
 impl GlossaType {
     /// Get the Greek name for this type
     pub fn to_greek(&self) -> &'static str {
@@ -225,5 +247,25 @@ mod tests {
         assert!(detect_collection_type("συνολον").is_some());
         assert!(detect_collection_type("χαρτης").is_some());
         assert!(detect_collection_type("other").is_none());
+    }
+
+    #[test]
+    fn test_display_formatting() {
+        assert_eq!(format!("{}", GlossaType::Number), "Ἀριθμός");
+        assert_eq!(format!("{}", GlossaType::String), "Ὄνομα");
+        assert_eq!(
+            format!("{}", GlossaType::List(Box::new(GlossaType::Number))),
+            "Λίστη<Ἀριθμός>"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                GlossaType::Map(
+                    Box::new(GlossaType::String),
+                    Box::new(GlossaType::Option(Box::new(GlossaType::Number)))
+                )
+            ),
+            "Χάρτης<Ὄνομα, Εὑρεθείη<Ἀριθμός>>"
+        );
     }
 }


### PR DESCRIPTION
This PR polishes the UI of the Glossa REPL by:
1. Replacing manual string alignment with `comfy-table` for `.help` and `.env` commands.
2. Implementing `std::fmt::Display` for `GlossaType` to provide user-friendly Greek type names.
3. Updating tests to ensure correctness of the new output formats.

---
*PR created automatically by Jules for task [7120512076072674340](https://jules.google.com/task/7120512076072674340) started by @madmax983*