### PR TITLE
📜 Codex: ADR 009 & Architecture Diagram Update

### DIFF
--- a/docs/adr/009-replace-oracle-with-report-and-highlight.md
+++ b/docs/adr/009-replace-oracle-with-report-and-highlight.md
@@ -1,0 +1,40 @@
+# 9. Replace Oracle with Report and Highlight
+
+Date: 2025-02-12
+
+## Status
+
+Accepted
+
+## Context
+
+The `Oracle` component was initially designed to provide explanation services, attempting to generate human-readable descriptions of the code's intent. However, its scope became ill-defined, overlapping with both error reporting and documentation generation. As the compiler matured, the need for distinct, specialized components became apparent:
+1.  **Syntax Highlighting:** A purely presentational layer for the CLI (`highlight` command) to visualize the grammatical structure (Subject, Object, Verb) using ANSI colors.
+2.  **Structured Reporting:** An analytical layer (`report` command) to provide statistics on code complexity, function counts, and other metrics, as well as structured error reporting.
+
+The `Oracle` became a monolithic and obsolete abstraction that didn't fit well into the compilation pipeline.
+
+## Decision
+
+We will remove the `src/semantic/oracle.rs` component and replace its responsibilities with two new, focused modules:
+
+1.  **Highlight (`src/highlight.rs`):**
+    -   Responsible for semantic syntax highlighting.
+    -   Consumes the AST directly from the Parser.
+    -   Uses morphological analysis to color-code words based on their role (Case, Part of Speech).
+    -   Outputs ANSI-colored text for the CLI.
+
+2.  **Report (`src/report.rs`):**
+    -   Responsible for generating compilation reports and program statistics.
+    -   Consumes the `AnalyzedProgram` from the Semantic Analyzer.
+    -   Calculates metrics like Statement Count, Expression Count, Max Depth, etc.
+    -   Provides structured output for the `check` and `build` CLI commands.
+
+The `Oracle` component will be removed from the codebase and the architecture documentation.
+
+## Consequences
+
+*   **Separation of Concerns:** The distinction between *visualizing* code structure (Highlight) and *analyzing* code metrics (Report) is now explicit.
+*   **CLI Improvements:** The `glossa` CLI now supports dedicated `highlight` and `check` commands backed by these specialized modules.
+*   **Reduced Complexity:** The Semantic Analysis phase is simplified by removing the `Oracle` dependency.
+*   **Documentation Update:** The architecture diagrams must be updated to reflect these changes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,11 +31,15 @@ C4Container
     Container(parser, "Parser", "src/parser", "Constructs AST, enforcing recursion limits (max depth 500)")
     Container(morphology, "Declension Resolver", "src/morphology", "Analyzes case, gender, number, and resolves agreement")
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
+    Container(highlight, "Highlighter", "src/highlight.rs", "Semantic syntax highlighting")
+    Container(report, "Reporter", "src/report.rs", "Generates statistics and structured reports")
     Container(codegen, "Code Generator", "src/codegen", "Generates Rust source code")
 
     Rel(lexer, parser, "Stream<Token>")
     Rel(parser, morphology, "AST (Unresolved)")
+    Rel(parser, highlight, "AST (Unresolved)")
     Rel(morphology, semantic, "AST (Resolved Morphology)")
+    Rel(semantic, report, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 ```
 
@@ -53,7 +57,6 @@ C4Component
         Component(converter, "Converter", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs (Iterators, Structs)")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")
-        Component(oracle, "Oracle", "src/semantic/oracle.rs", "Generates human-readable explanations")
     }
 
     Container(morphology, "Morphology", "src/morphology", "Provides Case/Gender/Number analysis")
@@ -64,5 +67,4 @@ C4Component
     Rel(converter, patterns, "Delegates complex patterns")
     Rel(patterns, model, "Produces AnalyzedStatement")
     Rel(converter, model, "Produces AnalyzedStatement")
-    Rel(oracle, assembler, "Uses (via assemble_statement)")
 ```


### PR DESCRIPTION
This PR documents the architectural shift from a monolithic `Oracle` component to specialized `Highlight` and `Report` modules.

**Changes:**
- Added ADR 009 describing the decision and context.
- Updated `docs/architecture.md` to reflect the current codebase structure:
    - Removed `Oracle` from Semantic Analysis component diagram.
    - Added `Highlight` and `Report` to the Compiler Pipeline container diagram.

---
*PR created automatically by Jules for task [8615660553879017953](https://jules.google.com/task/8615660553879017953) started by @madmax983*