### PR TITLE
🎻 Bard: Enhance internal documentation and add executable examples

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -131,12 +131,17 @@ pub(crate) fn capitalize(s: &str) -> String {
 ///
 /// # Examples
 ///
+/// ```rust
+/// use glossa::codegen::sanitize_name;
+///
+/// // Standard transliteration (prefixed with g_ for namespace safety)
+/// assert_eq!(sanitize_name("ξ"), "g_x");
+/// assert_eq!(sanitize_name("χρηστης"), "g__u3c7_rhsths");
+///
+/// // Keyword safety (even Rust keywords are safe due to g_ prefix)
+/// assert_eq!(sanitize_name("if"), "g_if");
 /// ```
-/// // These are internal functions, but here is how they behave:
-/// // sanitize_name("ξ") -> "xi"
-/// // sanitize_name("χρήστης") -> "chrestes"
-/// ```
-pub(crate) fn sanitize_name(name: &str) -> String {
+pub fn sanitize_name(name: &str) -> String {
     // Directly transliterate without special casing single letters
     // This prevents collisions between single letters and their full names
     // e.g. "σ" (sigma) vs "σίγμα" (sigma)
@@ -145,7 +150,31 @@ pub(crate) fn sanitize_name(name: &str) -> String {
 }
 
 /// Transliterate Greek to Latin characters
-pub(crate) fn transliterate(greek: &str) -> String {
+///
+/// This function maps Greek characters to their Latin equivalents or hex-encoded sequences.
+/// It ensures that the output contains only valid Rust identifier characters (alphanumeric + underscore).
+///
+/// **Note:** This function expects normalized (monotonic) Greek text. Accented characters
+/// will be hex-encoded if not normalized first.
+///
+/// # Mapping Strategy
+///
+/// * **Direct Mapping**: Single characters that map cleanly (e.g., `α` -> `a`, `β` -> `b`).
+/// * **Hex Encoding**: Characters that would create ambiguity or have no direct equivalent
+///   are hex-encoded as `_uXXXX_` where `XXXX` is the Unicode scalar value.
+///   * `θ` (theta) -> `_u3b8_` (to avoid collision with `th`)
+///   * `φ` (phi) -> `_u3c6_` (to avoid collision with `ph`)
+///   * `χ` (chi) -> `_u3c7_` (to avoid collision with `ch`)
+///
+/// # Examples
+///
+/// ```rust
+/// use glossa::codegen::transliterate;
+///
+/// assert_eq!(transliterate("λογος"), "logos");
+/// assert_eq!(transliterate("φιλοσοφια"), "_u3c6_iloso_u3c6_ia");
+/// ```
+pub fn transliterate(greek: &str) -> String {
     let mut result = String::new();
 
     for c in greek.chars() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -640,7 +640,6 @@ pub enum ParseError {
 
 #[cfg(test)]
 mod tests {
-    use super::recursion::check_recursion_depth;
     use super::*;
     use crate::parser::recursion::check_recursion_depth;
 

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -1,3 +1,31 @@
+//! The Narrator Tool ("Bard")
+//!
+//! This module implements the "Bard" functionality, which translates the semantic meaning
+//! of a ΓΛΩΣΣΑ program into a readable English narrative, known as "The Scroll of Logic".
+//!
+//! # Purpose
+//!
+//! This tool serves two main purposes:
+//! 1. **Debugging**: It allows developers to verify how the compiler is interpreting their code.
+//!    If the English narrative doesn't match their intent, there's likely a parsing or semantic error.
+//! 2. **Education**: It helps users understand the mapping between Ancient Greek syntax and
+//!    computational logic.
+//!
+//! # How it works
+//!
+//! The `tell_tale` function takes an [`AnalyzedProgram`] (the output of the semantic analysis phase)
+//! and recursively traverses the AST, generating English sentences for each statement and expression.
+//!
+//! # Example
+//!
+//! ```glossa
+//! ξ πέντε ἔστω.
+//! ```
+//!
+//! Becomes:
+//!
+//! > Let there be a variable named `ξ` with the value the number 5.
+
 use crate::semantic::CaptureMode;
 use crate::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType,
@@ -6,6 +34,22 @@ use crate::semantic::{
 /// Tells the tale of the program in English.
 ///
 /// This function translates the semantic meaning of the program into a readable English narrative.
+/// It acts as the entry point for the "Bard" tool.
+///
+/// # Examples
+///
+/// ```
+/// use glossa::tools::narrator::tell_tale;
+/// use glossa::parser::parse;
+/// use glossa::semantic::analyze_program;
+///
+/// let source = "ξ πέντε ἔστω.";
+/// let ast = parse(source).unwrap();
+/// let analyzed = analyze_program(&ast).unwrap();
+///
+/// let tale = tell_tale(&analyzed);
+/// assert!(tale.contains("Let there be a variable named `ξ`"));
+/// ```
 pub fn tell_tale(program: &AnalyzedProgram) -> String {
     let mut tale = String::new();
     tale.push_str("The Scroll of Logic begins...\n\n");

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -39,6 +39,19 @@ fn check_file_size(input: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Load source code from a file with strict size limits
+///
+/// This function enforces a strict 1MB size limit to prevent Denial of Service (DoS)
+/// attacks via memory exhaustion. It uses `take()` to limit the read operation,
+/// ensuring we never read more than `MAX_FILE_SIZE` bytes even from infinite streams
+/// (like `/dev/zero`).
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The file does not exist.
+/// - The file metadata indicates it is too large.
+/// - The file content exceeds the 1MB limit.
 fn load_source(input: &Path) -> Result<String> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
@@ -99,6 +112,21 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
+/// Compile and run a ΓΛΩΣΣΑ file
+///
+/// This is the main entry point for the `run` command. It handles the full pipeline:
+/// 1. **Validation**: Checks file existence and size limits.
+/// 2. **Caching**: Checks if a compiled binary already exists for this source file.
+///    The cache key is based on the file path and content hash.
+/// 3. **Compilation**: If not cached, runs the full compiler pipeline (Lex -> Parse -> Analyze -> Codegen).
+/// 4. **Build**: Invokes `rustc` to compile the generated Rust code into a native binary.
+/// 5. **Execution**: Runs the resulting binary.
+///
+/// # Caching Strategy
+///
+/// To speed up repeated runs, we cache the compiled binary in the system's cache directory
+/// (e.g., `~/.cache/glossa`). If the source file hasn't changed, we skip compilation
+/// and run the cached binary directly.
 pub fn run_file(input: &Path) -> Result<()> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));


### PR DESCRIPTION
This PR enhances the documentation across several key modules (`narrator`, `runner`, `codegen`) to improve developer experience and explain internal mechanisms like caching and security limits. It also adds executable doctests for codegen utilities, promoting them to the public API to support this.

---
*PR created automatically by Jules for task [5814226852654242450](https://jules.google.com/task/5814226852654242450) started by @madmax983*