### PR TITLE
DX Audit Report by Echo

### DIFF
--- a/docs/audit_report_echo.md
+++ b/docs/audit_report_echo.md
@@ -1,0 +1,30 @@
+# 🗣️ Echo: DX Audit Report
+
+**Auditor:** Echo (Jules)
+**Date:** 2024-02-14
+
+## Summary
+I have audited the Developer Experience for the "Quick Start" and error handling flows.
+
+### ✅ What Worked
+*   **The "Quick Start" Example:** The code in `README.md` (defining a struct and printing a field) works perfectly on the first try.
+*   **"Hello World":** `examples/hello.γλ` runs correctly.
+*   **File Not Found Error:** Running a non-existent file produces a clear, localized error message: `× Ἀρχεῖον οὐχ εὑρέθη: ...`.
+*   **Syntax Errors:** The parser correctly identifies missing punctuation and suggests expected tokens.
+*   **Immutable Assignment:** Assigning to an immutable variable produces a helpful, localized semantic error.
+
+### 🚧 Friction Points (The "Stumbles")
+
+1.  **Silent Failure on Nonsense:**
+    Typing `foo bar baz.` (valid Greek letters or ASCII treated as Greek) results in a successful compilation that does **absolutely nothing**. The compiler silently ignores recognized words that don't fit into grammatical slots, generating an empty `main` function. This is extremely confusing.
+
+2.  **Silent Print Failure:**
+    `nonexistent λέγε.` (print nonexistent variable) compiles successfully and prints a newline, silently ignoring the unknown variable. It should be a compile-time error.
+
+3.  **Raw Rust Errors:**
+    Type mismatch errors (e.g., assigning a string to an integer variable) dump raw `rustc` error messages to the user. These messages contain mangled internal identifiers (e.g., `g__u3c7_` instead of `χ`) and Rust type names (`i64`, `&str`) instead of Glossa types (`ἀριθμός`, `κείμενον`).
+
+### 📢 Recommendations
+*   **Strict Mode:** The Assembler should error or warn when tokens are discarded/ignored.
+*   **Semantic Check for Print:** The `Print` statement analysis must verify that variables exist in the scope.
+*   **Error Wrapping:** Catch `rustc` errors and map them back to Glossa source locations and types, hiding the transpilation details.


### PR DESCRIPTION
Added `docs/audit_report_echo.md` containing findings from the Developer Experience audit. Identified issues with silent failures and raw Rust errors.

---
*PR created automatically by Jules for task [4717649042816543688](https://jules.google.com/task/4717649042816543688) started by @madmax983*