### PR TITLE
Simplify codebase structure and error messaging

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -17,3 +17,13 @@
 **Bloat:** `src/semantic/assembled.rs` containing DTOs (`AssembledStatement`, `Constituent`) tightly coupled to `src/semantic/assembler.rs`.
 **Cut:** Merged `assembled.rs` into `assembler.rs` and deleted the file.
 **Saved:** Removed 1 file, reduced module indirection, improved cohesion.
+
+## [Reduction]
+**Bloat:** `src/experimental/numerals.rs` was a fully functional module inside a misleading "experimental" folder.
+**Cut:** Moved to `src/parser/numerals.rs` and deleted `src/experimental`.
+**Saved:** 1 folder, clearer project structure.
+
+## [Reduction]
+**Bloat:** Ad-hoc helper functions (`case_name`, `gender_name`, `number_name`) in `src/errors/messages.rs` for string conversion.
+**Cut:** Implemented `std::fmt::Display` for `Case`, `Gender`, and `Number` enums in `src/morphology/mod.rs`.
+**Saved:** Removed 3 helper functions, enforced standard Rust traits.

--- a/src/errors/messages.rs
+++ b/src/errors/messages.rs
@@ -81,10 +81,7 @@ pub fn immutable_assignment(name: &str) -> String {
 pub fn gender_mismatch(word1: &str, gender1: Gender, word2: &str, gender2: Gender) -> String {
     format!(
         "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
-        word1,
-        gender1,
-        word2,
-        gender2
+        word1, gender1, word2, gender2
     )
 }
 
@@ -104,10 +101,7 @@ pub fn gender_mismatch(word1: &str, gender1: Gender, word2: &str, gender2: Gende
 pub fn number_mismatch(word1: &str, num1: Number, word2: &str, num2: Number) -> String {
     format!(
         "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
-        word1,
-        num1,
-        word2,
-        num2
+        word1, num1, word2, num2
     )
 }
 
@@ -127,10 +121,7 @@ pub fn number_mismatch(word1: &str, num1: Number, word2: &str, num2: Number) -> 
 pub fn case_mismatch(word1: &str, case1: Case, word2: &str, case2: Case) -> String {
     format!(
         "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
-        word1,
-        case1,
-        word2,
-        case2
+        word1, case1, word2, case2
     )
 }
 

--- a/src/errors/messages.rs
+++ b/src/errors/messages.rs
@@ -82,9 +82,9 @@ pub fn gender_mismatch(word1: &str, gender1: Gender, word2: &str, gender2: Gende
     format!(
         "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
         word1,
-        gender_name(gender1),
+        gender1,
         word2,
-        gender_name(gender2)
+        gender2
     )
 }
 
@@ -105,9 +105,9 @@ pub fn number_mismatch(word1: &str, num1: Number, word2: &str, num2: Number) -> 
     format!(
         "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
         word1,
-        number_name(num1),
+        num1,
         word2,
-        number_name(num2)
+        num2
     )
 }
 
@@ -128,38 +128,10 @@ pub fn case_mismatch(word1: &str, case1: Case, word2: &str, case2: Case) -> Stri
     format!(
         "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
         word1,
-        case_name(case1),
+        case1,
         word2,
-        case_name(case2)
+        case2
     )
-}
-
-/// Get the Greek name for a gender
-pub fn gender_name(gender: Gender) -> &'static str {
-    match gender {
-        Gender::Masculine => "ἀρσενικόν",
-        Gender::Feminine => "θηλυκόν",
-        Gender::Neuter => "οὐδέτερον",
-    }
-}
-
-/// Get the Greek name for a number
-pub fn number_name(number: Number) -> &'static str {
-    match number {
-        Number::Singular => "ἑνικός",
-        Number::Plural => "πληθυντικός",
-    }
-}
-
-/// Get the Greek name for a case
-pub fn case_name(case: Case) -> &'static str {
-    match case {
-        Case::Nominative => "ὀνομαστική",
-        Case::Genitive => "γενική",
-        Case::Dative => "δοτική",
-        Case::Accusative => "αἰτιατική",
-        Case::Vocative => "κλητική",
-    }
 }
 
 /// Help messages in Greek

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -1,1 +1,0 @@
-pub mod numerals;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@
 pub mod ast;
 pub mod codegen;
 pub mod errors;
-pub mod experimental;
 pub mod grammar;
 pub mod morphology;
 pub mod parser;

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -377,6 +377,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_display_impls() {
+        assert_eq!(Case::Nominative.to_string(), "ὀνομαστική");
+        assert_eq!(Case::Genitive.to_string(), "γενική");
+        assert_eq!(Case::Dative.to_string(), "δοτική");
+        assert_eq!(Case::Accusative.to_string(), "αἰτιατική");
+        assert_eq!(Case::Vocative.to_string(), "κλητική");
+
+        assert_eq!(Number::Singular.to_string(), "ἑνικός");
+        assert_eq!(Number::Plural.to_string(), "πληθυντικός");
+
+        assert_eq!(Gender::Masculine.to_string(), "ἀρσενικόν");
+        assert_eq!(Gender::Feminine.to_string(), "θηλυκόν");
+        assert_eq!(Gender::Neuter.to_string(), "οὐδέτερον");
+    }
+
+    #[test]
     fn test_analyze_nominative() {
         let analysis = analyze("χρήστος");
         assert_eq!(analysis.case, Some(Case::Nominative));

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -341,6 +341,37 @@ pub enum Voice {
     Passive,
 }
 
+impl std::fmt::Display for Case {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Case::Nominative => write!(f, "ὀνομαστική"),
+            Case::Genitive => write!(f, "γενική"),
+            Case::Dative => write!(f, "δοτική"),
+            Case::Accusative => write!(f, "αἰτιατική"),
+            Case::Vocative => write!(f, "κλητική"),
+        }
+    }
+}
+
+impl std::fmt::Display for Number {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Number::Singular => write!(f, "ἑνικός"),
+            Number::Plural => write!(f, "πληθυντικός"),
+        }
+    }
+}
+
+impl std::fmt::Display for Gender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Gender::Masculine => write!(f, "ἀρσενικόν"),
+            Gender::Feminine => write!(f, "θηλυκόν"),
+            Gender::Neuter => write!(f, "οὐδέτερον"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/parser/builder.rs
+++ b/src/parser/builder.rs
@@ -18,7 +18,7 @@ fn parse_number_literal(text: &str) -> Result<i64, ParseError> {
     if let Ok(val) = text.parse::<i64>() {
         Ok(val)
     } else {
-        crate::experimental::numerals::parse_greek_numeral(text)
+        crate::parser::numerals::parse_greek_numeral(text)
             .map_err(|e| ParseError::InvalidNumber(format!("{} - {}", text, e)))
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,6 +23,7 @@
 //! * Provide better error messages during the conversion phase.
 
 pub(crate) mod builder;
+pub mod numerals;
 
 use crate::ast::Program;
 use crate::errors::GlossaError;

--- a/src/parser/numerals.rs
+++ b/src/parser/numerals.rs
@@ -24,7 +24,7 @@ use crate::text::normalize_greek;
 /// # Examples
 ///
 /// ```
-/// use glossa::experimental::numerals::parse_greek_numeral;
+/// use glossa::parser::numerals::parse_greek_numeral;
 ///
 /// assert_eq!(parse_greek_numeral("αʹ").unwrap(), 1);
 /// assert_eq!(parse_greek_numeral("βʹ").unwrap(), 2);


### PR DESCRIPTION
Applied Razor's philosophy to simplify the codebase. Removed the "experimental" folder by promoting `numerals.rs` to the main `parser` module. Replaced ad-hoc helper functions for enum string conversion with standard `Display` trait implementations, improving code idiomaticity and reducing API surface area. Verified with full test suite pass.

---
*PR created automatically by Jules for task [13957197118107948864](https://jules.google.com/task/13957197118107948864) started by @madmax983*