### PR TITLE
⚡ Bolt: Avoid re-normalization in Assembler

### DIFF
--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -170,20 +170,32 @@ impl Assembler {
     /// ```
     pub fn feed(&mut self, analysis: &MorphAnalysis, original: &str) -> Result<(), AssemblyError> {
         let normalized = normalize_greek(original);
+        self.feed_with_normalized(analysis, original, &normalized)
+    }
 
-        if self.check_special_markers(&normalized) {
+    /// Feed a morphologically-analyzed token with pre-computed normalization
+    ///
+    /// This is a zero-allocation path when the normalized form is already known (e.g. from AST).
+    /// It bypasses the costly `normalize_greek` call which may allocate strings.
+    pub fn feed_with_normalized(
+        &mut self,
+        analysis: &MorphAnalysis,
+        original: &str,
+        normalized: &str,
+    ) -> Result<(), AssemblyError> {
+        if self.check_special_markers(normalized) {
             return Ok(());
         }
 
-        if self.check_method_verbs(&normalized) {
+        if self.check_method_verbs(normalized) {
             return Ok(());
         }
 
-        if self.check_operators(&normalized, original) {
+        if self.check_operators(normalized, original) {
             return Ok(());
         }
 
-        if self.check_special_properties(&normalized) {
+        if self.check_special_properties(normalized) {
             return Ok(());
         }
 

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -421,7 +421,7 @@ fn feed_expr_recursive(
             let mut success = false;
 
             for candidate in candidates {
-                match asm.feed(&candidate, &w.original) {
+                match asm.feed_with_normalized(&candidate, &w.original, &w.normalized) {
                     Ok(_) => {
                         success = true;
                         break;
@@ -471,7 +471,7 @@ fn feed_expr_recursive(
             // Set context from verb for potential subject agreement
             *context = DisambiguationContext::from_verb(&best_verb);
 
-            if let Err(e) = asm.feed(&best_verb, &verb.original) {
+            if let Err(e) = asm.feed_with_normalized(&best_verb, &verb.original, &verb.normalized) {
                 return Err(GlossaError::semantic(e.to_string()));
             }
 
@@ -485,7 +485,7 @@ fn feed_expr_recursive(
             let analyses = morphology::analyze_all(&name.normalized);
             let best_name = resolve_best(analyses, context);
 
-            if let Err(e) = asm.feed(&best_name, &name.original) {
+            if let Err(e) = asm.feed_with_normalized(&best_name, &name.original, &name.normalized) {
                 return Err(GlossaError::semantic(e.to_string()));
             }
             feed_expr_recursive(asm, value, context, depth + 1)?;

--- a/tests/nova_numerals.rs
+++ b/tests/nova_numerals.rs
@@ -1,11 +1,11 @@
 use glossa::ast::{Expr, Statement};
-use glossa::parser::builder::parse_source;
+use glossa::parser::parse;
 
 #[test]
 fn test_greek_numerals_assignment() {
     // x = 22 (κβʹ)
     let source = "ξ κβʹ ἔστω.";
-    let program = parse_source(source).unwrap();
+    let program = parse(source).unwrap();
 
     assert_eq!(program.statements.len(), 1);
 
@@ -29,7 +29,7 @@ fn test_greek_numerals_assignment() {
 fn test_greek_numerals_array() {
     // [1, 2, 3] = [αʹ, βʹ, γʹ]
     let source = "[αʹ, βʹ, γʹ] λέγε.";
-    let program = parse_source(source).unwrap();
+    let program = parse(source).unwrap();
 
     let Statement::Regular { clauses, .. } = &program.statements[0] else {
         panic!("Expected Regular Statement");
@@ -54,7 +54,7 @@ fn test_greek_numerals_array() {
 fn test_greek_numerals_index() {
     // arr[10] = arr[ιʹ]
     let source = "πίνακας[ιʹ] λέγε.";
-    let program = parse_source(source).unwrap();
+    let program = parse(source).unwrap();
 
     let Statement::Regular { clauses, .. } = &program.statements[0] else {
         panic!("Expected Regular Statement");
@@ -79,7 +79,7 @@ fn test_greek_numerals_index() {
 fn test_greek_numerals_mixed() {
     // 2024 (͵βκδʹ)
     let source = "͵βκδʹ λέγε.";
-    let program = parse_source(source).unwrap();
+    let program = parse(source).unwrap();
 
     let Statement::Regular { clauses, .. } = &program.statements[0] else {
         panic!("Expected Regular Statement");
@@ -99,7 +99,7 @@ fn test_greek_numerals_mixed() {
 fn test_arabic_fallback() {
     // 42 λέγε.
     let source = "42 λέγε.";
-    let program = parse_source(source).unwrap();
+    let program = parse(source).unwrap();
 
     let Statement::Regular { clauses, .. } = &program.statements[0] else {
         panic!("Expected Regular Statement");
@@ -121,7 +121,7 @@ fn test_invalid_greek_logic() {
     // But parse_greek_numeral returns error ("Empty or invalid numeral")
     // This tests the map_err path in parse_number_literal
     let source = "\u{0300}ʹ λέγε.";
-    let result = parse_source(source);
+    let result = parse(source);
 
     assert!(result.is_err());
     let err = result.unwrap_err();


### PR DESCRIPTION
💡 What:
Refactored `Assembler::feed` to delegate to a new `feed_with_normalized` method.
Updated `src/semantic/expressions.rs` to pass the pre-computed `.normalized` string from `Word` AST nodes to the assembler.
Fixed `tests/nova_numerals.rs` to use the public `parse` API instead of the internal `builder`.

🎯 Why:
`normalize_greek` allocates a new `String` (or `SmolStr`) for every token fed into the assembler. Since the AST `Word` node already stores the normalized form, this re-computation was wasteful (O(N) redundant allocations).

📊 Impact:
Removes 1 heap allocation and string processing overhead per word during the semantic analysis phase. This is a zero-cost abstraction improvement.

🔬 Measurement:
Verified by inspection that `normalize_greek` is bypassed in the hot path. Existing tests pass, ensuring no regression.


---
*PR created automatically by Jules for task [1819767018869523995](https://jules.google.com/task/1819767018869523995) started by @madmax983*