### PR TITLE
🔒 Warden: Prevent stack overflow via semantic depth limit

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -73,3 +73,11 @@
 2. **Standard Method Allowlist:** Added `GlossaType::Unknown` to `is_std_type` in `src/codegen/rust.rs` to prevent prefixing standard methods on inferred/iterator types.
 
 **Severity:** Medium (DoS via CPU exhaustion & Compilation Failure).
+
+## 2026-06-05 - Stack Overflow DoS in Semantic Analysis
+
+**Threat:** Stack Overflow (DoS) in `src/semantic/mod.rs` and `src/codegen/rust.rs`. Deeply nested expression trees (e.g., `1 + 1 + ...`) caused unbounded recursion during semantic analysis and code generation, crashing the compiler with a stack overflow.
+
+**Defense:** Implemented `check_program_depth` in `src/semantic/mod.rs` to enforce a strict recursion limit (`MAX_EXPRESSION_DEPTH = 200`). Analysis now fails gracefully with `GlossaError::LimitExceeded` if the depth is exceeded.
+
+**Severity:** High (DoS via compiler crash).

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -52,6 +52,10 @@ pub enum GlossaError {
     #[diagnostic(code(glossa::io))]
     IoError { message: String },
 
+    #[error("Ὑπέρβασις ὀρίου: {resource} ({max})")]
+    #[diagnostic(code(glossa::limit_exceeded))]
+    LimitExceeded { resource: String, max: usize },
+
     #[error(transparent)]
     #[diagnostic(transparent)]
     AssemblyError(#[from] assembly::AssemblyError),
@@ -130,6 +134,7 @@ impl GlossaError {
             GlossaError::AgreementError { .. } => "Συμφωνία",
             GlossaError::CodegenError { .. } => "Κῶδιξ",
             GlossaError::IoError { .. } => "Ἀρχεῖον",
+            GlossaError::LimitExceeded { .. } => "Όριον",
             GlossaError::AssemblyError(_) => "Συναρμογή",
         }
     }

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -95,10 +95,164 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
         analyzed_statements.extend(analyze_statement(stmt, &mut scope)?);
     }
 
-    Ok(AnalyzedProgram {
+    let analyzed = AnalyzedProgram {
         statements: analyzed_statements,
         scope,
-    })
+    };
+
+    check_program_depth(&analyzed)?;
+
+    Ok(analyzed)
+}
+
+const MAX_EXPRESSION_DEPTH: usize = 200;
+
+fn check_program_depth(program: &AnalyzedProgram) -> Result<(), GlossaError> {
+    for stmt in &program.statements {
+        check_statement_depth(stmt, 0)?;
+    }
+    Ok(())
+}
+
+fn check_statement_depth(stmt: &AnalyzedStatement, depth: usize) -> Result<(), GlossaError> {
+    if depth > MAX_EXPRESSION_DEPTH {
+        return Err(GlossaError::LimitExceeded {
+            resource: "statement depth".into(),
+            max: MAX_EXPRESSION_DEPTH,
+        });
+    }
+
+    match stmt {
+        AnalyzedStatement::Binding { value, .. } | AnalyzedStatement::Assignment { value, .. } => {
+            check_expr_depth(value, depth + 1)?;
+        }
+        AnalyzedStatement::Print(exprs)
+        | AnalyzedStatement::Expression(exprs)
+        | AnalyzedStatement::Query(exprs) => {
+            for expr in exprs {
+                check_expr_depth(expr, depth + 1)?;
+            }
+        }
+        AnalyzedStatement::If {
+            condition,
+            then_body,
+            else_body,
+        } => {
+            check_expr_depth(condition, depth + 1)?;
+            for s in then_body {
+                check_statement_depth(s, depth + 1)?;
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    check_statement_depth(s, depth + 1)?;
+                }
+            }
+        }
+        AnalyzedStatement::While { condition, body } => {
+            check_expr_depth(condition, depth + 1)?;
+            for s in body {
+                check_statement_depth(s, depth + 1)?;
+            }
+        }
+        AnalyzedStatement::For { iterator, body, .. } => {
+            check_expr_depth(iterator, depth + 1)?;
+            for s in body {
+                check_statement_depth(s, depth + 1)?;
+            }
+        }
+        AnalyzedStatement::Match { scrutinee, arms } => {
+            check_expr_depth(scrutinee, depth + 1)?;
+            for (pat, body) in arms {
+                check_expr_depth(pat, depth + 1)?;
+                for s in body {
+                    check_statement_depth(s, depth + 1)?;
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { body, .. }
+        | AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                check_statement_depth(s, depth + 1)?;
+            }
+        }
+        AnalyzedStatement::Return { value } => {
+            if let Some(v) = value {
+                check_expr_depth(v, depth + 1)?;
+            }
+        }
+        AnalyzedStatement::Break
+        | AnalyzedStatement::Continue
+        | AnalyzedStatement::TypeDefinition { .. }
+        | AnalyzedStatement::TraitDefinition { .. }
+        | AnalyzedStatement::TraitImplementation { .. } => {}
+    }
+    Ok(())
+}
+
+fn check_expr_depth(expr: &AnalyzedExpr, depth: usize) -> Result<(), GlossaError> {
+    if depth > MAX_EXPRESSION_DEPTH {
+        return Err(GlossaError::LimitExceeded {
+            resource: "expression depth".into(),
+            max: MAX_EXPRESSION_DEPTH,
+        });
+    }
+
+    match &expr.expr {
+        AnalyzedExprKind::PropertyAccess { owner, .. } => check_expr_depth(owner, depth + 1)?,
+        AnalyzedExprKind::VerbCall { args, .. } | AnalyzedExprKind::FunctionCall { args, .. } => {
+            for arg in args {
+                check_expr_depth(arg, depth + 1)?;
+            }
+        }
+        AnalyzedExprKind::BinOp { left, right, .. } => {
+            check_expr_depth(left, depth + 1)?;
+            check_expr_depth(right, depth + 1)?;
+        }
+        AnalyzedExprKind::UnaryOp { operand, .. } => check_expr_depth(operand, depth + 1)?,
+        AnalyzedExprKind::Range { start, end, .. } => {
+            check_expr_depth(start, depth + 1)?;
+            check_expr_depth(end, depth + 1)?;
+        }
+        AnalyzedExprKind::ArrayLiteral(exprs) => {
+            for e in exprs {
+                check_expr_depth(e, depth + 1)?;
+            }
+        }
+        AnalyzedExprKind::Some(e)
+        | AnalyzedExprKind::Ok(e)
+        | AnalyzedExprKind::Err(e)
+        | AnalyzedExprKind::Unwrap(e)
+        | AnalyzedExprKind::Try(e) => check_expr_depth(e, depth + 1)?,
+        AnalyzedExprKind::IndexAccess { array, index } => {
+            check_expr_depth(array, depth + 1)?;
+            check_expr_depth(index, depth + 1)?;
+        }
+        AnalyzedExprKind::MethodCall { receiver, args, .. }
+        | AnalyzedExprKind::TraitMethodCall { receiver, args, .. } => {
+            check_expr_depth(receiver, depth + 1)?;
+            for arg in args {
+                check_expr_depth(arg, depth + 1)?;
+            }
+        }
+        AnalyzedExprKind::StructInstantiation { args, .. } => {
+            for arg in args {
+                check_expr_depth(arg, depth + 1)?;
+            }
+        }
+        AnalyzedExprKind::Lambda { body, .. } => check_expr_depth(body, depth + 1)?,
+        AnalyzedExprKind::Assert { condition } => check_expr_depth(condition, depth + 1)?,
+        AnalyzedExprKind::AssertEq { left, right } => {
+            check_expr_depth(left, depth + 1)?;
+            check_expr_depth(right, depth + 1)?;
+        }
+        AnalyzedExprKind::StringLiteral(_)
+        | AnalyzedExprKind::NumberLiteral(_)
+        | AnalyzedExprKind::BooleanLiteral(_)
+        | AnalyzedExprKind::Variable(_)
+        | AnalyzedExprKind::None
+        | AnalyzedExprKind::CollectionNew { .. } => {}
+    }
+    Ok(())
 }
 
 /// Analyze a single statement (which might produce multiple analyzed statements if it's a block)

--- a/tests/havoc_overflow.rs
+++ b/tests/havoc_overflow.rs
@@ -1,6 +1,6 @@
+use glossa::errors::GlossaError;
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
-use glossa::errors::GlossaError;
 
 /// 👺 Havoc: Stack Overflow Mitigation
 ///
@@ -28,7 +28,9 @@ fn test_stack_overflow_mitigation() {
     println!("Analyzing...");
     // This should fail gracefully with LimitExceeded
     match analyze_program(&ast) {
-        Ok(_) => panic!("Expected depth limit exceeded error, but analysis succeeded! The mitigation failed."),
+        Ok(_) => panic!(
+            "Expected depth limit exceeded error, but analysis succeeded! The mitigation failed."
+        ),
         Err(e) => {
             println!("Caught expected error: {:?}", e);
             if !matches!(e, GlossaError::LimitExceeded { .. }) {

--- a/tests/havoc_overflow.rs
+++ b/tests/havoc_overflow.rs
@@ -1,51 +1,39 @@
-use glossa::codegen::generate_rust;
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
-use std::thread;
+use glossa::errors::GlossaError;
 
-/// 👺 Havoc: Stack Overflow in CodeGen via Deep Expression Trees
+/// 👺 Havoc: Stack Overflow Mitigation
 ///
-/// This test demonstrates a stack overflow vulnerability in `generate_rust`.
-/// The parser limits recursion depth to 500, but binary expressions (e.g., `1 + 1 + ...`)
-/// are parsed iteratively into a flat `AnalyzedExpr` tree.
-/// However, `generate_rust` processes this tree recursively, causing a stack overflow
-/// when the tree depth exceeds the stack size.
+/// This test originally demonstrated a stack overflow in `generate_rust` due to deep recursion.
+/// Warden has mitigated this by enforcing a semantic depth limit (MAX_EXPRESSION_DEPTH).
 ///
-/// We "fix" the test crash by running it in a thread with a massive stack.
-/// This proves the code is correct (just stack-hungry).
+/// Instead of needing a massive stack to survive, the compiler should now strictly reject
+/// deeply nested expressions with a `LimitExceeded` error.
 #[test]
-fn test_stack_overflow_expression() {
-    // Spawn a thread with 32MB stack.
-    let builder = thread::Builder::new().stack_size(32 * 1024 * 1024);
+fn test_stack_overflow_mitigation() {
+    // Generate a massive expression: 1 + 1 + 1 + ...
+    // Depth 1000 exceeds the limit (200)
+    let n = 1_000;
+    let mut s = String::with_capacity(n * 15);
+    s.push('1');
+    for _ in 0..n {
+        // "ἄθροισμα" means "+" (sum)
+        s.push_str(" ἄθροισμα 1");
+    }
+    s.push_str(" λέγε.");
 
-    let handler = builder
-        .spawn(|| {
-            // Generate a massive expression: 1 + 1 + 1 + ...
-            // We use 1000 to ensure it passes with the custom stack size.
-            // This is still 2x the parser's nesting limit (500), proving we bypassed it.
-            let n = 1_000;
-            let mut s = String::with_capacity(n * 15);
-            s.push('1');
-            for _ in 0..n {
-                // "ἄθροισμα" means "+" (sum)
-                s.push_str(" ἄθροισμα 1");
+    println!("Parsing...");
+    let ast = parse(&s).expect("Failed to parse");
+
+    println!("Analyzing...");
+    // This should fail gracefully with LimitExceeded
+    match analyze_program(&ast) {
+        Ok(_) => panic!("Expected depth limit exceeded error, but analysis succeeded! The mitigation failed."),
+        Err(e) => {
+            println!("Caught expected error: {:?}", e);
+            if !matches!(e, GlossaError::LimitExceeded { .. }) {
+                panic!("Expected LimitExceeded error, got: {:?}", e);
             }
-            s.push_str(" λέγε.");
-
-            println!("Parsing...");
-            // This works fine (linear loop in parser)
-            let ast = parse(&s).expect("Failed to parse");
-
-            println!("Analyzing...");
-            // This works fine (linear loop in build_expressions_from_literals_and_ops)
-            let analyzed = analyze_program(&ast).expect("Failed to analyze");
-
-            println!("Generating...");
-            // This should pass with 32MB stack
-            let code = generate_rust(&analyzed);
-            assert!(!code.is_empty());
-        })
-        .unwrap();
-
-    handler.join().unwrap();
+        }
+    }
 }


### PR DESCRIPTION
Implemented a recursion depth check in the semantic analysis phase to prevent stack overflows during compilation of deeply nested expressions. This mitigates a DoS vector.

---
*PR created automatically by Jules for task [9023102523851322987](https://jules.google.com/task/9023102523851322987) started by @madmax983*