### PR TITLE
Fix silent failure on undefined struct instantiation and improve test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,29 @@ GLOSSA provides native test declarations using idiomatic Greek verbs:
 
 Tests transpile to Rust `#[test]` functions and can be run with standard Rust tools.
 
-## Building
+### Running Glossa Tests
+
+To run tests written in Glossa (e.g., `tests.γλ`):
+
+1. Build the file to generate Rust code:
+   ```bash
+   cargo run --release -- build tests.γλ
+   ```
+
+2. Compile and run the generated Rust test harness:
+   ```bash
+   rustc --test tests.rs && ./tests
+   ```
+
+## Compiler Development
+
+### Building the Compiler
 
 ```bash
 cargo build --release
 ```
 
-## Testing
+### Running Compiler Tests
 
 ```bash
 cargo test

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -318,6 +318,10 @@ pub fn try_parse_struct_instantiation(
                     value: struct_inst,
                     mutable: false,
                 }));
+            } else {
+                // If it looks like a struct instantiation (var νέον Type ... ἔστω)
+                // but the type is unknown, return an error instead of falling back.
+                return Err(GlossaError::undefined(type_name.to_string()));
             }
         }
     }

--- a/tests/reproduce_silent_failure.rs
+++ b/tests/reproduce_silent_failure.rs
@@ -1,0 +1,29 @@
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_undefined_struct_type_error() {
+    let code = "
+    εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. }.
+    χρήστης νέον Χρήστος «Σωκράτης» ἔστω.
+    ";
+
+    let ast = parse(code).unwrap();
+    let result = analyze_program(&ast);
+
+    match result {
+        Ok(_) => panic!(
+            "Expected compilation error for undefined type 'Χρήστος', but compilation succeeded."
+        ),
+        Err(e) => {
+            let msg = e.to_string();
+            // Expected error message should contain the unknown name
+            assert!(
+                msg.contains("Χρήστος")
+                    || msg.contains("undefined")
+                    || msg.contains("Ἄγνωστον")
+                    || msg.contains("Άγνωστον")
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses DX issues identified during an "Echo" audit. 

1.  **Silent Failure Fix:** Previously, a typo in a struct type name (e.g., `χρήστης νέον Typo ...`) would cause the compiler to silently fall back to parsing the statement as a regular sentence, resulting in garbage Rust code and no error message. The parser now strictly validates the type name when the `νέον` (new) keyword is used in a struct instantiation pattern and returns a clear `UndefinedName` error if the type is not found.
2.  **Documentation Improvement:** The `README.md` was updated to provide explicit instructions on how to run user-defined Glossa tests (`tests.γλ`), distinguishing them from the compiler's own development tests (`cargo test`).

Verified with new regression test `tests/reproduce_silent_failure.rs` and manual verification of the README.

---
*PR created automatically by Jules for task [10155508108839606670](https://jules.google.com/task/10155508108839606670) started by @madmax983*