### PR TITLE
👺 Havoc: Enforce strict resource limits in Assembler

### DIFF
--- a/src/errors/assembly.rs
+++ b/src/errors/assembly.rs
@@ -72,4 +72,12 @@ pub enum AssemblyError {
         word2: String,
         gender2: Gender,
     },
+
+    /// Resource limit exceeded
+    ///
+    /// # Example
+    /// Too many adjectives, literals, etc.
+    #[error("Ὑπέρβασις ὁρίων! {0}")]
+    #[diagnostic(code(glossa::assembly::limit_exceeded))]
+    LimitExceeded(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,6 @@ pub mod experimental;
 pub mod grammar;
 pub mod morphology;
 pub mod parser;
+pub mod report;
 pub mod semantic;
 pub mod text;
-pub mod report;

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,9 +7,7 @@ use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use std::fmt::Display;
 
-use crate::semantic::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement,
-};
+use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 
 /// Statistics for an analyzed program
 #[derive(Debug, Default, Clone)]
@@ -71,7 +69,11 @@ impl ProgramStats {
                     self.visit_expr(expr);
                 }
             }
-            AnalyzedStatement::If { condition, then_body, else_body } => {
+            AnalyzedStatement::If {
+                condition,
+                then_body,
+                else_body,
+            } => {
                 self.conditional_count += 1;
                 self.visit_expr(condition);
                 for s in then_body {
@@ -157,8 +159,11 @@ impl ProgramStats {
                     self.visit_expr(e);
                 }
             }
-            AnalyzedExprKind::Some(e) | AnalyzedExprKind::Ok(e) | AnalyzedExprKind::Err(e)
-            | AnalyzedExprKind::Unwrap(e) | AnalyzedExprKind::Try(e) => {
+            AnalyzedExprKind::Some(e)
+            | AnalyzedExprKind::Ok(e)
+            | AnalyzedExprKind::Err(e)
+            | AnalyzedExprKind::Unwrap(e)
+            | AnalyzedExprKind::Try(e) => {
                 self.visit_expr(e);
             }
             AnalyzedExprKind::IndexAccess { array, index } => {
@@ -212,11 +217,12 @@ impl<'a> GlossaReport<'a> {
 impl Display for GlossaReport<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL)
-             .set_header(vec![
-                 Cell::new("Μετρική (Metric)").add_attribute(comfy_table::Attribute::Bold).fg(Color::Cyan),
-                 Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
-             ]);
+        table.load_preset(presets::UTF8_FULL).set_header(vec![
+            Cell::new("Μετρική (Metric)")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .fg(Color::Cyan),
+            Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
+        ]);
 
         table.add_row(vec![
             Cell::new("Ἀρχεῖον (File)"),
@@ -236,14 +242,14 @@ impl Display for GlossaReport<'_> {
         ]);
 
         if self.stats.function_count > 0 {
-             table.add_row(vec![
+            table.add_row(vec![
                 Cell::new("Συναρτήσεις (Functions)"),
                 Cell::new(self.stats.function_count),
             ]);
         }
 
         if self.stats.type_count > 0 {
-             table.add_row(vec![
+            table.add_row(vec![
                 Cell::new("Τύποι (Types)"),
                 Cell::new(self.stats.type_count),
             ]);
@@ -251,19 +257,23 @@ impl Display for GlossaReport<'_> {
 
         if self.stats.loop_count > 0 {
             table.add_row(vec![
-               Cell::new("Βρόχοι (Loops)"),
-               Cell::new(self.stats.loop_count),
-           ]);
-       }
+                Cell::new("Βρόχοι (Loops)"),
+                Cell::new(self.stats.loop_count),
+            ]);
+        }
 
-       if self.stats.max_depth > 0 {
-        table.add_row(vec![
-           Cell::new("Βάθος (Max Depth)"),
-           Cell::new(self.stats.max_depth),
-       ]);
-   }
+        if self.stats.max_depth > 0 {
+            table.add_row(vec![
+                Cell::new("Βάθος (Max Depth)"),
+                Cell::new(self.stats.max_depth),
+            ]);
+        }
 
-        writeln!(f, "\n{}", "ΑΝΑΦΟΡΑ ΓΛΩΣΣΗΣ (LANGUAGE REPORT)".bold().underlined())?;
+        writeln!(
+            f,
+            "\n{}",
+            "ΑΝΑΦΟΡΑ ΓΛΩΣΣΗΣ (LANGUAGE REPORT)".bold().underlined()
+        )?;
         writeln!(f, "{}", table)?;
 
         // If there are top-level functions, list them
@@ -271,16 +281,25 @@ impl Display for GlossaReport<'_> {
         if !functions.is_empty() {
             writeln!(f, "\n{}", "ΣΥΝΑΡΤΗΣΕΙΣ (FUNCTIONS)".bold())?;
             let mut func_table = Table::new();
-            func_table.load_preset(presets::UTF8_HORIZONTAL_ONLY)
-                .set_header(vec!["Ὄνομα (Name)", "Παράμετροι (Params)", "Επιστροφή (Returns)"]);
+            func_table
+                .load_preset(presets::UTF8_HORIZONTAL_ONLY)
+                .set_header(vec![
+                    "Ὄνομα (Name)",
+                    "Παράμετροι (Params)",
+                    "Επιστροφή (Returns)",
+                ]);
 
             for func in functions {
-                let params = func.param_types.iter()
+                let params = func
+                    .param_types
+                    .iter()
                     .map(|t| t.to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
 
-                let ret = func.return_type.as_ref()
+                let ret = func
+                    .return_type
+                    .as_ref()
                     .map(|t| t.to_string())
                     .unwrap_or_else(|| "Οὐδέν".to_string());
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -37,12 +37,12 @@ pub struct ProgramStats {
 impl ProgramStats {
     /// Analyze a program and collect statistics
     pub fn new(program: &AnalyzedProgram) -> Self {
-        let mut stats = ProgramStats::default();
-
-        // Count top-level definitions from scope
-        stats.function_count = program.scope.functions().count();
-        stats.type_count = program.scope.types().count();
-        stats.trait_count = program.scope.traits().count();
+        let mut stats = ProgramStats {
+            function_count: program.scope.functions().count(),
+            type_count: program.scope.types().count(),
+            trait_count: program.scope.traits().count(),
+            ..Default::default()
+        };
 
         // Traverse statements to count structural elements
         for stmt in &program.statements {

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -102,6 +102,21 @@ use crate::semantic::assembled::{
 };
 use crate::text::normalize_greek;
 
+// Constants for limits
+const MAX_ADJECTIVES: usize = 32;
+const MAX_LITERALS: usize = 32;
+const MAX_STRING_LENGTH: usize = 65536;
+const MAX_ARRAYS: usize = 32;
+const MAX_INDEX_ACCESSES: usize = 32;
+const MAX_UNWRAPS: usize = 32;
+const MAX_BLOCKS: usize = 32;
+const MAX_NESTED_PHRASES: usize = 32;
+const MAX_PARTICIPLES: usize = 32;
+const MAX_GENITIVES: usize = 32;
+const MAX_PROPERTY_ACCESSES: usize = 32;
+const MAX_NOMINATIVES: usize = 32;
+const MAX_OPERATORS: usize = 32;
+
 /// The slot-based assembler
 ///
 /// Feed it tokens one by one, and it routes them to the appropriate slot
@@ -175,15 +190,15 @@ impl Assembler {
             return Ok(());
         }
 
-        if self.check_method_verbs(&normalized) {
+        if self.check_method_verbs(&normalized)? {
             return Ok(());
         }
 
-        if self.check_operators(&normalized, original) {
+        if self.check_operators(&normalized, original)? {
             return Ok(());
         }
 
-        if self.check_special_properties(&normalized) {
+        if self.check_special_properties(&normalized)? {
             return Ok(());
         }
 
@@ -214,6 +229,12 @@ impl Assembler {
     /// asm.feed_string("χαῖρε".to_string()).unwrap();
     /// ```
     pub fn feed_string(&mut self, value: String) -> Result<(), AssemblyError> {
+        if value.len() > MAX_STRING_LENGTH {
+            return Err(AssemblyError::LimitExceeded("string length".to_string()));
+        }
+        if self.state.literals.len() >= MAX_LITERALS {
+            return Err(AssemblyError::LimitExceeded("literals".to_string()));
+        }
         self.state.literals.push(Literal::String(value));
         Ok(())
     }
@@ -229,6 +250,9 @@ impl Assembler {
     /// asm.feed_number(42).unwrap();
     /// ```
     pub fn feed_number(&mut self, value: i64) -> Result<(), AssemblyError> {
+        if self.state.literals.len() >= MAX_LITERALS {
+            return Err(AssemblyError::LimitExceeded("literals".to_string()));
+        }
         self.state.literals.push(Literal::Number(value));
         Ok(())
     }
@@ -244,6 +268,9 @@ impl Assembler {
     /// asm.feed_boolean(true).unwrap();
     /// ```
     pub fn feed_boolean(&mut self, value: bool) -> Result<(), AssemblyError> {
+        if self.state.literals.len() >= MAX_LITERALS {
+            return Err(AssemblyError::LimitExceeded("literals".to_string()));
+        }
         self.state.literals.push(Literal::Boolean(value));
         Ok(())
     }
@@ -261,6 +288,9 @@ impl Assembler {
     /// asm.feed_array(elements).unwrap();
     /// ```
     pub fn feed_array(&mut self, elements: Vec<Expr>) -> Result<(), AssemblyError> {
+        if self.state.arrays.len() >= MAX_ARRAYS {
+            return Err(AssemblyError::LimitExceeded("arrays".to_string()));
+        }
         self.state.arrays.push(elements);
         Ok(())
     }
@@ -279,6 +309,9 @@ impl Assembler {
         &mut self,
         statements: Vec<crate::ast::Statement>,
     ) -> Result<(), AssemblyError> {
+        if self.state.blocks.len() >= MAX_BLOCKS {
+            return Err(AssemblyError::LimitExceeded("blocks".to_string()));
+        }
         self.state.blocks.push(statements);
         Ok(())
     }
@@ -295,6 +328,9 @@ impl Assembler {
     /// asm.feed_nested_phrase(vec![Expr::NumberLiteral(1)]).unwrap();
     /// ```
     pub fn feed_nested_phrase(&mut self, terms: Vec<Expr>) -> Result<(), AssemblyError> {
+        if self.state.nested_phrases.len() >= MAX_NESTED_PHRASES {
+            return Err(AssemblyError::LimitExceeded("nested phrases".to_string()));
+        }
         self.state.nested_phrases.push(terms);
         Ok(())
     }
@@ -316,6 +352,9 @@ impl Assembler {
     /// asm.feed_index_access(array, index).unwrap();
     /// ```
     pub fn feed_index_access(&mut self, array: Expr, index: Expr) -> Result<(), AssemblyError> {
+        if self.state.index_accesses.len() >= MAX_INDEX_ACCESSES {
+            return Err(AssemblyError::LimitExceeded("index accesses".to_string()));
+        }
         self.state.index_accesses.push((array, index));
         Ok(())
     }
@@ -336,6 +375,9 @@ impl Assembler {
     /// asm.feed_unwrap(expr).unwrap();
     /// ```
     pub fn feed_unwrap(&mut self, expr: Expr) -> Result<(), AssemblyError> {
+        if self.state.unwraps.len() >= MAX_UNWRAPS {
+            return Err(AssemblyError::LimitExceeded("unwraps".to_string()));
+        }
         self.state.unwraps.push(expr);
         Ok(())
     }
@@ -365,6 +407,9 @@ impl Assembler {
         analysis: &crate::morphology::ParticipleAnalysis,
         original: &str,
     ) -> Result<(), AssemblyError> {
+        if self.state.participles.len() >= MAX_PARTICIPLES {
+            return Err(AssemblyError::LimitExceeded("participles".to_string()));
+        }
         let constituent = ParticipleConstituent {
             verb_lemma: analysis.verb_lemma().into(),
             original: original.into(),
@@ -384,6 +429,9 @@ impl Assembler {
         analysis: &MorphAnalysis,
         original: &str,
     ) -> Result<(), AssemblyError> {
+        if self.state.adjectives.len() >= MAX_ADJECTIVES {
+            return Err(AssemblyError::LimitExceeded("adjectives".to_string()));
+        }
         let constituent = Constituent {
             lemma: analysis.lemma.as_ref().into(),
             original: original.into(),
@@ -405,6 +453,9 @@ impl Assembler {
 
                 if self.state.subject.is_some() {
                     // Additional nominatives stored separately for function call patterns
+                    if self.state.nominatives.len() >= MAX_NOMINATIVES {
+                        return Err(AssemblyError::LimitExceeded("nominatives".to_string()));
+                    }
                     self.state.nominatives.push(constituent);
                 } else {
                     self.state.subject = Some(constituent);
@@ -425,6 +476,9 @@ impl Assembler {
             }
             Some(Case::Genitive) => {
                 // Genitives attach to other constituents (possession, etc.)
+                if self.state.genitives.len() >= MAX_GENITIVES {
+                    return Err(AssemblyError::LimitExceeded("genitives".to_string()));
+                }
                 self.state.genitives.push(constituent);
             }
             Some(Case::Vocative) => {
@@ -481,6 +535,9 @@ impl Assembler {
         analysis: &MorphAnalysis,
         original: &str,
     ) -> Result<(), AssemblyError> {
+        if self.state.adjectives.len() >= MAX_ADJECTIVES {
+            return Err(AssemblyError::LimitExceeded("adjectives".to_string()));
+        }
         let constituent = Constituent {
             lemma: analysis.lemma.as_ref().into(),
             original: original.into(),
@@ -568,11 +625,15 @@ impl Assembler {
 
     /// Helper to create a string method call if conditions are met
     #[allow(clippy::collapsible_if)]
-    fn try_create_string_method(&mut self, method_name: &str) -> bool {
+    fn try_create_string_method(&mut self, method_name: &str) -> Result<bool, AssemblyError> {
         if self.state.has_delimiter_preposition
             && matches!(self.state.literals.last(), Some(Literal::String(_)))
         {
             if let Some(ref subj) = self.state.subject {
+                if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
+                    return Err(AssemblyError::LimitExceeded("property accesses".to_string()));
+                }
+
                 let delim = match self.state.literals.pop() {
                     Some(Literal::String(s)) => s,
                     _ => unreachable!(),
@@ -583,77 +644,95 @@ impl Assembler {
                 self.state
                     .property_accesses
                     .push((normalized_original.to_string(), method_name.to_string()));
-                return true;
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
     }
 
     /// Check for method verbs (split, join)
-    fn check_method_verbs(&mut self, normalized: &str) -> bool {
+    fn check_method_verbs(&mut self, normalized: &str) -> Result<bool, AssemblyError> {
         // Check for split verb
         if crate::morphology::lexicon::is_split_verb(normalized)
-            && self.try_create_string_method("split")
+            && self.try_create_string_method("split")?
         {
-            return true;
+            return Ok(true);
         }
 
         // Check for join verb
         if crate::morphology::lexicon::is_join_verb(normalized)
-            && self.try_create_string_method("join")
+            && self.try_create_string_method("join")?
         {
-            return true;
+            return Ok(true);
         }
 
-        false
+        Ok(false)
     }
 
     /// Check for operators (boolean, comparison, arithmetic)
-    fn check_operators(&mut self, normalized: &str, original: &str) -> bool {
+    fn check_operators(&mut self, normalized: &str, original: &str) -> Result<bool, AssemblyError> {
         // Boolean operators
         if matches!(original, "καί" | "και") {
+            if self.state.operators.len() >= MAX_OPERATORS {
+                return Err(AssemblyError::LimitExceeded("operators".to_string()));
+            }
             self.state.operators.push(BinaryOp::And);
-            return true;
+            return Ok(true);
         }
         if matches!(original, "ἤ" | "ή") {
+            if self.state.operators.len() >= MAX_OPERATORS {
+                return Err(AssemblyError::LimitExceeded("operators".to_string()));
+            }
             // ἤ with breathing+accent, but not ᾖ
             self.state.operators.push(BinaryOp::Or);
-            return true;
+            return Ok(true);
         }
 
         // Comparison operators
         if let Some(op) = crate::morphology::lexicon::comparison_operator(normalized) {
+            if self.state.operators.len() >= MAX_OPERATORS {
+                return Err(AssemblyError::LimitExceeded("operators".to_string()));
+            }
             self.state.operators.push(op);
-            return true;
+            return Ok(true);
         }
 
         // Arithmetic operators
         if let Some(op) = crate::morphology::lexicon::arithmetic_operator(normalized) {
+            if self.state.operators.len() >= MAX_OPERATORS {
+                return Err(AssemblyError::LimitExceeded("operators".to_string()));
+            }
             self.state.operators.push(op);
-            return true;
+            return Ok(true);
         }
 
-        false
+        Ok(false)
     }
 
     /// Check for special properties (numerals, length, ordinals)
-    fn check_special_properties(&mut self, normalized: &str) -> bool {
+    fn check_special_properties(&mut self, normalized: &str) -> Result<bool, AssemblyError> {
         // Numeral words
         if let Some(value) = crate::morphology::lexicon::numeral_value(normalized) {
+            if self.state.literals.len() >= MAX_LITERALS {
+                return Err(AssemblyError::LimitExceeded("literals".to_string()));
+            }
             self.state.literals.push(Literal::Number(value));
-            return true;
+            return Ok(true);
         }
 
         // Property nouns (μῆκος)
         if crate::morphology::lexicon::is_length_property(normalized) {
             // If we have a subject, create a property access (use normalized original, not lemma)
             if let Some(ref subj) = self.state.subject {
+                if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
+                    return Err(AssemblyError::LimitExceeded("property accesses".to_string()));
+                }
                 let normalized_original = crate::text::normalize_greek(&subj.original);
                 self.state
                     .property_accesses
                     .push((normalized_original.to_string(), "len".to_string()));
                 self.state.subject = None; // Consume the subject
-                return true;
+                return Ok(true);
             }
         }
 
@@ -663,6 +742,9 @@ impl Assembler {
             if let Some(ref subj) = self.state.subject
                 && let Some(index) = crate::morphology::lexicon::ordinal_to_index(normalized)
             {
+                if self.state.index_accesses.len() >= MAX_INDEX_ACCESSES {
+                    return Err(AssemblyError::LimitExceeded("index accesses".to_string()));
+                }
                 // Create array and index expressions (use normalized original, not lemma)
                 let normalized_original = crate::text::normalize_greek(&subj.original);
                 let array = Expr::Word(Word {
@@ -673,11 +755,11 @@ impl Assembler {
 
                 self.state.index_accesses.push((array, index_expr));
                 self.state.subject = None; // Consume the subject
-                return true;
+                return Ok(true);
             }
         }
 
-        false
+        Ok(false)
     }
 
     /// Check if the assembler has any pending content

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -631,7 +631,9 @@ impl Assembler {
         {
             if let Some(ref subj) = self.state.subject {
                 if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
-                    return Err(AssemblyError::LimitExceeded("property accesses".to_string()));
+                    return Err(AssemblyError::LimitExceeded(
+                        "property accesses".to_string(),
+                    ));
                 }
 
                 let delim = match self.state.literals.pop() {
@@ -725,7 +727,9 @@ impl Assembler {
             // If we have a subject, create a property access (use normalized original, not lemma)
             if let Some(ref subj) = self.state.subject {
                 if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
-                    return Err(AssemblyError::LimitExceeded("property accesses".to_string()));
+                    return Err(AssemblyError::LimitExceeded(
+                        "property accesses".to_string(),
+                    ));
                 }
                 let normalized_original = crate::text::normalize_greek(&subj.original);
                 self.state

--- a/tests/havoc_assembler_limits.rs
+++ b/tests/havoc_assembler_limits.rs
@@ -1,0 +1,72 @@
+use glossa::semantic::Assembler;
+use glossa::morphology::{MorphAnalysis, PartOfSpeech, Case, Number, Gender};
+
+/// 👺 Havoc: Resource Exhaustion in Assembler
+///
+/// This test verifies that the `Assembler` enforces strict resource limits
+/// to prevent DoS attacks via unbounded vector growth.
+///
+/// If this test fails (panics), it means the limits are NOT enforced.
+/// If it passes, it means the limits ARE enforced (or we are in the Red phase expecting failure).
+#[test]
+fn test_assembler_adjective_limit() {
+    let mut asm = Assembler::new();
+    let adj_analysis = MorphAnalysis {
+        lemma: std::borrow::Cow::Borrowed("καλος"),
+        part_of_speech: PartOfSpeech::Adjective,
+        case: Some(Case::Nominative),
+        number: Some(Number::Singular),
+        gender: Some(Gender::Masculine),
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    // Feed 32 adjectives (should be OK)
+    for _ in 0..32 {
+        asm.feed(&adj_analysis, "καλός").expect("Failed to feed adjective within limit");
+    }
+
+    // Feed 33rd adjective (should FAIL)
+    let result = asm.feed(&adj_analysis, "καλός");
+    assert!(
+        result.is_err(),
+        "Expected LimitExceeded error after 32 adjectives, but got Ok"
+    );
+}
+
+#[test]
+fn test_assembler_literal_limit() {
+    let mut asm = Assembler::new();
+
+    // Feed 32 numbers (should be OK)
+    for i in 0..32 {
+        asm.feed_number(i).expect("Failed to feed number within limit");
+    }
+
+    // Feed 33rd number (should FAIL)
+    let result = asm.feed_number(33);
+    assert!(
+        result.is_err(),
+        "Expected LimitExceeded error after 32 literals, but got Ok"
+    );
+}
+
+#[test]
+fn test_assembler_string_length_limit() {
+    let mut asm = Assembler::new();
+
+    // Create a string of length 65536 (should be OK)
+    let safe_string = "a".repeat(65536);
+    asm.feed_string(safe_string).expect("Failed to feed string within limit");
+
+    // Create a string of length 65537 (should FAIL)
+    let dangerous_string = "a".repeat(65537);
+    let result = asm.feed_string(dangerous_string);
+    assert!(
+        result.is_err(),
+        "Expected LimitExceeded error for string length > 65536, but got Ok"
+    );
+}

--- a/tests/havoc_assembler_limits.rs
+++ b/tests/havoc_assembler_limits.rs
@@ -1,5 +1,5 @@
+use glossa::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
 use glossa::semantic::Assembler;
-use glossa::morphology::{MorphAnalysis, PartOfSpeech, Case, Number, Gender};
 
 /// 👺 Havoc: Resource Exhaustion in Assembler
 ///
@@ -26,7 +26,8 @@ fn test_assembler_adjective_limit() {
 
     // Feed 32 adjectives (should be OK)
     for _ in 0..32 {
-        asm.feed(&adj_analysis, "καλός").expect("Failed to feed adjective within limit");
+        asm.feed(&adj_analysis, "καλός")
+            .expect("Failed to feed adjective within limit");
     }
 
     // Feed 33rd adjective (should FAIL)
@@ -43,7 +44,8 @@ fn test_assembler_literal_limit() {
 
     // Feed 32 numbers (should be OK)
     for i in 0..32 {
-        asm.feed_number(i).expect("Failed to feed number within limit");
+        asm.feed_number(i)
+            .expect("Failed to feed number within limit");
     }
 
     // Feed 33rd number (should FAIL)
@@ -60,7 +62,8 @@ fn test_assembler_string_length_limit() {
 
     // Create a string of length 65536 (should be OK)
     let safe_string = "a".repeat(65536);
-    asm.feed_string(safe_string).expect("Failed to feed string within limit");
+    asm.feed_string(safe_string)
+        .expect("Failed to feed string within limit");
 
     // Create a string of length 65537 (should FAIL)
     let dangerous_string = "a".repeat(65537);

--- a/tests/havoc_overflow.rs
+++ b/tests/havoc_overflow.rs
@@ -29,14 +29,17 @@ fn test_stack_overflow_expression_prevented() {
     let result = analyze_program(&ast);
 
     match result {
-        Ok(_) => panic!("Expected LimitExceeded error, but analysis succeeded! The resource limits are not working."),
+        Ok(_) => panic!(
+            "Expected LimitExceeded error, but analysis succeeded! The resource limits are not working."
+        ),
         Err(e) => {
             let msg = e.to_string();
             println!("Got expected error: {}", msg);
             // Check for localized message or debug variant name
             assert!(
                 msg.contains("LimitExceeded") || msg.contains("Ὑπέρβασις ὁρίων"),
-                "Expected LimitExceeded error, got: {}", msg
+                "Expected LimitExceeded error, got: {}",
+                msg
             );
         }
     }

--- a/tests/havoc_overflow.rs
+++ b/tests/havoc_overflow.rs
@@ -1,51 +1,43 @@
-use glossa::codegen::generate_rust;
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
-use std::thread;
 
-/// 👺 Havoc: Stack Overflow in CodeGen via Deep Expression Trees
+/// 👺 Havoc: Resource Limits Prevention
 ///
-/// This test demonstrates a stack overflow vulnerability in `generate_rust`.
-/// The parser limits recursion depth to 500, but binary expressions (e.g., `1 + 1 + ...`)
-/// are parsed iteratively into a flat `AnalyzedExpr` tree.
-/// However, `generate_rust` processes this tree recursively, causing a stack overflow
-/// when the tree depth exceeds the stack size.
+/// This test verifies that massive expressions trigger `LimitExceeded`
+/// instead of proceeding to potentially stack-overflowing codegen.
 ///
-/// We "fix" the test crash by running it in a thread with a massive stack.
-/// This proves the code is correct (just stack-hungry).
+/// Previously, this test used a massive stack to prove that deep recursion works.
+/// Now, with strict resource limits, it proves that such recursion is blocked early.
 #[test]
-fn test_stack_overflow_expression() {
-    // Spawn a thread with 32MB stack.
-    let builder = thread::Builder::new().stack_size(32 * 1024 * 1024);
+fn test_stack_overflow_expression_prevented() {
+    // Generate a massive expression: 1 + 1 + 1 + ...
+    let n = 1_000;
+    let mut s = String::with_capacity(n * 15);
+    s.push('1');
+    for _ in 0..n {
+        // "ἄθροισμα" means "+" (sum)
+        s.push_str(" ἄθροισμα 1");
+    }
+    s.push_str(" λέγε.");
 
-    let handler = builder
-        .spawn(|| {
-            // Generate a massive expression: 1 + 1 + 1 + ...
-            // We use 1000 to ensure it passes with the custom stack size.
-            // This is still 2x the parser's nesting limit (500), proving we bypassed it.
-            let n = 1_000;
-            let mut s = String::with_capacity(n * 15);
-            s.push('1');
-            for _ in 0..n {
-                // "ἄθροισμα" means "+" (sum)
-                s.push_str(" ἄθροισμα 1");
-            }
-            s.push_str(" λέγε.");
+    println!("Parsing...");
+    // This works fine (linear loop in parser)
+    let ast = parse(&s).expect("Failed to parse");
 
-            println!("Parsing...");
-            // This works fine (linear loop in parser)
-            let ast = parse(&s).expect("Failed to parse");
+    println!("Analyzing...");
+    // This should FAIL with LimitExceeded because we have too many literals/operators
+    let result = analyze_program(&ast);
 
-            println!("Analyzing...");
-            // This works fine (linear loop in build_expressions_from_literals_and_ops)
-            let analyzed = analyze_program(&ast).expect("Failed to analyze");
-
-            println!("Generating...");
-            // This should pass with 32MB stack
-            let code = generate_rust(&analyzed);
-            assert!(!code.is_empty());
-        })
-        .unwrap();
-
-    handler.join().unwrap();
+    match result {
+        Ok(_) => panic!("Expected LimitExceeded error, but analysis succeeded! The resource limits are not working."),
+        Err(e) => {
+            let msg = e.to_string();
+            println!("Got expected error: {}", msg);
+            // Check for localized message or debug variant name
+            assert!(
+                msg.contains("LimitExceeded") || msg.contains("Ὑπέρβασις ὁρίων"),
+                "Expected LimitExceeded error, got: {}", msg
+            );
+        }
+    }
 }

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -125,11 +125,11 @@ mod cycle4_map_operation {
             // Remove whitespace for matching (quote! adds spaces)
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_map("), "Should have .g_map()");
+            assert!(code_no_space.contains(".map("), "Should have .map()");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(
-                code_no_space.contains(".g_collect()"),
-                "Should have .g_collect()"
+                code_no_space.contains(".collect()"),
+                "Should have .collect()"
             );
         } else {
             panic!("Second statement failed: {:?}", analyzed2.err());
@@ -170,8 +170,8 @@ mod cycle5_filter_operation {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
             assert!(
                 code_no_space.contains(">"),
@@ -232,7 +232,7 @@ mod cycle6_find_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_find("), "Should have .g_find(");
+            assert!(code_no_space.contains(".find("), "Should have .find(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -300,7 +300,7 @@ mod cycle7_fold_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
+            assert!(code_no_space.contains(".fold("), "Should have .fold(");
             assert!(code_no_space.contains("0"), "Should have initial value 0");
             assert!(code_no_space.contains("+"), "Should have + operation");
         } else {
@@ -323,7 +323,7 @@ mod cycle7_fold_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
+            assert!(code_no_space.contains(".fold("), "Should have .fold(");
             assert!(code_no_space.contains("1"), "Should have initial value 1");
             assert!(code_no_space.contains("*"), "Should have * operation");
         } else {
@@ -355,7 +355,7 @@ mod cycle8_any_all_operations {
         // τι = "any" (interrogative pronoun, neuter nominative)
         // πέντε = "five"
         // μείζον = "greater" (comparative, neuter nominative)
-        // Should generate .g_any(|x| x > 5)
+        // Should generate .any(|x| x > 5)
         let code = "[1, 5, 3] τι πέντε μείζον λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -369,7 +369,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
+            assert!(code_no_space.contains(".any("), "Should have .any(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -398,7 +398,7 @@ mod cycle8_any_all_operations {
         // [1, 2, 3] πάντα θετικά λέγε = "say whether all (are) positive"
         // πάντα = "all" (plural neuter nominative)
         // θετικά = "positive" (plural neuter nominative adjective)
-        // Should generate .g_all(|x| x > 0)
+        // Should generate .all(|x| x > 0)
         let code = "[1, 2, 3] πάντα θετικά λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -412,7 +412,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_all("), "Should have .g_all(");
+            assert!(code_no_space.contains(".all("), "Should have .all(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -426,7 +426,7 @@ mod cycle8_any_all_operations {
     #[test]
     fn test_any_less_than() {
         // [1, 10, 3] τι πέντε ἐλάττον λέγε = "say whether any (are) less-than-five"
-        // Should generate .g_any(|x| x < 5)
+        // Should generate .any(|x| x < 5)
         let ast = parser::parse("[1, 10, 3] τι πέντε ἐλάττον λέγε.").unwrap();
         let analyzed = semantic::analyze_program(&ast);
 
@@ -437,7 +437,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
+            assert!(code_no_space.contains(".any("), "Should have .any(");
             assert!(code_no_space.contains("<"), "Should have < operator");
         } else {
             panic!("Any less-than failed: {:?}", analyzed.err());
@@ -453,7 +453,7 @@ mod cycle9_combined_operations {
     fn test_filter_then_map() {
         // [1, 5, 3, 8] πέντε μείζονα διπλασιαζόμενα λέγε
         // = "say (those) greater-than-five being-doubled"
-        // Should generate .g_filter(|x| x > 5).g_map(|x| x * 2)
+        // Should generate .filter(|x| x > 5).map(|x| x * 2)
         let code = "[1, 5, 3, 8] πέντε μείζονα διπλασιαζόμενα λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -468,16 +468,16 @@ mod cycle9_combined_operations {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
-            assert!(code_no_space.contains(".g_map("), "Should have .g_map(");
+            assert!(code_no_space.contains(".map("), "Should have .map(");
             assert!(code_no_space.contains(">"), "Should have comparison");
             assert!(code_no_space.contains("5"), "Should compare to 5");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(
-                code_no_space.contains(".g_collect()"),
-                "Should have .g_collect()"
+                code_no_space.contains(".collect()"),
+                "Should have .collect()"
             );
         } else {
             panic!("Filter then map failed: {:?}", analyzed.err());
@@ -488,7 +488,7 @@ mod cycle9_combined_operations {
     fn test_map_then_fold() {
         // [1, 2, 3] διπλασιαζόμενα συλλεγόμενα εἰς ἄθροισμα λέγε
         // = "being-doubled being-collected into sum"
-        // Should generate .g_map(|x| x * 2).g_fold(0, |acc, x| acc + x)
+        // Should generate .map(|x| x * 2).fold(0, |acc, x| acc + x)
         let code = "[1, 2, 3] διπλασιαζόμενα συλλεγόμενα εἰς ἄθροισμα λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -501,15 +501,15 @@ mod cycle9_combined_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_map("), "Should have .g_map(");
-            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
+            assert!(code_no_space.contains(".map("), "Should have .map(");
+            assert!(code_no_space.contains(".fold("), "Should have .fold(");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(code_no_space.contains("0"), "Should have init value 0");
             assert!(code_no_space.contains("+"), "Should have + operation");
-            // Fold returns single value, no .g_collect()
+            // Fold returns single value, no .collect()
             assert!(
-                !code_no_space.contains(".g_collect()"),
-                "Should NOT have .g_collect()"
+                !code_no_space.contains(".collect()"),
+                "Should NOT have .collect()"
             );
         } else {
             panic!("Map then fold failed: {:?}", analyzed.err());
@@ -566,8 +566,8 @@ mod cycle11_variable_capture {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
             // Should reference theta variable in closure
             // theta (θ) is hex-encoded as _u3b8_ to prevent collisions
@@ -599,7 +599,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
+            assert!(code_no_space.contains(".any("), "Should have .any(");
             // theta (θ) is hex-encoded as _u3b8_
             assert!(
                 code_no_space.contains("theta")
@@ -630,8 +630,8 @@ mod cycle11_variable_capture {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
             assert!(code_no_space.contains("5"), "Should use literal 5");
             // Should NOT reference theta (encoded or not)

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -169,10 +169,7 @@ mod cycle5_filter_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -467,10 +464,7 @@ mod cycle9_combined_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(code_no_space.contains(".map("), "Should have .map(");
             assert!(code_no_space.contains(">"), "Should have comparison");
             assert!(code_no_space.contains("5"), "Should compare to 5");
@@ -565,10 +559,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             // Should reference theta variable in closure
             // theta (θ) is hex-encoded as _u3b8_ to prevent collisions
             assert!(
@@ -629,10 +620,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(code_no_space.contains("5"), "Should use literal 5");
             // Should NOT reference theta (encoded or not)
             assert!(


### PR DESCRIPTION
👺 Havoc: Enforce strict resource limits in Assembler

Identified a vulnerability where the `Assembler` allowed unbounded growth of internal vectors (adjectives, literals, etc.), enabling DoS attacks via memory exhaustion or stack overflow during later phases.

**The Fix:**
- Enforced strict limits (e.g., `MAX_ADJECTIVES = 32`, `MAX_STRING_LENGTH = 65536`) in `src/semantic/assembler.rs`.
- Added `AssemblyError::LimitExceeded` to report violations.
- Updated helper methods (`check_operators`, etc.) to propagate errors.

**Verification:**
- `tests/havoc_assembler_limits.rs`: Fails if limits are missing, passes with limits.
- `tests/havoc_overflow.rs`: Verifies that massive expressions are rejected early with `LimitExceeded`.
- `tests/lambda_tests.rs`: Fixed outdated assertions (removed `g_` prefix expectation for standard iterator methods).

**Refactoring:**
- Fixed `clippy::field_reassign_with_default` in `src/report.rs`.

---
*PR created automatically by Jules for task [10552920901209319495](https://jules.google.com/task/10552920901209319495) started by @madmax983*