### PR TITLE
🛡️ Sentry: Enforce Assembler Resource Limits

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -17,3 +17,7 @@
 ## [Silent Token Swallowing in Special Checks]
 **Learning:** Functions like `check_method_verbs` and `check_special_properties` were returning `true` (indicating "handled") even when they failed to match the full pattern (e.g., missing subject), causing tokens like "split" or "length" to be silently ignored instead of falling back to normal verb/noun processing.
 **Action:** Ensure that special handling functions only return `true` when they *successfully* handle the token. If prerequisites aren't met, return `false` to allow fallback to standard processing.
+
+## [Resource Exhaustion (DoS) in Assembler]
+**Learning:** The `Assembler` was using unbounded `Vec::push()` for adjectives, literals, and other constituents. This allowed malicious input (e.g., infinite adjectives) to cause OOM panics or Denial of Service.
+**Action:** Implemented strict resource limits (`MAX_ADJECTIVES`, etc.) and a new `LimitExceeded` error. Always validate collection sizes before pushing, especially in assemblers/parsers exposed to user input.

--- a/src/errors/assembly.rs
+++ b/src/errors/assembly.rs
@@ -79,8 +79,5 @@ pub enum AssemblyError {
     /// Too many adjectives in a single sentence
     #[error("Ὑπέρβασις ὁρίου: {resource} > {max}. Μηδὲν ἄγαν!")]
     #[diagnostic(code(glossa::assembly::limit_exceeded))]
-    LimitExceeded {
-        resource: String,
-        max: usize,
-    },
+    LimitExceeded { resource: String, max: usize },
 }

--- a/src/errors/assembly.rs
+++ b/src/errors/assembly.rs
@@ -72,4 +72,15 @@ pub enum AssemblyError {
         word2: String,
         gender2: Gender,
     },
+
+    /// Resource limit exceeded to prevent denial of service
+    ///
+    /// # Example
+    /// Too many adjectives in a single sentence
+    #[error("Ὑπέρβασις ὁρίου: {resource} > {max}. Μηδὲν ἄγαν!")]
+    #[diagnostic(code(glossa::assembly::limit_exceeded))]
+    LimitExceeded {
+        resource: String,
+        max: usize,
+    },
 }

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -102,6 +102,20 @@ use crate::morphology::{
 use crate::text::normalize_greek;
 use smol_str::SmolStr;
 
+// Constants for resource limits to prevent DoS
+pub const MAX_ADJECTIVES: usize = 1024;
+pub const MAX_LITERALS: usize = 1024;
+pub const MAX_NOMINATIVES: usize = 256;
+pub const MAX_GENITIVES: usize = 256;
+pub const MAX_ARRAYS: usize = 256;
+pub const MAX_INDEX_ACCESSES: usize = 256;
+pub const MAX_PROPERTY_ACCESSES: usize = 256;
+pub const MAX_NESTED_PHRASES: usize = 256;
+pub const MAX_PARTICIPLES: usize = 256;
+pub const MAX_UNWRAPS: usize = 256;
+pub const MAX_OPERATORS: usize = 256;
+pub const MAX_BLOCKS: usize = 256;
+
 /// The slot-based assembler
 ///
 /// Feed it tokens one by one, and it routes them to the appropriate slot
@@ -226,6 +240,12 @@ impl Assembler {
     /// asm.feed_string("χαῖρε".to_string()).unwrap();
     /// ```
     pub fn feed_string(&mut self, value: String) -> Result<(), AssemblyError> {
+        if self.state.literals.len() >= MAX_LITERALS {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Literals".to_string(),
+                max: MAX_LITERALS,
+            });
+        }
         self.state.literals.push(Literal::String(value));
         Ok(())
     }
@@ -241,6 +261,12 @@ impl Assembler {
     /// asm.feed_number(42).unwrap();
     /// ```
     pub fn feed_number(&mut self, value: i64) -> Result<(), AssemblyError> {
+        if self.state.literals.len() >= MAX_LITERALS {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Literals".to_string(),
+                max: MAX_LITERALS,
+            });
+        }
         self.state.literals.push(Literal::Number(value));
         Ok(())
     }
@@ -256,6 +282,12 @@ impl Assembler {
     /// asm.feed_boolean(true).unwrap();
     /// ```
     pub fn feed_boolean(&mut self, value: bool) -> Result<(), AssemblyError> {
+        if self.state.literals.len() >= MAX_LITERALS {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Literals".to_string(),
+                max: MAX_LITERALS,
+            });
+        }
         self.state.literals.push(Literal::Boolean(value));
         Ok(())
     }
@@ -273,6 +305,12 @@ impl Assembler {
     /// asm.feed_array(elements).unwrap();
     /// ```
     pub fn feed_array(&mut self, elements: Vec<Expr>) -> Result<(), AssemblyError> {
+        if self.state.arrays.len() >= MAX_ARRAYS {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Arrays".to_string(),
+                max: MAX_ARRAYS,
+            });
+        }
         self.state.arrays.push(elements);
         Ok(())
     }
@@ -291,6 +329,12 @@ impl Assembler {
         &mut self,
         statements: Vec<crate::ast::Statement>,
     ) -> Result<(), AssemblyError> {
+        if self.state.blocks.len() >= MAX_BLOCKS {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Blocks".to_string(),
+                max: MAX_BLOCKS,
+            });
+        }
         self.state.blocks.push(statements);
         Ok(())
     }
@@ -307,6 +351,12 @@ impl Assembler {
     /// asm.feed_nested_phrase(vec![Expr::NumberLiteral(1)]).unwrap();
     /// ```
     pub fn feed_nested_phrase(&mut self, terms: Vec<Expr>) -> Result<(), AssemblyError> {
+        if self.state.nested_phrases.len() >= MAX_NESTED_PHRASES {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Nested Phrases".to_string(),
+                max: MAX_NESTED_PHRASES,
+            });
+        }
         self.state.nested_phrases.push(terms);
         Ok(())
     }
@@ -328,6 +378,12 @@ impl Assembler {
     /// asm.feed_index_access(array, index).unwrap();
     /// ```
     pub fn feed_index_access(&mut self, array: Expr, index: Expr) -> Result<(), AssemblyError> {
+        if self.state.index_accesses.len() >= MAX_INDEX_ACCESSES {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Index Accesses".to_string(),
+                max: MAX_INDEX_ACCESSES,
+            });
+        }
         self.state.index_accesses.push((array, index));
         Ok(())
     }
@@ -348,6 +404,12 @@ impl Assembler {
     /// asm.feed_unwrap(expr).unwrap();
     /// ```
     pub fn feed_unwrap(&mut self, expr: Expr) -> Result<(), AssemblyError> {
+        if self.state.unwraps.len() >= MAX_UNWRAPS {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Unwraps".to_string(),
+                max: MAX_UNWRAPS,
+            });
+        }
         self.state.unwraps.push(expr);
         Ok(())
     }
@@ -377,6 +439,12 @@ impl Assembler {
         analysis: &crate::morphology::ParticipleAnalysis,
         original: &str,
     ) -> Result<(), AssemblyError> {
+        if self.state.participles.len() >= MAX_PARTICIPLES {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Participles".to_string(),
+                max: MAX_PARTICIPLES,
+            });
+        }
         let constituent = ParticipleConstituent {
             verb_lemma: analysis.verb_lemma().into(),
             original: original.into(),
@@ -417,6 +485,12 @@ impl Assembler {
 
                 if self.state.subject.is_some() {
                     // Additional nominatives stored separately for function call patterns
+                    if self.state.nominatives.len() >= MAX_NOMINATIVES {
+                        return Err(AssemblyError::LimitExceeded {
+                            resource: "Nominatives".to_string(),
+                            max: MAX_NOMINATIVES,
+                        });
+                    }
                     self.state.nominatives.push(constituent);
                 } else {
                     self.state.subject = Some(constituent);
@@ -437,6 +511,12 @@ impl Assembler {
             }
             Some(Case::Genitive) => {
                 // Genitives attach to other constituents (possession, etc.)
+                if self.state.genitives.len() >= MAX_GENITIVES {
+                    return Err(AssemblyError::LimitExceeded {
+                        resource: "Genitives".to_string(),
+                        max: MAX_GENITIVES,
+                    });
+                }
                 self.state.genitives.push(constituent);
             }
             Some(Case::Vocative) => {
@@ -502,6 +582,12 @@ impl Assembler {
             person: None, // Adjectives don't really have person
         };
 
+        if self.state.adjectives.len() >= MAX_ADJECTIVES {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Adjectives".to_string(),
+                max: MAX_ADJECTIVES,
+            });
+        }
         self.state.adjectives.push(constituent);
         Ok(())
     }
@@ -585,6 +671,10 @@ impl Assembler {
             && matches!(self.state.literals.last(), Some(Literal::String(_)))
         {
             if let Some(ref subj) = self.state.subject {
+                if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
+                    return false;
+                }
+
                 let delim = match self.state.literals.pop() {
                     Some(Literal::String(s)) => s,
                     _ => unreachable!(),
@@ -624,10 +714,16 @@ impl Assembler {
     fn check_operators(&mut self, normalized: &str, original: &str) -> bool {
         // Boolean operators
         if matches!(original, "καί" | "και") {
+            if self.state.operators.len() >= MAX_OPERATORS {
+                return false;
+            }
             self.state.operators.push(BinaryOp::And);
             return true;
         }
         if matches!(original, "ἤ" | "ή") {
+            if self.state.operators.len() >= MAX_OPERATORS {
+                return false;
+            }
             // ἤ with breathing+accent, but not ᾖ
             self.state.operators.push(BinaryOp::Or);
             return true;
@@ -635,12 +731,18 @@ impl Assembler {
 
         // Comparison operators
         if let Some(op) = crate::morphology::lexicon::comparison_operator(normalized) {
+            if self.state.operators.len() >= MAX_OPERATORS {
+                return false;
+            }
             self.state.operators.push(op);
             return true;
         }
 
         // Arithmetic operators
         if let Some(op) = crate::morphology::lexicon::arithmetic_operator(normalized) {
+            if self.state.operators.len() >= MAX_OPERATORS {
+                return false;
+            }
             self.state.operators.push(op);
             return true;
         }
@@ -660,6 +762,9 @@ impl Assembler {
         if crate::morphology::lexicon::is_length_property(normalized) {
             // If we have a subject, create a property access (use normalized original, not lemma)
             if let Some(ref subj) = self.state.subject {
+                if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
+                    return false;
+                }
                 let normalized_original = crate::text::normalize_greek(&subj.original);
                 self.state
                     .property_accesses
@@ -675,6 +780,9 @@ impl Assembler {
             if let Some(ref subj) = self.state.subject
                 && let Some(index) = crate::morphology::lexicon::ordinal_to_index(normalized)
             {
+                if self.state.index_accesses.len() >= MAX_INDEX_ACCESSES {
+                    return false;
+                }
                 // Create array and index expressions (use normalized original, not lemma)
                 let normalized_original = crate::text::normalize_greek(&subj.original);
                 let array = Expr::Word(Word {

--- a/tests/havoc_assembler_dos.rs
+++ b/tests/havoc_assembler_dos.rs
@@ -1,12 +1,25 @@
-use glossa::semantic::{Assembler, AssemblyError};
+use glossa::ast::{Expr, Word};
 use glossa::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
+use glossa::semantic::{Assembler, AssemblyError};
 use std::borrow::Cow;
 
+// Constants from src/semantic/assembler.rs
+const MAX_ADJECTIVES: usize = 1024;
+const MAX_LITERALS: usize = 1024;
+const MAX_NOMINATIVES: usize = 256;
+const MAX_GENITIVES: usize = 256;
+const MAX_ARRAYS: usize = 256;
+const MAX_INDEX_ACCESSES: usize = 256;
+const MAX_NESTED_PHRASES: usize = 256;
+const MAX_PARTICIPLES: usize = 256;
+const MAX_UNWRAPS: usize = 256;
+const MAX_BLOCKS: usize = 256;
+
 #[test]
-fn test_assembler_enforces_limits() {
+fn test_limit_adjectives() {
     let mut asm = Assembler::new();
-    let adj_analysis = MorphAnalysis {
-        lemma: Cow::Borrowed("test_adj"),
+    let analysis = MorphAnalysis {
+        lemma: Cow::Borrowed("adj"),
         part_of_speech: PartOfSpeech::Adjective,
         case: Some(Case::Nominative),
         number: Some(Number::Singular),
@@ -18,22 +31,204 @@ fn test_assembler_enforces_limits() {
         confidence: 1.0,
     };
 
-    // Fill up to the limit (1024)
-    for _ in 0..1024 {
-        let res = asm.feed(&adj_analysis, "test_adj");
-        assert!(res.is_ok(), "Should accept up to 1024 adjectives");
+    for _ in 0..MAX_ADJECTIVES {
+        asm.feed(&analysis, "adj").unwrap();
     }
 
-    // Attempt to exceed the limit
-    let res = asm.feed(&adj_analysis, "test_adj");
-
-    // Sentry: Assert that we get the correct LimitExceeded error
-    match res {
+    match asm.feed(&analysis, "adj") {
         Err(AssemblyError::LimitExceeded { resource, max }) => {
             assert_eq!(resource, "Adjectives");
-            assert_eq!(max, 1024);
+            assert_eq!(max, MAX_ADJECTIVES);
         }
-        Err(e) => panic!("Expected LimitExceeded, got {:?}", e),
-        Ok(_) => panic!("Assembler allowed unbounded growth! Expected LimitExceeded error."),
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_literals() {
+    let mut asm = Assembler::new();
+    for _ in 0..MAX_LITERALS {
+        asm.feed_number(1).unwrap();
+    }
+
+    match asm.feed_number(1) {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Literals");
+            assert_eq!(max, MAX_LITERALS);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_nominatives() {
+    let mut asm = Assembler::new();
+    let analysis = MorphAnalysis {
+        lemma: Cow::Borrowed("noun"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Nominative),
+        number: Some(Number::Singular),
+        gender: Some(Gender::Masculine),
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    // First nominative goes to subject slot
+    asm.feed(&analysis, "noun").unwrap();
+
+    // Subsequent nominatives go to nominatives list
+    for _ in 0..MAX_NOMINATIVES {
+        asm.feed(&analysis, "noun").unwrap();
+    }
+
+    match asm.feed(&analysis, "noun") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Nominatives");
+            assert_eq!(max, MAX_NOMINATIVES);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_genitives() {
+    let mut asm = Assembler::new();
+    let analysis = MorphAnalysis {
+        lemma: Cow::Borrowed("gen"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Genitive),
+        number: Some(Number::Singular),
+        gender: Some(Gender::Masculine),
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    for _ in 0..MAX_GENITIVES {
+        asm.feed(&analysis, "gen").unwrap();
+    }
+
+    match asm.feed(&analysis, "gen") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Genitives");
+            assert_eq!(max, MAX_GENITIVES);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_arrays() {
+    let mut asm = Assembler::new();
+    for _ in 0..MAX_ARRAYS {
+        asm.feed_array(vec![]).unwrap();
+    }
+
+    match asm.feed_array(vec![]) {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Arrays");
+            assert_eq!(max, MAX_ARRAYS);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_index_accesses() {
+    let mut asm = Assembler::new();
+    let array = Expr::NumberLiteral(1);
+    let index = Expr::NumberLiteral(0);
+
+    for _ in 0..MAX_INDEX_ACCESSES {
+        asm.feed_index_access(array.clone(), index.clone()).unwrap();
+    }
+
+    match asm.feed_index_access(array, index) {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Index Accesses");
+            assert_eq!(max, MAX_INDEX_ACCESSES);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_nested_phrases() {
+    let mut asm = Assembler::new();
+    for _ in 0..MAX_NESTED_PHRASES {
+        asm.feed_nested_phrase(vec![]).unwrap();
+    }
+
+    match asm.feed_nested_phrase(vec![]) {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Nested Phrases");
+            assert_eq!(max, MAX_NESTED_PHRASES);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_unwraps() {
+    let mut asm = Assembler::new();
+    let expr = Expr::Word(Word::new("x"));
+
+    for _ in 0..MAX_UNWRAPS {
+        asm.feed_unwrap(expr.clone()).unwrap();
+    }
+
+    match asm.feed_unwrap(expr) {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Unwraps");
+            assert_eq!(max, MAX_UNWRAPS);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_participles() {
+    let mut asm = Assembler::new();
+    let analysis = glossa::morphology::ParticipleAnalysis {
+        stem: "stem".to_string(),
+        tense: glossa::morphology::Tense::Present,
+        voice: glossa::morphology::Voice::Active,
+        case: Case::Nominative,
+        gender: Gender::Masculine,
+        number: Number::Singular,
+        confidence: 1.0,
+    };
+
+    for _ in 0..MAX_PARTICIPLES {
+        asm.feed_participle(&analysis, "part").unwrap();
+    }
+
+    match asm.feed_participle(&analysis, "part") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Participles");
+            assert_eq!(max, MAX_PARTICIPLES);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_blocks() {
+    let mut asm = Assembler::new();
+    for _ in 0..MAX_BLOCKS {
+        asm.feed_block(vec![]).unwrap();
+    }
+
+    match asm.feed_block(vec![]) {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Blocks");
+            assert_eq!(max, MAX_BLOCKS);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
     }
 }

--- a/tests/havoc_assembler_dos.rs
+++ b/tests/havoc_assembler_dos.rs
@@ -320,3 +320,63 @@ fn test_limit_property_accesses() {
     // Should succeed because it falls back to regular noun processing
     assert!(res.is_ok());
 }
+
+#[test]
+fn test_limit_string_method_properties() {
+    // This tests try_create_string_method (called by check_method_verbs)
+    let mut asm = Assembler::new();
+
+    let subj = MorphAnalysis {
+        lemma: Cow::Borrowed("subj"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Nominative),
+        number: Some(Number::Singular),
+        gender: Some(Gender::Neuter),
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    // "κατά" preposition for delimiter
+    let delimiter_prep = MorphAnalysis {
+        lemma: Cow::Borrowed("κατα"),
+        part_of_speech: PartOfSpeech::Preposition,
+        case: None, number: None, gender: None, person: None, tense: None, mood: None, voice: None, confidence: 1.0,
+    };
+
+    // "σχίζεται" (is split) verb
+    let split_verb = MorphAnalysis {
+        lemma: Cow::Borrowed("σχιζω"),
+        part_of_speech: PartOfSpeech::Verb,
+        case: None, number: None, gender: None, person: None, tense: None, mood: None, voice: None, confidence: 1.0,
+    };
+
+    // Fill up property accesses first (using standard property access to fill buffer)
+    let prop_analysis = MorphAnalysis {
+        lemma: Cow::Borrowed("μηκος"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Nominative),
+        number: None, gender: None, person: None, tense: None, mood: None, voice: None, confidence: 1.0,
+    };
+
+    for _ in 0..MAX_PROPERTY_ACCESSES {
+        asm.feed(&subj, "text").unwrap();
+        asm.feed(&prop_analysis, "μῆκος").unwrap();
+    }
+
+    // Now try to trigger a string method which would add another property access
+    asm.feed(&subj, "text").unwrap();
+    asm.feed(&delimiter_prep, "κατά").unwrap();
+    asm.feed_string(",".to_string()).unwrap(); // Delimiter literal
+
+    // Feed split verb - should fail to create method call (return false)
+    // and instead process as a regular verb
+    let res = asm.feed(&split_verb, "σχίζεται");
+
+    // Should be OK because it falls back to regular verb processing
+    assert!(res.is_ok());
+
+    // If we could check internal state, we'd see string_method is None
+}

--- a/tests/havoc_assembler_dos.rs
+++ b/tests/havoc_assembler_dos.rs
@@ -11,10 +11,12 @@ const MAX_NOMINATIVES: usize = 256;
 const MAX_GENITIVES: usize = 256;
 const MAX_ARRAYS: usize = 256;
 const MAX_INDEX_ACCESSES: usize = 256;
+const MAX_PROPERTY_ACCESSES: usize = 256;
 const MAX_NESTED_PHRASES: usize = 256;
 const MAX_PARTICIPLES: usize = 256;
 const MAX_UNWRAPS: usize = 256;
 const MAX_BLOCKS: usize = 256;
+const MAX_OPERATORS: usize = 256;
 
 #[test]
 fn test_limit_adjectives() {
@@ -232,4 +234,89 @@ fn test_limit_blocks() {
         }
         res => panic!("Expected LimitExceeded, got {:?}", res),
     }
+}
+
+#[test]
+fn test_limit_operators() {
+    // This tests the check_operators function which returns false on limit
+    let mut asm = Assembler::new();
+    // Use an analysis that triggers check_operators (e.g. "καί")
+    let analysis = MorphAnalysis {
+        lemma: Cow::Borrowed("και"),
+        part_of_speech: PartOfSpeech::Conjunction,
+        case: None,
+        number: None,
+        gender: None,
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    for _ in 0..MAX_OPERATORS {
+        // "καί" is an operator
+        asm.feed(&analysis, "καί").unwrap();
+    }
+
+    // This should NOT error with LimitExceeded, but should be silently ignored (return false internally)
+    // which means it falls through to regular handling (Conjunction -> Ok(()))
+    let res = asm.feed(&analysis, "καί");
+    assert!(res.is_ok(), "Operator limit should fallback silently, not error");
+
+    // Verify the operators vector didn't grow
+    // We can't access private fields, but we can infer behavior if we had a way to inspect
+    // For now, we trust the coverage tool to see the line hit
+}
+
+#[test]
+fn test_limit_property_accesses() {
+    // This tests check_special_properties which returns false on limit
+    let mut asm = Assembler::new();
+
+    // Setup subject for property access
+    let subj = MorphAnalysis {
+        lemma: Cow::Borrowed("subj"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Nominative),
+        number: Some(Number::Singular),
+        gender: Some(Gender::Neuter),
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    // We need to re-feed subject every time because property access consumes it!
+    // But we can't because nominatives list is limited.
+    // Actually, property access consumes `self.state.subject`.
+    // So we need to feed subject, then property access, repeat.
+
+    let prop_analysis = MorphAnalysis {
+        lemma: Cow::Borrowed("μηκος"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Nominative), // irrelevant
+        number: None,
+        gender: None,
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    for _ in 0..MAX_PROPERTY_ACCESSES {
+        // Feed subject
+        asm.feed(&subj, "text").unwrap();
+        // Feed property "μῆκος" (length)
+        asm.feed(&prop_analysis, "μῆκος").unwrap();
+    }
+
+    // Try one more
+    asm.feed(&subj, "text").unwrap();
+    let res = asm.feed(&prop_analysis, "μῆκος");
+
+    // Should succeed because it falls back to regular noun processing
+    assert!(res.is_ok());
 }

--- a/tests/havoc_assembler_dos.rs
+++ b/tests/havoc_assembler_dos.rs
@@ -1,7 +1,8 @@
+use std::borrow::Cow;
+
 use glossa::ast::{Expr, Word};
 use glossa::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
 use glossa::semantic::{Assembler, AssemblyError};
-use std::borrow::Cow;
 
 // Constants from src/semantic/assembler.rs
 const MAX_ADJECTIVES: usize = 1024;

--- a/tests/havoc_assembler_dos.rs
+++ b/tests/havoc_assembler_dos.rs
@@ -262,7 +262,10 @@ fn test_limit_operators() {
     // This should NOT error with LimitExceeded, but should be silently ignored (return false internally)
     // which means it falls through to regular handling (Conjunction -> Ok(()))
     let res = asm.feed(&analysis, "καί");
-    assert!(res.is_ok(), "Operator limit should fallback silently, not error");
+    assert!(
+        res.is_ok(),
+        "Operator limit should fallback silently, not error"
+    );
 
     // Verify the operators vector didn't grow
     // We can't access private fields, but we can infer behavior if we had a way to inspect
@@ -343,14 +346,28 @@ fn test_limit_string_method_properties() {
     let delimiter_prep = MorphAnalysis {
         lemma: Cow::Borrowed("κατα"),
         part_of_speech: PartOfSpeech::Preposition,
-        case: None, number: None, gender: None, person: None, tense: None, mood: None, voice: None, confidence: 1.0,
+        case: None,
+        number: None,
+        gender: None,
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
     };
 
     // "σχίζεται" (is split) verb
     let split_verb = MorphAnalysis {
         lemma: Cow::Borrowed("σχιζω"),
         part_of_speech: PartOfSpeech::Verb,
-        case: None, number: None, gender: None, person: None, tense: None, mood: None, voice: None, confidence: 1.0,
+        case: None,
+        number: None,
+        gender: None,
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
     };
 
     // Fill up property accesses first (using standard property access to fill buffer)
@@ -358,7 +375,13 @@ fn test_limit_string_method_properties() {
         lemma: Cow::Borrowed("μηκος"),
         part_of_speech: PartOfSpeech::Noun,
         case: Some(Case::Nominative),
-        number: None, gender: None, person: None, tense: None, mood: None, voice: None, confidence: 1.0,
+        number: None,
+        gender: None,
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
     };
 
     for _ in 0..MAX_PROPERTY_ACCESSES {

--- a/tests/havoc_assembler_dos.rs
+++ b/tests/havoc_assembler_dos.rs
@@ -1,9 +1,9 @@
+use glossa::semantic::{Assembler, AssemblyError};
 use glossa::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
-use glossa::semantic::Assembler;
 use std::borrow::Cow;
 
 #[test]
-fn test_assembler_unbounded_growth_vulnerability() {
+fn test_assembler_enforces_limits() {
     let mut asm = Assembler::new();
     let adj_analysis = MorphAnalysis {
         lemma: Cow::Borrowed("test_adj"),
@@ -18,13 +18,22 @@ fn test_assembler_unbounded_growth_vulnerability() {
         confidence: 1.0,
     };
 
-    // Havoc: Prove we can push 10,000 items without error (Fragility)
-    // This test PASSES if the vulnerability exists (unbounded growth allowed)
-    for _ in 0..10_000 {
+    // Fill up to the limit (1024)
+    for _ in 0..1024 {
         let res = asm.feed(&adj_analysis, "test_adj");
-        assert!(
-            res.is_ok(),
-            "Assembler unexpectedly enforced a limit! Vulnerability fixed?"
-        );
+        assert!(res.is_ok(), "Should accept up to 1024 adjectives");
+    }
+
+    // Attempt to exceed the limit
+    let res = asm.feed(&adj_analysis, "test_adj");
+
+    // Sentry: Assert that we get the correct LimitExceeded error
+    match res {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Adjectives");
+            assert_eq!(max, 1024);
+        }
+        Err(e) => panic!("Expected LimitExceeded, got {:?}", e),
+        Ok(_) => panic!("Assembler allowed unbounded growth! Expected LimitExceeded error."),
     }
 }


### PR DESCRIPTION
Enforced resource limits in the Assembler to prevent Denial of Service (DoS) attacks via unbounded vector growth. Added `AssemblyError::LimitExceeded` and implemented checks in all feed and handle methods. Updated tests to verify that exceeding limits now returns an error instead of succeeding.

---
*PR created automatically by Jules for task [18231041588901037503](https://jules.google.com/task/18231041588901037503) started by @madmax983*