### PR TITLE
🔒 Warden: Fix Insecure Cache Key Hashing

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -81,3 +81,11 @@
 **Defense:** Implemented `check_program_depth` in `src/semantic/mod.rs` to enforce a strict recursion limit (`MAX_EXPRESSION_DEPTH = 200`). Analysis now fails gracefully with `GlossaError::LimitExceeded` if the depth is exceeded.
 
 **Severity:** High (DoS via compiler crash).
+
+## 2026-06-06 - Insecure Cache Key Hashing
+
+**Threat:** The build cache in `src/tools/cache.rs` used `std::collections::hash_map::DefaultHasher` to compute cache keys from file paths. `DefaultHasher` is not cryptographically secure and its stability across releases or environments is not guaranteed. This could lead to cache collisions (incorrect binary execution) or unstable keys (cache thrashing/DoS).
+
+**Defense:** Replaced `DefaultHasher` with `sha2::Sha256` to ensure deterministic, cryptographically secure, and collision-resistant cache keys (64-character hex strings).
+
+**Severity:** Medium (Cache Collision / DoS).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "comfy-table",
  "crossterm",
  "dirs-next",
+ "hex",
  "insta",
  "miette",
  "pest",
@@ -424,6 +425,7 @@ dependencies = [
  "proptest",
  "quote",
  "rustc-hash",
+ "sha2",
  "smol_str",
  "tempfile",
  "thiserror 2.0.18",
@@ -435,6 +437,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "insta"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ proc-macro2 = "1"
 smol_str = "0.3"
 rustc-hash = "2"
 comfy-table = "7.2.2"
+sha2 = "0.10"
+hex = "0.4"
 
 [dev-dependencies]
 insta = "1"

--- a/src/tools/cache.rs
+++ b/src/tools/cache.rs
@@ -31,13 +31,20 @@ impl Cache {
 
     /// Generate a cache key from the source file path.
     pub fn key(&self, input: &Path) -> String {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+        use sha2::{Digest, Sha256};
 
         let canonical = input.canonicalize().unwrap_or_else(|_| input.to_path_buf());
-        let mut hasher = DefaultHasher::new();
-        canonical.hash(&mut hasher);
-        format!("{:016x}", hasher.finish())
+        // Convert path to bytes. On unix this is OsStr bytes, on Windows it's UTF-8 if valid or WTF-8.
+        // We use to_string_lossy() to get a consistent string representation for hashing.
+        // Ideally we'd use OsStr bytes directly but that's platform specific (OsStrExt).
+        // For cross-platform consistency in this context (local cache), stringified path is fine.
+        let path_str = canonical.to_string_lossy();
+
+        let mut hasher = Sha256::new();
+        hasher.update(path_str.as_bytes());
+        let result = hasher.finalize();
+
+        hex::encode(result)
     }
 
     /// Get the paths for the cached Rust source and executable.

--- a/tests/warden_hashdos.rs
+++ b/tests/warden_hashdos.rs
@@ -1,0 +1,66 @@
+use glossa::tools::cache::Cache;
+use std::path::Path;
+
+#[test]
+fn test_cache_key_determinism() {
+    let cache = Cache::new();
+    let path = Path::new("src/main.rs");
+
+    // Key generation should be deterministic
+    let key1 = cache.key(path);
+    let key2 = cache.key(path);
+
+    assert_eq!(key1, key2, "Cache key must be deterministic");
+}
+
+#[test]
+fn test_cache_key_format() {
+    let cache = Cache::new();
+    let path = Path::new("src/main.rs");
+    let key = cache.key(path);
+
+    // SHA-256 hex string is 64 chars
+    assert_eq!(
+        key.len(),
+        64,
+        "Cache key must be 64 characters long (SHA-256 hex)"
+    );
+
+    // Check if it's hex
+    assert!(
+        key.chars().all(|c| c.is_ascii_hexdigit()),
+        "Cache key must be hex string"
+    );
+}
+
+#[test]
+fn test_cache_key_uniqueness() {
+    let cache = Cache::new();
+    // Use paths that resolve to different locations
+    let path1 = Path::new("src/main.rs");
+    let path2 = Path::new("src/lib.rs");
+
+    let key1 = cache.key(path1);
+    let key2 = cache.key(path2);
+
+    assert_ne!(key1, key2, "Different paths must produce different keys");
+}
+
+#[test]
+fn test_cache_key_canonicalization() {
+    // If the file exists, canonicalization should work and produce the same key for relative vs absolute
+    // This depends on file system state, so we use existing files.
+    let cache = Cache::new();
+    let path = Path::new("src/main.rs");
+
+    if path.exists() {
+        let abs_path = path.canonicalize().unwrap();
+        let key_rel = cache.key(path);
+        let key_abs = cache.key(&abs_path);
+
+        assert_eq!(
+            key_rel, key_abs,
+            "Relative and absolute paths should hash to same key"
+        );
+    }
+}


### PR DESCRIPTION
Replaced insecure `DefaultHasher` with `SHA-256` for cache key generation to prevent HashDoS and ensure deterministic builds. Added comprehensive tests in `tests/warden_hashdos.rs` to verify the fix.

---
*PR created automatically by Jules for task [13528844502806621530](https://jules.google.com/task/13528844502806621530) started by @madmax983*