### PR TITLE
🔒 Warden: Prevent HashDoS in Resolver & Fix Iterator Codegen

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -61,3 +61,15 @@
 2. **Std Lib Preservation:** Implemented `is_std_method` and `is_std_type` allowlists in code generation to detect calls to standard library methods and preserve their original names (e.g. `len`) instead of prefixing them.
 
 **Severity:** Medium (Logic Bug / Compilation Failure).
+
+## 2026-06-04 - HashDoS in Resolver & Iterator Prefixing Bug
+
+**Threat:**
+1. **HashDoS in Resolver:** User-controlled variable/type names were stored in `FxHashMap` (from `rustc-hash`), which uses a non-cryptographic hash function. A malicious source file with many colliding identifiers could cause quadratic lookup times (DoS) during semantic analysis.
+2. **Broken Code Generation:** Iterator methods (e.g., `map`, `filter`) on intermediate `Unknown` types were incorrectly sanitized (prefixed with `g_`), resulting in invalid Rust code (e.g., `.g_map()`) that failed to compile.
+
+**Defense:**
+1. **Secure Hashing:** Replaced `FxHashMap` with `std::collections::HashMap` (SipHash) in `src/semantic/resolver.rs` for all user-controlled scopes.
+2. **Standard Method Allowlist:** Added `GlossaType::Unknown` to `is_std_type` in `src/codegen/rust.rs` to prevent prefixing standard methods on inferred/iterator types.
+
+**Severity:** Medium (DoS via CPU exhaustion & Compilation Failure).

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -928,6 +928,7 @@ fn is_std_type(ty: &GlossaType) -> bool {
             | GlossaType::Option(_)
             | GlossaType::Result(_, _)
             | GlossaType::Unit
+            | GlossaType::Unknown
     )
 }
 

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -3,20 +3,20 @@
 //! Manages variable bindings and scope for ΓΛΩΣΣΑ programs.
 
 use crate::semantic::GlossaType;
-use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
+use std::collections::HashMap;
 
 /// A scope level containing variable bindings
 #[derive(Debug, Clone, Default)]
 struct ScopeLevel {
     /// Variable bindings in this scope
-    bindings: FxHashMap<SmolStr, Binding>,
+    bindings: HashMap<SmolStr, Binding>,
     /// Function definitions in this scope
-    functions: FxHashMap<SmolStr, FunctionSignature>,
+    functions: HashMap<SmolStr, FunctionSignature>,
     /// Type definitions in this scope
-    types: FxHashMap<SmolStr, GlossaType>,
+    types: HashMap<SmolStr, GlossaType>,
     /// Trait definitions in this scope
-    traits: FxHashMap<SmolStr, crate::semantic::model::TraitDef>,
+    traits: HashMap<SmolStr, crate::semantic::model::TraitDef>,
     /// Trait implementations in this scope
     trait_impls: Vec<crate::semantic::model::TraitImpl>,
 }


### PR DESCRIPTION
This PR addresses two critical issues identified during a security audit:

1.  **HashDoS Vulnerability in Resolver:** The compiler was using `FxHashMap` (a fast but non-cryptographic hash map) to store user-defined variable and type names. This could allow a malicious actor to craft a source file with colliding identifiers, causing quadratic lookup times (DoS). This has been mitigated by switching to `std::collections::HashMap` (which uses SipHash).

2.  **Broken Code Generation for Iterators:** A logic bug in `src/codegen/rust.rs` caused standard iterator methods (like `map`, `filter`) to be prefixed with `g_` (e.g., `g_map`) when the semantic analyzer could not infer the exact iterator type (`GlossaType::Unknown`). This resulted in generated Rust code that failed to compile. This has been fixed by treating `Unknown` types as potentially standard types, preventing the prefixing of standard method names.

Verified with `cargo check` and `cargo test`. All tests passed.

---
*PR created automatically by Jules for task [16341247140565223760](https://jules.google.com/task/16341247140565223760) started by @madmax983*