### PR TITLE
docs: Add ADR and Architecture Diagram for Storage Module

### DIFF
--- a/docs/adr/010-decouple-storage.md
+++ b/docs/adr/010-decouple-storage.md
@@ -1,0 +1,24 @@
+# 10. Decouple Storage from Core
+
+Date: 2025-05-20
+
+## Status
+
+Proposed
+
+## Context
+
+Circular dependencies between the core compiler modules and the persistence logic were causing build failures and making it difficult to test components in isolation. The `storage` logic was tightly coupled with `semantic` analysis, leading to a monolithic structure.
+
+## Decision
+
+We will move all persistence and storage logic to a dedicated `storage` module (or crate).
+
+1.  **Create `src/storage/`:** A new module for persistence.
+2.  **Decouple:** The core compiler will interact with storage via a trait boundary, removing the direct dependency.
+
+## Consequences
+
+*   **Build Times:** Compilation time should improve due to better parallelism.
+*   **Complexity:** FFI complexity might increase if we extract this to a separate crate later.
+*   **Testing:** Storage logic can be tested independently of the compiler core.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,7 @@ C4Container
     Container(highlight, "Highlighter", "src/highlight.rs", "Semantic syntax highlighting")
     Container(report, "Reporter", "src/report.rs", "Generates statistics and structured reports")
     Container(codegen, "Code Generator", "src/codegen", "Generates Rust source code")
+    Container(storage, "Storage", "src/storage", "Decoupled Persistence Logic")
 
     Rel(lexer, parser, "Stream<Token>")
     Rel(parser, morphology, "AST (Unresolved)")
@@ -41,6 +42,17 @@ C4Container
     Rel(morphology, semantic, "AST (Resolved Morphology)")
     Rel(semantic, report, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
+    Rel(semantic, storage, "Uses (Trait Bound)")
+```
+
+## Storage Architecture (Class Diagram)
+
+```mermaid
+classDiagram
+  class Core
+  class Storage
+  Core --> Storage : Uses (Trait Bound)
+  %% Removed the circular dependency arrow
 ```
 
 ## Semantic Analysis (C4 Component Level)


### PR DESCRIPTION
This PR adds the necessary documentation for the `storage` module refactor, as triggered by the Codex persona instructions.

Changes:
- Added `docs/adr/010-decouple-storage.md`.
- Updated `docs/architecture.md` with a new Storage container and Class Diagram.

---
*PR created automatically by Jules for task [1561930352488014669](https://jules.google.com/task/1561930352488014669) started by @madmax983*