### PR TITLE
🛡️ Sentry: Add recursion limit tests

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -809,4 +809,67 @@ mod tests {
         assert_eq!(ast.statements.len(), 1);
         assert_eq!(ast.statements[0].clauses().len(), 2); // Two clauses separated by comma
     }
+
+    #[test]
+    fn test_recursion_limit_exceeded() {
+        // 501 nested parentheses
+        let source = "(".repeat(501) + &")".repeat(501);
+        let result = parse_source(&source);
+        assert!(matches!(
+            result,
+            Err(ParseError::RecursionLimitExceeded(500))
+        ));
+    }
+
+    #[test]
+    fn test_recursion_limit_not_exceeded() {
+        // 500 nested parentheses (should pass check, though pest might fail to parse empty parens)
+        let source = "(".repeat(500) + &")".repeat(500);
+        // We only care about the recursion check here
+        let result = check_recursion_depth(&source);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_recursion_limit_ignored_in_string() {
+        // Parentheses inside string literal shouldn't count
+        let source = "«".to_string() + &"(".repeat(600) + "»";
+        let result = check_recursion_depth(&source);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_recursion_limit_ignored_in_comment() {
+        // Parentheses inside comment shouldn't count
+        let source = "// ".to_string() + &"(".repeat(600);
+        let result = check_recursion_depth(&source);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_recursion_limit_mixed_brackets() {
+        // Mixed brackets should all count towards the same limit
+        // 200 (, 200 {, 101 [ = 501 total
+        let source = "(".repeat(200)
+            + &"{".repeat(200)
+            + &"[".repeat(101)
+            + &"]".repeat(101)
+            + &"}".repeat(200)
+            + &")".repeat(200);
+        let result = check_recursion_depth(&source);
+        assert!(matches!(
+            result,
+            Err(ParseError::RecursionLimitExceeded(500))
+        ));
+    }
+
+    #[test]
+    fn test_recursion_limit_unbalanced_but_safe() {
+        // Unbalanced brackets that don't exceed depth
+        // (((...))) then (((...))) - sequential, not nested
+        let part = "(".repeat(400) + &")".repeat(400);
+        let source = part.clone() + &part;
+        let result = check_recursion_depth(&source);
+        assert!(result.is_ok());
+    }
 }

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -1122,4 +1122,21 @@ mod tests {
             panic!("Second expression should be NumberLiteral(3)");
         }
     }
+
+    #[test]
+    fn test_recursion_limit_expression_analysis() {
+        // Construct a deeply nested Expr structure
+        // Expr::Phrase -> Expr::Phrase -> ... (51 times)
+        let mut deep_expr = Expr::NumberLiteral(1);
+        for _ in 0..52 {
+            deep_expr = Expr::Phrase(vec![deep_expr]);
+        }
+
+        let scope = Scope::new();
+        let result = analyze_argument_expr(&deep_expr, &scope);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Recursion limit exceeded"));
+    }
 }


### PR DESCRIPTION
This PR adds critical test coverage for recursion limits in both the parser (`check_recursion_depth`) and the semantic expression analyzer (`MAX_RECURSION_DEPTH`). These tests ensure that the compiler safely handles deeply nested inputs without stack overflowing, and correctly ignores structural characters (like parentheses) when they appear inside strings or comments.

**Target:** `src/parser.rs`, `src/semantic/expressions.rs`
**Risk:** Stack overflow on deep nesting, or false positives on valid strings/comments.
**Strategy:**
- `test_recursion_limit_exceeded`: Verify failure at >500 depth.
- `test_recursion_limit_ignored_in_string`: Verify `«((...))»` is ignored.
- `test_recursion_limit_expression_analysis`: Verify semantic analysis fails at >50 depth.
**Verification:** `cargo test` passes all new tests.

---
*PR created automatically by Jules for task [15127059994522036346](https://jules.google.com/task/15127059994522036346) started by @madmax983*