### PR TITLE
🔒 Warden: Fix identifier collision in transliteration

### DIFF
--- a/src/codegen/rust.rs
+++ b/src/codegen/rust.rs
@@ -956,7 +956,8 @@ mod tests {
     fn test_generate_binding() {
         let code = compile("ξ πέντε ἔστω.");
         // Variables are now prefixed with g_
-        assert!(code.contains("let g_x"));
+        // Greek letters map to _x, so sanitize adds g_ => g__x
+        assert!(code.contains("let g__x"));
         assert!(code.contains("5"));
     }
 
@@ -971,8 +972,9 @@ mod tests {
     fn test_generate_full_program() {
         let code = compile("ξ πέντε ἔστω. ξ λέγε.");
         // Variables are now prefixed with g_
+        // Greek letters map to _x, so sanitize adds g_ => g__x
         assert!(
-            code.contains("let g_x = 5"),
+            code.contains("let g__x = 5"),
             "Expected binding in: {}",
             code
         );

--- a/src/codegen/types.rs
+++ b/src/codegen/types.rs
@@ -90,9 +90,9 @@ mod tests {
             gender: crate::morphology::Gender::Masculine,
             fields: vec![],
         };
-        // Sanitize: χρηστης -> g__u3c7_rhsths
-        // Capitalize: g__u3c7_rhsths -> G__u3c7_rhsths
-        assert_eq!(to_rust_type(&ty), "G__u3c7_rhsths");
+        // Sanitize: χρηστης -> g__ch_r_h_s_t_h_s
+        // Capitalize: g__ch_r_h_s_t_h_s -> G__ch_r_h_s_t_h_s
+        assert_eq!(to_rust_type(&ty), "G__ch_r_h_s_t_h_s");
     }
 
     #[test]

--- a/src/codegen/utils.rs
+++ b/src/codegen/utils.rs
@@ -185,10 +185,30 @@ mod tests {
     #[test]
     fn test_transliterate_collision() {
         // These currently fail because transliterate("α") == "a" == transliterate("a")
-        assert_ne!(transliterate("α"), transliterate("a"), "Alpha should not collide with a");
-        assert_ne!(transliterate("η"), transliterate("h"), "Eta should not collide with h");
-        assert_ne!(transliterate("ω"), transliterate("w"), "Omega should not collide with w");
-        assert_ne!(transliterate("σ"), transliterate("s"), "Sigma should not collide with s");
-        assert_ne!(transliterate("αa"), transliterate("aa"), "Mixed alpha should not collide");
+        assert_ne!(
+            transliterate("α"),
+            transliterate("a"),
+            "Alpha should not collide with a"
+        );
+        assert_ne!(
+            transliterate("η"),
+            transliterate("h"),
+            "Eta should not collide with h"
+        );
+        assert_ne!(
+            transliterate("ω"),
+            transliterate("w"),
+            "Omega should not collide with w"
+        );
+        assert_ne!(
+            transliterate("σ"),
+            transliterate("s"),
+            "Sigma should not collide with s"
+        );
+        assert_ne!(
+            transliterate("αa"),
+            transliterate("aa"),
+            "Mixed alpha should not collide"
+        );
     }
 }

--- a/src/codegen/utils.rs
+++ b/src/codegen/utils.rs
@@ -211,4 +211,48 @@ mod tests {
             "Mixed alpha should not collide"
         );
     }
+
+    #[test]
+    fn test_transliterate_underscore() {
+        // _ maps to __
+        assert_eq!(transliterate("_"), "__");
+        assert_eq!(transliterate("a_b"), "a__b");
+    }
+
+    #[test]
+    fn test_transliterate_ascii_u() {
+        // u maps to u (ensure no collision with hex prefix _u)
+        assert_eq!(transliterate("u"), "u");
+        // Check collision with hypothetical hex code
+        // Koppa (ϟ) -> _u3df_
+        // "u3df" -> u3df
+        assert_ne!(transliterate("ϟ"), transliterate("u3df"));
+        // "_u3df_" -> __u3df__
+        assert_ne!(transliterate("ϟ"), transliterate("_u3df_"));
+    }
+
+    #[test]
+    fn test_transliterate_invalid_unicode() {
+        // ⚡ (High Voltage) -> _u26a1_
+        // 26A1 is the hex code
+        assert_eq!(transliterate("⚡"), "_u26a1_");
+    }
+
+    #[test]
+    fn test_sanitize_empty() {
+        assert_eq!(sanitize_name(""), "g__var_empty");
+    }
+
+    #[test]
+    fn test_sanitize_numeric_start() {
+        // "123" -> "_123" (via transliterate logic at end of function)
+        // sanitize_name prefixes with g_, so g_ + _123 = g__123
+        // Wait, sanitize_name calls transliterate.
+        // transliterate("123"):
+        //   result = "123".
+        //   result starts with numeric -> returns "_123".
+        // sanitize_name adds "g_".
+        // So "g__123".
+        assert_eq!(sanitize_name("123"), "g__123");
+    }
 }

--- a/src/codegen/utils.rs
+++ b/src/codegen/utils.rs
@@ -43,35 +43,53 @@ pub(crate) fn transliterate(greek: &str) -> String {
 
     for c in greek.chars() {
         let trans = match c {
-            'α' => "a",
-            'β' => "b",
-            'γ' => "g",
-            'δ' => "d",
-            'ε' => "e",
-            'ζ' => "z",
-            'η' => "h", // Distinct from 'e' (epsilon)
-            'ι' => "i",
-            'κ' => "k",
-            'λ' => "l",
-            'μ' => "m",
-            'ν' => "n",
-            'ξ' => "x",
-            'ο' => "o",
-            'π' => "p",
-            'ρ' => "r",
-            'σ' | 'ς' => "s",
-            'τ' => "t",
-            'υ' => "u",
-            'ω' => "w", // Distinct from 'o' (omicron)
-            // Digraphs and other characters are hex-encoded to prevent collisions
-            // θ, φ, χ, ψ map to _u..._ because th, ph, ch, ps collide with sequences
+            // Greek characters are prefixed with "_" to avoid collision with ASCII identifiers
+            // e.g. "α" -> "_a", but "a" -> "a"
+            'α' => "_a",
+            'β' => "_b",
+            'γ' => "_g",
+            'δ' => "_d",
+            'ε' => "_e",
+            'ζ' => "_z",
+            'η' => "_h", // Distinct from 'e' (epsilon)
+            'θ' => "_th",
+            'ι' => "_i",
+            'κ' => "_k",
+            'λ' => "_l",
+            'μ' => "_m",
+            'ν' => "_n",
+            'ξ' => "_x",
+            'ο' => "_o",
+            'π' => "_p",
+            'ρ' => "_r",
+            'σ' | 'ς' => "_s",
+            'τ' => "_t",
+            'υ' => "_u",
+            'φ' => "_ph",
+            'χ' => "_ch",
+            'ψ' => "_ps",
+            'ω' => "_w", // Distinct from 'o' (omicron)
+            // Underscore is escaped to "__" to avoid collision with prefixed Greek chars
+            // e.g. "_a" -> "__a", but "α" -> "_a"
+            '_' => "__",
             _ => {
-                // Keep only ASCII alphanumeric characters and underscore
-                if c.is_ascii_alphanumeric() || c == '_' {
+                // Keep only ASCII alphanumeric characters
+                if c.is_ascii_alphanumeric() {
                     result.push(c);
                 } else {
                     // Replace invalid characters with unique hex code to prevent collisions
                     // e.g. ϟ -> _u3df_
+                    // This is safe from collision because:
+                    // 1. Literal underscores '_' map to '__'
+                    // 2. Greek characters map to '_x' (single underscore)
+                    // 3. Hex encoding uses '_u..._' (single underscore + 'u')
+                    // 4. Literal 'u' in input maps to 'u'
+                    //
+                    // Example:
+                    // Koppa (ϟ) -> _u3df_
+                    // User input "_u3df_" -> __u3df__
+                    // User input "u3df" -> u3df
+                    // Greek Upsilon + "3df" -> _u3df (no trailing underscore)
                     use std::fmt::Write;
                     write!(result, "_u{:x}_", c as u32).unwrap();
                 }
@@ -104,20 +122,18 @@ mod tests {
 
     #[test]
     fn test_sanitize_greek_letter() {
-        assert_eq!(sanitize_name("ξ"), "g_x");
-        assert_eq!(sanitize_name("α"), "g_a");
-        assert_eq!(sanitize_name("ω"), "g_w");
+        assert_eq!(sanitize_name("ξ"), "g__x");
+        assert_eq!(sanitize_name("α"), "g__a");
+        assert_eq!(sanitize_name("ω"), "g__w");
     }
 
     #[test]
     fn test_transliterate() {
-        // χ (chi) -> hex, ρ -> r, η -> h, σ -> s, τ -> t, ο -> o, ς -> s
-        // χ is 0x3c7
-        assert_eq!(transliterate("χρηστος"), "_u3c7_rhstos");
-        assert_eq!(transliterate("λογος"), "logos");
-        // φ (phi) -> hex
-        // φ is 0x3c6
-        assert_eq!(transliterate("φιλοσοφια"), "_u3c6_iloso_u3c6_ia");
+        // χ (chi) -> _ch, ρ -> _r, η -> _h, σ -> _s, τ -> _t, ο -> _o, ς -> _s
+        assert_eq!(transliterate("χρηστος"), "_ch_r_h_s_t_o_s");
+        assert_eq!(transliterate("λογος"), "_l_o_g_o_s");
+        // φ (phi) -> _ph
+        assert_eq!(transliterate("φιλοσοφια"), "_ph_i_l_o_s_o_ph_i_a");
     }
 
     #[test]
@@ -142,7 +158,7 @@ mod tests {
         // Test mixing valid and invalid characters
         let input = "αϟβ";
         let output = transliterate(input);
-        assert_eq!(output, "a_u3df_b");
+        assert_eq!(output, "_a_u3df__b");
     }
 
     #[test]
@@ -164,5 +180,15 @@ mod tests {
         // This ensures a unique namespace for user variables
         assert_eq!(sanitize_name("x"), "g_x");
         assert_eq!(sanitize_name("foo"), "g_foo");
+    }
+
+    #[test]
+    fn test_transliterate_collision() {
+        // These currently fail because transliterate("α") == "a" == transliterate("a")
+        assert_ne!(transliterate("α"), transliterate("a"), "Alpha should not collide with a");
+        assert_ne!(transliterate("η"), transliterate("h"), "Eta should not collide with h");
+        assert_ne!(transliterate("ω"), transliterate("w"), "Omega should not collide with w");
+        assert_ne!(transliterate("σ"), transliterate("s"), "Sigma should not collide with s");
+        assert_ne!(transliterate("αa"), transliterate("aa"), "Mixed alpha should not collide");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,6 @@ pub mod experimental;
 pub mod grammar;
 pub mod morphology;
 pub mod parser;
+pub mod report;
 pub mod semantic;
 pub mod text;
-pub mod report;

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,9 +7,7 @@ use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use std::fmt::Display;
 
-use crate::semantic::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement,
-};
+use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 
 /// Statistics for an analyzed program
 #[derive(Debug, Default, Clone)]
@@ -37,12 +35,12 @@ pub struct ProgramStats {
 impl ProgramStats {
     /// Analyze a program and collect statistics
     pub fn new(program: &AnalyzedProgram) -> Self {
-        let mut stats = ProgramStats::default();
-
-        // Count top-level definitions from scope
-        stats.function_count = program.scope.functions().count();
-        stats.type_count = program.scope.types().count();
-        stats.trait_count = program.scope.traits().count();
+        let mut stats = ProgramStats {
+            function_count: program.scope.functions().count(),
+            type_count: program.scope.types().count(),
+            trait_count: program.scope.traits().count(),
+            ..Default::default()
+        };
 
         // Traverse statements to count structural elements
         for stmt in &program.statements {
@@ -71,7 +69,11 @@ impl ProgramStats {
                     self.visit_expr(expr);
                 }
             }
-            AnalyzedStatement::If { condition, then_body, else_body } => {
+            AnalyzedStatement::If {
+                condition,
+                then_body,
+                else_body,
+            } => {
                 self.conditional_count += 1;
                 self.visit_expr(condition);
                 for s in then_body {
@@ -157,8 +159,11 @@ impl ProgramStats {
                     self.visit_expr(e);
                 }
             }
-            AnalyzedExprKind::Some(e) | AnalyzedExprKind::Ok(e) | AnalyzedExprKind::Err(e)
-            | AnalyzedExprKind::Unwrap(e) | AnalyzedExprKind::Try(e) => {
+            AnalyzedExprKind::Some(e)
+            | AnalyzedExprKind::Ok(e)
+            | AnalyzedExprKind::Err(e)
+            | AnalyzedExprKind::Unwrap(e)
+            | AnalyzedExprKind::Try(e) => {
                 self.visit_expr(e);
             }
             AnalyzedExprKind::IndexAccess { array, index } => {
@@ -212,11 +217,12 @@ impl<'a> GlossaReport<'a> {
 impl Display for GlossaReport<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL)
-             .set_header(vec![
-                 Cell::new("Μετρική (Metric)").add_attribute(comfy_table::Attribute::Bold).fg(Color::Cyan),
-                 Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
-             ]);
+        table.load_preset(presets::UTF8_FULL).set_header(vec![
+            Cell::new("Μετρική (Metric)")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .fg(Color::Cyan),
+            Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
+        ]);
 
         table.add_row(vec![
             Cell::new("Ἀρχεῖον (File)"),
@@ -236,14 +242,14 @@ impl Display for GlossaReport<'_> {
         ]);
 
         if self.stats.function_count > 0 {
-             table.add_row(vec![
+            table.add_row(vec![
                 Cell::new("Συναρτήσεις (Functions)"),
                 Cell::new(self.stats.function_count),
             ]);
         }
 
         if self.stats.type_count > 0 {
-             table.add_row(vec![
+            table.add_row(vec![
                 Cell::new("Τύποι (Types)"),
                 Cell::new(self.stats.type_count),
             ]);
@@ -251,19 +257,23 @@ impl Display for GlossaReport<'_> {
 
         if self.stats.loop_count > 0 {
             table.add_row(vec![
-               Cell::new("Βρόχοι (Loops)"),
-               Cell::new(self.stats.loop_count),
-           ]);
-       }
+                Cell::new("Βρόχοι (Loops)"),
+                Cell::new(self.stats.loop_count),
+            ]);
+        }
 
-       if self.stats.max_depth > 0 {
-        table.add_row(vec![
-           Cell::new("Βάθος (Max Depth)"),
-           Cell::new(self.stats.max_depth),
-       ]);
-   }
+        if self.stats.max_depth > 0 {
+            table.add_row(vec![
+                Cell::new("Βάθος (Max Depth)"),
+                Cell::new(self.stats.max_depth),
+            ]);
+        }
 
-        writeln!(f, "\n{}", "ΑΝΑΦΟΡΑ ΓΛΩΣΣΗΣ (LANGUAGE REPORT)".bold().underlined())?;
+        writeln!(
+            f,
+            "\n{}",
+            "ΑΝΑΦΟΡΑ ΓΛΩΣΣΗΣ (LANGUAGE REPORT)".bold().underlined()
+        )?;
         writeln!(f, "{}", table)?;
 
         // If there are top-level functions, list them
@@ -271,16 +281,25 @@ impl Display for GlossaReport<'_> {
         if !functions.is_empty() {
             writeln!(f, "\n{}", "ΣΥΝΑΡΤΗΣΕΙΣ (FUNCTIONS)".bold())?;
             let mut func_table = Table::new();
-            func_table.load_preset(presets::UTF8_HORIZONTAL_ONLY)
-                .set_header(vec!["Ὄνομα (Name)", "Παράμετροι (Params)", "Επιστροφή (Returns)"]);
+            func_table
+                .load_preset(presets::UTF8_HORIZONTAL_ONLY)
+                .set_header(vec![
+                    "Ὄνομα (Name)",
+                    "Παράμετροι (Params)",
+                    "Επιστροφή (Returns)",
+                ]);
 
             for func in functions {
-                let params = func.param_types.iter()
+                let params = func
+                    .param_types
+                    .iter()
                     .map(|t| t.to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
 
-                let ret = func.return_type.as_ref()
+                let ret = func
+                    .return_type
+                    .as_ref()
                     .map(|t| t.to_string())
                     .unwrap_or_else(|| "Οὐδέν".to_string());
 

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -21,16 +21,18 @@ fn test_hello_cosmos() {
 #[test]
 fn test_variable_binding() {
     let code = compile("ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let g_x"));
+    // g_ prefix + transliterated ξ (_x) = g__x
+    assert!(code.contains("let g__x"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_variable_binding_and_use() {
     let code = compile("ξ πέντε ἔστω. ξ λέγε.").unwrap();
-    assert!(code.contains("let g_x = 5"));
+    // g_ prefix + transliterated ξ (_x) = g__x
+    assert!(code.contains("let g__x = 5"));
     assert!(code.contains("println"));
-    assert!(code.contains("g_x"));
+    assert!(code.contains("g__x"));
 }
 
 #[test]
@@ -42,8 +44,10 @@ fn test_number_literal() {
 #[test]
 fn test_multiple_statements() {
     let code = compile("α πέντε ἔστω. β δέκα ἔστω. α λέγε.").unwrap();
-    assert!(code.contains("let g_a = 5"));
-    assert!(code.contains("let g_b = 10"));
+    // g_ prefix + transliterated α (_a) = g__a
+    assert!(code.contains("let g__a = 5"));
+    // g_ prefix + transliterated β (_b) = g__b
+    assert!(code.contains("let g__b = 10"));
 }
 
 #[test]
@@ -61,15 +65,15 @@ fn test_preserves_greek_in_strings() {
 #[test]
 fn test_mutable_binding() {
     let code = compile("μετά ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let mut g_x"));
+    assert!(code.contains("let mut g__x"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_assignment_codegen() {
     let code = compile("μετά ξ πέντε ἔστω. ξ δέκα γίγνεται.").unwrap();
-    assert!(code.contains("let mut g_x = 5"));
-    assert!(code.contains("g_x = 10"));
+    assert!(code.contains("let mut g__x = 5"));
+    assert!(code.contains("g__x = 10"));
 }
 
 #[test]
@@ -89,8 +93,8 @@ fn test_undefined_assignment_error() {
 #[test]
 fn test_mutable_binding_and_reassignment() {
     let code = compile("μετά ξ πέντε ἔστω. ξ λέγε. ξ δέκα γίγνεται. ξ λέγε.").unwrap();
-    assert!(code.contains("let mut g_x = 5"));
-    assert!(code.contains("g_x = 10"));
+    assert!(code.contains("let mut g__x = 5"));
+    assert!(code.contains("g__x = 10"));
     assert!(code.matches("println").count() >= 2);
 }
 

--- a/tests/function_tests.rs
+++ b/tests/function_tests.rs
@@ -39,8 +39,8 @@ fn test_function_with_two_params() {
     let code = compile("προσθεσις ὁρίζειν τῷ ξ τῷ ψ· δός ξ ψ ἄθροισμα.");
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("fn"));
-    // ξ -> g_x, ψ -> g__u3c8_
-    assert!(code.contains("g_x") && code.contains("g__u3c8_"));
+    // ξ -> g_x -> g__x, ψ -> g_ps -> g__ps
+    assert!(code.contains("g__x") && code.contains("g__ps"));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_simple_return() {
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("return"));
     // Should return x * 2, not just a literal
-    assert!(code.contains("g_x") || code.contains("*") || code.contains("2"));
+    assert!(code.contains("g__x") || code.contains("*") || code.contains("2"));
 }
 
 #[test]
@@ -82,10 +82,11 @@ fn test_function_call() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
-    // πρόσθεσις -> g_pros_u3b8_esis
+    // πρόσθεσις -> g__p_r_o_s_th_e_s_i_s
+    let name = "g__p_r_o_s_th_e_s_i_s";
     assert!(
-        code.contains("g_pros_u3b8_esis")
-            && (code.contains("g_pros_u3b8_esis(") || code.contains("g_pros_u3b8_esis ("))
+        code.contains(name)
+            && (code.contains(&format!("{}(", name)) || code.contains(&format!("{} (", name)))
     );
 }
 
@@ -99,8 +100,10 @@ fn test_nested_calls() {
     );
     eprintln!("Generated code:\n{}", code);
     // Check for nested diplasiasmos calls (allowing for whitespace)
+    // διπλασιασμος -> g__d_i_p_l_a_s_i_a_s_m_o_s
+    let name = "g__d_i_p_l_a_s_i_a_s_m_o_s";
     assert!(
-        code.matches("g_diplasiasmos").count() >= 3,
+        code.matches(name).count() >= 3,
         "Expected at least 3 occurrences of diplasiasmos (fn def + 2 calls)"
     );
     assert!(code.contains("5i64"), "Expected literal 5 as argument");
@@ -120,7 +123,8 @@ fn test_function_local_variables() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
-    assert!(code.contains("let g_topikon"));
+    // τοπικον -> g__t_o_p_i_k_o_n
+    assert!(code.contains("let g__t_o_p_i_k_o_n"));
 }
 
 #[test]

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -169,10 +169,7 @@ mod cycle5_filter_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -467,10 +464,7 @@ mod cycle9_combined_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(code_no_space.contains(".map("), "Should have .map(");
             assert!(code_no_space.contains(">"), "Should have comparison");
             assert!(code_no_space.contains("5"), "Should compare to 5");
@@ -565,10 +559,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             // Should reference theta variable in closure
             // theta (θ) is mapped to _th to prevent collisions
             assert!(
@@ -629,10 +620,7 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(
-                code_no_space.contains(".filter("),
-                "Should have .filter("
-            );
+            assert!(code_no_space.contains(".filter("), "Should have .filter(");
             assert!(code_no_space.contains("5"), "Should use literal 5");
             // Should NOT reference theta (encoded or not)
             assert!(

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -125,11 +125,11 @@ mod cycle4_map_operation {
             // Remove whitespace for matching (quote! adds spaces)
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_map("), "Should have .g_map()");
+            assert!(code_no_space.contains(".map("), "Should have .map()");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(
-                code_no_space.contains(".g_collect()"),
-                "Should have .g_collect()"
+                code_no_space.contains(".collect()"),
+                "Should have .collect()"
             );
         } else {
             panic!("Second statement failed: {:?}", analyzed2.err());
@@ -170,8 +170,8 @@ mod cycle5_filter_operation {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
             assert!(
                 code_no_space.contains(">"),
@@ -232,7 +232,7 @@ mod cycle6_find_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_find("), "Should have .g_find(");
+            assert!(code_no_space.contains(".find("), "Should have .find(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -300,7 +300,7 @@ mod cycle7_fold_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
+            assert!(code_no_space.contains(".fold("), "Should have .fold(");
             assert!(code_no_space.contains("0"), "Should have initial value 0");
             assert!(code_no_space.contains("+"), "Should have + operation");
         } else {
@@ -323,7 +323,7 @@ mod cycle7_fold_operation {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
+            assert!(code_no_space.contains(".fold("), "Should have .fold(");
             assert!(code_no_space.contains("1"), "Should have initial value 1");
             assert!(code_no_space.contains("*"), "Should have * operation");
         } else {
@@ -369,7 +369,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
+            assert!(code_no_space.contains(".any("), "Should have .any(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -412,7 +412,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_all("), "Should have .g_all(");
+            assert!(code_no_space.contains(".all("), "Should have .all(");
             assert!(
                 code_no_space.contains(">"),
                 "Should have comparison operator"
@@ -437,7 +437,7 @@ mod cycle8_any_all_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
+            assert!(code_no_space.contains(".any("), "Should have .any(");
             assert!(code_no_space.contains("<"), "Should have < operator");
         } else {
             panic!("Any less-than failed: {:?}", analyzed.err());
@@ -468,16 +468,16 @@ mod cycle9_combined_operations {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
-            assert!(code_no_space.contains(".g_map("), "Should have .g_map(");
+            assert!(code_no_space.contains(".map("), "Should have .map(");
             assert!(code_no_space.contains(">"), "Should have comparison");
             assert!(code_no_space.contains("5"), "Should compare to 5");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(
-                code_no_space.contains(".g_collect()"),
-                "Should have .g_collect()"
+                code_no_space.contains(".collect()"),
+                "Should have .collect()"
             );
         } else {
             panic!("Filter then map failed: {:?}", analyzed.err());
@@ -501,15 +501,15 @@ mod cycle9_combined_operations {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_map("), "Should have .g_map(");
-            assert!(code_no_space.contains(".g_fold("), "Should have .g_fold(");
+            assert!(code_no_space.contains(".map("), "Should have .map(");
+            assert!(code_no_space.contains(".fold("), "Should have .fold(");
             assert!(code_no_space.contains("*2"), "Should multiply by 2");
             assert!(code_no_space.contains("0"), "Should have init value 0");
             assert!(code_no_space.contains("+"), "Should have + operation");
-            // Fold returns single value, no .g_collect()
+            // Fold returns single value, no .collect()
             assert!(
-                !code_no_space.contains(".g_collect()"),
-                "Should NOT have .g_collect()"
+                !code_no_space.contains(".collect()"),
+                "Should NOT have .collect()"
             );
         } else {
             panic!("Map then fold failed: {:?}", analyzed.err());
@@ -566,15 +566,15 @@ mod cycle11_variable_capture {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
             // Should reference theta variable in closure
-            // theta (θ) is hex-encoded as _u3b8_ to prevent collisions
+            // theta (θ) is mapped to _th to prevent collisions
             assert!(
                 code_no_space.contains("theta")
                     || code_no_space.contains("θ")
-                    || code_no_space.contains("_u3b8_"),
+                    || code_no_space.contains("_th"),
                 "Should capture theta"
             );
         } else {
@@ -599,12 +599,12 @@ mod cycle11_variable_capture {
 
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
-            assert!(code_no_space.contains(".g_any("), "Should have .g_any(");
-            // theta (θ) is hex-encoded as _u3b8_
+            assert!(code_no_space.contains(".any("), "Should have .any(");
+            // theta (θ) is mapped to _th
             assert!(
                 code_no_space.contains("theta")
                     || code_no_space.contains("θ")
-                    || code_no_space.contains("_u3b8_"),
+                    || code_no_space.contains("_th"),
                 "Should capture theta"
             );
         } else {
@@ -630,15 +630,15 @@ mod cycle11_variable_capture {
             let code_no_space = code_str.replace(" ", "");
             assert!(code_no_space.contains(".iter()"), "Should have .iter()");
             assert!(
-                code_no_space.contains(".g_filter("),
-                "Should have .g_filter("
+                code_no_space.contains(".filter("),
+                "Should have .filter("
             );
             assert!(code_no_space.contains("5"), "Should use literal 5");
             // Should NOT reference theta (encoded or not)
             assert!(
                 !code_no_space.contains("theta")
                     && !code_no_space.contains("θ")
-                    && !code_no_space.contains("_u3b8_"),
+                    && !code_no_space.contains("_th"),
                 "Should NOT capture theta"
             );
         } else {

--- a/tests/trait_tests.rs
+++ b/tests/trait_tests.rs
@@ -582,7 +582,8 @@ fn test_standalone_method_call() {
     let code = compile(source);
 
     // Should contain the method call
-    assert!(code.contains("g_p . g_show") || code.contains("g_p.g_show"));
+    // π -> g__p
+    assert!(code.contains("g__p . g_show") || code.contains("g__p.g_show"));
 }
 
 // ============================================================================

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -43,8 +43,8 @@ fn test_instantiation() {
         π νέον σημεῖον πέντε ἔστω.
     "#;
     let code = compile(source);
-    // σημεῖον -> G_shmeion
-    assert!(code.contains("G_shmeion"));
+    // σημεῖον -> G__s_h_m_e_i_o_n
+    assert!(code.contains("G__s_h_m_e_i_o_n"));
     assert!(code.contains("5"));
 }
 
@@ -55,7 +55,7 @@ fn test_instantiation_multiple_fields() {
         π νέον σημεῖον πέντε τρία ἔστω.
     "#;
     let code = compile(source);
-    assert!(code.contains("G_shmeion"));
+    assert!(code.contains("G__s_h_m_e_i_o_n"));
 }
 
 // Cycle 5: Field Access
@@ -68,8 +68,8 @@ fn test_field_access() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    // ξ -> g_x
-    assert!(code.contains(".g_x") || code.contains(". g_x"));
+    // ξ -> g__x
+    assert!(code.contains(".g__x") || code.contains(". g__x"));
 }
 
 #[test]
@@ -82,10 +82,10 @@ fn test_field_access_multiple_fields() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    // ξ -> g_x
-    assert!(code.contains(". g_x") || code.contains(".g_x"));
-    // ψ -> g__u3c8_
-    assert!(code.contains(". g__u3c8_") || code.contains(".g__u3c8_"));
+    // ξ -> g__x
+    assert!(code.contains(". g__x") || code.contains(".g__x"));
+    // ψ -> g__ps
+    assert!(code.contains(". g__ps") || code.contains(".g__ps"));
 }
 
 #[test]
@@ -97,9 +97,9 @@ fn test_instantiation_with_literals() {
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
     // It should generate struct instantiation, not string assignment
-    // Χρήστης -> G__u3c7_rhsths
-    assert!(code.contains("struct G__u3c7_rhsths"));
-    assert!(code.contains("let g__u3c7_rhsths = G__u3c7_rhsths"));
+    // Χρήστης -> G__ch_r_h_s_t_h_s
+    assert!(code.contains("struct G__ch_r_h_s_t_h_s"));
+    assert!(code.contains("let g__ch_r_h_s_t_h_s = G__ch_r_h_s_t_h_s"));
     assert!(code.contains("Σωκράτης"));
     assert!(code.contains("70"));
 }

--- a/tests/word_order_tests.rs
+++ b/tests/word_order_tests.rs
@@ -23,7 +23,7 @@ fn test_binding_word_order_independence() {
     let sov = compile_to_rust("ξ πέντε ἔστω.");
 
     // These should all produce equivalent output
-    assert!(sov.contains("let g_x"));
+    assert!(sov.contains("let g__x"));
     assert!(sov.contains("5i64") || sov.contains("5 "));
 }
 
@@ -44,7 +44,7 @@ fn test_variable_binding_and_reference() {
     let output = compile_to_rust(source);
 
     // Should have binding
-    assert!(output.contains("let g_x"));
+    assert!(output.contains("let g__x"));
     // Should have print
     assert!(output.contains("println"));
 }
@@ -54,12 +54,12 @@ fn test_variable_binding_and_reference() {
 fn test_number_binding_variations() {
     // Arabic numeral
     let arabic = compile_to_rust("ξ 42 ἔστω.");
-    assert!(arabic.contains("let g_x"));
+    assert!(arabic.contains("let g__x"));
     assert!(arabic.contains("42"));
 
     // Greek numeral word
     let greek_word = compile_to_rust("ξ πέντε ἔστω.");
-    assert!(greek_word.contains("let g_x"));
+    assert!(greek_word.contains("let g__x"));
     assert!(greek_word.contains("5"));
 }
 
@@ -104,8 +104,8 @@ fn test_multiple_statement_scope() {
     let output = compile_to_rust(source);
 
     // Both bindings should exist
-    assert!(output.contains("let g_a"));
-    assert!(output.contains("let g_b"));
+    assert!(output.contains("let g__a"));
+    assert!(output.contains("let g__b"));
 }
 
 /// Test that queries produce output


### PR DESCRIPTION
This PR addresses a security vulnerability where Greek characters and their ASCII transliterations could collide in the generated Rust code (e.g., `α` and `a` both becoming `g_a`). 

Changes:
- Modified `src/codegen/utils.rs`: `transliterate` now prefixes Greek character mappings with `_` and escapes literal `_` as `__`.
- Updated `src/codegen/types.rs`: Adjusted expected type name generation in tests.
- Updated `src/codegen/rust.rs`: Adjusted expected variable names in tests.
- Updated `tests/compile_tests.rs`: Adjusted expected generated code.
- Updated `tests/function_tests.rs`: Adjusted expected generated code.
- Updated `tests/lambda_tests.rs`: Adjusted expected generated code (also fixed incorrect expectations about standard method prefixing).
- Updated `tests/trait_tests.rs`: Adjusted expected generated code.
- Updated `tests/type_tests.rs`: Adjusted expected generated code.
- Updated `tests/word_order_tests.rs`: Adjusted expected generated code.

All tests passed.

---
*PR created automatically by Jules for task [8967117459339543976](https://jules.google.com/task/8967117459339543976) started by @madmax983*