### PR TITLE
feat: Add 'The Muse' code snippet generator

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -9,3 +9,8 @@
 **Concept:** A semantic syntax highlighter (`glossa highlight`) that colors code based on morphological analysis (Subject=Blue, Object=Red, etc.) instead of regexes.
 **Fate:** Merged
 **Lesson:** Visualizing the compiler's understanding reveals subtle analysis behaviors (like "λόγον" being potentially analyzed as an Adjective). It proves the morphological engine is robust enough for reverse-mapping.
+
+## 🌟 The Muse (ὁ Μοῦσα)
+**Concept:** A generative tool (`glossa muse`) that provides themed code snippets ("Inspirations") to help users learn the language and its mythology.
+**Fate:** Merged
+**Lesson:** Adding a "Creative Mode" to the CLI makes the learning curve less steep and reinforces the "Code as Myth" philosophy. Also, verified that `syntax` for functions is still evolving (no explicit `fn` keyword in grammar, handled semantically via `ὁρίζειν`).

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -1,1 +1,2 @@
 pub mod bard;
+pub mod muse;

--- a/src/experimental/muse.rs
+++ b/src/experimental/muse.rs
@@ -1,0 +1,126 @@
+use clap::ValueEnum;
+
+/// The type of inspiration to seek from the Muse.
+#[derive(ValueEnum, Clone, Debug)]
+pub enum Inspiration {
+    /// A simple "Hello World" style program (The Hero's Journey).
+    Hero,
+    /// A program demonstrating struct definition and usage (The Myth).
+    Myth,
+    /// A program demonstrating loops and control flow (The Chorus).
+    Chorus,
+    /// A program demonstrating functions and complexity (The Epic).
+    Epic,
+}
+
+/// Invokes the Muse to generate a code snippet based on the inspiration type.
+pub fn invoke_muse(inspiration: Inspiration) -> String {
+    match inspiration {
+        Inspiration::Hero => r#"// The Hero's Journey (ὁ τοῦ Ἥρωος βίος)
+// A simple program to declare a variable and print it.
+
+// "x" (variable) "five" (value) "let be" (assignment).
+// ξ πέντε ἔστω.
+ξ πέντε ἔστω.
+
+// "x" (variable) "say" (print).
+// ξ λέγε.
+ξ λέγε.
+"#
+        .to_string(),
+        Inspiration::Myth => r#"// The Myth (ὁ Μῦθος)
+// Defining a Form (struct) and creating an instance.
+
+// Define a type: God
+// εἶδος Θεός ὁρίζειν { ... }.
+εἶδος Θεός ὁρίζειν {
+    ὄνομα ὀνόματος.
+    δύναμις ἀριθμοῦ.
+}.
+
+// Create an instance: Zeus
+// Ζεύς νέον Θεός ... ἔστω.
+// "Zeus" (Name) "new" (Keyword) "God" (Type)
+Ζεύς νέον Θεός
+    «Κρονίδης»
+    100
+ἔστω.
+
+// Print the name
+// Ζεύς ὄνομα λέγε.
+Ζεύς ὄνομα λέγε.
+"#
+        .to_string(),
+        Inspiration::Chorus => r#"// The Chorus (ὁ Χορός)
+// A loop example (Repetition).
+
+// Loop from 0 to 5 (exclusive)
+// ἀπὸ μηδενὸς μέχρι πέντε, ...
+ἀπὸ μηδενὸς μέχρι πέντε, ι λέγε.
+"#
+        .to_string(),
+        Inspiration::Epic => r#"// The Epic (τὸ Ἔπος)
+// A function definition and usage.
+
+// Define a function: square (τετράγωνον)
+// Parameter: x (χ) of type Number (ἀριθμοῦ - genitive)
+// Body: return x * x (product - γινόμενον)
+// Note: · (middle dot) separates signature from body.
+τετράγωνον ὁρίζειν τῷ χ ἀριθμοῦ· δός χ χ γινόμενον.
+
+// Call the function
+// ξ τετράγωνον πέντε ἔστω.
+ξ τετράγωνον πέντε ἔστω.
+
+// Print the result
+ξ λέγε.
+"#
+        .to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse;
+
+    #[test]
+    fn test_invoke_hero() {
+        let code = invoke_muse(Inspiration::Hero);
+        assert!(code.contains("ξ πέντε ἔστω."));
+        assert!(
+            parse(&code).is_ok(),
+            "Hero snippet should be valid Glossa code"
+        );
+    }
+
+    #[test]
+    fn test_invoke_myth() {
+        let code = invoke_muse(Inspiration::Myth);
+        assert!(code.contains("εἶδος Θεός"));
+        assert!(
+            parse(&code).is_ok(),
+            "Myth snippet should be valid Glossa code"
+        );
+    }
+
+    #[test]
+    fn test_invoke_chorus() {
+        let code = invoke_muse(Inspiration::Chorus);
+        assert!(code.contains("ἀπὸ μηδενὸς"));
+        assert!(
+            parse(&code).is_ok(),
+            "Chorus snippet should be valid Glossa code"
+        );
+    }
+
+    #[test]
+    fn test_invoke_epic() {
+        let code = invoke_muse(Inspiration::Epic);
+        assert!(code.contains("τετράγωνον ὁρίζειν"));
+        assert!(
+            parse(&code).is_ok(),
+            "Epic snippet should be valid Glossa code"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 use clap::Parser;
 use miette::Result;
 
+use glossa::experimental::muse::invoke_muse;
 use glossa::tools::cli::{Cli, Commands};
 use glossa::tools::dictionary::lookup_word;
 use glossa::tools::repl::run_repl;
@@ -41,6 +42,10 @@ fn main() -> Result<()> {
 
         Some(Commands::Lookup { word }) => {
             lookup_word(&word)?;
+        }
+
+        Some(Commands::Muse { inspiration }) => {
+            println!("{}", invoke_muse(inspiration));
         }
 
         Some(Commands::Repl) | None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,12 @@
 use clap::Parser;
 use miette::Result;
 
-use glossa::experimental::muse::invoke_muse;
 use glossa::tools::cli::{Cli, Commands};
 use glossa::tools::dictionary::lookup_word;
 use glossa::tools::repl::run_repl;
-use glossa::tools::runner::{bard_file, build_file, check_file, highlight_file, run_file};
+use glossa::tools::runner::{
+    bard_file, build_file, check_file, highlight_file, muse_inspiration, run_file,
+};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -45,7 +46,7 @@ fn main() -> Result<()> {
         }
 
         Some(Commands::Muse { inspiration }) => {
-            println!("{}", invoke_muse(inspiration));
+            muse_inspiration(inspiration)?;
         }
 
         Some(Commands::Repl) | None => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -641,6 +641,7 @@ pub enum ParseError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::recursion::check_recursion_depth;
 
     /// Helper to get the first expression of the first clause
     fn first_expr(stmt: &Statement) -> &Expr {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+use crate::experimental::muse::Inspiration;
+
 #[derive(Parser)]
 #[command(name = "glossa")]
 #[command(about = "ΓΛΩΣΣΑ - Ancient Greek morphology as programming semantics")]
@@ -57,5 +59,12 @@ pub enum Commands {
     Lookup {
         /// The Greek word to analyze
         word: String,
+    },
+
+    /// Invoke the Muse for inspiration (generates code snippets)
+    Muse {
+        /// The type of inspiration to seek (hero, myth, chorus, epic)
+        #[arg(value_enum)]
+        inspiration: Inspiration,
     },
 }

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -1,6 +1,6 @@
 use crate::codegen::generate_rust_file;
 use crate::experimental::bard::tell_tale;
-use crate::experimental::muse::{invoke_muse, Inspiration};
+use crate::experimental::muse::{Inspiration, invoke_muse};
 use crate::parser::parse;
 use crate::report::{CompilationReport, GlossaReport, ProgramStats};
 use crate::semantic::{AnalyzedProgram, analyze_program};
@@ -436,8 +436,17 @@ mod tests {
 
     #[test]
     fn test_muse_inspiration_valid() {
-        // Just verify it runs without error (prints to stdout)
-        let result = muse_inspiration(Inspiration::Hero);
-        assert!(result.is_ok());
+        // Verify all variants work
+        let inspirations = vec![
+            Inspiration::Hero,
+            Inspiration::Myth,
+            Inspiration::Chorus,
+            Inspiration::Epic,
+        ];
+
+        for insp in inspirations {
+            let result = muse_inspiration(insp);
+            assert!(result.is_ok());
+        }
     }
 }

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -1,5 +1,6 @@
 use crate::codegen::generate_rust_file;
 use crate::experimental::bard::tell_tale;
+use crate::experimental::muse::{invoke_muse, Inspiration};
 use crate::parser::parse;
 use crate::report::{CompilationReport, GlossaReport, ProgramStats};
 use crate::semantic::{AnalyzedProgram, analyze_program};
@@ -96,6 +97,12 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 
     println!("{}", report);
 
+    Ok(())
+}
+
+pub fn muse_inspiration(inspiration: Inspiration) -> Result<()> {
+    let content = invoke_muse(inspiration);
+    println!("{}", content);
     Ok(())
 }
 
@@ -424,6 +431,13 @@ mod tests {
         }
 
         let result = bard_file(&input_path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_muse_inspiration_valid() {
+        // Just verify it runs without error (prints to stdout)
+        let result = muse_inspiration(Inspiration::Hero);
         assert!(result.is_ok());
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,14 @@
+#[test]
+fn test_cli_muse_execution() {
+    // This test runs the actual binary to ensure src/main.rs code is covered
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_glossa"))
+        .arg("muse")
+        .arg("hero")
+        .output()
+        .expect("Failed to execute glossa binary");
+
+    assert!(status.status.success());
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(stdout.contains("Hero"));
+    assert!(stdout.contains("ξ πέντε ἔστω"));
+}

--- a/tests/muse_coverage.rs
+++ b/tests/muse_coverage.rs
@@ -1,0 +1,72 @@
+use clap::Parser;
+use glossa::experimental::muse::Inspiration;
+use glossa::tools::cli::{Cli, Commands};
+
+#[test]
+fn test_cli_muse_hero_parsing() {
+    let args = vec!["glossa", "muse", "hero"];
+    let cli = Cli::try_parse_from(args).expect("Failed to parse muse hero");
+
+    if let Some(Commands::Muse { inspiration }) = cli.command {
+        assert!(matches!(inspiration, Inspiration::Hero));
+    } else {
+        panic!("Expected Muse command");
+    }
+}
+
+#[test]
+fn test_cli_muse_myth_parsing() {
+    let args = vec!["glossa", "muse", "myth"];
+    let cli = Cli::try_parse_from(args).expect("Failed to parse muse myth");
+
+    if let Some(Commands::Muse { inspiration }) = cli.command {
+        assert!(matches!(inspiration, Inspiration::Myth));
+    } else {
+        panic!("Expected Muse command");
+    }
+}
+
+#[test]
+fn test_cli_muse_chorus_parsing() {
+    let args = vec!["glossa", "muse", "chorus"];
+    let cli = Cli::try_parse_from(args).expect("Failed to parse muse chorus");
+
+    if let Some(Commands::Muse { inspiration }) = cli.command {
+        assert!(matches!(inspiration, Inspiration::Chorus));
+    } else {
+        panic!("Expected Muse command");
+    }
+}
+
+#[test]
+fn test_cli_muse_epic_parsing() {
+    let args = vec!["glossa", "muse", "epic"];
+    let cli = Cli::try_parse_from(args).expect("Failed to parse muse epic");
+
+    if let Some(Commands::Muse { inspiration }) = cli.command {
+        assert!(matches!(inspiration, Inspiration::Epic));
+    } else {
+        panic!("Expected Muse command");
+    }
+}
+
+#[test]
+fn test_inspiration_debug() {
+    let insp = Inspiration::Hero;
+    let debug_str = format!("{:?}", insp);
+    assert_eq!(debug_str, "Hero");
+}
+
+#[test]
+fn test_inspiration_clone() {
+    let insp = Inspiration::Chorus;
+    let cloned = insp.clone();
+    assert!(matches!(cloned, Inspiration::Chorus));
+}
+
+#[test]
+fn test_cli_muse_invalid_variant() {
+    let args = vec!["glossa", "muse", "tragedy"];
+    let result = Cli::try_parse_from(args);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Implemented 'The Muse' (ὁ Μοῦσα), a CLI tool that generates themed Glossa code snippets to help users learn the language.

Key changes:
- Created `src/experimental/muse.rs` containing the generator logic and snippets for 'Hero', 'Myth', 'Chorus', and 'Epic' themes.
- Updated `src/tools/cli.rs` and `src/main.rs` to expose the `muse` command.
- Verified that all generated snippets are valid Glossa code via unit tests that run the parser.
- Fixed a pre-existing issue in `src/parser.rs` tests where `check_recursion_depth` was not imported.

This feature is additive and isolated in the `experimental` module.

---
*PR created automatically by Jules for task [1974127074675639026](https://jules.google.com/task/1974127074675639026) started by @madmax983*