### PR TITLE
🌟 Nova: The Bard - Semantic Narrative Generator

### DIFF
--- a/src/experimental/bard.rs
+++ b/src/experimental/bard.rs
@@ -1,0 +1,370 @@
+use crate::semantic::CaptureMode;
+use crate::semantic::{
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType,
+};
+
+/// Tells the tale of the program in English.
+///
+/// This function translates the semantic meaning of the program into a readable English narrative.
+pub fn tell_tale(program: &AnalyzedProgram) -> String {
+    let mut tale = String::new();
+    tale.push_str("The Scroll of Logic begins...\n\n");
+
+    for stmt in &program.statements {
+        tale.push_str(&tell_statement(stmt, 0));
+        tale.push('\n');
+    }
+
+    tale.push_str("\n...and thus the ritual is complete.");
+    tale
+}
+
+fn indent(level: usize) -> String {
+    "  ".repeat(level)
+}
+
+fn tell_statement(stmt: &AnalyzedStatement, level: usize) -> String {
+    let prefix = indent(level);
+    match stmt {
+        AnalyzedStatement::Binding {
+            name,
+            value,
+            mutable,
+        } => {
+            let mutability = if *mutable { "mutable " } else { "" };
+            format!(
+                "{}Let there be a {}variable named `{}` with the value {}.",
+                prefix,
+                mutability,
+                name,
+                tell_expr(value)
+            )
+        }
+        AnalyzedStatement::Assignment { name, value } => {
+            format!(
+                "{}Update `{}` to become {}.",
+                prefix,
+                name,
+                tell_expr(value)
+            )
+        }
+        AnalyzedStatement::Print(exprs) => {
+            let expr_strs: Vec<String> = exprs.iter().map(tell_expr).collect();
+            format!("{}Proclaim to the world: {}.", prefix, expr_strs.join(", "))
+        }
+        AnalyzedStatement::Expression(exprs) => {
+            let expr_strs: Vec<String> = exprs.iter().map(tell_expr).collect();
+            format!("{}Perform the following: {}.", prefix, expr_strs.join(", "))
+        }
+        AnalyzedStatement::Query(exprs) => {
+            let expr_strs: Vec<String> = exprs.iter().map(tell_expr).collect();
+            format!(
+                "{}Query the oracle about: {}.",
+                prefix,
+                expr_strs.join(", ")
+            )
+        }
+        AnalyzedStatement::If {
+            condition,
+            then_body,
+            else_body,
+        } => {
+            let mut s = format!(
+                "{}If it is true that {}, then:\n",
+                prefix,
+                tell_expr(condition)
+            );
+            for stmt in then_body {
+                s.push_str(&tell_statement(stmt, level + 1));
+                s.push('\n');
+            }
+            if let Some(else_stmts) = else_body {
+                s.push_str(&format!("{}Otherwise:\n", prefix));
+                for stmt in else_stmts {
+                    s.push_str(&tell_statement(stmt, level + 1));
+                    s.push('\n');
+                }
+            }
+            s
+        }
+        AnalyzedStatement::While { condition, body } => {
+            let mut s = format!("{}As long as {}, repeat:\n", prefix, tell_expr(condition));
+            for stmt in body {
+                s.push_str(&tell_statement(stmt, level + 1));
+                s.push('\n');
+            }
+            s
+        }
+        AnalyzedStatement::For {
+            variable,
+            iterator,
+            body,
+        } => {
+            let mut s = format!(
+                "{}For each `{}` found in {}, do:\n",
+                prefix,
+                variable,
+                tell_expr(iterator)
+            );
+            for stmt in body {
+                s.push_str(&tell_statement(stmt, level + 1));
+                s.push('\n');
+            }
+            s
+        }
+        AnalyzedStatement::Match { scrutinee, arms } => {
+            let mut s = format!(
+                "{}Consider the nature of {}:\n",
+                prefix,
+                tell_expr(scrutinee)
+            );
+            for (pat, body) in arms {
+                s.push_str(&format!("{}  In the case of {}:\n", prefix, tell_expr(pat)));
+                for stmt in body {
+                    s.push_str(&tell_statement(stmt, level + 2));
+                    s.push('\n');
+                }
+            }
+            s
+        }
+        AnalyzedStatement::Break => format!("{}Break the cycle.", prefix),
+        AnalyzedStatement::Continue => format!("{}Continue to the next iteration.", prefix),
+        AnalyzedStatement::Return { value } => {
+            if let Some(v) = value {
+                format!("{}Return with the offering {}.", prefix, tell_expr(v))
+            } else {
+                format!("{}Return with nothing.", prefix)
+            }
+        }
+        AnalyzedStatement::FunctionDef {
+            name,
+            params,
+            body,
+            return_type,
+        } => {
+            let params_str: Vec<String> = params
+                .iter()
+                .map(|(n, t)| {
+                    let type_str = t.as_ref().map(tell_type).unwrap_or("unknown".to_string());
+                    format!("`{}` ({})", n, type_str)
+                })
+                .collect();
+            let ret_str = return_type
+                .as_ref()
+                .map(tell_type)
+                .unwrap_or("nothing".to_string());
+            let mut s = format!(
+                "{}Define a ritual called `{}` expecting [{}] which returns {}:\n",
+                prefix,
+                name,
+                params_str.join(", "),
+                ret_str
+            );
+            for stmt in body {
+                s.push_str(&tell_statement(stmt, level + 1));
+                s.push('\n');
+            }
+            s
+        }
+        AnalyzedStatement::TypeDefinition { name, fields } => {
+            let fields_str: Vec<String> = fields
+                .iter()
+                .map(|(n, t)| format!("`{}` as {}", n, tell_type(t)))
+                .collect();
+            format!(
+                "{}Declare a new form `{}` with attributes: {}.",
+                prefix,
+                name,
+                fields_str.join(", ")
+            )
+        }
+        AnalyzedStatement::TraitDefinition { name, methods: _ } => {
+            format!("{}Declare a characteristic named `{}`.", prefix, name)
+        }
+        AnalyzedStatement::TraitImplementation {
+            trait_name,
+            type_name,
+            methods: _,
+        } => {
+            format!(
+                "{}Imbue `{}` with the characteristic of `{}`.",
+                prefix, type_name, trait_name
+            )
+        }
+        AnalyzedStatement::TestDeclaration { name, body } => {
+            let mut s = format!("{}Define a trial named `{}`:\n", prefix, name);
+            for stmt in body {
+                s.push_str(&tell_statement(stmt, level + 1));
+                s.push('\n');
+            }
+            s
+        }
+    }
+}
+
+fn tell_expr(expr: &AnalyzedExpr) -> String {
+    match &expr.expr {
+        AnalyzedExprKind::StringLiteral(s) => format!("the text \"{}\"", s),
+        AnalyzedExprKind::NumberLiteral(n) => format!("the number {}", n),
+        AnalyzedExprKind::BooleanLiteral(b) => format!("the truth {}", b),
+        AnalyzedExprKind::Variable(name) => format!("`{}`", name),
+        AnalyzedExprKind::PropertyAccess { owner, property } => {
+            format!("the `{}` of {}", property, tell_expr(owner))
+        }
+        AnalyzedExprKind::VerbCall { verb, args } => {
+            let args_str: Vec<String> = args.iter().map(tell_expr).collect();
+            format!("{}ing [{}]", verb, args_str.join(", "))
+        }
+        AnalyzedExprKind::BinOp { left, op, right } => {
+            format!("({} {:?} {})", tell_expr(left), op, tell_expr(right))
+        }
+        AnalyzedExprKind::UnaryOp { op, operand } => {
+            format!("({:?} {})", op, tell_expr(operand))
+        }
+        AnalyzedExprKind::Range {
+            start,
+            end,
+            inclusive,
+        } => {
+            let range_op = if *inclusive { "through" } else { "up to" };
+            format!("from {} {} {}", tell_expr(start), range_op, tell_expr(end))
+        }
+        AnalyzedExprKind::ArrayLiteral(exprs) => {
+            let expr_strs: Vec<String> = exprs.iter().map(tell_expr).collect();
+            format!("a list containing [{}]", expr_strs.join(", "))
+        }
+        AnalyzedExprKind::Some(e) => format!("something ({})", tell_expr(e)),
+        AnalyzedExprKind::None => "nothing".to_string(),
+        AnalyzedExprKind::Ok(e) => format!("success ({})", tell_expr(e)),
+        AnalyzedExprKind::Err(e) => format!("failure ({})", tell_expr(e)),
+        AnalyzedExprKind::Unwrap(e) => format!("the essence of {}", tell_expr(e)),
+        AnalyzedExprKind::Try(e) => format!("attempting {}", tell_expr(e)),
+        AnalyzedExprKind::IndexAccess { array, index } => {
+            format!("the item at {} in {}", tell_expr(index), tell_expr(array))
+        }
+        AnalyzedExprKind::FunctionCall { func, args } => {
+            let args_str: Vec<String> = args.iter().map(tell_expr).collect();
+            format!("calling `{}` with [{}]", func, args_str.join(", "))
+        }
+        AnalyzedExprKind::MethodCall {
+            receiver,
+            method,
+            args,
+        } => {
+            let args_str: Vec<String> = args.iter().map(tell_expr).collect();
+            format!(
+                "invoking `{}` on {} with [{}]",
+                method,
+                tell_expr(receiver),
+                args_str.join(", ")
+            )
+        }
+        AnalyzedExprKind::TraitMethodCall {
+            receiver,
+            trait_name,
+            method_name,
+            args,
+        } => {
+            let args_str: Vec<String> = args.iter().map(tell_expr).collect();
+            format!(
+                "invoking `{}` (as `{}`) on {} with [{}]",
+                method_name,
+                trait_name,
+                tell_expr(receiver),
+                args_str.join(", ")
+            )
+        }
+        AnalyzedExprKind::StructInstantiation {
+            type_name,
+            fields,
+            args,
+        } => {
+            let args_str: Vec<String> = args.iter().map(tell_expr).collect();
+            format!(
+                "a new `{}` with fields [{}] set to [{}]",
+                type_name,
+                fields.join(", "),
+                args_str.join(", ")
+            )
+        }
+        AnalyzedExprKind::Lambda {
+            params,
+            body,
+            capture_mode,
+        } => {
+            let mode = match capture_mode {
+                CaptureMode::Borrow => "borrowing",
+                CaptureMode::Move => "moving",
+                CaptureMode::Memoize => "remembering",
+            };
+            format!(
+                "a spirit {} [{}] that produces {}",
+                mode,
+                params.join(", "),
+                tell_expr(body)
+            )
+        }
+        AnalyzedExprKind::CollectionNew { collection_type } => {
+            format!("a new empty {}", collection_type)
+        }
+        AnalyzedExprKind::Assert { condition } => {
+            format!("asserting that {} is true", tell_expr(condition))
+        }
+        AnalyzedExprKind::AssertEq { left, right } => format!(
+            "asserting that {} equals {}",
+            tell_expr(left),
+            tell_expr(right)
+        ),
+    }
+}
+
+fn tell_type(ty: &GlossaType) -> String {
+    match ty {
+        GlossaType::Number => "Number".to_string(),
+        GlossaType::String => "Text".to_string(),
+        GlossaType::Boolean => "Truth".to_string(),
+        GlossaType::List(inner) => format!("List of {}", tell_type(inner)),
+        GlossaType::Set(inner) => format!("Set of {}", tell_type(inner)),
+        GlossaType::Map(k, v) => format!("Map from {} to {}", tell_type(k), tell_type(v)),
+        GlossaType::Option(inner) => format!("Maybe {}", tell_type(inner)),
+        GlossaType::Result(ok, err) => format!("Result of {} or {}", tell_type(ok), tell_type(err)),
+        GlossaType::Struct { name, .. } => format!("Form `{}`", name),
+        GlossaType::Function { params, returns } => {
+            let params_str: Vec<String> = params.iter().map(tell_type).collect();
+            format!(
+                "Function({}) -> {}",
+                params_str.join(", "),
+                tell_type(returns)
+            )
+        }
+        GlossaType::Unit => "Nothing".to_string(),
+        GlossaType::Unknown => "Mystery".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse;
+    use crate::semantic::analyze_program;
+
+    #[test]
+    fn test_bard_basic() {
+        let source = "ξ πέντε ἔστω.";
+        let ast = parse(source).unwrap();
+        let analyzed = analyze_program(&ast).unwrap();
+        let tale = tell_tale(&analyzed);
+
+        assert!(tale.contains("Let there be a variable named `ξ` with the value the number 5."));
+    }
+
+    #[test]
+    fn test_bard_print() {
+        let source = "«χαῖρε» λέγε.";
+        let ast = parse(source).unwrap();
+        let analyzed = analyze_program(&ast).unwrap();
+        let tale = tell_tale(&analyzed);
+
+        assert!(tale.contains("Proclaim to the world: the text \"χαῖρε\"."));
+    }
+}

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -1,0 +1,1 @@
+pub mod bard;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,4 +90,6 @@ pub mod semantic;
 pub mod text;
 pub mod tools;
 
+pub mod experimental;
+
 pub use tools::highlight;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use miette::Result;
 
 use glossa::tools::cli::{Cli, Commands};
 use glossa::tools::repl::run_repl;
-use glossa::tools::runner::{build_file, check_file, highlight_file, run_file};
+use glossa::tools::runner::{bard_file, build_file, check_file, highlight_file, run_file};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -32,6 +32,10 @@ fn main() -> Result<()> {
 
         Some(Commands::Highlight { input }) => {
             highlight_file(&input)?;
+        }
+
+        Some(Commands::Bard { input }) => {
+            bard_file(&input)?;
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -46,4 +46,10 @@ pub enum Commands {
 
     /// Start the interactive REPL
     Repl,
+
+    /// Translate a .γλ file to English logic (Experimental)
+    Bard {
+        /// Input file (.γλ)
+        input: PathBuf,
+    },
 }

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -6,6 +6,7 @@ use std::time::SystemTime;
 
 use crate::codegen::generate_rust_file;
 use crate::errors::GlossaError;
+use crate::experimental::bard::tell_tale;
 use crate::parser::parse;
 use crate::report::{CompilationReport, GlossaReport, ProgramStats};
 use crate::semantic::analyze_program;
@@ -193,6 +194,19 @@ pub fn highlight_file(input: &Path) -> Result<()> {
     let highlighted = highlight(&source).map_err(|e| miette::miette!("{}", e))?;
 
     println!("{}", highlighted);
+
+    Ok(())
+}
+
+pub fn bard_file(input: &Path) -> Result<()> {
+    check_file_size(input)?;
+
+    let source = fs::read_to_string(input).into_diagnostic()?;
+    let ast = parse(&source).map_err(|e| miette::miette!("{}", e))?;
+    let analyzed = analyze_program(&ast).map_err(|e| miette::miette!("{}", e))?;
+
+    let tale = tell_tale(&analyzed);
+    println!("{}", tale);
 
     Ok(())
 }

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -391,4 +391,17 @@ mod tests {
         let result = highlight_file(&input_path);
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_bard_file_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("bard.gl");
+        {
+            let mut f = std::fs::File::create(&input_path).unwrap();
+            f.write_all("ξ πέντε ἔστω.".as_bytes()).unwrap();
+        }
+
+        let result = bard_file(&input_path);
+        assert!(result.is_ok());
+    }
 }

--- a/tests/bard_coverage.rs
+++ b/tests/bard_coverage.rs
@@ -1,0 +1,358 @@
+use glossa::parser::parse;
+use glossa::semantic::{analyze_program, AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, CaptureMode};
+use glossa::experimental::bard::tell_tale;
+
+fn compile_and_tell(source: &str) -> String {
+    let ast = parse(source).expect("AST build failed");
+    let analyzed = analyze_program(&ast).expect("Analysis failed");
+    tell_tale(&analyzed)
+}
+
+#[test]
+fn test_bard_binding_mutable() {
+    let stmt = AnalyzedStatement::Binding {
+        name: "x".into(),
+        value: AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(5),
+            glossa_type: GlossaType::Number,
+        },
+        mutable: true,
+    };
+
+    let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+
+    let tale = tell_tale(&program);
+    assert!(tale.contains("mutable variable named `x`"));
+}
+
+#[test]
+fn test_bard_assignment() {
+    // Manually construct assignment to avoid mutable syntax issues in parser
+    let stmt = AnalyzedStatement::Assignment {
+        name: "x".into(),
+        value: AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(10),
+            glossa_type: GlossaType::Number,
+        }
+    };
+    let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains("Update `x` to become the number 10"));
+}
+
+#[test]
+fn test_bard_print_multiple() {
+    let source = "«α», «β» λέγε.";
+    let tale = compile_and_tell(source);
+    assert!(tale.contains("Proclaim to the world: the text \"α\", the text \"β\""));
+}
+
+#[test]
+fn test_bard_expression_stmt() {
+    let stmt = AnalyzedStatement::Expression(vec![
+        AnalyzedExpr {
+            expr: AnalyzedExprKind::StringLiteral("test".into()),
+            glossa_type: GlossaType::String,
+        }
+    ]);
+     let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains("Perform the following: the text \"test\""));
+}
+
+#[test]
+fn test_bard_query() {
+    let source = "ξ πέντε ἔστω. ξ?";
+    let tale = compile_and_tell(source);
+    assert!(tale.contains("Query the oracle about: `ξ`"));
+}
+
+#[test]
+fn test_bard_while() {
+    let source = "ξ πέντε ἔστω. ἕως ξ μηδενὸς μεῖζον ᾖ, ξ λέγε.";
+    let tale = compile_and_tell(source);
+    assert!(tale.contains("As long as"));
+    assert!(tale.contains("repeat:"));
+}
+
+#[test]
+fn test_bard_for() {
+    let source = "ἀπὸ μηδενὸς μέχρι πέντε, ι λέγε.";
+    let tale = compile_and_tell(source);
+    assert!(tale.contains("For each `ι` found in"));
+}
+
+#[test]
+fn test_bard_match() {
+    let source = "ξ πέντε ἔστω. κατὰ ξ· μηδὲν ᾖ, «μηδέν» λέγε.";
+    let tale = compile_and_tell(source);
+    assert!(tale.contains("Consider the nature of `ξ`"));
+    assert!(tale.contains("In the case of"));
+}
+
+#[test]
+fn test_bard_break_continue() {
+    // Manually construct to ensure we hit the variants
+    let stmts = vec![
+        AnalyzedStatement::Break,
+        AnalyzedStatement::Continue,
+    ];
+    let program = glossa::semantic::AnalyzedProgram {
+        statements: stmts,
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains("Break the cycle"));
+    assert!(tale.contains("Continue to the next iteration"));
+}
+
+#[test]
+fn test_bard_return() {
+    let stmt = AnalyzedStatement::Return {
+        value: Some(Box::new(AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(42),
+            glossa_type: GlossaType::Number,
+        }))
+    };
+     let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains("Return with the offering the number 42"));
+
+     let stmt_empty = AnalyzedStatement::Return { value: None };
+     let program_empty = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt_empty],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale_empty = tell_tale(&program_empty);
+    assert!(tale_empty.contains("Return with nothing"));
+}
+
+#[test]
+fn test_bard_function_def() {
+    // Manually construct
+    let stmt = AnalyzedStatement::FunctionDef {
+        name: "my_func".into(),
+        params: vec![("p1".into(), Some(GlossaType::Number))],
+        body: vec![],
+        return_type: Some(GlossaType::Boolean),
+    };
+
+    let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains("Define a ritual called `my_func`"));
+    assert!(tale.contains("expecting [`p1` (Number)]"));
+    assert!(tale.contains("returns Truth"));
+}
+
+#[test]
+fn test_bard_type_def() {
+    let stmt = AnalyzedStatement::TypeDefinition {
+        name: "MyType".into(),
+        fields: vec![("field1".into(), GlossaType::Number)],
+    };
+    let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains("Declare a new form `MyType`"));
+    assert!(tale.contains("attributes: `field1` as Number"));
+}
+
+#[test]
+fn test_bard_trait_def() {
+    let stmt = AnalyzedStatement::TraitDefinition {
+        name: "MyTrait".into(),
+        methods: vec![],
+    };
+    let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains("Declare a characteristic named `MyTrait`"));
+}
+
+#[test]
+fn test_bard_trait_impl() {
+    let stmt = AnalyzedStatement::TraitImplementation {
+        trait_name: "MyTrait".into(),
+        type_name: "MyType".into(),
+        methods: vec![],
+    };
+    let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains("Imbue `MyType` with the characteristic of `MyTrait`"));
+}
+
+#[test]
+fn test_bard_test_decl() {
+    let stmt = AnalyzedStatement::TestDeclaration {
+        name: "my_test".into(),
+        body: vec![],
+    };
+    let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains("Define a trial named `my_test`"));
+}
+
+// --- Expression Coverage ---
+
+fn wrap_expr(expr: AnalyzedExprKind) -> AnalyzedStatement {
+    AnalyzedStatement::Expression(vec![AnalyzedExpr {
+        expr,
+        glossa_type: GlossaType::Unknown,
+    }])
+}
+
+fn test_expr_tale(kind: AnalyzedExprKind, expected: &str) {
+    let stmt = wrap_expr(kind);
+    let program = glossa::semantic::AnalyzedProgram {
+        statements: vec![stmt],
+        scope: glossa::semantic::Scope::new(),
+    };
+    let tale = tell_tale(&program);
+    assert!(tale.contains(expected), "Expected '{}' in '{}'", expected, tale);
+}
+
+#[test]
+fn test_bard_exprs() {
+    test_expr_tale(AnalyzedExprKind::BooleanLiteral(true), "the truth true");
+    test_expr_tale(AnalyzedExprKind::PropertyAccess {
+        owner: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("obj".into()), glossa_type: GlossaType::Unknown }),
+        property: "prop".into(),
+    }, "the `prop` of `obj`");
+
+    test_expr_tale(AnalyzedExprKind::VerbCall {
+        verb: "run".into(),
+        args: vec![],
+    }, "runing []");
+
+    test_expr_tale(AnalyzedExprKind::UnaryOp {
+        op: glossa::morphology::lexicon::UnaryOp::Not,
+        operand: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::BooleanLiteral(true), glossa_type: GlossaType::Boolean }),
+    }, "(Not the truth true)");
+
+    test_expr_tale(AnalyzedExprKind::Range {
+        start: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number }),
+        end: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(10), glossa_type: GlossaType::Number }),
+        inclusive: true,
+    }, "from the number 1 through the number 10");
+
+    test_expr_tale(AnalyzedExprKind::ArrayLiteral(vec![]), "a list containing []");
+
+    test_expr_tale(AnalyzedExprKind::Some(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number })), "something (the number 1)");
+    test_expr_tale(AnalyzedExprKind::None, "nothing");
+    test_expr_tale(AnalyzedExprKind::Ok(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number })), "success (the number 1)");
+    test_expr_tale(AnalyzedExprKind::Err(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number })), "failure (the number 1)");
+
+    test_expr_tale(AnalyzedExprKind::Unwrap(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("x".into()), glossa_type: GlossaType::Option(Box::new(GlossaType::Number)) })), "the essence of `x`");
+    test_expr_tale(AnalyzedExprKind::Try(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("x".into()), glossa_type: GlossaType::Option(Box::new(GlossaType::Number)) })), "attempting `x`");
+
+    test_expr_tale(AnalyzedExprKind::IndexAccess {
+        array: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("arr".into()), glossa_type: GlossaType::List(Box::new(GlossaType::Number)) }),
+        index: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(0), glossa_type: GlossaType::Number }),
+    }, "the item at the number 0 in `arr`");
+
+    test_expr_tale(AnalyzedExprKind::FunctionCall {
+        func: "f".into(),
+        args: vec![],
+    }, "calling `f` with []");
+
+    test_expr_tale(AnalyzedExprKind::MethodCall {
+        receiver: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("obj".into()), glossa_type: GlossaType::Unknown }),
+        method: "m".into(),
+        args: vec![],
+    }, "invoking `m` on `obj` with []");
+
+    test_expr_tale(AnalyzedExprKind::TraitMethodCall {
+        receiver: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("obj".into()), glossa_type: GlossaType::Unknown }),
+        trait_name: "T".into(),
+        method_name: "m".into(),
+        args: vec![],
+    }, "invoking `m` (as `T`) on `obj` with []");
+
+    test_expr_tale(AnalyzedExprKind::StructInstantiation {
+        type_name: "S".into(),
+        fields: vec!["f".into()],
+        args: vec![AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number }],
+    }, "a new `S` with fields [f] set to [the number 1]");
+
+    test_expr_tale(AnalyzedExprKind::Lambda {
+        params: vec!["p".into()],
+        body: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("p".into()), glossa_type: GlossaType::Unknown }),
+        capture_mode: CaptureMode::Borrow,
+    }, "a spirit borrowing [p] that produces `p`");
+
+     test_expr_tale(AnalyzedExprKind::Lambda {
+        params: vec![],
+        body: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unit }),
+        capture_mode: CaptureMode::Move,
+    }, "a spirit moving []");
+
+     test_expr_tale(AnalyzedExprKind::Lambda {
+        params: vec![],
+        body: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unit }),
+        capture_mode: CaptureMode::Memoize,
+    }, "a spirit remembering []");
+
+    test_expr_tale(AnalyzedExprKind::CollectionNew { collection_type: "HashSet".into() }, "a new empty HashSet");
+
+    test_expr_tale(AnalyzedExprKind::Assert {
+        condition: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::BooleanLiteral(true), glossa_type: GlossaType::Boolean }),
+    }, "asserting that the truth true is true");
+
+    test_expr_tale(AnalyzedExprKind::AssertEq {
+        left: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number }),
+        right: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number }),
+    }, "asserting that the number 1 equals the number 1");
+}
+
+#[test]
+fn test_bard_types() {
+    fn check_type(ty: GlossaType, expected: &str) {
+        let stmt = AnalyzedStatement::FunctionDef {
+            name: "f".into(),
+            params: vec![],
+            body: vec![],
+            return_type: Some(ty),
+        };
+        let program = glossa::semantic::AnalyzedProgram {
+            statements: vec![stmt],
+            scope: glossa::semantic::Scope::new(),
+        };
+        let tale = tell_tale(&program);
+        assert!(tale.contains(expected), "Expected '{}' in '{}'", expected, tale);
+    }
+
+    check_type(GlossaType::List(Box::new(GlossaType::Number)), "List of Number");
+    check_type(GlossaType::Set(Box::new(GlossaType::Number)), "Set of Number");
+    check_type(GlossaType::Map(Box::new(GlossaType::String), Box::new(GlossaType::Number)), "Map from Text to Number");
+    check_type(GlossaType::Option(Box::new(GlossaType::Number)), "Maybe Number");
+    check_type(GlossaType::Result(Box::new(GlossaType::Number), Box::new(GlossaType::String)), "Result of Number or Text");
+    check_type(GlossaType::Struct { name: "S".into(), gender: glossa::morphology::Gender::Neuter, fields: vec![] }, "Form `S`");
+    check_type(GlossaType::Function { params: vec![GlossaType::Number], returns: Box::new(GlossaType::Boolean) }, "Function(Number) -> Truth");
+    check_type(GlossaType::Unit, "Nothing");
+    check_type(GlossaType::Unknown, "Mystery");
+}

--- a/tests/bard_coverage.rs
+++ b/tests/bard_coverage.rs
@@ -1,6 +1,8 @@
-use glossa::parser::parse;
-use glossa::semantic::{analyze_program, AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, CaptureMode};
 use glossa::experimental::bard::tell_tale;
+use glossa::parser::parse;
+use glossa::semantic::{
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, CaptureMode, GlossaType, analyze_program,
+};
 
 fn compile_and_tell(source: &str) -> String {
     let ast = parse(source).expect("AST build failed");
@@ -36,7 +38,7 @@ fn test_bard_assignment() {
         value: AnalyzedExpr {
             expr: AnalyzedExprKind::NumberLiteral(10),
             glossa_type: GlossaType::Number,
-        }
+        },
     };
     let program = glossa::semantic::AnalyzedProgram {
         statements: vec![stmt],
@@ -55,13 +57,11 @@ fn test_bard_print_multiple() {
 
 #[test]
 fn test_bard_expression_stmt() {
-    let stmt = AnalyzedStatement::Expression(vec![
-        AnalyzedExpr {
-            expr: AnalyzedExprKind::StringLiteral("test".into()),
-            glossa_type: GlossaType::String,
-        }
-    ]);
-     let program = glossa::semantic::AnalyzedProgram {
+    let stmt = AnalyzedStatement::Expression(vec![AnalyzedExpr {
+        expr: AnalyzedExprKind::StringLiteral("test".into()),
+        glossa_type: GlossaType::String,
+    }]);
+    let program = glossa::semantic::AnalyzedProgram {
         statements: vec![stmt],
         scope: glossa::semantic::Scope::new(),
     };
@@ -102,10 +102,7 @@ fn test_bard_match() {
 #[test]
 fn test_bard_break_continue() {
     // Manually construct to ensure we hit the variants
-    let stmts = vec![
-        AnalyzedStatement::Break,
-        AnalyzedStatement::Continue,
-    ];
+    let stmts = vec![AnalyzedStatement::Break, AnalyzedStatement::Continue];
     let program = glossa::semantic::AnalyzedProgram {
         statements: stmts,
         scope: glossa::semantic::Scope::new(),
@@ -121,17 +118,17 @@ fn test_bard_return() {
         value: Some(Box::new(AnalyzedExpr {
             expr: AnalyzedExprKind::NumberLiteral(42),
             glossa_type: GlossaType::Number,
-        }))
+        })),
     };
-     let program = glossa::semantic::AnalyzedProgram {
+    let program = glossa::semantic::AnalyzedProgram {
         statements: vec![stmt],
         scope: glossa::semantic::Scope::new(),
     };
     let tale = tell_tale(&program);
     assert!(tale.contains("Return with the offering the number 42"));
 
-     let stmt_empty = AnalyzedStatement::Return { value: None };
-     let program_empty = glossa::semantic::AnalyzedProgram {
+    let stmt_empty = AnalyzedStatement::Return { value: None };
+    let program_empty = glossa::semantic::AnalyzedProgram {
         statements: vec![stmt_empty],
         scope: glossa::semantic::Scope::new(),
     };
@@ -233,100 +230,230 @@ fn test_expr_tale(kind: AnalyzedExprKind, expected: &str) {
         scope: glossa::semantic::Scope::new(),
     };
     let tale = tell_tale(&program);
-    assert!(tale.contains(expected), "Expected '{}' in '{}'", expected, tale);
+    assert!(
+        tale.contains(expected),
+        "Expected '{}' in '{}'",
+        expected,
+        tale
+    );
 }
 
 #[test]
 fn test_bard_exprs() {
     test_expr_tale(AnalyzedExprKind::BooleanLiteral(true), "the truth true");
-    test_expr_tale(AnalyzedExprKind::PropertyAccess {
-        owner: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("obj".into()), glossa_type: GlossaType::Unknown }),
-        property: "prop".into(),
-    }, "the `prop` of `obj`");
+    test_expr_tale(
+        AnalyzedExprKind::PropertyAccess {
+            owner: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable("obj".into()),
+                glossa_type: GlossaType::Unknown,
+            }),
+            property: "prop".into(),
+        },
+        "the `prop` of `obj`",
+    );
 
-    test_expr_tale(AnalyzedExprKind::VerbCall {
-        verb: "run".into(),
-        args: vec![],
-    }, "runing []");
+    test_expr_tale(
+        AnalyzedExprKind::VerbCall {
+            verb: "run".into(),
+            args: vec![],
+        },
+        "runing []",
+    );
 
-    test_expr_tale(AnalyzedExprKind::UnaryOp {
-        op: glossa::morphology::lexicon::UnaryOp::Not,
-        operand: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::BooleanLiteral(true), glossa_type: GlossaType::Boolean }),
-    }, "(Not the truth true)");
+    test_expr_tale(
+        AnalyzedExprKind::UnaryOp {
+            op: glossa::morphology::lexicon::UnaryOp::Not,
+            operand: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::BooleanLiteral(true),
+                glossa_type: GlossaType::Boolean,
+            }),
+        },
+        "(Not the truth true)",
+    );
 
-    test_expr_tale(AnalyzedExprKind::Range {
-        start: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number }),
-        end: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(10), glossa_type: GlossaType::Number }),
-        inclusive: true,
-    }, "from the number 1 through the number 10");
+    test_expr_tale(
+        AnalyzedExprKind::Range {
+            start: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(1),
+                glossa_type: GlossaType::Number,
+            }),
+            end: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(10),
+                glossa_type: GlossaType::Number,
+            }),
+            inclusive: true,
+        },
+        "from the number 1 through the number 10",
+    );
 
-    test_expr_tale(AnalyzedExprKind::ArrayLiteral(vec![]), "a list containing []");
+    test_expr_tale(
+        AnalyzedExprKind::ArrayLiteral(vec![]),
+        "a list containing []",
+    );
 
-    test_expr_tale(AnalyzedExprKind::Some(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number })), "something (the number 1)");
+    test_expr_tale(
+        AnalyzedExprKind::Some(Box::new(AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(1),
+            glossa_type: GlossaType::Number,
+        })),
+        "something (the number 1)",
+    );
     test_expr_tale(AnalyzedExprKind::None, "nothing");
-    test_expr_tale(AnalyzedExprKind::Ok(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number })), "success (the number 1)");
-    test_expr_tale(AnalyzedExprKind::Err(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number })), "failure (the number 1)");
+    test_expr_tale(
+        AnalyzedExprKind::Ok(Box::new(AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(1),
+            glossa_type: GlossaType::Number,
+        })),
+        "success (the number 1)",
+    );
+    test_expr_tale(
+        AnalyzedExprKind::Err(Box::new(AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(1),
+            glossa_type: GlossaType::Number,
+        })),
+        "failure (the number 1)",
+    );
 
-    test_expr_tale(AnalyzedExprKind::Unwrap(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("x".into()), glossa_type: GlossaType::Option(Box::new(GlossaType::Number)) })), "the essence of `x`");
-    test_expr_tale(AnalyzedExprKind::Try(Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("x".into()), glossa_type: GlossaType::Option(Box::new(GlossaType::Number)) })), "attempting `x`");
+    test_expr_tale(
+        AnalyzedExprKind::Unwrap(Box::new(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable("x".into()),
+            glossa_type: GlossaType::Option(Box::new(GlossaType::Number)),
+        })),
+        "the essence of `x`",
+    );
+    test_expr_tale(
+        AnalyzedExprKind::Try(Box::new(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable("x".into()),
+            glossa_type: GlossaType::Option(Box::new(GlossaType::Number)),
+        })),
+        "attempting `x`",
+    );
 
-    test_expr_tale(AnalyzedExprKind::IndexAccess {
-        array: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("arr".into()), glossa_type: GlossaType::List(Box::new(GlossaType::Number)) }),
-        index: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(0), glossa_type: GlossaType::Number }),
-    }, "the item at the number 0 in `arr`");
+    test_expr_tale(
+        AnalyzedExprKind::IndexAccess {
+            array: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable("arr".into()),
+                glossa_type: GlossaType::List(Box::new(GlossaType::Number)),
+            }),
+            index: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(0),
+                glossa_type: GlossaType::Number,
+            }),
+        },
+        "the item at the number 0 in `arr`",
+    );
 
-    test_expr_tale(AnalyzedExprKind::FunctionCall {
-        func: "f".into(),
-        args: vec![],
-    }, "calling `f` with []");
+    test_expr_tale(
+        AnalyzedExprKind::FunctionCall {
+            func: "f".into(),
+            args: vec![],
+        },
+        "calling `f` with []",
+    );
 
-    test_expr_tale(AnalyzedExprKind::MethodCall {
-        receiver: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("obj".into()), glossa_type: GlossaType::Unknown }),
-        method: "m".into(),
-        args: vec![],
-    }, "invoking `m` on `obj` with []");
+    test_expr_tale(
+        AnalyzedExprKind::MethodCall {
+            receiver: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable("obj".into()),
+                glossa_type: GlossaType::Unknown,
+            }),
+            method: "m".into(),
+            args: vec![],
+        },
+        "invoking `m` on `obj` with []",
+    );
 
-    test_expr_tale(AnalyzedExprKind::TraitMethodCall {
-        receiver: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("obj".into()), glossa_type: GlossaType::Unknown }),
-        trait_name: "T".into(),
-        method_name: "m".into(),
-        args: vec![],
-    }, "invoking `m` (as `T`) on `obj` with []");
+    test_expr_tale(
+        AnalyzedExprKind::TraitMethodCall {
+            receiver: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable("obj".into()),
+                glossa_type: GlossaType::Unknown,
+            }),
+            trait_name: "T".into(),
+            method_name: "m".into(),
+            args: vec![],
+        },
+        "invoking `m` (as `T`) on `obj` with []",
+    );
 
-    test_expr_tale(AnalyzedExprKind::StructInstantiation {
-        type_name: "S".into(),
-        fields: vec!["f".into()],
-        args: vec![AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number }],
-    }, "a new `S` with fields [f] set to [the number 1]");
+    test_expr_tale(
+        AnalyzedExprKind::StructInstantiation {
+            type_name: "S".into(),
+            fields: vec!["f".into()],
+            args: vec![AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(1),
+                glossa_type: GlossaType::Number,
+            }],
+        },
+        "a new `S` with fields [f] set to [the number 1]",
+    );
 
-    test_expr_tale(AnalyzedExprKind::Lambda {
-        params: vec!["p".into()],
-        body: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::Variable("p".into()), glossa_type: GlossaType::Unknown }),
-        capture_mode: CaptureMode::Borrow,
-    }, "a spirit borrowing [p] that produces `p`");
+    test_expr_tale(
+        AnalyzedExprKind::Lambda {
+            params: vec!["p".into()],
+            body: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable("p".into()),
+                glossa_type: GlossaType::Unknown,
+            }),
+            capture_mode: CaptureMode::Borrow,
+        },
+        "a spirit borrowing [p] that produces `p`",
+    );
 
-     test_expr_tale(AnalyzedExprKind::Lambda {
-        params: vec![],
-        body: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unit }),
-        capture_mode: CaptureMode::Move,
-    }, "a spirit moving []");
+    test_expr_tale(
+        AnalyzedExprKind::Lambda {
+            params: vec![],
+            body: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::None,
+                glossa_type: GlossaType::Unit,
+            }),
+            capture_mode: CaptureMode::Move,
+        },
+        "a spirit moving []",
+    );
 
-     test_expr_tale(AnalyzedExprKind::Lambda {
-        params: vec![],
-        body: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unit }),
-        capture_mode: CaptureMode::Memoize,
-    }, "a spirit remembering []");
+    test_expr_tale(
+        AnalyzedExprKind::Lambda {
+            params: vec![],
+            body: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::None,
+                glossa_type: GlossaType::Unit,
+            }),
+            capture_mode: CaptureMode::Memoize,
+        },
+        "a spirit remembering []",
+    );
 
-    test_expr_tale(AnalyzedExprKind::CollectionNew { collection_type: "HashSet".into() }, "a new empty HashSet");
+    test_expr_tale(
+        AnalyzedExprKind::CollectionNew {
+            collection_type: "HashSet".into(),
+        },
+        "a new empty HashSet",
+    );
 
-    test_expr_tale(AnalyzedExprKind::Assert {
-        condition: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::BooleanLiteral(true), glossa_type: GlossaType::Boolean }),
-    }, "asserting that the truth true is true");
+    test_expr_tale(
+        AnalyzedExprKind::Assert {
+            condition: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::BooleanLiteral(true),
+                glossa_type: GlossaType::Boolean,
+            }),
+        },
+        "asserting that the truth true is true",
+    );
 
-    test_expr_tale(AnalyzedExprKind::AssertEq {
-        left: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number }),
-        right: Box::new(AnalyzedExpr { expr: AnalyzedExprKind::NumberLiteral(1), glossa_type: GlossaType::Number }),
-    }, "asserting that the number 1 equals the number 1");
+    test_expr_tale(
+        AnalyzedExprKind::AssertEq {
+            left: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(1),
+                glossa_type: GlossaType::Number,
+            }),
+            right: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(1),
+                glossa_type: GlossaType::Number,
+            }),
+        },
+        "asserting that the number 1 equals the number 1",
+    );
 }
 
 #[test]
@@ -343,16 +470,49 @@ fn test_bard_types() {
             scope: glossa::semantic::Scope::new(),
         };
         let tale = tell_tale(&program);
-        assert!(tale.contains(expected), "Expected '{}' in '{}'", expected, tale);
+        assert!(
+            tale.contains(expected),
+            "Expected '{}' in '{}'",
+            expected,
+            tale
+        );
     }
 
-    check_type(GlossaType::List(Box::new(GlossaType::Number)), "List of Number");
-    check_type(GlossaType::Set(Box::new(GlossaType::Number)), "Set of Number");
-    check_type(GlossaType::Map(Box::new(GlossaType::String), Box::new(GlossaType::Number)), "Map from Text to Number");
-    check_type(GlossaType::Option(Box::new(GlossaType::Number)), "Maybe Number");
-    check_type(GlossaType::Result(Box::new(GlossaType::Number), Box::new(GlossaType::String)), "Result of Number or Text");
-    check_type(GlossaType::Struct { name: "S".into(), gender: glossa::morphology::Gender::Neuter, fields: vec![] }, "Form `S`");
-    check_type(GlossaType::Function { params: vec![GlossaType::Number], returns: Box::new(GlossaType::Boolean) }, "Function(Number) -> Truth");
+    check_type(
+        GlossaType::List(Box::new(GlossaType::Number)),
+        "List of Number",
+    );
+    check_type(
+        GlossaType::Set(Box::new(GlossaType::Number)),
+        "Set of Number",
+    );
+    check_type(
+        GlossaType::Map(Box::new(GlossaType::String), Box::new(GlossaType::Number)),
+        "Map from Text to Number",
+    );
+    check_type(
+        GlossaType::Option(Box::new(GlossaType::Number)),
+        "Maybe Number",
+    );
+    check_type(
+        GlossaType::Result(Box::new(GlossaType::Number), Box::new(GlossaType::String)),
+        "Result of Number or Text",
+    );
+    check_type(
+        GlossaType::Struct {
+            name: "S".into(),
+            gender: glossa::morphology::Gender::Neuter,
+            fields: vec![],
+        },
+        "Form `S`",
+    );
+    check_type(
+        GlossaType::Function {
+            params: vec![GlossaType::Number],
+            returns: Box::new(GlossaType::Boolean),
+        },
+        "Function(Number) -> Truth",
+    );
     check_type(GlossaType::Unit, "Nothing");
     check_type(GlossaType::Unknown, "Mystery");
 }


### PR DESCRIPTION
💡 **The Spark:**
I realized that since Glossa uses semantic assembly to understand Greek grammar (Subject-Object-Verb slots), we could reverse this process to "explain" the code back to the user in English, verifying that the compiler understood the intent correctly.

🚀 **The Feature:**
Implemented `src/experimental/bard.rs`, a transpiler that converts the semantic AST (`AnalyzedProgram`) into a whimsical English narrative.
- **Input:** `ξ πέντε ἔστω.`
- **Output:** `Let there be a variable named 'ξ' with the value the number 5.`

🔮 **The Potential:**
This serves as:
1.  **A Debugger:** "Why is my code failing?" -> Run `bard` to see if the Subject/Object were parsed correctly.
2.  **A Documentation Generator:** Auto-generate English specs from Greek code.
3.  **A Learning Tool:** Helps users map Greek morphology to programming concepts.

⚠️ **Risk:**
**Low.** The logic is completely isolated in `src/experimental/bard.rs`. It reads the `AnalyzedProgram` (read-only) and produces a string. It is exposed via a new optional CLI command `bard` and does not affect the core compilation pipeline.

---
*PR created automatically by Jules for task [746260702873821019](https://jules.google.com/task/746260702873821019) started by @madmax983*