### PR TITLE
⚒️ Forge: Refactor Assembler to use AssembledStatement state

### DIFF
--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -138,7 +138,6 @@ impl Assembler {
         }
     }
 
-
     /// Mark this statement as a query
     pub fn set_query(&mut self, is_query: bool) {
         self.state.is_query = is_query;
@@ -581,7 +580,8 @@ impl Assembler {
 
                 let normalized_original = normalize_greek(&subj.original);
                 self.state.string_method = Some((method_name.to_string(), delim));
-                self.state.property_accesses
+                self.state
+                    .property_accesses
                     .push((normalized_original.to_string(), method_name.to_string()));
                 return true;
             }
@@ -649,7 +649,8 @@ impl Assembler {
             // If we have a subject, create a property access (use normalized original, not lemma)
             if let Some(ref subj) = self.state.subject {
                 let normalized_original = crate::text::normalize_greek(&subj.original);
-                self.state.property_accesses
+                self.state
+                    .property_accesses
                     .push((normalized_original.to_string(), "len".to_string()));
                 self.state.subject = None; // Consume the subject
                 return true;

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -110,49 +110,16 @@ use crate::text::normalize_greek;
 ///
 /// # State Machine
 ///
-/// The assembler maintains "pending" slots. As tokens arrive:
-/// - **Nominative** -> `pending_subject` (or `pending_nominatives` if subject full)
-/// - **Accusative** -> `pending_object`
-/// - **Dative** -> `pending_indirect`
-/// - **Verb** -> `pending_verb`
+/// The assembler maintains "pending" slots in its `state`. As tokens arrive:
+/// - **Nominative** -> `state.subject` (or `state.nominatives` if subject full)
+/// - **Accusative** -> `state.object`
+/// - **Dative** -> `state.indirect`
+/// - **Verb** -> `state.verb`
 ///
 /// This allows tokens to arrive in any order (Subject-Verb-Object, Verb-Object-Subject, etc.)
 /// and still fill the correct semantic roles.
 pub struct Assembler {
-    /// Slot for the subject (Nominative case)
-    pending_subject: Option<Constituent>,
-    /// Storage for extra nominatives (e.g. predicate nominatives)
-    pending_nominatives: Vec<Constituent>,
-    /// Slot for the direct object (Accusative case)
-    pending_object: Option<Constituent>,
-    /// Slot for the indirect object (Dative case)
-    pending_indirect: Option<Constituent>,
-    /// Slot for the main verb
-    pending_verb: Option<VerbConstituent>,
-    /// Accumulated genitives (possessors)
-    pending_genitives: Vec<Constituent>,
-    /// Accumulated adjectives
-    pending_adjectives: Vec<Constituent>,
-    /// Accumulated literals (numbers, strings)
-    pending_literals: Vec<Literal>,
-    /// Accumulated array literals
-    pending_arrays: Vec<Vec<Expr>>,
-    pending_index_accesses: Vec<(Expr, Expr)>,
-    pending_property_accesses: Vec<(String, String)>,
-    pending_operators: Vec<BinaryOp>,
-    pending_blocks: Vec<Vec<crate::ast::Statement>>,
-    pending_nested_phrases: Vec<Vec<Expr>>,
-    pending_participles: Vec<ParticipleConstituent>,
-    pending_unwraps: Vec<Expr>,
-    pending_mutable_marker: bool,
-    /// Track containment preposition (ἐν) for contains patterns
-    has_containment_preposition: bool,
-    /// Track delimiter preposition (κατά) for split/join patterns
-    has_delimiter_preposition: bool,
-    /// Track split/join method call: (method_name, delimiter)
-    pending_string_method: Option<(String, String)>,
-    is_query: bool,
-    is_propagate: bool,
+    state: AssembledStatement,
 }
 
 impl Assembler {
@@ -167,48 +134,19 @@ impl Assembler {
     /// ```
     pub fn new() -> Self {
         Assembler {
-            pending_subject: None,
-            pending_nominatives: Vec::new(),
-            pending_object: None,
-            pending_indirect: None,
-            pending_verb: None,
-            pending_genitives: Vec::new(),
-            pending_adjectives: Vec::new(),
-            pending_literals: Vec::new(),
-            pending_arrays: Vec::new(),
-            pending_index_accesses: Vec::new(),
-            pending_property_accesses: Vec::new(),
-            pending_operators: Vec::new(),
-            pending_blocks: Vec::new(),
-            pending_nested_phrases: Vec::new(),
-            pending_participles: Vec::new(),
-            pending_unwraps: Vec::new(),
-            pending_mutable_marker: false,
-            has_containment_preposition: false,
-            has_delimiter_preposition: false,
-            pending_string_method: None,
-            is_query: false,
-            is_propagate: false,
+            state: AssembledStatement::default(),
         }
     }
 
-    /// Reset the assembler for a new statement
-    ///
-    /// Clears all pending slots, preparing the assembler for the next sentence.
-    /// This is typically called automatically by `finalize()`, but can be
-    /// called manually to discard a partial statement.
-    fn reset(&mut self) {
-        *self = Self::new();
-    }
 
     /// Mark this statement as a query
     pub fn set_query(&mut self, is_query: bool) {
-        self.is_query = is_query;
+        self.state.is_query = is_query;
     }
 
     /// Mark this statement as propagation (ends with `;` → converts to `?`)
     pub fn set_propagate(&mut self, is_propagate: bool) {
-        self.is_propagate = is_propagate;
+        self.state.is_propagate = is_propagate;
     }
 
     /// Feed a morphologically-analyzed token into the assembler
@@ -277,7 +215,7 @@ impl Assembler {
     /// asm.feed_string("χαῖρε".to_string()).unwrap();
     /// ```
     pub fn feed_string(&mut self, value: String) -> Result<(), AssemblyError> {
-        self.pending_literals.push(Literal::String(value));
+        self.state.literals.push(Literal::String(value));
         Ok(())
     }
 
@@ -292,7 +230,7 @@ impl Assembler {
     /// asm.feed_number(42).unwrap();
     /// ```
     pub fn feed_number(&mut self, value: i64) -> Result<(), AssemblyError> {
-        self.pending_literals.push(Literal::Number(value));
+        self.state.literals.push(Literal::Number(value));
         Ok(())
     }
 
@@ -307,7 +245,7 @@ impl Assembler {
     /// asm.feed_boolean(true).unwrap();
     /// ```
     pub fn feed_boolean(&mut self, value: bool) -> Result<(), AssemblyError> {
-        self.pending_literals.push(Literal::Boolean(value));
+        self.state.literals.push(Literal::Boolean(value));
         Ok(())
     }
 
@@ -324,7 +262,7 @@ impl Assembler {
     /// asm.feed_array(elements).unwrap();
     /// ```
     pub fn feed_array(&mut self, elements: Vec<Expr>) -> Result<(), AssemblyError> {
-        self.pending_arrays.push(elements);
+        self.state.arrays.push(elements);
         Ok(())
     }
 
@@ -342,7 +280,7 @@ impl Assembler {
         &mut self,
         statements: Vec<crate::ast::Statement>,
     ) -> Result<(), AssemblyError> {
-        self.pending_blocks.push(statements);
+        self.state.blocks.push(statements);
         Ok(())
     }
 
@@ -358,7 +296,7 @@ impl Assembler {
     /// asm.feed_nested_phrase(vec![Expr::NumberLiteral(1)]).unwrap();
     /// ```
     pub fn feed_nested_phrase(&mut self, terms: Vec<Expr>) -> Result<(), AssemblyError> {
-        self.pending_nested_phrases.push(terms);
+        self.state.nested_phrases.push(terms);
         Ok(())
     }
 
@@ -379,7 +317,7 @@ impl Assembler {
     /// asm.feed_index_access(array, index).unwrap();
     /// ```
     pub fn feed_index_access(&mut self, array: Expr, index: Expr) -> Result<(), AssemblyError> {
-        self.pending_index_accesses.push((array, index));
+        self.state.index_accesses.push((array, index));
         Ok(())
     }
 
@@ -399,7 +337,7 @@ impl Assembler {
     /// asm.feed_unwrap(expr).unwrap();
     /// ```
     pub fn feed_unwrap(&mut self, expr: Expr) -> Result<(), AssemblyError> {
-        self.pending_unwraps.push(expr);
+        self.state.unwraps.push(expr);
         Ok(())
     }
 
@@ -437,7 +375,7 @@ impl Assembler {
             gender: analysis.gender,
             number: analysis.number,
         };
-        self.pending_participles.push(constituent);
+        self.state.participles.push(constituent);
         Ok(())
     }
 
@@ -459,48 +397,48 @@ impl Assembler {
         match analysis.case {
             Some(Case::Nominative) => {
                 // If we already have a verb, check agreement immediately!
-                if let Some(verb) = &self.pending_verb {
+                if let Some(verb) = &self.state.verb {
                     // Don't check agreement if we already have a subject (this is an extra nominative)
-                    if self.pending_subject.is_none() {
+                    if self.state.subject.is_none() {
                         self.check_agreement(&constituent, verb)?;
                     }
                 }
 
-                if self.pending_subject.is_some() {
+                if self.state.subject.is_some() {
                     // Additional nominatives stored separately for function call patterns
-                    self.pending_nominatives.push(constituent);
+                    self.state.nominatives.push(constituent);
                 } else {
-                    self.pending_subject = Some(constituent);
+                    self.state.subject = Some(constituent);
                 }
             }
             Some(Case::Accusative) => {
-                if self.pending_object.is_some() {
+                if self.state.object.is_some() {
                     return Err(AssemblyError::DoubleObject);
                 }
-                self.pending_object = Some(constituent);
+                self.state.object = Some(constituent);
             }
             Some(Case::Dative) => {
                 // Dative can stack (multiple recipients) but for simplicity, one for now
-                if self.pending_indirect.is_some() {
+                if self.state.indirect.is_some() {
                     return Err(AssemblyError::DoubleIndirect);
                 }
-                self.pending_indirect = Some(constituent);
+                self.state.indirect = Some(constituent);
             }
             Some(Case::Genitive) => {
                 // Genitives attach to other constituents (possession, etc.)
-                self.pending_genitives.push(constituent);
+                self.state.genitives.push(constituent);
             }
             Some(Case::Vocative) => {
                 // Vocative is direct address - treat as subject for now
-                if self.pending_subject.is_none() {
-                    self.pending_subject = Some(constituent);
+                if self.state.subject.is_none() {
+                    self.state.subject = Some(constituent);
                 }
             }
             None => {
                 // Unknown case - try to infer from context
                 // Default to accusative (object) if we have no object
-                if self.pending_object.is_none() {
-                    self.pending_object = Some(constituent);
+                if self.state.object.is_none() {
+                    self.state.object = Some(constituent);
                 }
             }
         }
@@ -514,7 +452,7 @@ impl Assembler {
         analysis: &MorphAnalysis,
         original: &str,
     ) -> Result<(), AssemblyError> {
-        if self.pending_verb.is_some() {
+        if self.state.verb.is_some() {
             return Err(AssemblyError::DoubleVerb);
         }
 
@@ -529,11 +467,11 @@ impl Assembler {
         };
 
         // If we already have a subject, check agreement immediately!
-        if let Some(subject) = &self.pending_subject {
+        if let Some(subject) = &self.state.subject {
             self.check_agreement(subject, &verb_constituent)?;
         }
 
-        self.pending_verb = Some(verb_constituent);
+        self.state.verb = Some(verb_constituent);
 
         Ok(())
     }
@@ -553,7 +491,7 @@ impl Assembler {
             person: None, // Adjectives don't really have person
         };
 
-        self.pending_adjectives.push(constituent);
+        self.state.adjectives.push(constituent);
         Ok(())
     }
 
@@ -587,47 +525,22 @@ impl Assembler {
     /// - Grammatical gender mismatch occurs
     pub fn finalize(&mut self) -> Result<AssembledStatement, AssemblyError> {
         // Check for required verb (unless it's a query or has only literals)
-        let has_content = self.pending_subject.is_some()
-            || self.pending_object.is_some()
-            || !self.pending_literals.is_empty();
+        let has_content = self.state.subject.is_some()
+            || self.state.object.is_some()
+            || !self.state.literals.is_empty();
 
-        if self.pending_verb.is_none() && has_content && !self.is_query {
+        if self.state.verb.is_none() && has_content && !self.state.is_query {
             // Allow verbless statements for queries and pure literal expressions
             // But for now, let's be lenient
         }
 
         // Check subject-verb agreement if both present
-        if let (Some(subject), Some(verb)) = (&self.pending_subject, &self.pending_verb) {
+        if let (Some(subject), Some(verb)) = (&self.state.subject, &self.state.verb) {
             self.check_agreement(subject, verb)?;
         }
 
-        // Assemble the statement
-        let statement = AssembledStatement {
-            subject: self.pending_subject.take(),
-            nominatives: std::mem::take(&mut self.pending_nominatives),
-            verb: self.pending_verb.take(),
-            object: self.pending_object.take(),
-            indirect: self.pending_indirect.take(),
-            genitives: std::mem::take(&mut self.pending_genitives),
-            adjectives: std::mem::take(&mut self.pending_adjectives),
-            literals: std::mem::take(&mut self.pending_literals),
-            arrays: std::mem::take(&mut self.pending_arrays),
-            index_accesses: std::mem::take(&mut self.pending_index_accesses),
-            property_accesses: std::mem::take(&mut self.pending_property_accesses),
-            operators: std::mem::take(&mut self.pending_operators),
-            blocks: std::mem::take(&mut self.pending_blocks),
-            nested_phrases: std::mem::take(&mut self.pending_nested_phrases),
-            participles: std::mem::take(&mut self.pending_participles),
-            unwraps: std::mem::take(&mut self.pending_unwraps),
-            has_mutable_marker: self.pending_mutable_marker,
-            is_query: self.is_query,
-            is_propagate: self.is_propagate,
-            has_containment_preposition: self.has_containment_preposition,
-            has_delimiter_preposition: self.has_delimiter_preposition,
-            string_method: self.pending_string_method.take(),
-        };
-
-        self.reset();
+        // Return the assembled statement
+        let statement = std::mem::take(&mut self.state);
         Ok(statement)
     }
 
@@ -635,19 +548,19 @@ impl Assembler {
     fn check_special_markers(&mut self, normalized: &str) -> bool {
         // Check for mutable marker (μετά)
         if crate::morphology::lexicon::is_mutable_marker(normalized) {
-            self.pending_mutable_marker = true;
+            self.state.has_mutable_marker = true;
             return true;
         }
 
         // Check for containment preposition (ἐν)
         if crate::morphology::lexicon::is_containment_preposition(normalized) {
-            self.has_containment_preposition = true;
+            self.state.has_containment_preposition = true;
             return true;
         }
 
         // Check for delimiter preposition (κατά)
         if crate::morphology::lexicon::is_delimiter_preposition(normalized) {
-            self.has_delimiter_preposition = true;
+            self.state.has_delimiter_preposition = true;
             return true;
         }
 
@@ -657,18 +570,18 @@ impl Assembler {
     /// Helper to create a string method call if conditions are met
     #[allow(clippy::collapsible_if)]
     fn try_create_string_method(&mut self, method_name: &str) -> bool {
-        if self.has_delimiter_preposition
-            && matches!(self.pending_literals.last(), Some(Literal::String(_)))
+        if self.state.has_delimiter_preposition
+            && matches!(self.state.literals.last(), Some(Literal::String(_)))
         {
-            if let Some(ref subj) = self.pending_subject {
-                let delim = match self.pending_literals.pop() {
+            if let Some(ref subj) = self.state.subject {
+                let delim = match self.state.literals.pop() {
                     Some(Literal::String(s)) => s,
                     _ => unreachable!(),
                 };
 
                 let normalized_original = normalize_greek(&subj.original);
-                self.pending_string_method = Some((method_name.to_string(), delim));
-                self.pending_property_accesses
+                self.state.string_method = Some((method_name.to_string(), delim));
+                self.state.property_accesses
                     .push((normalized_original.to_string(), method_name.to_string()));
                 return true;
             }
@@ -699,24 +612,24 @@ impl Assembler {
     fn check_operators(&mut self, normalized: &str, original: &str) -> bool {
         // Boolean operators
         if matches!(original, "καί" | "και") {
-            self.pending_operators.push(BinaryOp::And);
+            self.state.operators.push(BinaryOp::And);
             return true;
         }
         if matches!(original, "ἤ" | "ή") {
             // ἤ with breathing+accent, but not ᾖ
-            self.pending_operators.push(BinaryOp::Or);
+            self.state.operators.push(BinaryOp::Or);
             return true;
         }
 
         // Comparison operators
         if let Some(op) = crate::morphology::lexicon::comparison_operator(normalized) {
-            self.pending_operators.push(op);
+            self.state.operators.push(op);
             return true;
         }
 
         // Arithmetic operators
         if let Some(op) = crate::morphology::lexicon::arithmetic_operator(normalized) {
-            self.pending_operators.push(op);
+            self.state.operators.push(op);
             return true;
         }
 
@@ -727,18 +640,18 @@ impl Assembler {
     fn check_special_properties(&mut self, normalized: &str) -> bool {
         // Numeral words
         if let Some(value) = crate::morphology::lexicon::numeral_value(normalized) {
-            self.pending_literals.push(Literal::Number(value));
+            self.state.literals.push(Literal::Number(value));
             return true;
         }
 
         // Property nouns (μῆκος)
         if crate::morphology::lexicon::is_length_property(normalized) {
             // If we have a subject, create a property access (use normalized original, not lemma)
-            if let Some(ref subj) = self.pending_subject {
+            if let Some(ref subj) = self.state.subject {
                 let normalized_original = crate::text::normalize_greek(&subj.original);
-                self.pending_property_accesses
+                self.state.property_accesses
                     .push((normalized_original.to_string(), "len".to_string()));
-                self.pending_subject = None; // Consume the subject
+                self.state.subject = None; // Consume the subject
                 return true;
             }
         }
@@ -746,7 +659,7 @@ impl Assembler {
         // Ordinal adjectives
         if crate::morphology::lexicon::is_ordinal(normalized) {
             // If we have a subject, create an index access with the ordinal index
-            if let Some(ref subj) = self.pending_subject
+            if let Some(ref subj) = self.state.subject
                 && let Some(index) = crate::morphology::lexicon::ordinal_to_index(normalized)
             {
                 // Create array and index expressions (use normalized original, not lemma)
@@ -757,8 +670,8 @@ impl Assembler {
                 });
                 let index_expr = Expr::NumberLiteral(index);
 
-                self.pending_index_accesses.push((array, index_expr));
-                self.pending_subject = None; // Consume the subject
+                self.state.index_accesses.push((array, index_expr));
+                self.state.subject = None; // Consume the subject
                 return true;
             }
         }
@@ -768,15 +681,15 @@ impl Assembler {
 
     /// Check if the assembler has any pending content
     pub fn has_content(&self) -> bool {
-        self.pending_subject.is_some()
-            || self.pending_object.is_some()
-            || self.pending_indirect.is_some()
-            || self.pending_verb.is_some()
-            || !self.pending_genitives.is_empty()
-            || !self.pending_literals.is_empty()
-            || !self.pending_arrays.is_empty()
-            || !self.pending_index_accesses.is_empty()
-            || !self.pending_property_accesses.is_empty()
+        self.state.subject.is_some()
+            || self.state.object.is_some()
+            || self.state.indirect.is_some()
+            || self.state.verb.is_some()
+            || !self.state.genitives.is_empty()
+            || !self.state.literals.is_empty()
+            || !self.state.arrays.is_empty()
+            || !self.state.index_accesses.is_empty()
+            || !self.state.property_accesses.is_empty()
     }
 
     /// Check subject-verb agreement

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -169,7 +169,10 @@ mod cycle5_filter_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_filter("), "Should have .g_filter(");
+            assert!(
+                code_no_space.contains(".g_filter("),
+                "Should have .g_filter("
+            );
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -464,7 +467,10 @@ mod cycle9_combined_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_filter("), "Should have .g_filter(");
+            assert!(
+                code_no_space.contains(".g_filter("),
+                "Should have .g_filter("
+            );
             assert!(code_no_space.contains(".g_map("), "Should have .g_map(");
             assert!(code_no_space.contains(">"), "Should have comparison");
             assert!(code_no_space.contains("5"), "Should compare to 5");
@@ -559,7 +565,10 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_filter("), "Should have .g_filter(");
+            assert!(
+                code_no_space.contains(".g_filter("),
+                "Should have .g_filter("
+            );
             // Should reference theta variable in closure
             // theta (θ) is hex-encoded as _u3b8_ to prevent collisions
             assert!(
@@ -620,7 +629,10 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_filter("), "Should have .g_filter(");
+            assert!(
+                code_no_space.contains(".g_filter("),
+                "Should have .g_filter("
+            );
             assert!(code_no_space.contains("5"), "Should use literal 5");
             // Should NOT reference theta (encoded or not)
             assert!(

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -125,11 +125,11 @@ mod cycle4_map_operation {
             // Remove whitespace for matching (quote! adds spaces)
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".map("), "Should have .map()");
+            assert!(code_no_space.contains(".g_map("), "Should have .g_map()");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(
-                code_no_space.contains(".collect()"),
-                "Should have .collect()"
+                code_no_space.contains(".g_collect()"),
+                "Should have .g_collect()"
             );
         } else {
             panic!("Second statement failed: {:?}", analyzed2.err());
@@ -169,7 +169,7 @@ mod cycle5_filter_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".filter("), "Should have .filter(");
+            assert!(code_no_space.contains(".g_filter("), "Should have .g_filter(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -229,7 +229,7 @@ mod cycle6_find_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".find("), "Should have .find(");
+            assert!(code_no_space.contains(".g_find("), "Should have .g_find(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -297,7 +297,7 @@ mod cycle7_fold_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".fold("), "Should have .fold(");
+            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
             assert!(code_no_space.contains("0"), "Should have initial value 0");
             assert!(code_no_space.contains("+"), "Should have + operation");
         } else {
@@ -320,7 +320,7 @@ mod cycle7_fold_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".fold("), "Should have .fold(");
+            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
             assert!(code_no_space.contains("1"), "Should have initial value 1");
             assert!(code_no_space.contains("*"), "Should have * operation");
         } else {
@@ -352,7 +352,7 @@ mod cycle8_any_all_operations {
         // τι = "any" (interrogative pronoun, neuter nominative)
         // πέντε = "five"
         // μείζον = "greater" (comparative, neuter nominative)
-        // Should generate .any(|x| x > 5)
+        // Should generate .g_any(|x| x > 5)
         let code = "[1, 5, 3] τι πέντε μείζον λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -366,7 +366,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".any("), "Should have .any(");
+            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -395,7 +395,7 @@ mod cycle8_any_all_operations {
         // [1, 2, 3] πάντα θετικά λέγε = "say whether all (are) positive"
         // πάντα = "all" (plural neuter nominative)
         // θετικά = "positive" (plural neuter nominative adjective)
-        // Should generate .all(|x| x > 0)
+        // Should generate .g_all(|x| x > 0)
         let code = "[1, 2, 3] πάντα θετικά λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -409,7 +409,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".all("), "Should have .all(");
+            assert!(code_no_space.contains(".g_all("), "Should have .g_all(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -423,7 +423,7 @@ mod cycle8_any_all_operations {
     #[test]
     fn test_any_less_than() {
         // [1, 10, 3] τι πέντε ἐλάττον λέγε = "say whether any (are) less-than-five"
-        // Should generate .any(|x| x < 5)
+        // Should generate .g_any(|x| x < 5)
         let ast = parser::parse("[1, 10, 3] τι πέντε ἐλάττον λέγε.").unwrap();
         let analyzed = semantic::analyze_program(&ast);
 
@@ -434,7 +434,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".any("), "Should have .any(");
+            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
             assert!(code_no_space.contains("<"), "Should have < operator");
         } else {
             panic!("Any less-than failed: {:?}", analyzed.err());
@@ -450,7 +450,7 @@ mod cycle9_combined_operations {
     fn test_filter_then_map() {
         // [1, 5, 3, 8] πέντε μείζονα διπλασιαζόμενα λέγε
         // = "say (those) greater-than-five being-doubled"
-        // Should generate .filter(|x| x > 5).map(|x| x * 2)
+        // Should generate .g_filter(|x| x > 5).g_map(|x| x * 2)
         let code = "[1, 5, 3, 8] πέντε μείζονα διπλασιαζόμενα λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -464,14 +464,14 @@ mod cycle9_combined_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".filter("), "Should have .filter(");
-            assert!(code_no_space.contains(".map("), "Should have .map(");
+            assert!(code_no_space.contains(".g_filter("), "Should have .g_filter(");
+            assert!(code_no_space.contains(".g_map("), "Should have .g_map(");
             assert!(code_no_space.contains(">"), "Should have comparison");
             assert!(code_no_space.contains("5"), "Should compare to 5");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(
-                code_no_space.contains(".collect()"),
-                "Should have .collect()"
+                code_no_space.contains(".g_collect()"),
+                "Should have .g_collect()"
             );
         } else {
             panic!("Filter then map failed: {:?}", analyzed.err());
@@ -482,7 +482,7 @@ mod cycle9_combined_operations {
     fn test_map_then_fold() {
         // [1, 2, 3] διπλασιαζόμενα συλλεγόμενα εἰς ἄθροισμα λέγε
         // = "being-doubled being-collected into sum"
-        // Should generate .map(|x| x * 2).fold(0, |acc, x| acc + x)
+        // Should generate .g_map(|x| x * 2).g_fold(0, |acc, x| acc + x)
         let code = "[1, 2, 3] διπλασιαζόμενα συλλεγόμενα εἰς ἄθροισμα λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -495,15 +495,15 @@ mod cycle9_combined_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".map("), "Should have .map(");
-            assert!(code_no_space.contains(".fold("), "Should have .fold(");
+            assert!(code_no_space.contains(".g_map("), "Should have .g_map(");
+            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(code_no_space.contains("0"), "Should have init value 0");
             assert!(code_no_space.contains("+"), "Should have + operation");
-            // Fold returns single value, no .collect()
+            // Fold returns single value, no .g_collect()
             assert!(
-                !code_no_space.contains(".collect()"),
-                "Should NOT have .collect()"
+                !code_no_space.contains(".g_collect()"),
+                "Should NOT have .g_collect()"
             );
         } else {
             panic!("Map then fold failed: {:?}", analyzed.err());
@@ -559,7 +559,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".filter("), "Should have .filter(");
+            assert!(code_no_space.contains(".g_filter("), "Should have .g_filter(");
             // Should reference theta variable in closure
             // theta (θ) is hex-encoded as _u3b8_ to prevent collisions
             assert!(
@@ -590,7 +590,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".any("), "Should have .any(");
+            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
             // theta (θ) is hex-encoded as _u3b8_
             assert!(
                 code_no_space.contains("theta")
@@ -620,7 +620,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".filter("), "Should have .filter(");
+            assert!(code_no_space.contains(".g_filter("), "Should have .g_filter(");
             assert!(code_no_space.contains("5"), "Should use literal 5");
             // Should NOT reference theta (encoded or not)
             assert!(


### PR DESCRIPTION
Refactored `Assembler` struct to hold its state in a single `AssembledStatement` field instead of duplicating all fields. This simplifies the struct, removes the "God Object" feel of the field list, and makes `finalize()` more efficient using `std::mem::take`. Also updated `tests/lambda_tests.rs` to correctly assert the presence of `g_` prefixed iterator methods (e.g., `g_map`, `g_filter`), fixing a discrepancy between tests and actual code generation that was revealed during verification. Verified with `cargo test`.

---
*PR created automatically by Jules for task [5735921698790350070](https://jules.google.com/task/5735921698790350070) started by @madmax983*