### PR TITLE
👺 Havoc: Fix Identifier Collision Vulnerability

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -145,47 +145,20 @@ pub(crate) fn sanitize_name(name: &str) -> String {
 }
 
 /// Transliterate Greek to Latin characters
-pub(crate) fn transliterate(greek: &str) -> String {
+pub fn transliterate(greek: &str) -> String {
     let mut result = String::new();
 
     for c in greek.chars() {
-        let trans = match c {
-            'α' => "a",
-            'β' => "b",
-            'γ' => "g",
-            'δ' => "d",
-            'ε' => "e",
-            'ζ' => "z",
-            'η' => "h", // Distinct from 'e' (epsilon)
-            'ι' => "i",
-            'κ' => "k",
-            'λ' => "l",
-            'μ' => "m",
-            'ν' => "n",
-            'ξ' => "x",
-            'ο' => "o",
-            'π' => "p",
-            'ρ' => "r",
-            'σ' | 'ς' => "s",
-            'τ' => "t",
-            'υ' => "u",
-            'ω' => "w", // Distinct from 'o' (omicron)
-            // Digraphs and other characters are hex-encoded to prevent collisions
-            // θ, φ, χ, ψ map to _u..._ because th, ph, ch, ps collide with sequences
-            _ => {
-                // Keep only ASCII alphanumeric characters and underscore
-                if c.is_ascii_alphanumeric() || c == '_' {
-                    result.push(c);
-                } else {
-                    // Replace invalid characters with unique hex code to prevent collisions
-                    // e.g. ϟ -> _u3df_
-                    use std::fmt::Write;
-                    write!(result, "_u{:x}_", c as u32).unwrap();
-                }
-                continue;
-            }
-        };
-        result.push_str(trans);
+        // Keep only ASCII alphanumeric characters and underscore
+        if c.is_ascii_alphanumeric() || c == '_' {
+            result.push(c);
+        } else {
+            // Replace invalid characters with unique hex code to prevent collisions
+            // e.g. ϟ -> _u3df_
+            // e.g. α -> _u3b1_ (Distinct from 'a')
+            use std::fmt::Write;
+            write!(result, "_u{:x}_", c as u32).unwrap();
+        }
     }
 
     // Ensure it starts with a letter or underscore (valid Rust identifier)
@@ -1200,20 +1173,29 @@ mod tests {
 
     #[test]
     fn test_sanitize_greek_letter() {
-        assert_eq!(sanitize_name("ξ"), "g_x");
-        assert_eq!(sanitize_name("α"), "g_a");
-        assert_eq!(sanitize_name("ω"), "g_w");
+        assert_eq!(sanitize_name("ξ"), "g__u3be_");
+        assert_eq!(sanitize_name("α"), "g__u3b1_");
+        assert_eq!(sanitize_name("ω"), "g__u3c9_");
     }
 
     #[test]
     fn test_transliterate() {
-        // χ (chi) -> hex, ρ -> r, η -> h, σ -> s, τ -> t, ο -> o, ς -> s
+        // χ (chi) -> hex, ρ -> hex, etc.
         // χ is 0x3c7
-        assert_eq!(transliterate("χρηστος"), "_u3c7_rhstos");
-        assert_eq!(transliterate("λογος"), "logos");
-        // φ (phi) -> hex
-        // φ is 0x3c6
-        assert_eq!(transliterate("φιλοσοφια"), "_u3c6_iloso_u3c6_ia");
+        // ρ is 0x3c1
+        // η is 0x3b7
+        // σ is 0x3c3
+        // τ is 0x3c4
+        // ο is 0x3bf
+        // ς is 0x3c2
+        assert_eq!(transliterate("χρηστος"), "_u3c7__u3c1__u3b7__u3c3__u3c4__u3bf__u3c2_");
+
+        // λ (lambda) -> _u3bb_
+        // ο (omicron) -> _u3bf_
+        // γ (gamma) -> _u3b3_
+        // ο (omicron) -> _u3bf_
+        // ς (final sigma) -> _u3c2_
+        assert_eq!(transliterate("λογος"), "_u3bb__u3bf__u3b3__u3bf__u3c2_");
     }
 
     #[test]
@@ -1236,7 +1218,7 @@ mod tests {
     #[test]
     fn test_transliterate_mixed_valid_invalid() {
         // Test mixing valid and invalid characters
-        let input = "αϟβ";
+        let input = "aϟb";
         let output = transliterate(input);
         assert_eq!(output, "a_u3df_b");
     }
@@ -1311,9 +1293,13 @@ mod tests {
             gender: crate::morphology::Gender::Masculine,
             fields: vec![],
         };
-        // Sanitize: χρηστης -> g__u3c7_rhsths
-        // Capitalize: g__u3c7_rhsths -> G__u3c7_rhsths
-        assert_eq!(to_rust_type(&ty), "G__u3c7_rhsths");
+        // Sanitize: χρηστης -> g__u3c7_rhsths (Old)
+        // New: All chars hex encoded
+        // χ(3c7) ρ(3c1) η(3b7) σ(3c3) τ(3c4) η(3b7) ς(3c2)
+        // g__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_
+        // Capitalized: G__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_
+        let expected = "G__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_";
+        assert_eq!(to_rust_type(&ty), expected);
     }
 
     // --- Rust Codegen Tests ---
@@ -1336,7 +1322,8 @@ mod tests {
     fn test_generate_binding() {
         let code = compile("ξ πέντε ἔστω.");
         // Variables are now prefixed with g_
-        assert!(code.contains("let g_x"));
+        // ξ -> _u3be_
+        assert!(code.contains("let g__u3be_"));
         assert!(code.contains("5"));
     }
 
@@ -1351,8 +1338,9 @@ mod tests {
     fn test_generate_full_program() {
         let code = compile("ξ πέντε ἔστω. ξ λέγε.");
         // Variables are now prefixed with g_
+        // ξ -> _u3be_
         assert!(
-            code.contains("let g_x = 5"),
+            code.contains("let g__u3be_ = 5"),
             "Expected binding in: {}",
             code
         );

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1188,7 +1188,10 @@ mod tests {
         // τ is 0x3c4
         // ο is 0x3bf
         // ς is 0x3c2
-        assert_eq!(transliterate("χρηστος"), "_u3c7__u3c1__u3b7__u3c3__u3c4__u3bf__u3c2_");
+        assert_eq!(
+            transliterate("χρηστος"),
+            "_u3c7__u3c1__u3b7__u3c3__u3c4__u3bf__u3c2_"
+        );
 
         // λ (lambda) -> _u3bb_
         // ο (omicron) -> _u3bf_

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -21,16 +21,17 @@ fn test_hello_cosmos() {
 #[test]
 fn test_variable_binding() {
     let code = compile("ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let g_x"));
+    assert!(code.contains("let g__u3be_"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_variable_binding_and_use() {
     let code = compile("ξ πέντε ἔστω. ξ λέγε.").unwrap();
-    assert!(code.contains("let g_x = 5"));
+    // ξ -> _u3be_
+    assert!(code.contains("let g__u3be_ = 5"));
     assert!(code.contains("println"));
-    assert!(code.contains("g_x"));
+    assert!(code.contains("g__u3be_"));
 }
 
 #[test]
@@ -42,8 +43,9 @@ fn test_number_literal() {
 #[test]
 fn test_multiple_statements() {
     let code = compile("α πέντε ἔστω. β δέκα ἔστω. α λέγε.").unwrap();
-    assert!(code.contains("let g_a = 5"));
-    assert!(code.contains("let g_b = 10"));
+    // α -> _u3b1_, β -> _u3b2_
+    assert!(code.contains("let g__u3b1_ = 5"));
+    assert!(code.contains("let g__u3b2_ = 10"));
 }
 
 #[test]
@@ -61,15 +63,17 @@ fn test_preserves_greek_in_strings() {
 #[test]
 fn test_mutable_binding() {
     let code = compile("μετά ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let mut g_x"));
+    // ξ -> _u3be_
+    assert!(code.contains("let mut g__u3be_"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_assignment_codegen() {
     let code = compile("μετά ξ πέντε ἔστω. ξ δέκα γίγνεται.").unwrap();
-    assert!(code.contains("let mut g_x = 5"));
-    assert!(code.contains("g_x = 10"));
+    // ξ -> _u3be_
+    assert!(code.contains("let mut g__u3be_ = 5"));
+    assert!(code.contains("g__u3be_ = 10"));
 }
 
 #[test]
@@ -89,8 +93,9 @@ fn test_undefined_assignment_error() {
 #[test]
 fn test_mutable_binding_and_reassignment() {
     let code = compile("μετά ξ πέντε ἔστω. ξ λέγε. ξ δέκα γίγνεται. ξ λέγε.").unwrap();
-    assert!(code.contains("let mut g_x = 5"));
-    assert!(code.contains("g_x = 10"));
+    // ξ -> _u3be_
+    assert!(code.contains("let mut g__u3be_ = 5"));
+    assert!(code.contains("g__u3be_ = 10"));
     assert!(code.matches("println").count() >= 2);
 }
 

--- a/tests/function_tests.rs
+++ b/tests/function_tests.rs
@@ -85,7 +85,11 @@ fn test_function_call() {
     // πρόσθεσις -> hex encoded
     // π(3c0) ρ(3c1) ο(3bf) σ(3c3) θ(3b8) ε(3b5) σ(3c3) ι(3b9) ς(3c2)
     let expected = "g__u3c0__u3c1__u3bf__u3c3__u3b8__u3b5__u3c3__u3b9__u3c2_";
-    assert!(code.contains(expected), "Expected function name: {}", expected);
+    assert!(
+        code.contains(expected),
+        "Expected function name: {}",
+        expected
+    );
 }
 
 #[test]

--- a/tests/function_tests.rs
+++ b/tests/function_tests.rs
@@ -39,8 +39,8 @@ fn test_function_with_two_params() {
     let code = compile("προσθεσις ὁρίζειν τῷ ξ τῷ ψ· δός ξ ψ ἄθροισμα.");
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("fn"));
-    // ξ -> g_x, ψ -> g__u3c8_
-    assert!(code.contains("g_x") && code.contains("g__u3c8_"));
+    // ξ -> g__u3be_, ψ -> g__u3c8_
+    assert!(code.contains("g__u3be_") && code.contains("g__u3c8_"));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_simple_return() {
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("return"));
     // Should return x * 2, not just a literal
-    assert!(code.contains("g_x") || code.contains("*") || code.contains("2"));
+    assert!(code.contains("g__u3be_") || code.contains("*") || code.contains("2"));
 }
 
 #[test]
@@ -82,11 +82,10 @@ fn test_function_call() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
-    // πρόσθεσις -> g_pros_u3b8_esis
-    assert!(
-        code.contains("g_pros_u3b8_esis")
-            && (code.contains("g_pros_u3b8_esis(") || code.contains("g_pros_u3b8_esis ("))
-    );
+    // πρόσθεσις -> hex encoded
+    // π(3c0) ρ(3c1) ο(3bf) σ(3c3) θ(3b8) ε(3b5) σ(3c3) ι(3b9) ς(3c2)
+    let expected = "g__u3c0__u3c1__u3bf__u3c3__u3b8__u3b5__u3c3__u3b9__u3c2_";
+    assert!(code.contains(expected), "Expected function name: {}", expected);
 }
 
 #[test]
@@ -99,8 +98,11 @@ fn test_nested_calls() {
     );
     eprintln!("Generated code:\n{}", code);
     // Check for nested diplasiasmos calls (allowing for whitespace)
+    // διπλασιασμος -> hex encoded
+    // δ(3b4) ι(3b9) π(3c0) λ(3bb) α(3b1) σ(3c3) ι(3b9) α(3b1) σ(3c3) μ(3bc) ο(3bf) ς(3c2)
+    let expected = "g__u3b4__u3b9__u3c0__u3bb__u3b1__u3c3__u3b9__u3b1__u3c3__u3bc__u3bf__u3c2_";
     assert!(
-        code.matches("g_diplasiasmos").count() >= 3,
+        code.matches(expected).count() >= 3,
         "Expected at least 3 occurrences of diplasiasmos (fn def + 2 calls)"
     );
     assert!(code.contains("5i64"), "Expected literal 5 as argument");
@@ -120,7 +122,10 @@ fn test_function_local_variables() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
-    assert!(code.contains("let g_topikon"));
+    // τοπικον -> hex encoded
+    // τ(3c4) ο(3bf) π(3c0) ι(3b9) κ(3ba) ο(3bf) ν(3bd)
+    let expected = "g__u3c4__u3bf__u3c0__u3b9__u3ba__u3bf__u3bd_";
+    assert!(code.contains(expected));
 }
 
 #[test]

--- a/tests/havoc_compiler_crash.rs
+++ b/tests/havoc_compiler_crash.rs
@@ -1,0 +1,33 @@
+use glossa::tools::runner::run_file;
+use std::fs::File;
+use std::io::Write;
+
+#[test]
+fn test_compiler_crash_collision_structs() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("crash_structs.gl");
+
+    // Program:
+    // εἶδος a ὁρίζειν { }. (Struct 'A')
+    // εἶδος α ὁρίζειν { }. (Struct 'Alpha' -> 'A')
+    //
+    // Collision: `struct G_A {}` and `struct G_A {}`
+    // Rustc Error: the name `G_A` is defined multiple times
+
+    let source = r#"
+    εἶδος a ὁρίζειν { }.
+    εἶδος α ὁρίζειν { }.
+    "#;
+
+    {
+        let mut f = File::create(&input_path).unwrap();
+        f.write_all(source.as_bytes()).unwrap();
+    }
+
+    let result = run_file(&input_path);
+
+    // We expect this to SUCCEED now that collision is fixed
+    if let Err(e) = result {
+        panic!("Compiler crashed: {}", e);
+    }
+}

--- a/tests/havoc_transliteration.rs
+++ b/tests/havoc_transliteration.rs
@@ -15,7 +15,11 @@ fn test_known_collision_alpha() {
     assert_ne!(greek, latin);
 
     // They should transliterate to different strings to avoid collision.
-    assert_ne!(transliterate(greek), transliterate(latin), "Collision detected: α maps to same output as a");
+    assert_ne!(
+        transliterate(greek),
+        transliterate(latin),
+        "Collision detected: α maps to same output as a"
+    );
 }
 
 proptest! {

--- a/tests/havoc_transliteration.rs
+++ b/tests/havoc_transliteration.rs
@@ -1,0 +1,30 @@
+use glossa::codegen::transliterate;
+use proptest::prelude::*;
+
+// Havoc Test: Verify transliteration uniqueness
+// Logic: If two different source identifiers map to the same target identifier,
+// the compiler will generate broken code (shadowing or type errors).
+
+#[test]
+fn test_known_collision_alpha() {
+    // The "Golden Hammer" of collisions: α vs a
+    let greek = "α";
+    let latin = "a";
+
+    // They are different strings
+    assert_ne!(greek, latin);
+
+    // They should transliterate to different strings to avoid collision.
+    assert_ne!(transliterate(greek), transliterate(latin), "Collision detected: α maps to same output as a");
+}
+
+proptest! {
+    #[test]
+    fn test_transliteration_unique(s1 in "[a-zA-Zα-ω]+", s2 in "[a-zA-Zα-ω]+") {
+        // Generate strings containing Latin and Greek letters
+        if s1 != s2 {
+            // We expect unique transliterations for unique inputs
+            prop_assert_ne!(transliterate(&s1), transliterate(&s2));
+        }
+    }
+}

--- a/tests/trait_tests.rs
+++ b/tests/trait_tests.rs
@@ -582,7 +582,9 @@ fn test_standalone_method_call() {
     let code = compile(source);
 
     // Should contain the method call
-    assert!(code.contains("g_p . g_show") || code.contains("g_p.g_show"));
+    // π -> _u3c0_
+    let var = "g__u3c0_";
+    assert!(code.contains(&format!("{var} . g_show")) || code.contains(&format!("{var}.g_show")));
 }
 
 // ============================================================================

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -43,8 +43,10 @@ fn test_instantiation() {
         π νέον σημεῖον πέντε ἔστω.
     "#;
     let code = compile(source);
-    // σημεῖον -> G_shmeion
-    assert!(code.contains("G_shmeion"));
+    // σημεῖον -> hex encoded
+    // σ(3c3) η(3b7) μ(3bc) ε(3b5) ι(3b9) ο(3bf) ν(3bd)
+    let expected = "G__u3c3__u3b7__u3bc__u3b5__u3b9__u3bf__u3bd_";
+    assert!(code.contains(expected));
     assert!(code.contains("5"));
 }
 
@@ -55,7 +57,9 @@ fn test_instantiation_multiple_fields() {
         π νέον σημεῖον πέντε τρία ἔστω.
     "#;
     let code = compile(source);
-    assert!(code.contains("G_shmeion"));
+    // σημεῖον -> hex encoded
+    let expected = "G__u3c3__u3b7__u3bc__u3b5__u3b9__u3bf__u3bd_";
+    assert!(code.contains(expected));
 }
 
 // Cycle 5: Field Access
@@ -68,8 +72,9 @@ fn test_field_access() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    // ξ -> g_x
-    assert!(code.contains(".g_x") || code.contains(". g_x"));
+    // ξ -> g__u3be_
+    let var = "g__u3be_";
+    assert!(code.contains(&format!(".{var}")) || code.contains(&format!(". {var}")));
 }
 
 #[test]
@@ -82,10 +87,12 @@ fn test_field_access_multiple_fields() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    // ξ -> g_x
-    assert!(code.contains(". g_x") || code.contains(".g_x"));
+    // ξ -> g__u3be_
+    let x = "g__u3be_";
+    assert!(code.contains(&format!(".{x}")) || code.contains(&format!(". {x}")));
     // ψ -> g__u3c8_
-    assert!(code.contains(". g__u3c8_") || code.contains(".g__u3c8_"));
+    let psi = "g__u3c8_";
+    assert!(code.contains(&format!(".{psi}")) || code.contains(&format!(". {psi}")));
 }
 
 #[test]
@@ -97,9 +104,12 @@ fn test_instantiation_with_literals() {
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
     // It should generate struct instantiation, not string assignment
-    // Χρήστης -> G__u3c7_rhsths
-    assert!(code.contains("struct G__u3c7_rhsths"));
-    assert!(code.contains("let g__u3c7_rhsths = G__u3c7_rhsths"));
+    // Χρήστης -> hex encoded
+    // χ(3c7) ρ(3c1) η(3b7) σ(3c3) τ(3c4) η(3b7) ς(3c2)
+    let struct_name = "G__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_";
+    let var_name = "g__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_";
+    assert!(code.contains(&format!("struct {struct_name}")));
+    assert!(code.contains(&format!("let {var_name} = {struct_name}")));
     assert!(code.contains("Σωκράτης"));
     assert!(code.contains("70"));
 }

--- a/tests/warden_exploit.rs
+++ b/tests/warden_exploit.rs
@@ -30,8 +30,8 @@ fn test_exploit_unicode_panic() {
     // format_ident!("_a") is valid.
 
     assert!(
-        rust.contains("_a"),
-        "Generated code should contain sanitized identifier '_a'. Code: {}",
+        rust.contains("g__u1fbd__u3b1_"),
+        "Generated code should contain sanitized identifier 'g__u1fbd__u3b1_'. Code: {}",
         rust
     );
 }

--- a/tests/word_order_tests.rs
+++ b/tests/word_order_tests.rs
@@ -23,7 +23,8 @@ fn test_binding_word_order_independence() {
     let sov = compile_to_rust("ξ πέντε ἔστω.");
 
     // These should all produce equivalent output
-    assert!(sov.contains("let g_x"));
+    // ξ -> _u3be_
+    assert!(sov.contains("let g__u3be_"));
     assert!(sov.contains("5i64") || sov.contains("5 "));
 }
 
@@ -44,7 +45,8 @@ fn test_variable_binding_and_reference() {
     let output = compile_to_rust(source);
 
     // Should have binding
-    assert!(output.contains("let g_x"));
+    // ξ -> _u3be_
+    assert!(output.contains("let g__u3be_"));
     // Should have print
     assert!(output.contains("println"));
 }
@@ -54,12 +56,13 @@ fn test_variable_binding_and_reference() {
 fn test_number_binding_variations() {
     // Arabic numeral
     let arabic = compile_to_rust("ξ 42 ἔστω.");
-    assert!(arabic.contains("let g_x"));
+    // ξ -> _u3be_
+    assert!(arabic.contains("let g__u3be_"));
     assert!(arabic.contains("42"));
 
     // Greek numeral word
     let greek_word = compile_to_rust("ξ πέντε ἔστω.");
-    assert!(greek_word.contains("let g_x"));
+    assert!(greek_word.contains("let g__u3be_"));
     assert!(greek_word.contains("5"));
 }
 
@@ -104,8 +107,9 @@ fn test_multiple_statement_scope() {
     let output = compile_to_rust(source);
 
     // Both bindings should exist
-    assert!(output.contains("let g_a"));
-    assert!(output.contains("let g_b"));
+    // α -> _u3b1_, β -> _u3b2_
+    assert!(output.contains("let g__u3b1_"));
+    assert!(output.contains("let g__u3b2_"));
 }
 
 /// Test that queries produce output


### PR DESCRIPTION
Havoc operation revealed that Greek characters like 'α' were transliterated to 'a', causing collisions with existing Latin identifiers in the generated Rust code. This could lead to variable shadowing or invalid code generation.

This fix removes the manual phonetic mappings (e.g. 'α' -> 'a') in `src/codegen.rs` and enforces strict hex encoding (e.g. 'α' -> '_u3b1_') for all non-ASCII characters. This ensures that every unique Unicode identifier maps to a unique Rust identifier.

Includes new regression tests:
- `tests/havoc_transliteration.rs`: Fuzzing test using `proptest` to ensure no collisions occur.
- `tests/havoc_compiler_crash.rs`: Integration test verifying that `a` and `α` can coexist in the same program.

Updated existing tests in `compile_tests.rs`, `function_tests.rs`, `type_tests.rs`, `trait_tests.rs`, and `word_order_tests.rs` to reflect the new sanitization scheme.

---
*PR created automatically by Jules for task [389615810594696762](https://jules.google.com/task/389615810594696762) started by @madmax983*