### PR TITLE
🌟 Nova: Ancient Greek Numerals

### DIFF
--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -1,0 +1,1 @@
+pub mod numerals;

--- a/src/experimental/numerals.rs
+++ b/src/experimental/numerals.rs
@@ -84,7 +84,12 @@ pub fn parse_greek_numeral(text: &str) -> Result<i64, String> {
                     'ψ' => 700,
                     'ω' => 800,
                     '\u{03E0}' | '\u{03E1}' => 900, // Sampi (03E0 / 03E1)
-                    _ => return Err(format!("Invalid Greek numeral character: {} (U+{:04X})", c, c as u32)),
+                    _ => {
+                        return Err(format!(
+                            "Invalid Greek numeral character: {} (U+{:04X})",
+                            c, c as u32
+                        ));
+                    }
                 };
 
                 total += value * multiplier;
@@ -177,21 +182,47 @@ mod tests {
     fn test_full_coverage() {
         // Test every single character mapping to ensure 100% coverage
         let mappings = [
-            ("α", 1), ("β", 2), ("γ", 3), ("δ", 4), ("ε", 5),
-            ("\u{03DB}", 6), ("ς", 6), // Stigma
-            ("ζ", 7), ("η", 8), ("θ", 9),
-            ("ι", 10), ("κ", 20), ("λ", 30), ("μ", 40), ("ν", 50),
-            ("ξ", 60), ("ο", 70), ("π", 80),
-            ("\u{03D9}", 90), ("\u{03DF}", 90), // Koppa
-            ("ρ", 100), ("σ", 200), ("τ", 300), ("υ", 400), ("φ", 500),
-            ("χ", 600), ("ψ", 700), ("ω", 800),
-            ("\u{03E0}", 900), ("\u{03E1}", 900) // Sampi
+            ("α", 1),
+            ("β", 2),
+            ("γ", 3),
+            ("δ", 4),
+            ("ε", 5),
+            ("\u{03DB}", 6),
+            ("ς", 6), // Stigma
+            ("ζ", 7),
+            ("η", 8),
+            ("θ", 9),
+            ("ι", 10),
+            ("κ", 20),
+            ("λ", 30),
+            ("μ", 40),
+            ("ν", 50),
+            ("ξ", 60),
+            ("ο", 70),
+            ("π", 80),
+            ("\u{03D9}", 90),
+            ("\u{03DF}", 90), // Koppa
+            ("ρ", 100),
+            ("σ", 200),
+            ("τ", 300),
+            ("υ", 400),
+            ("φ", 500),
+            ("χ", 600),
+            ("ψ", 700),
+            ("ω", 800),
+            ("\u{03E0}", 900),
+            ("\u{03E1}", 900), // Sampi
         ];
 
         for (char_str, expected) in mappings {
             // Test with standard keraia
             let input = format!("{}ʹ", char_str);
-            assert_eq!(parse_greek_numeral(&input).unwrap(), expected, "Failed for {}", char_str);
+            assert_eq!(
+                parse_greek_numeral(&input).unwrap(),
+                expected,
+                "Failed for {}",
+                char_str
+            );
         }
     }
 }

--- a/src/experimental/numerals.rs
+++ b/src/experimental/numerals.rs
@@ -84,12 +84,7 @@ pub fn parse_greek_numeral(text: &str) -> Result<i64, String> {
                     'ψ' => 700,
                     'ω' => 800,
                     '\u{03E0}' | '\u{03E1}' => 900, // Sampi (03E0 / 03E1)
-                    _ => {
-                        return Err(format!(
-                            "Invalid Greek numeral character: {} (U+{:04X})",
-                            c, c as u32
-                        ));
-                    }
+                    _ => return Err(format!("Invalid Greek numeral character: {} (U+{:04X})", c, c as u32)),
                 };
 
                 total += value * multiplier;
@@ -161,6 +156,8 @@ mod tests {
 
         // Keraia alt (U+02B9)
         assert_eq!(parse_greek_numeral("α\u{02B9}").unwrap(), 1);
+        // Dexia Keraia (U+0374)
+        assert_eq!(parse_greek_numeral("α\u{0374}").unwrap(), 1);
     }
 
     #[test]
@@ -174,5 +171,27 @@ mod tests {
         // 20 = κ
         // 4 = δ
         assert_eq!(parse_greek_numeral("͵βκδʹ").unwrap(), 2024);
+    }
+
+    #[test]
+    fn test_full_coverage() {
+        // Test every single character mapping to ensure 100% coverage
+        let mappings = [
+            ("α", 1), ("β", 2), ("γ", 3), ("δ", 4), ("ε", 5),
+            ("\u{03DB}", 6), ("ς", 6), // Stigma
+            ("ζ", 7), ("η", 8), ("θ", 9),
+            ("ι", 10), ("κ", 20), ("λ", 30), ("μ", 40), ("ν", 50),
+            ("ξ", 60), ("ο", 70), ("π", 80),
+            ("\u{03D9}", 90), ("\u{03DF}", 90), // Koppa
+            ("ρ", 100), ("σ", 200), ("τ", 300), ("υ", 400), ("φ", 500),
+            ("χ", 600), ("ψ", 700), ("ω", 800),
+            ("\u{03E0}", 900), ("\u{03E1}", 900) // Sampi
+        ];
+
+        for (char_str, expected) in mappings {
+            // Test with standard keraia
+            let input = format!("{}ʹ", char_str);
+            assert_eq!(parse_greek_numeral(&input).unwrap(), expected, "Failed for {}", char_str);
+        }
     }
 }

--- a/src/experimental/numerals.rs
+++ b/src/experimental/numerals.rs
@@ -157,6 +157,10 @@ mod tests {
 
         // Sampi
         assert_eq!(parse_greek_numeral("\u{03E1}ʹ").unwrap(), 900);
+        assert_eq!(parse_greek_numeral("\u{03E0}ʹ").unwrap(), 900); // Sampi alt
+
+        // Keraia alt (U+02B9)
+        assert_eq!(parse_greek_numeral("α\u{02B9}").unwrap(), 1);
     }
 
     #[test]

--- a/src/experimental/numerals.rs
+++ b/src/experimental/numerals.rs
@@ -1,0 +1,174 @@
+//! Greek Numeral Parser
+//!
+//! Parses Ancient Greek alphabetic numerals into integers.
+//!
+//! # The System
+//!
+//! The Greek numeral system uses letters to represent numbers:
+//! * 1-9: α, β, γ, δ, ε, ϛ, ζ, η, θ
+//! * 10-90: ι, κ, λ, μ, ν, ξ, ο, π, ϟ
+//! * 100-900: ρ, σ, τ, υ, φ, χ, ψ, ω, ϡ
+//!
+//! The "keraia" (ʹ, U+0374) marks a number (e.g., `αʹ` = 1).
+//! The "lower keraia" (͵, U+0375) multiplies the following digit by 1000 (e.g., `͵α` = 1000).
+
+use crate::text::normalize_greek;
+
+/// Parse a Greek numeral string into an integer
+///
+/// Handles:
+/// * Standard letters (α-ω)
+/// * Archaic letters (stigma ϛ, koppa ϟ, sampi ϡ)
+/// * Numeric markers (keraia ʹ, lower keraia ͵)
+///
+/// # Examples
+///
+/// ```
+/// use glossa::experimental::numerals::parse_greek_numeral;
+///
+/// assert_eq!(parse_greek_numeral("αʹ").unwrap(), 1);
+/// assert_eq!(parse_greek_numeral("βʹ").unwrap(), 2);
+/// assert_eq!(parse_greek_numeral("ιαʹ").unwrap(), 11);
+/// assert_eq!(parse_greek_numeral("ρʹ").unwrap(), 100);
+/// assert_eq!(parse_greek_numeral("͵α").unwrap(), 1000);
+/// assert_eq!(parse_greek_numeral("͵ααʹ").unwrap(), 1001);
+/// ```
+pub fn parse_greek_numeral(text: &str) -> Result<i64, String> {
+    // Normalize first to handle case and diacritics
+    // Note: normalize_greek lowercases everything
+    let normalized = normalize_greek(text);
+
+    let mut total: i64 = 0;
+    let mut multiplier: i64 = 1;
+
+    for c in normalized.chars() {
+        match c {
+            // Keraia (numeral sign) - ignore, it just marks the end or acts as punctuation
+            // U+0374 (Dexia Keraia) or U+02B9 (Modifier Letter Prime) often used interchangeably
+            // The literal 'ʹ' in source is usually one of these. We handle both explicitly.
+            '\u{0374}' | '\u{02B9}' => continue,
+
+            // Lower Keraia - multiplies the *next* digit by 1000
+            '\u{0375}' => {
+                multiplier = 1000;
+                continue;
+            }
+
+            // Letters
+            _ => {
+                let value = match c {
+                    'α' => 1,
+                    'β' => 2,
+                    'γ' => 3,
+                    'δ' => 4,
+                    'ε' => 5,
+                    '\u{03DB}' | 'ς' => 6, // Stigma (03DB) or final sigma (03C2) fallback
+                    'ζ' => 7,
+                    'η' => 8,
+                    'θ' => 9,
+                    'ι' => 10,
+                    'κ' => 20,
+                    'λ' => 30,
+                    'μ' => 40,
+                    'ν' => 50,
+                    'ξ' => 60,
+                    'ο' => 70,
+                    'π' => 80,
+                    '\u{03D9}' | '\u{03DF}' => 90, // Koppa (archaic 03D9 / modern 03DF)
+                    'ρ' => 100,
+                    'σ' => 200,
+                    'τ' => 300,
+                    'υ' => 400,
+                    'φ' => 500,
+                    'χ' => 600,
+                    'ψ' => 700,
+                    'ω' => 800,
+                    '\u{03E0}' | '\u{03E1}' => 900, // Sampi (03E0 / 03E1)
+                    _ => {
+                        return Err(format!(
+                            "Invalid Greek numeral character: {} (U+{:04X})",
+                            c, c as u32
+                        ));
+                    }
+                };
+
+                total += value * multiplier;
+                // Reset multiplier after applying it to one digit
+                multiplier = 1;
+            }
+        }
+    }
+
+    if total == 0 {
+        return Err("Empty or invalid numeral".to_string());
+    }
+
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_units() {
+        assert_eq!(parse_greek_numeral("αʹ").unwrap(), 1);
+        assert_eq!(parse_greek_numeral("βʹ").unwrap(), 2);
+        assert_eq!(parse_greek_numeral("θʹ").unwrap(), 9);
+    }
+
+    #[test]
+    fn test_teens() {
+        assert_eq!(parse_greek_numeral("ιαʹ").unwrap(), 11);
+        assert_eq!(parse_greek_numeral("ιβʹ").unwrap(), 12);
+        assert_eq!(parse_greek_numeral("ιθʹ").unwrap(), 19);
+    }
+
+    #[test]
+    fn test_tens() {
+        assert_eq!(parse_greek_numeral("κʹ").unwrap(), 20);
+        assert_eq!(parse_greek_numeral("καʹ").unwrap(), 21);
+        assert_eq!(parse_greek_numeral("λβʹ").unwrap(), 32); // 30 + 2
+    }
+
+    #[test]
+    fn test_hundreds() {
+        assert_eq!(parse_greek_numeral("ρʹ").unwrap(), 100);
+        assert_eq!(parse_greek_numeral("σνγʹ").unwrap(), 253); // 200 + 50 + 3
+    }
+
+    #[test]
+    fn test_thousands() {
+        assert_eq!(parse_greek_numeral("͵α").unwrap(), 1000);
+        assert_eq!(parse_greek_numeral("͵ααʹ").unwrap(), 1001);
+        assert_eq!(parse_greek_numeral("͵β").unwrap(), 2000);
+        assert_eq!(parse_greek_numeral("͵βκβʹ").unwrap(), 2022); // 2000 + 20 + 2
+    }
+
+    #[test]
+    fn test_archaic() {
+        // Using strict chars
+        assert_eq!(parse_greek_numeral("\u{03DB}ʹ").unwrap(), 6); // Stigma
+        assert_eq!(parse_greek_numeral("ςʹ").unwrap(), 6); // Final Sigma fallback
+
+        // Koppa
+        assert_eq!(parse_greek_numeral("\u{03DF}ʹ").unwrap(), 90);
+        assert_eq!(parse_greek_numeral("\u{03D9}ʹ").unwrap(), 90);
+
+        // Sampi
+        assert_eq!(parse_greek_numeral("\u{03E1}ʹ").unwrap(), 900);
+    }
+
+    #[test]
+    fn test_invalid() {
+        assert!(parse_greek_numeral("abc").is_err());
+    }
+
+    #[test]
+    fn test_2024() {
+        // 2000 = ͵β
+        // 20 = κ
+        // 4 = δ
+        assert_eq!(parse_greek_numeral("͵βκδʹ").unwrap(), 2024);
+    }
+}

--- a/src/grammar/glossa.pest
+++ b/src/grammar/glossa.pest
@@ -132,7 +132,10 @@ string_literal = { "«" ~ string_content ~ "»" }
 string_content = { (!"»" ~ ANY)* }
 
 // Numbers (Arabic numerals for now, Greek numerals later)
-number_literal = @{ ASCII_DIGIT+ }
+number_literal = @{ ASCII_DIGIT+ | greek_numeral }
+
+keraia = { "\u{0374}" | "ʹ" | "\u{02B9}" }
+greek_numeral = @{ (GREEK_CHAR)+ ~ keraia }
 
 // Boolean literals
 boolean_literal = { "ἀληθές" | "ψεῦδος" | "αληθες" | "ψευδος" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 //! * [`ast`]: Abstract Syntax Tree definitions.
 //! * [`codegen`]: Rust code generation logic.
 //! * [`errors`]: Greek-native error messages and diagnostics.
+//! * [`experimental`]: Nova features (e.g., Greek Numerals).
 //! * [`grammar`]: PEG parser.
 //! * [`highlight`]: Semantic syntax highlighting.
 //! * [`morphology`]: Word analysis, lexicon, and participle parsing.
@@ -48,6 +49,7 @@
 pub mod ast;
 pub mod codegen;
 pub mod errors;
+pub mod experimental;
 pub mod grammar;
 pub mod highlight;
 pub mod morphology;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@
 //! * [`ast`]: Abstract Syntax Tree definitions.
 //! * [`codegen`]: Rust code generation logic.
 //! * [`errors`]: Greek-native error messages and diagnostics.
-//! * [`experimental`]: Nova features (e.g., Greek Numerals).
 //! * [`grammar`]: PEG parser.
 //! * [`highlight`]: Semantic syntax highlighting.
 //! * [`morphology`]: Word analysis, lexicon, and participle parsing.

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -14,6 +14,15 @@ use crate::ast::*;
 use crate::grammar::{Rule, parse};
 use pest::iterators::Pair;
 
+fn parse_number_literal(text: &str) -> Result<i64, ParseError> {
+    if let Ok(val) = text.parse::<i64>() {
+        Ok(val)
+    } else {
+        crate::experimental::numerals::parse_greek_numeral(text)
+            .map_err(|e| ParseError::InvalidNumber(format!("{} - {}", text, e)))
+    }
+}
+
 /// Build an AST from source code
 pub fn parse_source(source: &str) -> Result<Program, ParseError> {
     // Check recursion depth before parsing to prevent stack overflow
@@ -475,10 +484,7 @@ fn build_indexed_word_expr(inner: Pair<'_, Rule>) -> Result<Expr, ParseError> {
         .ok_or(ParseError::EmptyTerm)?;
     let index = match index_inner.as_rule() {
         Rule::number_literal => {
-            let value: i64 = index_inner
-                .as_str()
-                .parse()
-                .map_err(|_| ParseError::InvalidNumber(index_inner.as_str().to_string()))?;
+            let value = parse_number_literal(index_inner.as_str())?;
             Expr::NumberLiteral(value)
         }
         Rule::greek_word => Expr::Word(Word {
@@ -527,10 +533,7 @@ fn build_term(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
             Ok(Expr::StringLiteral(content))
         }
         Rule::number_literal => {
-            let value: i64 = inner
-                .as_str()
-                .parse()
-                .map_err(|_| ParseError::InvalidNumber(inner.as_str().to_string()))?;
+            let value = parse_number_literal(inner.as_str())?;
             Ok(Expr::NumberLiteral(value))
         }
         Rule::boolean_literal => {
@@ -565,10 +568,7 @@ fn build_array_element(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
             Ok(Expr::StringLiteral(content))
         }
         Rule::number_literal => {
-            let value: i64 = inner
-                .as_str()
-                .parse()
-                .map_err(|_| ParseError::InvalidNumber(inner.as_str().to_string()))?;
+            let value = parse_number_literal(inner.as_str())?;
             Ok(Expr::NumberLiteral(value))
         }
         Rule::boolean_literal => {

--- a/tests/nova_numerals.rs
+++ b/tests/nova_numerals.rs
@@ -1,0 +1,96 @@
+use glossa::ast::{Expr, Statement};
+use glossa::parser::builder::parse_source;
+
+#[test]
+fn test_greek_numerals_assignment() {
+    // x = 22 (κβʹ)
+    let source = "ξ κβʹ ἔστω.";
+    let program = parse_source(source).unwrap();
+
+    assert_eq!(program.statements.len(), 1);
+
+    let Statement::Regular { clauses, .. } = &program.statements[0] else {
+        panic!("Expected Regular Statement");
+    };
+
+    let Expr::Phrase(terms) = &clauses[0].expressions[0] else {
+        panic!("Expected Phrase");
+    };
+
+    // ξ, 22, ἔστω
+    assert_eq!(terms.len(), 3);
+    let Expr::NumberLiteral(val) = terms[1] else {
+        panic!("Expected NumberLiteral, got {:?}", terms[1]);
+    };
+    assert_eq!(val, 22);
+}
+
+#[test]
+fn test_greek_numerals_array() {
+    // [1, 2, 3] = [αʹ, βʹ, γʹ]
+    let source = "[αʹ, βʹ, γʹ] λέγε.";
+    let program = parse_source(source).unwrap();
+
+    let Statement::Regular { clauses, .. } = &program.statements[0] else {
+        panic!("Expected Regular Statement");
+    };
+
+    let Expr::Phrase(terms) = &clauses[0].expressions[0] else {
+        panic!("Expected Phrase");
+    };
+
+    // [1, 2, 3], λέγε
+    let Expr::ArrayLiteral(elements) = &terms[0] else {
+        panic!("Expected ArrayLiteral");
+    };
+
+    assert_eq!(elements.len(), 3);
+    assert!(matches!(elements[0], Expr::NumberLiteral(1)));
+    assert!(matches!(elements[1], Expr::NumberLiteral(2)));
+    assert!(matches!(elements[2], Expr::NumberLiteral(3)));
+}
+
+#[test]
+fn test_greek_numerals_index() {
+    // arr[10] = arr[ιʹ]
+    let source = "πίνακας[ιʹ] λέγε.";
+    let program = parse_source(source).unwrap();
+
+    let Statement::Regular { clauses, .. } = &program.statements[0] else {
+        panic!("Expected Regular Statement");
+    };
+
+    let Expr::Phrase(terms) = &clauses[0].expressions[0] else {
+        panic!("Expected Phrase");
+    };
+
+    // πίνακας[10], λέγε
+    let Expr::IndexAccess { index, .. } = &terms[0] else {
+        panic!("Expected IndexAccess");
+    };
+
+    let Expr::NumberLiteral(idx) = **index else {
+        panic!("Expected NumberLiteral index");
+    };
+    assert_eq!(idx, 10);
+}
+
+#[test]
+fn test_greek_numerals_mixed() {
+    // 2024 (͵βκδʹ)
+    let source = "͵βκδʹ λέγε.";
+    let program = parse_source(source).unwrap();
+
+    let Statement::Regular { clauses, .. } = &program.statements[0] else {
+        panic!("Expected Regular Statement");
+    };
+
+    let Expr::Phrase(terms) = &clauses[0].expressions[0] else {
+        panic!("Expected Phrase");
+    };
+
+    let Expr::NumberLiteral(val) = terms[0] else {
+        panic!("Expected NumberLiteral");
+    };
+    assert_eq!(val, 2024);
+}

--- a/tests/nova_numerals.rs
+++ b/tests/nova_numerals.rs
@@ -1,5 +1,5 @@
+use glossa::ast::{Expr, Statement};
 use glossa::parser::builder::parse_source;
-use glossa::ast::{Statement, Expr};
 
 #[test]
 fn test_greek_numerals_assignment() {

--- a/tests/nova_numerals.rs
+++ b/tests/nova_numerals.rs
@@ -1,5 +1,5 @@
-use glossa::ast::{Expr, Statement};
 use glossa::parser::builder::parse_source;
+use glossa::ast::{Statement, Expr};
 
 #[test]
 fn test_greek_numerals_assignment() {

--- a/tests/nova_numerals.rs
+++ b/tests/nova_numerals.rs
@@ -94,3 +94,36 @@ fn test_greek_numerals_mixed() {
     };
     assert_eq!(val, 2024);
 }
+
+#[test]
+fn test_arabic_fallback() {
+    // 42 λέγε.
+    let source = "42 λέγε.";
+    let program = parse_source(source).unwrap();
+
+    let Statement::Regular { clauses, .. } = &program.statements[0] else {
+        panic!("Expected Regular Statement");
+    };
+
+    let Expr::Phrase(terms) = &clauses[0].expressions[0] else {
+        panic!("Expected Phrase");
+    };
+
+    let Expr::NumberLiteral(val) = terms[0] else {
+        panic!("Expected NumberLiteral");
+    };
+    assert_eq!(val, 42);
+}
+
+#[test]
+fn test_invalid_greek_logic() {
+    // \u{0300}ʹ is a valid Greek char sequence in grammar (Combining Grave + Keraia)
+    // But parse_greek_numeral returns error ("Empty or invalid numeral")
+    // This tests the map_err path in parse_number_literal
+    let source = "\u{0300}ʹ λέγε.";
+    let result = parse_source(source);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(format!("{}", err).contains("Invalid number"));
+}


### PR DESCRIPTION
Implemented Ancient Greek alphabetic numerals support. Now the compiler accepts `αʹ`, `βʹ`, `ιʹ`, `͵α`, etc. as integer literals. This feature is additive and isolated in `src/experimental` with integration points in the grammar and AST builder. Verified with new integration tests.

---
*PR created automatically by Jules for task [7164346429181202319](https://jules.google.com/task/7164346429181202319) started by @madmax983*