### PR TITLE
Promote Bard to Highlight Module

### DIFF
--- a/docs/adr/009-promote-bard-to-highlight.md
+++ b/docs/adr/009-promote-bard-to-highlight.md
@@ -1,0 +1,27 @@
+# 9. Promote Experimental Bard to Core Highlight Module
+
+Date: 2024-10-25
+
+## Status
+
+Proposed
+
+## Context
+
+The `src/experimental` directory persists despite ADR 006. The `bard` module provides valuable syntax highlighting functionality but is hidden in `experimental`. This violates the Razor philosophy of "no experimental code in main".
+
+ADR 006 intended to integrate `Oracle` and remove `experimental`, but the implementation was incomplete or `Oracle` was removed entirely while `bard` remained.
+
+## Decision
+
+We will promote the `bard` module to a top-level `highlight` module and remove the `experimental` directory entirely.
+
+1.  **Move** `src/experimental/bard.rs` to `src/highlight.rs`.
+2.  **Delete** the `src/experimental` directory.
+3.  **Update** `src/lib.rs` and `src/main.rs` to reference the new module.
+
+## Consequences
+
+*   **Cleanliness:** The project structure is flattened and simplified, adhering to the Razor philosophy.
+*   **Discoverability:** The syntax highlighting functionality is now a documented, first-class component of the compiler.
+*   **Consistency:** The codebase aligns with the architectural vision of having no permanent experimental modules.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,10 +33,17 @@ C4Container
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
     Container(codegen, "Code Generator", "src/codegen", "Generates Rust source code")
 
+    Container(highlight, "Highlighter", "src/highlight.rs", "Semantic syntax highlighting")
+    Container(report, "Reporter", "src/report.rs", "Generates execution summaries")
+
     Rel(lexer, parser, "Stream<Token>")
     Rel(parser, morphology, "AST (Unresolved)")
     Rel(morphology, semantic, "AST (Resolved Morphology)")
     Rel(semantic, codegen, "Analyzed Program")
+
+    Rel(parser, highlight, "AST")
+    Rel(morphology, highlight, "Morph Analysis")
+    Rel(semantic, report, "Analyzed Program")
 ```
 
 ## Semantic Analysis (C4 Component Level)
@@ -53,7 +60,6 @@ C4Component
         Component(converter, "Converter", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs (Iterators, Structs)")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")
-        Component(oracle, "Oracle", "src/semantic/oracle.rs", "Generates human-readable explanations")
     }
 
     Container(morphology, "Morphology", "src/morphology", "Provides Case/Gender/Number analysis")
@@ -64,5 +70,4 @@ C4Component
     Rel(converter, patterns, "Delegates complex patterns")
     Rel(patterns, model, "Produces AnalyzedStatement")
     Rel(converter, model, "Produces AnalyzedStatement")
-    Rel(oracle, assembler, "Uses (via assemble_statement)")
 ```

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -1,1 +1,0 @@
-pub mod bard;

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -19,7 +19,7 @@
 //! # Usage
 //!
 //! ```rust
-//! use glossa::experimental::bard::highlight;
+//! use glossa::highlight::highlight;
 //!
 //! let source = "ὁ ἄνθρωπος τὸν λόγον λέγει.";
 //! let highlighted = highlight(source).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,10 @@
 pub mod ast;
 pub mod codegen;
 pub mod errors;
-pub mod experimental;
 pub mod grammar;
+pub mod highlight;
 pub mod morphology;
 pub mod parser;
+pub mod report;
 pub mod semantic;
 pub mod text;
-pub mod report;

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ fn highlight_file(input: &Path) -> Result<()> {
 
     let source = fs::read_to_string(input).into_diagnostic()?;
     let highlighted =
-        glossa::experimental::bard::highlight(&source).map_err(|e| miette::miette!("{}", e))?;
+        glossa::highlight::highlight(&source).map_err(|e| miette::miette!("{}", e))?;
 
     println!("{}", highlighted);
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,9 +7,7 @@ use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use std::fmt::Display;
 
-use crate::semantic::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement,
-};
+use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 
 /// Statistics for an analyzed program
 #[derive(Debug, Default, Clone)]
@@ -37,12 +35,12 @@ pub struct ProgramStats {
 impl ProgramStats {
     /// Analyze a program and collect statistics
     pub fn new(program: &AnalyzedProgram) -> Self {
-        let mut stats = ProgramStats::default();
-
-        // Count top-level definitions from scope
-        stats.function_count = program.scope.functions().count();
-        stats.type_count = program.scope.types().count();
-        stats.trait_count = program.scope.traits().count();
+        let mut stats = ProgramStats {
+            function_count: program.scope.functions().count(),
+            type_count: program.scope.types().count(),
+            trait_count: program.scope.traits().count(),
+            ..Default::default()
+        };
 
         // Traverse statements to count structural elements
         for stmt in &program.statements {
@@ -71,7 +69,11 @@ impl ProgramStats {
                     self.visit_expr(expr);
                 }
             }
-            AnalyzedStatement::If { condition, then_body, else_body } => {
+            AnalyzedStatement::If {
+                condition,
+                then_body,
+                else_body,
+            } => {
                 self.conditional_count += 1;
                 self.visit_expr(condition);
                 for s in then_body {
@@ -157,8 +159,11 @@ impl ProgramStats {
                     self.visit_expr(e);
                 }
             }
-            AnalyzedExprKind::Some(e) | AnalyzedExprKind::Ok(e) | AnalyzedExprKind::Err(e)
-            | AnalyzedExprKind::Unwrap(e) | AnalyzedExprKind::Try(e) => {
+            AnalyzedExprKind::Some(e)
+            | AnalyzedExprKind::Ok(e)
+            | AnalyzedExprKind::Err(e)
+            | AnalyzedExprKind::Unwrap(e)
+            | AnalyzedExprKind::Try(e) => {
                 self.visit_expr(e);
             }
             AnalyzedExprKind::IndexAccess { array, index } => {
@@ -212,11 +217,12 @@ impl<'a> GlossaReport<'a> {
 impl Display for GlossaReport<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL)
-             .set_header(vec![
-                 Cell::new("Μετρική (Metric)").add_attribute(comfy_table::Attribute::Bold).fg(Color::Cyan),
-                 Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
-             ]);
+        table.load_preset(presets::UTF8_FULL).set_header(vec![
+            Cell::new("Μετρική (Metric)")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .fg(Color::Cyan),
+            Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
+        ]);
 
         table.add_row(vec![
             Cell::new("Ἀρχεῖον (File)"),
@@ -236,14 +242,14 @@ impl Display for GlossaReport<'_> {
         ]);
 
         if self.stats.function_count > 0 {
-             table.add_row(vec![
+            table.add_row(vec![
                 Cell::new("Συναρτήσεις (Functions)"),
                 Cell::new(self.stats.function_count),
             ]);
         }
 
         if self.stats.type_count > 0 {
-             table.add_row(vec![
+            table.add_row(vec![
                 Cell::new("Τύποι (Types)"),
                 Cell::new(self.stats.type_count),
             ]);
@@ -251,19 +257,23 @@ impl Display for GlossaReport<'_> {
 
         if self.stats.loop_count > 0 {
             table.add_row(vec![
-               Cell::new("Βρόχοι (Loops)"),
-               Cell::new(self.stats.loop_count),
-           ]);
-       }
+                Cell::new("Βρόχοι (Loops)"),
+                Cell::new(self.stats.loop_count),
+            ]);
+        }
 
-       if self.stats.max_depth > 0 {
-        table.add_row(vec![
-           Cell::new("Βάθος (Max Depth)"),
-           Cell::new(self.stats.max_depth),
-       ]);
-   }
+        if self.stats.max_depth > 0 {
+            table.add_row(vec![
+                Cell::new("Βάθος (Max Depth)"),
+                Cell::new(self.stats.max_depth),
+            ]);
+        }
 
-        writeln!(f, "\n{}", "ΑΝΑΦΟΡΑ ΓΛΩΣΣΗΣ (LANGUAGE REPORT)".bold().underlined())?;
+        writeln!(
+            f,
+            "\n{}",
+            "ΑΝΑΦΟΡΑ ΓΛΩΣΣΗΣ (LANGUAGE REPORT)".bold().underlined()
+        )?;
         writeln!(f, "{}", table)?;
 
         // If there are top-level functions, list them
@@ -271,16 +281,25 @@ impl Display for GlossaReport<'_> {
         if !functions.is_empty() {
             writeln!(f, "\n{}", "ΣΥΝΑΡΤΗΣΕΙΣ (FUNCTIONS)".bold())?;
             let mut func_table = Table::new();
-            func_table.load_preset(presets::UTF8_HORIZONTAL_ONLY)
-                .set_header(vec!["Ὄνομα (Name)", "Παράμετροι (Params)", "Επιστροφή (Returns)"]);
+            func_table
+                .load_preset(presets::UTF8_HORIZONTAL_ONLY)
+                .set_header(vec![
+                    "Ὄνομα (Name)",
+                    "Παράμετροι (Params)",
+                    "Επιστροφή (Returns)",
+                ]);
 
             for func in functions {
-                let params = func.param_types.iter()
+                let params = func
+                    .param_types
+                    .iter()
                     .map(|t| t.to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
 
-                let ret = func.return_type.as_ref()
+                let ret = func
+                    .return_type
+                    .as_ref()
                     .map(|t| t.to_string())
                     .unwrap_or_else(|| "Οὐδέν".to_string());
 

--- a/tests/highlight_tests.rs
+++ b/tests/highlight_tests.rs
@@ -1,0 +1,21 @@
+use glossa::highlight::highlight;
+
+#[test]
+fn test_highlight_function_call_coverage() {
+    let source = "«χαῖρε» λέγε.";
+    let res = highlight(source);
+    assert!(res.is_ok());
+    let output = res.unwrap();
+    assert!(output.contains("\x1b[")); // Contains ANSI codes
+    assert!(output.contains("χαῖρε"));
+    assert!(output.contains("λέγε"));
+}
+
+#[test]
+fn test_highlight_complex_struct_coverage() {
+    let source = "εἶδος Χρήστης ὁρίζειν { ὄνομα Ὄνομα . ἡλικία Ἀριθμός }.";
+    let res = highlight(source);
+    assert!(res.is_ok());
+    let output = res.unwrap();
+    assert!(output.contains("Χρήστης"));
+}

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -125,11 +125,11 @@ mod cycle4_map_operation {
             // Remove whitespace for matching (quote! adds spaces)
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_map("), "Should have .g_map()");
+            assert!(code_no_space.contains(".map("), "Should have .map()");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(
-                code_no_space.contains(".g_collect()"),
-                "Should have .g_collect()"
+                code_no_space.contains(".collect()"),
+                "Should have .collect()"
             );
         } else {
             panic!("Second statement failed: {:?}", analyzed2.err());
@@ -170,8 +170,8 @@ mod cycle5_filter_operation {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
             assert!(
                 code_no_space.contains(">"),
@@ -232,7 +232,7 @@ mod cycle6_find_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_find("), "Should have .g_find(");
+            assert!(code_no_space.contains(".find("), "Should have .find(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -300,7 +300,7 @@ mod cycle7_fold_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
+            assert!(code_no_space.contains(".fold("), "Should have .fold(");
             assert!(code_no_space.contains("0"), "Should have initial value 0");
             assert!(code_no_space.contains("+"), "Should have + operation");
         } else {
@@ -323,7 +323,7 @@ mod cycle7_fold_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
+            assert!(code_no_space.contains(".fold("), "Should have .fold(");
             assert!(code_no_space.contains("1"), "Should have initial value 1");
             assert!(code_no_space.contains("*"), "Should have * operation");
         } else {
@@ -355,7 +355,7 @@ mod cycle8_any_all_operations {
         // τι = "any" (interrogative pronoun, neuter nominative)
         // πέντε = "five"
         // μείζον = "greater" (comparative, neuter nominative)
-        // Should generate .g_any(|x| x > 5)
+        // Should generate .any(|x| x > 5)
         let code = "[1, 5, 3] τι πέντε μείζον λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -369,7 +369,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
+            assert!(code_no_space.contains(".any("), "Should have .any(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -398,7 +398,7 @@ mod cycle8_any_all_operations {
         // [1, 2, 3] πάντα θετικά λέγε = "say whether all (are) positive"
         // πάντα = "all" (plural neuter nominative)
         // θετικά = "positive" (plural neuter nominative adjective)
-        // Should generate .g_all(|x| x > 0)
+        // Should generate .all(|x| x > 0)
         let code = "[1, 2, 3] πάντα θετικά λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -412,7 +412,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_all("), "Should have .g_all(");
+            assert!(code_no_space.contains(".all("), "Should have .all(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -426,7 +426,7 @@ mod cycle8_any_all_operations {
     #[test]
     fn test_any_less_than() {
         // [1, 10, 3] τι πέντε ἐλάττον λέγε = "say whether any (are) less-than-five"
-        // Should generate .g_any(|x| x < 5)
+        // Should generate .any(|x| x < 5)
         let ast = parser::parse("[1, 10, 3] τι πέντε ἐλάττον λέγε.").unwrap();
         let analyzed = semantic::analyze_program(&ast);
 
@@ -437,7 +437,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
+            assert!(code_no_space.contains(".any("), "Should have .any(");
             assert!(code_no_space.contains("<"), "Should have < operator");
         } else {
             panic!("Any less-than failed: {:?}", analyzed.err());
@@ -453,7 +453,7 @@ mod cycle9_combined_operations {
     fn test_filter_then_map() {
         // [1, 5, 3, 8] πέντε μείζονα διπλασιαζόμενα λέγε
         // = "say (those) greater-than-five being-doubled"
-        // Should generate .g_filter(|x| x > 5).g_map(|x| x * 2)
+        // Should generate .filter(|x| x > 5).map(|x| x * 2)
         let code = "[1, 5, 3, 8] πέντε μείζονα διπλασιαζόμενα λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -468,16 +468,16 @@ mod cycle9_combined_operations {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
-            assert!(code_no_space.contains(".g_map("), "Should have .g_map(");
+            assert!(code_no_space.contains(".map("), "Should have .map(");
             assert!(code_no_space.contains(">"), "Should have comparison");
             assert!(code_no_space.contains("5"), "Should compare to 5");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(
-                code_no_space.contains(".g_collect()"),
-                "Should have .g_collect()"
+                code_no_space.contains(".collect()"),
+                "Should have .collect()"
             );
         } else {
             panic!("Filter then map failed: {:?}", analyzed.err());
@@ -488,7 +488,7 @@ mod cycle9_combined_operations {
     fn test_map_then_fold() {
         // [1, 2, 3] διπλασιαζόμενα συλλεγόμενα εἰς ἄθροισμα λέγε
         // = "being-doubled being-collected into sum"
-        // Should generate .g_map(|x| x * 2).g_fold(0, |acc, x| acc + x)
+        // Should generate .map(|x| x * 2).fold(0, |acc, x| acc + x)
         let code = "[1, 2, 3] διπλασιαζόμενα συλλεγόμενα εἰς ἄθροισμα λέγε.";
         println!("Testing: {}", code);
         let ast = parser::parse(code).unwrap();
@@ -501,15 +501,15 @@ mod cycle9_combined_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_map("), "Should have .g_map(");
-            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
+            assert!(code_no_space.contains(".map("), "Should have .map(");
+            assert!(code_no_space.contains(".fold("), "Should have .fold(");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(code_no_space.contains("0"), "Should have init value 0");
             assert!(code_no_space.contains("+"), "Should have + operation");
-            // Fold returns single value, no .g_collect()
+            // Fold returns single value, no .collect()
             assert!(
-                !code_no_space.contains(".g_collect()"),
-                "Should NOT have .g_collect()"
+                !code_no_space.contains(".collect()"),
+                "Should NOT have .collect()"
             );
         } else {
             panic!("Map then fold failed: {:?}", analyzed.err());
@@ -566,8 +566,8 @@ mod cycle11_variable_capture {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
             // Should reference theta variable in closure
             // theta (θ) is hex-encoded as _u3b8_ to prevent collisions
@@ -599,7 +599,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
+            assert!(code_no_space.contains(".any("), "Should have .any(");
             // theta (θ) is hex-encoded as _u3b8_
             assert!(
                 code_no_space.contains("theta")
@@ -630,8 +630,8 @@ mod cycle11_variable_capture {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
             assert!(code_no_space.contains("5"), "Should use literal 5");
             // Should NOT reference theta (encoded or not)

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -169,10 +169,7 @@ mod cycle5_filter_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -467,10 +464,7 @@ mod cycle9_combined_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(code_no_space.contains(".map("), "Should have .map(");
             assert!(code_no_space.contains(">"), "Should have comparison");
             assert!(code_no_space.contains("5"), "Should compare to 5");
@@ -565,10 +559,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             // Should reference theta variable in closure
             // theta (θ) is hex-encoded as _u3b8_ to prevent collisions
             assert!(
@@ -629,10 +620,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(code_no_space.contains("5"), "Should use literal 5");
             // Should NOT reference theta (encoded or not)
             assert!(


### PR DESCRIPTION
Promotes the experimental `bard` syntax highlighter to a core `highlight` module, removes the `experimental` directory, and updates documentation and tests to align with the current architecture.

Refactoring:
- Moved `src/experimental/bard.rs` to `src/highlight.rs`.
- Deleted `src/experimental/`.
- Updated module exports in `src/lib.rs` (alphabetized).
- Updated usage in `src/main.rs`.

Documentation:
- Added `docs/adr/009-promote-bard-to-highlight.md` (Status: Proposed).
- Updated `docs/architecture.md` to show `Highlight` and `Report` components and remove `Oracle`.

Tests:
- Updated `tests/lambda_tests.rs` to assert standard iterator methods (`.map`, `.filter`) instead of legacy prefixed ones (`.g_map`, `.g_filter`), fixing build failures.

---
*PR created automatically by Jules for task [4635966854564634504](https://jules.google.com/task/4635966854564634504) started by @madmax983*