### PR TITLE
👺 Havoc: Hardened Greek Numeral Parser

### DIFF
--- a/src/parser/numerals.rs
+++ b/src/parser/numerals.rs
@@ -56,7 +56,7 @@ pub fn parse_greek_numeral(text: &str) -> Result<i64, String> {
 
             // Letters
             _ => {
-                let value = match c {
+                let value: i64 = match c {
                     'α' => 1,
                     'β' => 2,
                     'γ' => 3,
@@ -92,7 +92,14 @@ pub fn parse_greek_numeral(text: &str) -> Result<i64, String> {
                     }
                 };
 
-                total += value * multiplier;
+                let term = value
+                    .checked_mul(multiplier)
+                    .ok_or_else(|| "Numeric overflow".to_string())?;
+
+                total = total
+                    .checked_add(term)
+                    .ok_or_else(|| "Numeric overflow".to_string())?;
+
                 // Reset multiplier after applying it to one digit
                 multiplier = 1;
             }

--- a/tests/havoc.rs
+++ b/tests/havoc.rs
@@ -1,0 +1,35 @@
+use glossa::parser::numerals::parse_greek_numeral;
+use glossa::parser::parse;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    #[test]
+    fn fuzz_numerals(s in "[\\u0370-\\u03FF]*") {
+        // Attempt to parse random Greek strings.
+        // We don't care about the result (Ok/Err), only that it doesn't panic.
+        let _ = parse_greek_numeral(&s);
+    }
+
+    #[test]
+    fn fuzz_parser(s in "\\PC*") {
+        // Fuzz the entire parser with random strings.
+        // This checks for panics in the grammar or builder.
+        let _ = parse(&s);
+    }
+}
+
+#[test]
+fn test_huge_numeral_overflow_attempt() {
+    // Attempt to overflow i64 with a massive string of 900s (ϡ)
+    // Each ϡ is 900.
+    // i64::MAX is ~9e18.
+    // We need ~1e16 chars to overflow.
+    // We can't allocate that. But we can verify it handles a large-ish string gracefully.
+    // And if we ever switch to i32, this would catch it.
+    let huge_string = "ϡ".repeat(100_000); // 900 * 100,000 = 90,000,000
+    let res = parse_greek_numeral(&huge_string);
+    assert!(res.is_ok());
+    assert_eq!(res.unwrap(), 90_000_000);
+}


### PR DESCRIPTION
👺 **Havoc Report**

**Target:** `glossa::parser::numerals::parse_greek_numeral`

**The Vulnerability:**
The parser used standard arithmetic (`*`, `+`) to accumulate values. While `i64` is large enough to handle valid Greek numerals (which would require petabytes of text to overflow), the logic itself was unsafe and theoretically vulnerable to overflow panics (in debug) or wrapping (in release) if the type were smaller or input generation constraints changed.

**The Attack:**
I deployed a `proptest` harness (`tests/havoc.rs`) to fuzz the parser with random Greek unicode strings (`\u0370-\u03FF`).

**The Fix:**
I replaced the unchecked arithmetic with `checked_mul` and `checked_add`, ensuring that any overflow returns a proper `Result::Err("Numeric overflow")` rather than panicking or wrapping.

**Verification:**
The fuzz tests ran successfully with no panics. The codebase is now hardened against numeric overflow in this component.


---
*PR created automatically by Jules for task [10086385156931318953](https://jules.google.com/task/10086385156931318953) started by @madmax983*