### PR TITLE
Refactor Morphology and UI for Simplicity

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -8,6 +8,7 @@
 use std::borrow::Cow;
 
 use super::{Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice};
+use crate::morphology::matcher::match_suffix;
 use crate::text::normalize_greek;
 
 /// Present Active Indicative endings (ω-conjugation)
@@ -436,15 +437,16 @@ fn match_verb_endings<'a>(
     word: &'a str,
     endings: &[(&str, Person, Number)],
 ) -> Option<(&'a str, Person, Number)> {
-    // Endings are pre-sorted by length (longest first)
-    for (ending, person, number) in endings {
-        if let Some(stem) = word.strip_suffix(ending)
-            && !stem.is_empty()
-        {
-            return Some((stem, *person, *number));
+    let mut result = None;
+    match_suffix(word, endings, |e| e.0, |stem, pattern| {
+        if result.is_none() {
+            result = Some((stem, pattern.1, pattern.2));
+            false // Stop after first match
+        } else {
+            true // Should not happen if we stop, but safe default
         }
-    }
-    None
+    });
+    result
 }
 
 /// Match a word against ALL verb endings (for ambiguity resolution)
@@ -452,13 +454,10 @@ fn match_verb_endings_all<F>(word: &str, endings: &[(&str, Person, Number)], mut
 where
     F: FnMut(&str, Person, Number),
 {
-    for (ending, person, number) in endings {
-        if let Some(stem) = word.strip_suffix(ending)
-            && !stem.is_empty()
-        {
-            callback(stem, *person, *number);
-        }
-    }
+    match_suffix(word, endings, |e| e.0, |stem, pattern| {
+        callback(stem, pattern.1, pattern.2);
+        true // Continue searching
+    });
 }
 
 /// Analyze a word as a verb, returning ALL possible analyses

--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -438,14 +438,19 @@ fn match_verb_endings<'a>(
     endings: &[(&str, Person, Number)],
 ) -> Option<(&'a str, Person, Number)> {
     let mut result = None;
-    match_suffix(word, endings, |e| e.0, |stem, pattern| {
-        if result.is_none() {
-            result = Some((stem, pattern.1, pattern.2));
-            false // Stop after first match
-        } else {
-            true // Should not happen if we stop, but safe default
-        }
-    });
+    match_suffix(
+        word,
+        endings,
+        |e| e.0,
+        |stem, pattern| {
+            if result.is_none() {
+                result = Some((stem, pattern.1, pattern.2));
+                false // Stop after first match
+            } else {
+                true // Should not happen if we stop, but safe default
+            }
+        },
+    );
     result
 }
 
@@ -454,10 +459,15 @@ fn match_verb_endings_all<F>(word: &str, endings: &[(&str, Person, Number)], mut
 where
     F: FnMut(&str, Person, Number),
 {
-    match_suffix(word, endings, |e| e.0, |stem, pattern| {
-        callback(stem, pattern.1, pattern.2);
-        true // Continue searching
-    });
+    match_suffix(
+        word,
+        endings,
+        |e| e.0,
+        |stem, pattern| {
+            callback(stem, pattern.1, pattern.2);
+            true // Continue searching
+        },
+    );
 }
 
 /// Analyze a word as a verb, returning ALL possible analyses

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -173,10 +173,15 @@ fn match_endings_all<F>(word: &str, endings: &[(&str, Case, Number)], mut callba
 where
     F: FnMut(&str, Case, Number),
 {
-    match_suffix(word, endings, |e| e.0, |stem, pattern| {
-        callback(stem, pattern.1, pattern.2);
-        true
-    });
+    match_suffix(
+        word,
+        endings,
+        |e| e.0,
+        |stem, pattern| {
+            callback(stem, pattern.1, pattern.2);
+            true
+        },
+    );
 }
 
 /// Analyze a word as a noun, returning ALL possible analyses

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -8,6 +8,7 @@
 use std::borrow::Cow;
 
 use super::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
+use crate::morphology::matcher::match_suffix;
 
 /// Declension pattern
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -172,13 +173,10 @@ fn match_endings_all<F>(word: &str, endings: &[(&str, Case, Number)], mut callba
 where
     F: FnMut(&str, Case, Number),
 {
-    for (ending, case, number) in endings {
-        if let Some(stem) = word.strip_suffix(ending)
-            && !stem.is_empty()
-        {
-            callback(stem, *case, *number);
-        }
-    }
+    match_suffix(word, endings, |e| e.0, |stem, pattern| {
+        callback(stem, pattern.1, pattern.2);
+        true
+    });
 }
 
 /// Analyze a word as a noun, returning ALL possible analyses

--- a/src/morphology/matcher.rs
+++ b/src/morphology/matcher.rs
@@ -1,0 +1,41 @@
+//! Generic suffix matching utility for morphology
+//!
+//! This module provides a reusable function for matching suffixes against a word,
+//! which is a common pattern in declension, conjugation, and participle analysis.
+
+/// Match a word against a list of patterns by checking suffixes
+///
+/// Iterates through `patterns` and checks if `word` ends with the suffix provided by `get_suffix`.
+/// If a match is found and the resulting stem is not empty, `callback` is invoked with the stem and the matching pattern.
+///
+/// The callback must return a `bool`:
+/// - `true`: Continue searching for more matches.
+/// - `false`: Stop searching (early exit).
+///
+/// # Type Parameters
+///
+/// * `T`: The type of the pattern element (e.g., tuple or struct)
+/// * `S`: Closure that extracts the suffix string from `T`
+/// * `F`: Callback closure invoked on match
+pub fn match_suffix<'w, 'p, T, S, F>(
+    word: &'w str,
+    patterns: &'p [T],
+    get_suffix: S,
+    mut callback: F,
+) where
+    S: Fn(&T) -> &str,
+    F: FnMut(&'w str, &'p T) -> bool,
+{
+    for pattern in patterns {
+        let suffix = get_suffix(pattern);
+        if let Some(stem) = word.strip_suffix(suffix) {
+            // Stem must not be empty (avoid matching the entire word as a suffix if stem disappears)
+            // e.g. "ω" matching "ω" ending -> stem "" -> usually invalid for our morphology rules
+            if !stem.is_empty() {
+                if !callback(stem, pattern) {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/morphology/matcher.rs
+++ b/src/morphology/matcher.rs
@@ -31,10 +31,8 @@ pub fn match_suffix<'w, 'p, T, S, F>(
         if let Some(stem) = word.strip_suffix(suffix) {
             // Stem must not be empty (avoid matching the entire word as a suffix if stem disappears)
             // e.g. "ω" matching "ω" ending -> stem "" -> usually invalid for our morphology rules
-            if !stem.is_empty() {
-                if !callback(stem, pattern) {
-                    return;
-                }
+            if !stem.is_empty() && !callback(stem, pattern) {
+                return;
             }
         }
     }

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -23,6 +23,7 @@ pub mod conjugation;
 pub mod declension;
 pub mod disambiguation;
 pub mod lexicon;
+pub mod matcher;
 pub mod participle;
 
 pub use conjugation::*;

--- a/src/morphology/participle.rs
+++ b/src/morphology/participle.rs
@@ -25,6 +25,7 @@
 //! ```
 
 use super::{Case, Gender, Number, Tense, Voice};
+use crate::morphology::matcher::match_suffix;
 use std::sync::LazyLock;
 
 /// Result of participle morphological analysis
@@ -500,14 +501,10 @@ static ALL_PATTERNS: LazyLock<Vec<&'static ParticiplePattern>> = LazyLock::new(|
 /// assert_eq!(p.tense, Tense::Present);
 /// ```
 pub fn analyze_participle(word: &str) -> Option<ParticipleAnalysis> {
-    for pattern in ALL_PATTERNS.iter() {
-        if let Some(stem) = word.strip_suffix(pattern.ending) {
-            // Stem must not be empty
-            if stem.is_empty() {
-                continue;
-            }
-
-            return Some(ParticipleAnalysis {
+    let mut result = None;
+    match_suffix(word, &ALL_PATTERNS, |p| p.ending, |stem, pattern| {
+        if result.is_none() {
+            result = Some(ParticipleAnalysis {
                 stem: stem.to_string(),
                 tense: pattern.tense,
                 voice: pattern.voice,
@@ -516,10 +513,12 @@ pub fn analyze_participle(word: &str) -> Option<ParticipleAnalysis> {
                 number: pattern.number,
                 confidence: 0.9,
             });
+            false // Stop after first match
+        } else {
+            true
         }
-    }
-
-    None
+    });
+    result
 }
 
 #[cfg(test)]

--- a/src/morphology/participle.rs
+++ b/src/morphology/participle.rs
@@ -502,22 +502,27 @@ static ALL_PATTERNS: LazyLock<Vec<&'static ParticiplePattern>> = LazyLock::new(|
 /// ```
 pub fn analyze_participle(word: &str) -> Option<ParticipleAnalysis> {
     let mut result = None;
-    match_suffix(word, &ALL_PATTERNS, |p| p.ending, |stem, pattern| {
-        if result.is_none() {
-            result = Some(ParticipleAnalysis {
-                stem: stem.to_string(),
-                tense: pattern.tense,
-                voice: pattern.voice,
-                case: pattern.case,
-                gender: pattern.gender,
-                number: pattern.number,
-                confidence: 0.9,
-            });
-            false // Stop after first match
-        } else {
-            true
-        }
-    });
+    match_suffix(
+        word,
+        &ALL_PATTERNS,
+        |p| p.ending,
+        |stem, pattern| {
+            if result.is_none() {
+                result = Some(ParticipleAnalysis {
+                    stem: stem.to_string(),
+                    tense: pattern.tense,
+                    voice: pattern.voice,
+                    case: pattern.case,
+                    gender: pattern.gender,
+                    number: pattern.number,
+                    confidence: 0.9,
+                });
+                false // Stop after first match
+            } else {
+                true
+            }
+        },
+    );
     result
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -642,7 +642,6 @@ pub enum ParseError {
 mod tests {
     use super::recursion::check_recursion_depth;
     use super::*;
-    use crate::parser::recursion::check_recursion_depth;
 
     /// Helper to get the first expression of the first clause
     fn first_expr(stmt: &Statement) -> &Expr {

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -19,26 +19,14 @@ impl Status {
 
     /// Internal constructor for testing
     fn new(message: impl Into<String>, is_tty: bool) -> Self {
-        let message = message.into();
-
-        if is_tty {
-            let mut stderr = io::stderr();
-            // Hide cursor
-            let _ = stderr.execute(cursor::Hide);
-            // Print status
-            eprint!("{} {}...", "⚡".yellow(), message.clone().bold());
-            let _ = io::stderr().flush();
-        } else {
-            // For non-TTY, just print line
-            eprintln!("{} {}...", "⚡".yellow(), message.clone().bold());
-        }
-
-        Self {
-            message,
+        let status = Self {
+            message: message.into(),
             start: Instant::now(),
             is_tty,
             active: true,
-        }
+        };
+        status.print_running(false);
+        status
     }
 
     /// Update the status message
@@ -46,21 +34,8 @@ impl Status {
         if !self.active {
             return;
         }
-
-        let message = message.into();
-        self.message = message.clone();
-
-        if self.is_tty {
-            let mut stderr = io::stderr();
-            // Clear current line
-            eprint!("\r");
-            let _ = stderr.execute(terminal::Clear(terminal::ClearType::UntilNewLine));
-            // Print new status
-            eprint!("{} {}...", "⚡".yellow(), message.bold());
-            let _ = io::stderr().flush();
-        } else {
-            eprintln!("{} {}...", "⚡".yellow(), message.bold());
-        }
+        self.message = message.into();
+        self.print_running(true);
     }
 
     /// Mark the operation as complete success
@@ -71,30 +46,9 @@ impl Status {
 
         let duration = self.start.elapsed();
         let time_str = format!("({:.2?})", duration).dim();
+        let msg = format!("{} {}", self.message.as_str().bold(), time_str);
 
-        if self.is_tty {
-            let mut stderr = io::stderr();
-            // Clear line
-            eprint!("\r");
-            let _ = stderr.execute(terminal::Clear(terminal::ClearType::UntilNewLine));
-            // Print success
-            eprintln!(
-                "{} {} {}",
-                "✓".green(),
-                self.message.as_str().bold(),
-                time_str
-            );
-            // Show cursor
-            let _ = stderr.execute(cursor::Show);
-        } else {
-            eprintln!(
-                "{} {} {}",
-                "✓".green(),
-                self.message.as_str().bold(),
-                time_str
-            );
-        }
-
+        self.print_done("✓".green(), &msg);
         self.active = false;
     }
 
@@ -104,19 +58,41 @@ impl Status {
             return;
         }
 
+        let msg = self.message.as_str().bold().to_string();
+        self.print_done("✕".red(), &msg);
+        eprintln!("{}", err);
+        self.active = false;
+    }
+
+    fn print_running(&self, clear: bool) {
+        let symbol = "⚡".yellow();
+        let msg = format!("{}...", self.message.as_str().bold());
+
+        if self.is_tty {
+            let mut stderr = io::stderr();
+            if clear {
+                eprint!("\r");
+                let _ = stderr.execute(terminal::Clear(terminal::ClearType::UntilNewLine));
+            } else {
+                let _ = stderr.execute(cursor::Hide);
+            }
+            eprint!("{} {}", symbol, msg);
+            let _ = io::stderr().flush();
+        } else {
+            eprintln!("{} {}", symbol, msg);
+        }
+    }
+
+    fn print_done(&self, symbol: impl std::fmt::Display, message: &str) {
         if self.is_tty {
             let mut stderr = io::stderr();
             eprint!("\r");
             let _ = stderr.execute(terminal::Clear(terminal::ClearType::UntilNewLine));
-            eprintln!("{} {}", "✕".red(), self.message.as_str().bold());
-            // Show cursor
+            eprintln!("{} {}", symbol, message);
             let _ = stderr.execute(cursor::Show);
         } else {
-            eprintln!("{} {}", "✕".red(), self.message.as_str().bold());
+            eprintln!("{} {}", symbol, message);
         }
-
-        eprintln!("{}", err);
-        self.active = false;
     }
 }
 


### PR DESCRIPTION
Implemented `match_suffix` utility to deduplicate suffix matching logic in `morphology` module and simplified `Status` struct in `ui.rs` for cleaner code. This adheres to DRY and KISS principles.

---
*PR created automatically by Jules for task [9216805922354476325](https://jules.google.com/task/9216805922354476325) started by @madmax983*