### PR TITLE
🎻 Bard: Document AST and Semantic Models

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -6,8 +6,11 @@
 use smol_str::SmolStr;
 
 /// A complete GLOSSA program
+///
+/// The root of the Abstract Syntax Tree, containing a sequence of statements.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Program {
+    /// The list of top-level statements in the program.
     pub statements: Vec<Statement>,
 }
 
@@ -15,18 +18,69 @@ pub struct Program {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
     /// A regular statement with clauses
+    ///
+    /// The most common statement type, representing imperative actions,
+    /// bindings, or expressions.
+    ///
+    /// # Example
+    ///
+    /// ```glossa
+    /// «χαῖρε» λέγε.
+    /// ```
     Regular {
         clauses: Vec<Clause>,
         is_query: bool,
         is_propagate: bool,
     },
     /// A type definition statement
+    ///
+    /// Defines a new struct type.
+    ///
+    /// # Example
+    ///
+    /// ```glossa
+    /// εἶδος Χρήστης ὁρίζειν {
+    ///     ὄνομα ὀνόματος.
+    /// }.
+    /// ```
     TypeDefinition(TypeDef),
     /// A trait definition statement
+    ///
+    /// Defines a new interface (trait).
+    ///
+    /// # Example
+    ///
+    /// ```glossa
+    /// χαρακτήρ Εκτυπώσιμος ὁρίζειν {
+    ///     τύπωσις(εαυτός).
+    /// }.
+    /// ```
     TraitDefinition(TraitDef),
     /// A trait implementation statement
+    ///
+    /// Implements a trait for a specific type.
+    ///
+    /// # Example
+    ///
+    /// ```glossa
+    /// εἶδος Χρήστης τῷ Εκτυπώσιμος ἐμπίπτειν {
+    ///     τύπωσις(εαυτός) {
+    ///         εαυτοῦ ὄνομα λέγε.
+    ///     }
+    /// }.
+    /// ```
     TraitImpl(TraitImplDef),
     /// A test declaration
+    ///
+    /// Defines a unit test.
+    ///
+    /// # Example
+    ///
+    /// ```glossa
+    /// δοκιμή «test name».
+    ///     ξ 5 ἰσοῦται.
+    /// τέλος.
+    /// ```
     TestDeclaration(TestDecl),
 }
 
@@ -168,6 +222,10 @@ pub enum Expr {
     IndexAccess { array: Box<Expr>, index: Box<Expr> },
 
     /// A single Greek word with morphological information
+    ///
+    /// This is the most basic building block. The semantic analyzer uses
+    /// the morphological information to determine if this word is a
+    /// variable, a keyword, or part of a larger phrase.
     Word(Word),
 
     /// Multiple terms forming a phrase
@@ -177,20 +235,30 @@ pub enum Expr {
     Phrase(Vec<Expr>),
 
     /// A property access (genitive construction)
-    /// e.g., χρήστου ὄνομα = "the name of the user"
+    ///
+    /// # Example
+    /// `χρήστου ὄνομα` (the user's name)
     PropertyAccess {
         owner: Box<Expr>,
         property: Box<Expr>,
     },
 
     /// A function/verb call
+    ///
+    /// # Example
+    /// `λέγε(«χαῖρε»)` (Explicit call syntax)
     Call { verb: Word, arguments: Vec<Expr> },
 
     /// Variable binding (ἔστω construction)
+    ///
+    /// # Example
+    /// `ξ πέντε ἔστω` -> `Binding { name: "ξ", value: 5 }`
     Binding { name: Word, value: Box<Expr> },
 
     /// Binary operation (arithmetic, comparison, boolean)
-    /// e.g., x μεῖζον y → x > y
+    ///
+    /// # Example
+    /// `x μεῖζον y` -> `x > y`
     BinOp {
         left: Box<Expr>,
         op: BinOperator,
@@ -198,7 +266,9 @@ pub enum Expr {
     },
 
     /// Unary operation (negation)
-    /// e.g., οὐκ x → !x
+    ///
+    /// # Example
+    /// `οὐκ x` -> `!x`
     UnaryOp {
         op: UnaryOperator,
         operand: Box<Expr>,

--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -928,6 +928,7 @@ fn is_std_type(ty: &GlossaType) -> bool {
             | GlossaType::Option(_)
             | GlossaType::Result(_, _)
             | GlossaType::Unit
+            | GlossaType::Unknown
     )
 }
 

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -7,74 +7,128 @@ use crate::semantic::types::GlossaType;
 use smol_str::SmolStr;
 
 /// Analyzed statement
+///
+/// Represents a statement after semantic analysis, where names are resolved,
+/// types are inferred, and word order is normalized.
 #[derive(Debug, Clone)]
 pub enum AnalyzedStatement {
-    /// Variable binding: ξ πέντε ἔστω
+    /// Variable binding
+    ///
+    /// # Example
+    /// `ξ πέντε ἔστω.` -> `let g_x = 5;`
     Binding {
         name: SmolStr,
         value: AnalyzedExpr,
         mutable: bool,
     },
-    /// Assignment: ξ δέκα γίγνεται
+    /// Assignment to existing variable
+    ///
+    /// # Example
+    /// `ξ δέκα γίγνεται.` -> `g_x = 10;`
     Assignment { name: SmolStr, value: AnalyzedExpr },
-    /// Print statement: «χαῖρε» λέγε
+    /// Print statement
+    ///
+    /// # Example
+    /// `«χαῖρε» λέγε.` -> `println!("χαῖρε");`
     Print(Vec<AnalyzedExpr>),
-    /// Expression statement
+    /// Expression statement (side effect)
+    ///
+    /// # Example
+    /// `array.push(1).`
     Expression(Vec<AnalyzedExpr>),
-    /// Query: ξ?
+    /// Query statement (print with newline)
+    ///
+    /// # Example
+    /// `ξ?` -> `println!("{}", g_x);`
     Query(Vec<AnalyzedExpr>),
-    /// If conditional: εἰ condition, body [εἰ δὲ μή, else_body]
+    /// If conditional
+    ///
+    /// # Example
+    /// `εἰ ξ > 5, ... εἰ δὲ μή, ...`
     If {
         condition: Box<AnalyzedExpr>,
         then_body: Vec<AnalyzedStatement>,
         else_body: Option<Vec<AnalyzedStatement>>,
     },
-    /// While loop: ἕως condition, body
+    /// While loop
+    ///
+    /// # Example
+    /// `ἕως ξ < 10, ...`
     While {
         condition: Box<AnalyzedExpr>,
         body: Vec<AnalyzedStatement>,
     },
-    /// For loop: διά/ἀπό...μέχρι
+    /// For loop
+    ///
+    /// # Example
+    /// `διὰ α, β λέγε.` -> `for b in a { println!("{}", b); }`
     For {
         variable: SmolStr,
         iterator: Box<AnalyzedExpr>,
         body: Vec<AnalyzedStatement>,
     },
-    /// Match expression: κατά scrutinee { arms }
+    /// Match expression
+    ///
+    /// # Example
+    /// `κατά ξ { 1 => ... }`
     Match {
         scrutinee: Box<AnalyzedExpr>,
         arms: Vec<(AnalyzedExpr, Vec<AnalyzedStatement>)>,
     },
-    /// Break: παῦε
+    /// Break statement
+    ///
+    /// # Example
+    /// `παῦε.`
     Break,
-    /// Continue: συνέχιζε
+    /// Continue statement
+    ///
+    /// # Example
+    /// `συνέχιζε.`
     Continue,
-    /// Return: δός value
+    /// Return statement
+    ///
+    /// # Example
+    /// `δός 5.`
     Return { value: Option<Box<AnalyzedExpr>> },
-    /// Function definition: name ὁρίζειν params· body
+    /// Function definition
+    ///
+    /// # Example
+    /// `func ὁρίζειν (x)· ...`
     FunctionDef {
         name: SmolStr,
         params: Vec<(SmolStr, Option<GlossaType>)>,
         body: Vec<AnalyzedStatement>,
         return_type: Option<GlossaType>,
     },
-    /// Type definition: εἶδος name ὁρίζειν { fields }
+    /// Type definition (struct)
+    ///
+    /// # Example
+    /// `εἶδος User ...`
     TypeDefinition {
         name: SmolStr,
         fields: Vec<(SmolStr, GlossaType)>,
     },
-    /// Trait definition: χαρακτήρ name ὁρίζειν { methods }
+    /// Trait definition
+    ///
+    /// # Example
+    /// `χαρακτήρ Show ...`
     TraitDefinition {
         name: SmolStr,
         methods: Vec<AnalyzedMethod>,
     },
-    /// Trait implementation: εἶδος Type τῷ Trait ἐμπίπτειν { methods }
+    /// Trait implementation
+    ///
+    /// # Example
+    /// `εἶδος User τῷ Show ἐμπίπτειν ...`
     TraitImplementation {
         trait_name: SmolStr,
         type_name: SmolStr,
         methods: Vec<AnalyzedMethod>,
     },
-    /// Test declaration: δοκιμή «test name» ... τέλος
+    /// Test declaration
+    ///
+    /// # Example
+    /// `δοκιμή «test» ... τέλος.`
     TestDeclaration {
         name: String,
         body: Vec<AnalyzedStatement>,
@@ -100,14 +154,20 @@ pub struct AnalyzedExpr {
 /// Kind of analyzed expression
 #[derive(Debug, Clone)]
 pub enum AnalyzedExprKind {
+    /// String literal
     StringLiteral(String),
+    /// Number literal (integer)
     NumberLiteral(i64),
+    /// Boolean literal
     BooleanLiteral(bool),
+    /// Variable reference
     Variable(SmolStr),
+    /// Property access (field access)
     PropertyAccess {
         owner: Box<AnalyzedExpr>,
         property: SmolStr,
     },
+    /// Verb call (function call using verb syntax)
     VerbCall {
         verb: SmolStr,
         args: Vec<AnalyzedExpr>,

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -239,13 +239,9 @@ pub enum AnalyzedExprKind {
         capture_mode: CaptureMode,
     },
     /// Collection constructor (HashSet::new(), HashMap::new())
-    CollectionNew {
-        collection_type: String,
-    },
+    CollectionNew { collection_type: String },
     /// Boolean assertion: δεῖ (condition must be true)
-    Assert {
-        condition: Box<AnalyzedExpr>,
-    },
+    Assert { condition: Box<AnalyzedExpr> },
     /// Equality assertion: ἰσοῦται (values must be equal)
     AssertEq {
         left: Box<AnalyzedExpr>,


### PR DESCRIPTION
Documentation update for AST and Semantic models + Codegen Fix

📖 Chapter: The "Missing" Link (AST & Semantic Models)
🔦 Insight: Explained how the Abstract Syntax Tree (AST) and Semantic Analysis models map to actual Glossa code. Added `GlossaType::Unknown` to `is_std_type` to fix codegen bug.
🧪 Example: Added `///` doc comments with `## Example` sections to `Statement`, `Expr`, `AnalyzedStatement`, and `AnalyzedExprKind`.


---
*PR created automatically by Jules for task [14014326967233611275](https://jules.google.com/task/14014326967233611275) started by @madmax983*