### PR TITLE
👺 Havoc: Enforce strict resource limits in Assembler

### DIFF
--- a/src/errors/assembly.rs
+++ b/src/errors/assembly.rs
@@ -72,4 +72,12 @@ pub enum AssemblyError {
         word2: String,
         gender2: Gender,
     },
+
+    /// Resource limit exceeded during assembly (DoS protection)
+    ///
+    /// # Example
+    /// Too many adjectives, too many nested blocks, etc.
+    #[error("Ὅριον ὑπερβαῖνον: {resource} (μέγιστον: {max})")]
+    #[diagnostic(code(glossa::assembly::limit_exceeded))]
+    LimitExceeded { resource: String, max: usize },
 }

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -418,11 +418,7 @@ impl Assembler {
         analysis: &crate::morphology::ParticipleAnalysis,
         original: &str,
     ) -> Result<(), AssemblyError> {
-        self.check_limit(
-            self.state.participles.len(),
-            MAX_PARTICIPLES,
-            "participles",
-        )?;
+        self.check_limit(self.state.participles.len(), MAX_PARTICIPLES, "participles")?;
         let constituent = ParticipleConstituent {
             verb_lemma: analysis.verb_lemma().into(),
             original: original.into(),
@@ -463,11 +459,7 @@ impl Assembler {
 
                 if self.state.subject.is_some() {
                     // Additional nominatives stored separately for function call patterns
-                    self.check_limit(
-                        self.state.nominatives.len(),
-                        MAX_NOMINATIVES,
-                        "nominatives",
-                    )?;
+                    self.check_limit(self.state.nominatives.len(), MAX_NOMINATIVES, "nominatives")?;
                     self.state.nominatives.push(constituent);
                 } else {
                     self.state.subject = Some(constituent);
@@ -679,11 +671,7 @@ impl Assembler {
     }
 
     /// Check for operators (boolean, comparison, arithmetic)
-    fn check_operators(
-        &mut self,
-        normalized: &str,
-        original: &str,
-    ) -> Result<bool, AssemblyError> {
+    fn check_operators(&mut self, normalized: &str, original: &str) -> Result<bool, AssemblyError> {
         // Boolean operators
         if matches!(original, "καί" | "και") {
             self.check_limit(self.state.operators.len(), MAX_OPERATORS, "operators")?;

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -102,6 +102,20 @@ use crate::morphology::{
 use crate::text::normalize_greek;
 use smol_str::SmolStr;
 
+// Resource limits to prevent DoS
+const MAX_ADJECTIVES: usize = 1024;
+const MAX_LITERALS: usize = 1024;
+const MAX_NOMINATIVES: usize = 256;
+const MAX_GENITIVES: usize = 256;
+const MAX_ARRAYS: usize = 256;
+const MAX_BLOCKS: usize = 256;
+const MAX_OPERATORS: usize = 256;
+const MAX_PROPERTY_ACCESSES: usize = 256;
+const MAX_INDEX_ACCESSES: usize = 256;
+const MAX_NESTED_PHRASES: usize = 256;
+const MAX_PARTICIPLES: usize = 256;
+const MAX_UNWRAPS: usize = 256;
+
 /// The slot-based assembler
 ///
 /// Feed it tokens one by one, and it routes them to the appropriate slot
@@ -136,6 +150,17 @@ impl Assembler {
         Assembler {
             state: AssembledStatement::default(),
         }
+    }
+
+    /// Check if a resource limit has been reached
+    fn check_limit(&self, current: usize, max: usize, resource: &str) -> Result<(), AssemblyError> {
+        if current >= max {
+            return Err(AssemblyError::LimitExceeded {
+                resource: resource.to_string(),
+                max,
+            });
+        }
+        Ok(())
     }
 
     /// Mark this statement as a query
@@ -187,15 +212,15 @@ impl Assembler {
             return Ok(());
         }
 
-        if self.check_method_verbs(normalized) {
+        if self.check_method_verbs(normalized)? {
             return Ok(());
         }
 
-        if self.check_operators(normalized, original) {
+        if self.check_operators(normalized, original)? {
             return Ok(());
         }
 
-        if self.check_special_properties(normalized) {
+        if self.check_special_properties(normalized)? {
             return Ok(());
         }
 
@@ -226,6 +251,7 @@ impl Assembler {
     /// asm.feed_string("χαῖρε".to_string()).unwrap();
     /// ```
     pub fn feed_string(&mut self, value: String) -> Result<(), AssemblyError> {
+        self.check_limit(self.state.literals.len(), MAX_LITERALS, "literals")?;
         self.state.literals.push(Literal::String(value));
         Ok(())
     }
@@ -241,6 +267,7 @@ impl Assembler {
     /// asm.feed_number(42).unwrap();
     /// ```
     pub fn feed_number(&mut self, value: i64) -> Result<(), AssemblyError> {
+        self.check_limit(self.state.literals.len(), MAX_LITERALS, "literals")?;
         self.state.literals.push(Literal::Number(value));
         Ok(())
     }
@@ -256,6 +283,7 @@ impl Assembler {
     /// asm.feed_boolean(true).unwrap();
     /// ```
     pub fn feed_boolean(&mut self, value: bool) -> Result<(), AssemblyError> {
+        self.check_limit(self.state.literals.len(), MAX_LITERALS, "literals")?;
         self.state.literals.push(Literal::Boolean(value));
         Ok(())
     }
@@ -273,6 +301,7 @@ impl Assembler {
     /// asm.feed_array(elements).unwrap();
     /// ```
     pub fn feed_array(&mut self, elements: Vec<Expr>) -> Result<(), AssemblyError> {
+        self.check_limit(self.state.arrays.len(), MAX_ARRAYS, "arrays")?;
         self.state.arrays.push(elements);
         Ok(())
     }
@@ -291,6 +320,7 @@ impl Assembler {
         &mut self,
         statements: Vec<crate::ast::Statement>,
     ) -> Result<(), AssemblyError> {
+        self.check_limit(self.state.blocks.len(), MAX_BLOCKS, "blocks")?;
         self.state.blocks.push(statements);
         Ok(())
     }
@@ -307,6 +337,11 @@ impl Assembler {
     /// asm.feed_nested_phrase(vec![Expr::NumberLiteral(1)]).unwrap();
     /// ```
     pub fn feed_nested_phrase(&mut self, terms: Vec<Expr>) -> Result<(), AssemblyError> {
+        self.check_limit(
+            self.state.nested_phrases.len(),
+            MAX_NESTED_PHRASES,
+            "nested_phrases",
+        )?;
         self.state.nested_phrases.push(terms);
         Ok(())
     }
@@ -328,6 +363,11 @@ impl Assembler {
     /// asm.feed_index_access(array, index).unwrap();
     /// ```
     pub fn feed_index_access(&mut self, array: Expr, index: Expr) -> Result<(), AssemblyError> {
+        self.check_limit(
+            self.state.index_accesses.len(),
+            MAX_INDEX_ACCESSES,
+            "index_accesses",
+        )?;
         self.state.index_accesses.push((array, index));
         Ok(())
     }
@@ -348,6 +388,7 @@ impl Assembler {
     /// asm.feed_unwrap(expr).unwrap();
     /// ```
     pub fn feed_unwrap(&mut self, expr: Expr) -> Result<(), AssemblyError> {
+        self.check_limit(self.state.unwraps.len(), MAX_UNWRAPS, "unwraps")?;
         self.state.unwraps.push(expr);
         Ok(())
     }
@@ -377,6 +418,11 @@ impl Assembler {
         analysis: &crate::morphology::ParticipleAnalysis,
         original: &str,
     ) -> Result<(), AssemblyError> {
+        self.check_limit(
+            self.state.participles.len(),
+            MAX_PARTICIPLES,
+            "participles",
+        )?;
         let constituent = ParticipleConstituent {
             verb_lemma: analysis.verb_lemma().into(),
             original: original.into(),
@@ -417,6 +463,11 @@ impl Assembler {
 
                 if self.state.subject.is_some() {
                     // Additional nominatives stored separately for function call patterns
+                    self.check_limit(
+                        self.state.nominatives.len(),
+                        MAX_NOMINATIVES,
+                        "nominatives",
+                    )?;
                     self.state.nominatives.push(constituent);
                 } else {
                     self.state.subject = Some(constituent);
@@ -437,6 +488,7 @@ impl Assembler {
             }
             Some(Case::Genitive) => {
                 // Genitives attach to other constituents (possession, etc.)
+                self.check_limit(self.state.genitives.len(), MAX_GENITIVES, "genitives")?;
                 self.state.genitives.push(constituent);
             }
             Some(Case::Vocative) => {
@@ -502,6 +554,7 @@ impl Assembler {
             person: None, // Adjectives don't really have person
         };
 
+        self.check_limit(self.state.adjectives.len(), MAX_ADJECTIVES, "adjectives")?;
         self.state.adjectives.push(constituent);
         Ok(())
     }
@@ -580,7 +633,7 @@ impl Assembler {
 
     /// Helper to create a string method call if conditions are met
     #[allow(clippy::collapsible_if)]
-    fn try_create_string_method(&mut self, method_name: &str) -> bool {
+    fn try_create_string_method(&mut self, method_name: &str) -> Result<bool, AssemblyError> {
         if self.state.has_delimiter_preposition
             && matches!(self.state.literals.last(), Some(Literal::String(_)))
         {
@@ -592,68 +645,82 @@ impl Assembler {
 
                 let normalized_original = normalize_greek(&subj.original);
                 self.state.string_method = Some((method_name.to_string(), delim));
+                self.check_limit(
+                    self.state.property_accesses.len(),
+                    MAX_PROPERTY_ACCESSES,
+                    "property_accesses",
+                )?;
                 self.state
                     .property_accesses
                     .push((normalized_original.to_string(), method_name.to_string()));
-                return true;
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
     }
 
     /// Check for method verbs (split, join)
-    fn check_method_verbs(&mut self, normalized: &str) -> bool {
+    fn check_method_verbs(&mut self, normalized: &str) -> Result<bool, AssemblyError> {
         // Check for split verb
         if crate::morphology::lexicon::is_split_verb(normalized)
-            && self.try_create_string_method("split")
+            && self.try_create_string_method("split")?
         {
-            return true;
+            return Ok(true);
         }
 
         // Check for join verb
         if crate::morphology::lexicon::is_join_verb(normalized)
-            && self.try_create_string_method("join")
+            && self.try_create_string_method("join")?
         {
-            return true;
+            return Ok(true);
         }
 
-        false
+        Ok(false)
     }
 
     /// Check for operators (boolean, comparison, arithmetic)
-    fn check_operators(&mut self, normalized: &str, original: &str) -> bool {
+    fn check_operators(
+        &mut self,
+        normalized: &str,
+        original: &str,
+    ) -> Result<bool, AssemblyError> {
         // Boolean operators
         if matches!(original, "καί" | "και") {
+            self.check_limit(self.state.operators.len(), MAX_OPERATORS, "operators")?;
             self.state.operators.push(BinaryOp::And);
-            return true;
+            return Ok(true);
         }
         if matches!(original, "ἤ" | "ή") {
             // ἤ with breathing+accent, but not ᾖ
+            self.check_limit(self.state.operators.len(), MAX_OPERATORS, "operators")?;
             self.state.operators.push(BinaryOp::Or);
-            return true;
+            return Ok(true);
         }
 
         // Comparison operators
         if let Some(op) = crate::morphology::lexicon::comparison_operator(normalized) {
+            self.check_limit(self.state.operators.len(), MAX_OPERATORS, "operators")?;
             self.state.operators.push(op);
-            return true;
+            return Ok(true);
         }
 
         // Arithmetic operators
         if let Some(op) = crate::morphology::lexicon::arithmetic_operator(normalized) {
+            self.check_limit(self.state.operators.len(), MAX_OPERATORS, "operators")?;
             self.state.operators.push(op);
-            return true;
+            return Ok(true);
         }
 
-        false
+        Ok(false)
     }
 
     /// Check for special properties (numerals, length, ordinals)
-    fn check_special_properties(&mut self, normalized: &str) -> bool {
+    fn check_special_properties(&mut self, normalized: &str) -> Result<bool, AssemblyError> {
         // Numeral words
         if let Some(value) = crate::morphology::lexicon::numeral_value(normalized) {
+            self.check_limit(self.state.literals.len(), MAX_LITERALS, "literals")?;
             self.state.literals.push(Literal::Number(value));
-            return true;
+            return Ok(true);
         }
 
         // Property nouns (μῆκος)
@@ -661,11 +728,16 @@ impl Assembler {
             // If we have a subject, create a property access (use normalized original, not lemma)
             if let Some(ref subj) = self.state.subject {
                 let normalized_original = crate::text::normalize_greek(&subj.original);
+                self.check_limit(
+                    self.state.property_accesses.len(),
+                    MAX_PROPERTY_ACCESSES,
+                    "property_accesses",
+                )?;
                 self.state
                     .property_accesses
                     .push((normalized_original.to_string(), "len".to_string()));
                 self.state.subject = None; // Consume the subject
-                return true;
+                return Ok(true);
             }
         }
 
@@ -683,13 +755,18 @@ impl Assembler {
                 });
                 let index_expr = Expr::NumberLiteral(index);
 
+                self.check_limit(
+                    self.state.index_accesses.len(),
+                    MAX_INDEX_ACCESSES,
+                    "index_accesses",
+                )?;
                 self.state.index_accesses.push((array, index_expr));
                 self.state.subject = None; // Consume the subject
-                return true;
+                return Ok(true);
             }
         }
 
-        false
+        Ok(false)
     }
 
     /// Check if the assembler has any pending content

--- a/tests/havoc_assembler_dos.rs
+++ b/tests/havoc_assembler_dos.rs
@@ -1,6 +1,6 @@
-use glossa::semantic::Assembler;
-use glossa::morphology::{MorphAnalysis, PartOfSpeech, Case, Number, Gender};
 use glossa::ast::Expr;
+use glossa::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
+use glossa::semantic::Assembler;
 
 #[test]
 fn test_assembler_adjective_dos() {
@@ -28,7 +28,10 @@ fn test_assembler_adjective_dos() {
     }
 
     // The test expects the assembler to REJECT the excessive input
-    assert!(failed, "Assembler accepted infinite adjectives (DoS vulnerability)");
+    assert!(
+        failed,
+        "Assembler accepted infinite adjectives (DoS vulnerability)"
+    );
 }
 
 #[test]
@@ -44,7 +47,10 @@ fn test_assembler_literal_dos() {
         }
     }
 
-    assert!(failed, "Assembler accepted infinite string literals (DoS vulnerability)");
+    assert!(
+        failed,
+        "Assembler accepted infinite string literals (DoS vulnerability)"
+    );
 }
 
 #[test]
@@ -61,7 +67,10 @@ fn test_assembler_array_dos() {
         }
     }
 
-    assert!(failed, "Assembler accepted infinite arrays (DoS vulnerability)");
+    assert!(
+        failed,
+        "Assembler accepted infinite arrays (DoS vulnerability)"
+    );
 }
 
 #[test]
@@ -78,5 +87,8 @@ fn test_assembler_nested_phrase_dos() {
         }
     }
 
-    assert!(failed, "Assembler accepted infinite nested phrases (DoS vulnerability)");
+    assert!(
+        failed,
+        "Assembler accepted infinite nested phrases (DoS vulnerability)"
+    );
 }

--- a/tests/havoc_assembler_dos.rs
+++ b/tests/havoc_assembler_dos.rs
@@ -1,12 +1,12 @@
-use glossa::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
 use glossa::semantic::Assembler;
-use std::borrow::Cow;
+use glossa::morphology::{MorphAnalysis, PartOfSpeech, Case, Number, Gender};
+use glossa::ast::Expr;
 
 #[test]
-fn test_assembler_unbounded_growth_vulnerability() {
+fn test_assembler_adjective_dos() {
     let mut asm = Assembler::new();
-    let adj_analysis = MorphAnalysis {
-        lemma: Cow::Borrowed("test_adj"),
+    let adj = MorphAnalysis {
+        lemma: "καλός".into(),
         part_of_speech: PartOfSpeech::Adjective,
         case: Some(Case::Nominative),
         number: Some(Number::Singular),
@@ -18,13 +18,65 @@ fn test_assembler_unbounded_growth_vulnerability() {
         confidence: 1.0,
     };
 
-    // Havoc: Prove we can push 10,000 items without error (Fragility)
-    // This test PASSES if the vulnerability exists (unbounded growth allowed)
-    for _ in 0..10_000 {
-        let res = asm.feed(&adj_analysis, "test_adj");
-        assert!(
-            res.is_ok(),
-            "Assembler unexpectedly enforced a limit! Vulnerability fixed?"
-        );
+    // Feed 2000 adjectives (limit should be 1024)
+    let mut failed = false;
+    for _ in 0..2000 {
+        if asm.feed(&adj, "καλός").is_err() {
+            failed = true;
+            break;
+        }
     }
+
+    // The test expects the assembler to REJECT the excessive input
+    assert!(failed, "Assembler accepted infinite adjectives (DoS vulnerability)");
+}
+
+#[test]
+fn test_assembler_literal_dos() {
+    let mut asm = Assembler::new();
+
+    // Feed 2000 strings (limit should be 1024)
+    let mut failed = false;
+    for i in 0..2000 {
+        if asm.feed_string(format!("test_{}", i)).is_err() {
+            failed = true;
+            break;
+        }
+    }
+
+    assert!(failed, "Assembler accepted infinite string literals (DoS vulnerability)");
+}
+
+#[test]
+fn test_assembler_array_dos() {
+    let mut asm = Assembler::new();
+    let elements = vec![Expr::NumberLiteral(1)];
+
+    // Feed 1000 arrays (limit should be 256)
+    let mut failed = false;
+    for _ in 0..1000 {
+        if asm.feed_array(elements.clone()).is_err() {
+            failed = true;
+            break;
+        }
+    }
+
+    assert!(failed, "Assembler accepted infinite arrays (DoS vulnerability)");
+}
+
+#[test]
+fn test_assembler_nested_phrase_dos() {
+    let mut asm = Assembler::new();
+    let elements = vec![Expr::NumberLiteral(1)];
+
+    // Feed 1000 nested phrases (limit should be 256)
+    let mut failed = false;
+    for _ in 0..1000 {
+        if asm.feed_nested_phrase(elements.clone()).is_err() {
+            failed = true;
+            break;
+        }
+    }
+
+    assert!(failed, "Assembler accepted infinite nested phrases (DoS vulnerability)");
 }

--- a/tests/havoc_overflow.rs
+++ b/tests/havoc_overflow.rs
@@ -1,4 +1,3 @@
-use glossa::codegen::generate_rust;
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
 use std::thread;
@@ -37,13 +36,18 @@ fn test_stack_overflow_expression() {
             let ast = parse(&s).expect("Failed to parse");
 
             println!("Analyzing...");
-            // This works fine (linear loop in build_expressions_from_literals_and_ops)
-            let analyzed = analyze_program(&ast).expect("Failed to analyze");
+            // Now that we have strict resource limits (MAX_OPERATORS=256),
+            // this massive expression should be rejected gracefully.
+            let result = analyze_program(&ast);
 
-            println!("Generating...");
-            // This should pass with 32MB stack
-            let code = generate_rust(&analyzed);
-            assert!(!code.is_empty());
+            match result {
+                Ok(_) => panic!("Should have failed with LimitExceeded"),
+                Err(e) => {
+                    let msg = e.to_string();
+                    assert!(msg.contains("Ὅριον ὑπερβαῖνον"), "Expected limit error, got: {}", msg);
+                    assert!(msg.contains("operators"), "Expected operator limit, got: {}", msg);
+                }
+            }
         })
         .unwrap();
 

--- a/tests/havoc_overflow.rs
+++ b/tests/havoc_overflow.rs
@@ -44,8 +44,16 @@ fn test_stack_overflow_expression() {
                 Ok(_) => panic!("Should have failed with LimitExceeded"),
                 Err(e) => {
                     let msg = e.to_string();
-                    assert!(msg.contains("Ὅριον ὑπερβαῖνον"), "Expected limit error, got: {}", msg);
-                    assert!(msg.contains("operators"), "Expected operator limit, got: {}", msg);
+                    assert!(
+                        msg.contains("Ὅριον ὑπερβαῖνον"),
+                        "Expected limit error, got: {}",
+                        msg
+                    );
+                    assert!(
+                        msg.contains("operators"),
+                        "Expected operator limit, got: {}",
+                        msg
+                    );
                 }
             }
         })


### PR DESCRIPTION
Mitigate DoS vulnerability where unbounded accumulation of tokens could cause memory exhaustion.

Changes:
- Added `MAX_*` constants to `src/semantic/assembler.rs`.
- Implemented `check_limit` helper to enforce limits on all internal vectors.
- Added `LimitExceeded` variant to `AssemblyError` with localized Greek message.
- Updated helper methods to propagate errors.
- Added regression test `tests/havoc_assembler_dos.rs`.
- Updated `tests/havoc_overflow.rs` to expect graceful failure.

---
*PR created automatically by Jules for task [9958222954108775571](https://jules.google.com/task/9958222954108775571) started by @madmax983*