### PR TITLE
🎨 Mosaic: UI Polish for Build Command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::time::SystemTime;
 use glossa::codegen::{generate_rust_file, generate_statement_code};
 use glossa::errors::GlossaError;
 use glossa::parser::parse;
-use glossa::report::GlossaReport;
+use glossa::report::{CompilationReport, GlossaReport, ProgramStats};
 use glossa::semantic::{AnalyzedStatement, GlossaType, Scope, analyze_program};
 
 #[derive(Parser)]
@@ -154,7 +154,9 @@ fn check_file_size(input: &Path) -> Result<()> {
 fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
     check_file_size(input)?;
 
+    let start = std::time::Instant::now();
     let source = fs::read_to_string(input).into_diagnostic()?;
+    let input_size = source.len() as u64;
 
     // Split compile to get stats
     let ast = parse(&source).map_err(|e| miette::miette!("{}", e))?;
@@ -167,13 +169,20 @@ fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 
     fs::write(&output_path, &rust_code).into_diagnostic()?;
 
-    println!(
-        "{} Ἐγράφη: {} ({} statements, {} functions)",
-        "✓".green(),
-        output_path.display().to_string().bold(),
-        analyzed.statements.len(),
-        analyzed.scope.functions().count()
-    );
+    let output_size = fs::metadata(&output_path).into_diagnostic()?.len();
+    let duration = start.elapsed();
+    let stats = ProgramStats::new(&analyzed);
+
+    let report = CompilationReport {
+        input_path: input.to_path_buf(),
+        output_path,
+        input_size,
+        output_size,
+        duration,
+        stats,
+    };
+
+    println!("{}", report);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -659,6 +659,29 @@ mod tests {
     }
 
     #[test]
+    fn test_build_file_success() {
+        // Create a temporary input file
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("test.gl");
+        {
+            let mut f = std::fs::File::create(&input_path).unwrap();
+            f.write_all("«test» λέγε.".as_bytes()).unwrap();
+        }
+
+        // Call build_file
+        let result = build_file(&input_path, None);
+        assert!(result.is_ok());
+
+        // Verify output file exists
+        let output_path = input_path.with_extension("rs");
+        assert!(output_path.exists());
+
+        // Output size is > 0
+        let metadata = std::fs::metadata(&output_path).unwrap();
+        assert!(metadata.len() > 0);
+    }
+
+    #[test]
     fn test_run_file_size_limit() {
         // Create large file
         let dir = tempfile::tempdir().unwrap();

--- a/src/report.rs
+++ b/src/report.rs
@@ -6,6 +6,8 @@
 use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use std::fmt::Display;
+use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 
@@ -316,6 +318,77 @@ impl Display for GlossaReport<'_> {
     }
 }
 
+/// A comprehensive report for the compilation process
+pub struct CompilationReport {
+    pub input_path: PathBuf,
+    pub output_path: PathBuf,
+    pub input_size: u64,
+    pub output_size: u64,
+    pub duration: Duration,
+    pub stats: ProgramStats,
+}
+
+impl Display for CompilationReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL).set_header(vec![
+            Cell::new("Μετρική (Metric)")
+                .add_attribute(comfy_table::Attribute::Bold)
+                .fg(Color::Cyan),
+            Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
+        ]);
+
+        // Input File
+        table.add_row(vec![
+            Cell::new("Εἴσοδος (Input)"),
+            Cell::new(self.input_path.display().to_string()).fg(Color::Yellow),
+        ]);
+
+        // Output File
+        table.add_row(vec![
+            Cell::new("Ἔξοδος (Output)"),
+            Cell::new(self.output_path.display().to_string()).fg(Color::Green),
+        ]);
+
+        // Time
+        table.add_row(vec![
+            Cell::new("Χρόνος (Time)"),
+            Cell::new(format!("{:.2?}", self.duration)),
+        ]);
+
+        // Sizes
+        table.add_row(vec![
+            Cell::new("Μέγεθος Εἰσόδου (Input Size)"),
+            Cell::new(format!("{} bytes", self.input_size)),
+        ]);
+        table.add_row(vec![
+            Cell::new("Μέγεθος Ἐξόδου (Output Size)"),
+            Cell::new(format!("{} bytes", self.output_size)),
+        ]);
+
+        // Stats summary
+        table.add_row(vec![
+            Cell::new("Προτάσεις (Statements)"),
+            Cell::new(self.stats.statement_count),
+        ]);
+        table.add_row(vec![
+            Cell::new("Συναρτήσεις (Functions)"),
+            Cell::new(self.stats.function_count),
+        ]);
+
+        writeln!(
+            f,
+            "\n{}",
+            "ΑΝΑΦΟΡΑ ΜΕΤΑΓΛΩΤΤΙΣΕΩΣ (COMPILATION REPORT)"
+                .bold()
+                .underlined()
+        )?;
+        writeln!(f, "{}", table)?;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,6 +454,30 @@ mod tests {
         assert!(output.contains("test.gl"));
         assert!(output.contains("test_func")); // Function list
         assert!(output.contains("3")); // Statement count
+    }
+
+    #[test]
+    fn test_compilation_report_coverage() {
+        let program = create_dummy_program();
+        let stats = ProgramStats::new(&program);
+        let report = CompilationReport {
+            input_path: PathBuf::from("input.gl"),
+            output_path: PathBuf::from("output.rs"),
+            input_size: 100,
+            output_size: 200,
+            duration: Duration::from_millis(123),
+            stats,
+        };
+
+        let output = format!("{}", report);
+
+        assert!(output.contains("ΑΝΑΦΟΡΑ ΜΕΤΑΓΛΩΤΤΙΣΕΩΣ"));
+        assert!(output.contains("input.gl"));
+        assert!(output.contains("output.rs"));
+        assert!(output.contains("123")); // Time
+        assert!(output.contains("100 bytes")); // Input size
+        assert!(output.contains("200 bytes")); // Output size
+        assert!(output.contains("3")); // Statements
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -685,6 +685,26 @@ mod tests {
                     },
                     glossa_type: GlossaType::Unit,
                 },
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::PropertyAccess {
+                        owner: Box::new(AnalyzedExpr {
+                            expr: AnalyzedExprKind::StringLiteral("test".into()),
+                            glossa_type: GlossaType::String,
+                        }),
+                        property: "len".into(),
+                    },
+                    glossa_type: GlossaType::Number,
+                },
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::VerbCall {
+                        verb: "print".into(),
+                        args: vec![AnalyzedExpr {
+                            expr: AnalyzedExprKind::StringLiteral("test".into()),
+                            glossa_type: GlossaType::String,
+                        }],
+                    },
+                    glossa_type: GlossaType::Unit,
+                },
             ]),
         ];
 


### PR DESCRIPTION
- **Before:** The `build` command output a single line message: `✓ Ἐγράφη: output.rs (X statements, Y functions)`.
- **After:** The `build` command now outputs a detailed dashboard (table) showing:
    - Input and Output file paths.
    - Compilation time (in milliseconds/microseconds).
    - Input and Output file sizes.
    - Statement and Function counts.
- **Visuals:** Uses `comfy-table` and `crossterm` for a colorful, structured layout consistent with the `check` command.


---
*PR created automatically by Jules for task [15595970884260612820](https://jules.google.com/task/15595970884260612820) started by @madmax983*