### PR TITLE
🛡️ Sentry: Fix silent failure on Assembler resource limits

### DIFF
--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -202,15 +202,15 @@ impl Assembler {
             return Ok(());
         }
 
-        if self.check_method_verbs(normalized) {
+        if self.check_method_verbs(normalized)? {
             return Ok(());
         }
 
-        if self.check_operators(normalized, original) {
+        if self.check_operators(normalized, original)? {
             return Ok(());
         }
 
-        if self.check_special_properties(normalized) {
+        if self.check_special_properties(normalized)? {
             return Ok(());
         }
 
@@ -674,13 +674,16 @@ impl Assembler {
 
     /// Helper to create a string method call if conditions are met
     #[allow(clippy::collapsible_if)]
-    fn try_create_string_method(&mut self, method_name: &str) -> bool {
+    fn try_create_string_method(&mut self, method_name: &str) -> Result<bool, AssemblyError> {
         if self.state.has_delimiter_preposition
             && matches!(self.state.literals.last(), Some(Literal::String(_)))
         {
             if let Some(ref subj) = self.state.subject {
                 if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
-                    return false;
+                    return Err(AssemblyError::LimitExceeded {
+                        resource: "Property Accesses".to_string(),
+                        max: MAX_PROPERTY_ACCESSES,
+                    });
                 }
 
                 let delim = match self.state.literals.pop() {
@@ -693,77 +696,93 @@ impl Assembler {
                 self.state
                     .property_accesses
                     .push((normalized_original.to_string(), method_name.to_string()));
-                return true;
+                return Ok(true);
             }
         }
-        false
+        Ok(false)
     }
 
     /// Check for method verbs (split, join)
-    fn check_method_verbs(&mut self, normalized: &str) -> bool {
+    fn check_method_verbs(&mut self, normalized: &str) -> Result<bool, AssemblyError> {
         // Check for split verb
         if crate::morphology::lexicon::is_split_verb(normalized)
-            && self.try_create_string_method("split")
+            && self.try_create_string_method("split")?
         {
-            return true;
+            return Ok(true);
         }
 
         // Check for join verb
         if crate::morphology::lexicon::is_join_verb(normalized)
-            && self.try_create_string_method("join")
+            && self.try_create_string_method("join")?
         {
-            return true;
+            return Ok(true);
         }
 
-        false
+        Ok(false)
     }
 
     /// Check for operators (boolean, comparison, arithmetic)
-    fn check_operators(&mut self, normalized: &str, original: &str) -> bool {
+    fn check_operators(
+        &mut self,
+        normalized: &str,
+        original: &str,
+    ) -> Result<bool, AssemblyError> {
         // Boolean operators
         if matches!(original, "καί" | "και") {
             if self.state.operators.len() >= MAX_OPERATORS {
-                return false;
+                return Err(AssemblyError::LimitExceeded {
+                    resource: "Operators".to_string(),
+                    max: MAX_OPERATORS,
+                });
             }
             self.state.operators.push(BinaryOp::And);
-            return true;
+            return Ok(true);
         }
         if matches!(original, "ἤ" | "ή") {
             if self.state.operators.len() >= MAX_OPERATORS {
-                return false;
+                return Err(AssemblyError::LimitExceeded {
+                    resource: "Operators".to_string(),
+                    max: MAX_OPERATORS,
+                });
             }
             // ἤ with breathing+accent, but not ᾖ
             self.state.operators.push(BinaryOp::Or);
-            return true;
+            return Ok(true);
         }
 
         // Comparison operators
         if let Some(op) = crate::morphology::lexicon::comparison_operator(normalized) {
             if self.state.operators.len() >= MAX_OPERATORS {
-                return false;
+                return Err(AssemblyError::LimitExceeded {
+                    resource: "Operators".to_string(),
+                    max: MAX_OPERATORS,
+                });
             }
             self.state.operators.push(op);
-            return true;
+            return Ok(true);
         }
 
         // Arithmetic operators
         if let Some(op) = crate::morphology::lexicon::arithmetic_operator(normalized) {
             if self.state.operators.len() >= MAX_OPERATORS {
-                return false;
+                return Err(AssemblyError::LimitExceeded {
+                    resource: "Operators".to_string(),
+                    max: MAX_OPERATORS,
+                });
             }
             self.state.operators.push(op);
-            return true;
+            return Ok(true);
         }
 
-        false
+        Ok(false)
     }
 
     /// Check for special properties (numerals, length, ordinals)
-    fn check_special_properties(&mut self, normalized: &str) -> bool {
+    fn check_special_properties(&mut self, normalized: &str) -> Result<bool, AssemblyError> {
         // Numeral words
         if let Some(value) = crate::morphology::lexicon::numeral_value(normalized) {
             self.state.literals.push(Literal::Number(value));
-            return true;
+            return Ok(true);
         }
 
         // Property nouns (μῆκος)
@@ -771,14 +790,17 @@ impl Assembler {
             // If we have a subject, create a property access (use normalized original, not lemma)
             if let Some(ref subj) = self.state.subject {
                 if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
-                    return false;
+                    return Err(AssemblyError::LimitExceeded {
+                        resource: "Property Accesses".to_string(),
+                        max: MAX_PROPERTY_ACCESSES,
+                    });
                 }
                 let normalized_original = crate::text::normalize_greek(&subj.original);
                 self.state
                     .property_accesses
                     .push((normalized_original.to_string(), "len".to_string()));
                 self.state.subject = None; // Consume the subject
-                return true;
+                return Ok(true);
             }
         }
 
@@ -789,7 +811,10 @@ impl Assembler {
                 && let Some(index) = crate::morphology::lexicon::ordinal_to_index(normalized)
             {
                 if self.state.index_accesses.len() >= MAX_INDEX_ACCESSES {
-                    return false;
+                    return Err(AssemblyError::LimitExceeded {
+                        resource: "Index Accesses".to_string(),
+                        max: MAX_INDEX_ACCESSES,
+                    });
                 }
                 // Create array and index expressions (use normalized original, not lemma)
                 let normalized_original = crate::text::normalize_greek(&subj.original);
@@ -801,11 +826,11 @@ impl Assembler {
 
                 self.state.index_accesses.push((array, index_expr));
                 self.state.subject = None; // Consume the subject
-                return true;
+                return Ok(true);
             }
         }
 
-        false
+        Ok(false)
     }
 
     /// Check if the assembler has any pending content

--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -722,11 +722,7 @@ impl Assembler {
     }
 
     /// Check for operators (boolean, comparison, arithmetic)
-    fn check_operators(
-        &mut self,
-        normalized: &str,
-        original: &str,
-    ) -> Result<bool, AssemblyError> {
+    fn check_operators(&mut self, normalized: &str, original: &str) -> Result<bool, AssemblyError> {
         // Boolean operators
         if matches!(original, "καί" | "και") {
             if self.state.operators.len() >= MAX_OPERATORS {

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -434,10 +434,11 @@ fn feed_expr_recursive(
             }
 
             if !success {
-                let msg = last_error
-                    .map(|e| e.to_string())
-                    .unwrap_or_else(|| "Unknown assembly error".to_string());
-                return Err(GlossaError::semantic(msg));
+                if let Some(e) = last_error {
+                    return Err(GlossaError::from(e));
+                } else {
+                    return Err(GlossaError::semantic("Unknown assembly error"));
+                }
             }
 
             // Clear context after use (it was consumed by the following noun)

--- a/tests/havoc_assembler_dos.rs
+++ b/tests/havoc_assembler_dos.rs
@@ -259,17 +259,13 @@ fn test_limit_operators() {
         asm.feed(&analysis, "καί").unwrap();
     }
 
-    // This should NOT error with LimitExceeded, but should be silently ignored (return false internally)
-    // which means it falls through to regular handling (Conjunction -> Ok(()))
-    let res = asm.feed(&analysis, "καί");
-    assert!(
-        res.is_ok(),
-        "Operator limit should fallback silently, not error"
-    );
-
-    // Verify the operators vector didn't grow
-    // We can't access private fields, but we can infer behavior if we had a way to inspect
-    // For now, we trust the coverage tool to see the line hit
+    match asm.feed(&analysis, "καί") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Operators");
+            assert_eq!(max, MAX_OPERATORS);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
 }
 
 #[test]
@@ -318,10 +314,13 @@ fn test_limit_property_accesses() {
 
     // Try one more
     asm.feed(&subj, "text").unwrap();
-    let res = asm.feed(&prop_analysis, "μῆκος");
-
-    // Should succeed because it falls back to regular noun processing
-    assert!(res.is_ok());
+    match asm.feed(&prop_analysis, "μῆκος") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Property Accesses");
+            assert_eq!(max, MAX_PROPERTY_ACCESSES);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
 }
 
 #[test]
@@ -395,11 +394,11 @@ fn test_limit_string_method_properties() {
     asm.feed_string(",".to_string()).unwrap(); // Delimiter literal
 
     // Feed split verb - should fail to create method call (return false)
-    // and instead process as a regular verb
-    let res = asm.feed(&split_verb, "σχίζεται");
-
-    // Should be OK because it falls back to regular verb processing
-    assert!(res.is_ok());
-
-    // If we could check internal state, we'd see string_method is None
+    match asm.feed(&split_verb, "σχίζεται") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Property Accesses");
+            assert_eq!(max, MAX_PROPERTY_ACCESSES);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
 }

--- a/tests/havoc_assembler_dos_extra.rs
+++ b/tests/havoc_assembler_dos_extra.rs
@@ -1,8 +1,7 @@
-
-use std::borrow::Cow;
-use glossa::morphology::{MorphAnalysis, PartOfSpeech, Case, Number, Gender};
+use glossa::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
+use glossa::semantic::assembler::{MAX_INDEX_ACCESSES, MAX_OPERATORS};
 use glossa::semantic::{Assembler, AssemblyError};
-use glossa::semantic::assembler::{MAX_OPERATORS, MAX_INDEX_ACCESSES};
+use std::borrow::Cow;
 
 #[test]
 fn test_limit_operators_or() {

--- a/tests/havoc_assembler_dos_extra.rs
+++ b/tests/havoc_assembler_dos_extra.rs
@@ -1,0 +1,141 @@
+
+use std::borrow::Cow;
+use glossa::morphology::{MorphAnalysis, PartOfSpeech, Case, Number, Gender};
+use glossa::semantic::{Assembler, AssemblyError};
+use glossa::semantic::assembler::{MAX_OPERATORS, MAX_INDEX_ACCESSES};
+
+#[test]
+fn test_limit_operators_or() {
+    // This tests the OR path in check_operators
+    let mut asm = Assembler::new();
+    let analysis = MorphAnalysis {
+        lemma: Cow::Borrowed("η"),
+        part_of_speech: PartOfSpeech::Conjunction,
+        case: None,
+        number: None,
+        gender: None,
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    for _ in 0..MAX_OPERATORS {
+        asm.feed(&analysis, "ἤ").unwrap();
+    }
+
+    match asm.feed(&analysis, "ἤ") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Operators");
+            assert_eq!(max, MAX_OPERATORS);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_operators_comparison() {
+    // This tests the Comparison path in check_operators
+    let mut asm = Assembler::new();
+    let analysis = MorphAnalysis {
+        lemma: Cow::Borrowed("μειζον"),
+        part_of_speech: PartOfSpeech::Adjective,
+        case: None,
+        number: None,
+        gender: None,
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    for _ in 0..MAX_OPERATORS {
+        asm.feed(&analysis, "μεῖζον").unwrap();
+    }
+
+    match asm.feed(&analysis, "μεῖζον") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Operators");
+            assert_eq!(max, MAX_OPERATORS);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_operators_arithmetic() {
+    // This tests the Arithmetic path in check_operators
+    let mut asm = Assembler::new();
+    let analysis = MorphAnalysis {
+        lemma: Cow::Borrowed("αθροισμα"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: None,
+        number: None,
+        gender: None,
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    for _ in 0..MAX_OPERATORS {
+        asm.feed(&analysis, "ἄθροισμα").unwrap();
+    }
+
+    match asm.feed(&analysis, "ἄθροισμα") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Operators");
+            assert_eq!(max, MAX_OPERATORS);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}
+
+#[test]
+fn test_limit_ordinal_index() {
+    // This tests the ordinal adjective path in check_special_properties
+    let mut asm = Assembler::new();
+
+    let subj = MorphAnalysis {
+        lemma: Cow::Borrowed("subj"),
+        part_of_speech: PartOfSpeech::Noun,
+        case: Some(Case::Nominative),
+        number: Some(Number::Singular),
+        gender: Some(Gender::Neuter),
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    let ordinal = MorphAnalysis {
+        lemma: Cow::Borrowed("πρωτον"),
+        part_of_speech: PartOfSpeech::Adjective,
+        case: None,
+        number: None,
+        gender: None,
+        person: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        confidence: 1.0,
+    };
+
+    for _ in 0..MAX_INDEX_ACCESSES {
+        asm.feed(&subj, "text").unwrap();
+        asm.feed(&ordinal, "πρῶτον").unwrap();
+    }
+
+    asm.feed(&subj, "text").unwrap();
+    match asm.feed(&ordinal, "πρῶτον") {
+        Err(AssemblyError::LimitExceeded { resource, max }) => {
+            assert_eq!(resource, "Index Accesses");
+            assert_eq!(max, MAX_INDEX_ACCESSES);
+        }
+        res => panic!("Expected LimitExceeded, got {:?}", res),
+    }
+}

--- a/tests/havoc_overflow.rs
+++ b/tests/havoc_overflow.rs
@@ -35,8 +35,13 @@ fn test_stack_overflow_mitigation() {
             println!("Caught expected error: {:?}", e);
             match e {
                 GlossaError::LimitExceeded { .. } => {}
-                GlossaError::AssemblyError(glossa::semantic::AssemblyError::LimitExceeded { .. }) => {}
-                _ => panic!("Expected LimitExceeded error (Semantic or Assembly), got: {:?}", e),
+                GlossaError::AssemblyError(glossa::semantic::AssemblyError::LimitExceeded {
+                    ..
+                }) => {}
+                _ => panic!(
+                    "Expected LimitExceeded error (Semantic or Assembly), got: {:?}",
+                    e
+                ),
             }
         }
     }

--- a/tests/havoc_overflow.rs
+++ b/tests/havoc_overflow.rs
@@ -33,8 +33,10 @@ fn test_stack_overflow_mitigation() {
         ),
         Err(e) => {
             println!("Caught expected error: {:?}", e);
-            if !matches!(e, GlossaError::LimitExceeded { .. }) {
-                panic!("Expected LimitExceeded error, got: {:?}", e);
+            match e {
+                GlossaError::LimitExceeded { .. } => {}
+                GlossaError::AssemblyError(glossa::semantic::AssemblyError::LimitExceeded { .. }) => {}
+                _ => panic!("Expected LimitExceeded error (Semantic or Assembly), got: {:?}", e),
             }
         }
     }


### PR DESCRIPTION
This PR addresses a critical issue identified by Sentry where resource limits in the Assembler were failing silently.

Previously, if `MAX_OPERATORS` or other limits were reached, the helper functions returned `false`, causing the assembler to fall back to other parsing logic (often treating the token as a noun or unknown), effectively swallowing the operator/property.

This change enforces strict error reporting:
- `check_operators` now returns `Result<bool, AssemblyError>`.
- `check_special_properties` now returns `Result<bool, AssemblyError>`.
- `try_create_string_method` now returns `Result<bool, AssemblyError>`.
- `check_method_verbs` now returns `Result<bool, AssemblyError>`.

When a limit is reached, `AssemblyError::LimitExceeded` is returned immediately.

Tests in `tests/havoc_assembler_dos.rs` were updated to assert this new correct behavior.
`tests/havoc_overflow.rs` was updated to handle the `AssemblyError` variant.
`src/semantic/expressions.rs` was updated to propagate `AssemblyError` instead of wrapping it in a stringified `SemanticError`, improving error handling precision.

---
*PR created automatically by Jules for task [8017893392106860746](https://jules.google.com/task/8017893392106860746) started by @madmax983*