### PR TITLE
📜 Codex: ADR 010 & Architecture Diagram Update

### DIFF
--- a/docs/adr/010-decouple-storage-from-core.md
+++ b/docs/adr/010-decouple-storage-from-core.md
@@ -1,0 +1,34 @@
+# 10. Decouple Storage from Core
+
+Date: 2024-11-20
+
+## Status
+
+Proposed
+
+## Context
+
+The `Core` module of the ΓΛΩΣΣΑ compiler, responsible for parsing and semantic analysis, was directly depending on persistence logic (e.g., file caching, artifact management) located in `src/tools/cache.rs` and potentially other utility modules. This coupling created several issues:
+
+1.  **Circular Dependencies:** As the compiler grew, `Core` needed to verify artifacts, but `Storage` needed `Core`'s types to serialize them.
+2.  **Testing Difficulty:** Unit testing `Core` required mocking file system interactions, which was cumbersome.
+3.  **Build Times:** Changes in the storage layer forced recompilation of the entire core logic.
+
+## Decision
+
+We will decouple the persistence logic into a dedicated `Storage` component (currently implemented via `src/tools/cache.rs` and related utilities).
+
+The `Core` module will interact with `Storage` exclusively through trait bounds or clean interfaces, rather than direct dependencies on concrete implementations where possible. This aligns with the Hexagonal Architecture (Ports and Adapters) pattern.
+
+## Consequences
+
+### Positive
+
+*   **Improved Build Times:** Changes to the storage implementation will not necessarily trigger a full recompilation of `Core` if the interface remains stable.
+*   **Testability:** `Core` can be tested with in-memory storage mocks, isolating it from file system side effects.
+*   **Cleaner Architecture:** Clear separation of concerns makes the codebase easier to reason about.
+
+### Negative
+
+*   **Increased Complexity:** Introducing abstraction layers (traits) adds some boilerplate and indirection.
+*   **Interface Management:** We must carefully design the storage interface to be flexible enough for future needs without leaking implementation details.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,7 @@ C4Container
     Container(highlight, "Highlighter", "src/highlight.rs", "Semantic syntax highlighting")
     Container(report, "Reporter", "src/report.rs", "Generates statistics and structured reports")
     Container(codegen, "Code Generator", "src/codegen", "Generates Rust source code")
+    Container(storage, "Storage", "src/tools/cache.rs", "Manages file system, caching, and persistence")
 
     Rel(lexer, parser, "Stream<Token>")
     Rel(parser, morphology, "AST (Unresolved)")
@@ -41,6 +42,58 @@ C4Container
     Rel(morphology, semantic, "AST (Resolved Morphology)")
     Rel(semantic, report, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
+    Rel(codegen, storage, "Persists Artifacts")
+```
+
+## Core vs Storage (Class Diagram)
+
+This diagram illustrates the decoupling between the core compiler logic and the storage/persistence layer.
+
+```mermaid
+classDiagram
+    class Core {
+        +parse()
+        +analyze()
+        +compile()
+    }
+    class Storage {
+        +read_source()
+        +write_artifact()
+        +check_cache()
+    }
+    class Runner {
+        +run()
+    }
+
+    Runner --> Core : Orchestrates
+    Runner --> Storage : Uses
+    Core ..> Storage : Uses (Trait Bound)
+```
+
+## Compilation Flow (Sequence Diagram)
+
+This diagram shows the interaction between the Runner, Storage, and Core during a typical build/run cycle.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Runner
+    participant Storage
+    participant Core
+
+    User->>Runner: glossa run main.γλ
+    Runner->>Storage: check_cache(main.γλ)
+    alt Cache Valid
+        Storage-->>Runner: Returns cached binary path
+    else Cache Invalid
+        Storage-->>Runner: Cache miss
+        Runner->>Storage: read_source(main.γλ)
+        Storage-->>Runner: Source Content
+        Runner->>Core: compile(Source)
+        Core-->>Runner: Generated Rust Code
+        Runner->>Storage: write_artifact(Rust Code)
+    end
+    Runner->>User: Executes Binary
 ```
 
 ## Semantic Analysis (C4 Component Level)


### PR DESCRIPTION
🧠 **Decision:** Recorded the move to decouple persistence logic into a dedicated `Storage` component in `docs/adr/010-decouple-storage-from-core.md`.
🗺️ **Visuals:** Updated `docs/architecture.md` with a new Class Diagram showing the dependency inversion, a Sequence Diagram for the compilation flow, and an updated C4 Container diagram.
🔗 **Link:** See `docs/adr/010-decouple-storage-from-core.md`.

---
*PR created automatically by Jules for task [8652186849164971166](https://jules.google.com/task/8652186849164971166) started by @madmax983*