### PR TITLE
Fix DoS vulnerability in file loading mechanism

### DIFF
--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -9,6 +9,7 @@ use crate::tools::ui::Status;
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
 use std::fs;
+use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
@@ -43,7 +44,23 @@ fn load_source(input: &Path) -> Result<String> {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
     }
     check_file_size(input)?;
-    fs::read_to_string(input).into_diagnostic()
+
+    let file = fs::File::open(input).into_diagnostic()?;
+    let mut content = String::new();
+
+    // Use take to limit the read, preventing OOM on infinite streams (e.g. /dev/zero)
+    file.take(MAX_FILE_SIZE + 1)
+        .read_to_string(&mut content)
+        .into_diagnostic()?;
+
+    if content.len() as u64 > MAX_FILE_SIZE {
+        return Err(miette::miette!(
+            "Ἀρχεῖον λίαν μέγα (File too large): > {} bytes",
+            MAX_FILE_SIZE
+        ));
+    }
+
+    Ok(content)
 }
 
 pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
+use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
-use std::sync::mpsc;
 
 #[test]
 fn test_dos_dev_zero() {

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -1,0 +1,44 @@
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+use std::sync::mpsc;
+
+#[test]
+fn test_dos_dev_zero() {
+    // This test attempts to read from /dev/zero, which is an infinite stream.
+    // The current implementation of load_source uses fs::read_to_string, which reads until EOF.
+    // This should cause the thread to hang (or OOM eventually).
+    // We use a timeout to detect the hang.
+
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        let path = Path::new("/dev/zero");
+        // We expect run_file to fail either due to file size check (if fixed) or some other error.
+        // If it hangs, it won't return.
+        let result = glossa::tools::runner::run_file(path);
+        // Send the result back
+        // If run_file hangs, this line is never reached.
+        let _ = tx.send(result);
+    });
+
+    // Wait for 2 seconds. If no result, we assume it hung.
+    match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(res) => {
+            // It returned! Check if it errored (expected).
+            // Note: If the fix is NOT implemented, it might return OOM error if memory is small enough,
+            // or it might just hang.
+            // If it returns Ok, that's definitely wrong (it compiled infinite zeros??).
+            assert!(res.is_err(), "Should return error for /dev/zero");
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            // It timed out! This means it hung reading the file.
+            // This confirms the vulnerability.
+            // We panic to fail the test, as per "Red Phase".
+            panic!("Test timed out! run_file hung on /dev/zero, confirming DoS vulnerability.");
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("Thread disconnected unexpectedly");
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses a Denial of Service (DoS) vulnerability identified during Chaos Engineering (Havoc). The compiler previously used `fs::read_to_string` which reads until EOF. When pointed at an infinite stream like `/dev/zero`, this would cause the compiler to hang indefinitely or crash with OOM.

The fix implements a bounded read strategy using `std::io::Read::take` to limit the input to `MAX_FILE_SIZE` (1MB). If the input exceeds this limit, it returns a descriptive error.

A regression test `tests/havoc_dos.rs` is included to verify the fix and prevent future regressions. The test runs the file loading operation in a separate thread with a timeout to detect hangs.

---
*PR created automatically by Jules for task [17648214750579240108](https://jules.google.com/task/17648214750579240108) started by @madmax983*