### PR TITLE
Fix identifier collision via hex encoding for Greek characters

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1214,9 +1214,15 @@ mod tests {
         // ρ -> _u3c1_
         // η -> _u3b7_
         // ...
-        assert_eq!(transliterate("χρηστος"), "_u3c7__u3c1__u3b7__u3c3__u3c4__u3bf__u3c2_");
+        assert_eq!(
+            transliterate("χρηστος"),
+            "_u3c7__u3c1__u3b7__u3c3__u3c4__u3bf__u3c2_"
+        );
         assert_eq!(transliterate("λογος"), "_u3bb__u3bf__u3b3__u3bf__u3c2_");
-        assert_eq!(transliterate("φιλοσοφια"), "_u3c6__u3b9__u3bb__u3bf__u3c3__u3bf__u3c6__u3b9__u3b1_");
+        assert_eq!(
+            transliterate("φιλοσοφια"),
+            "_u3c6__u3b9__u3bb__u3bf__u3c3__u3bf__u3c6__u3b9__u3b1_"
+        );
     }
 
     #[test]
@@ -1319,7 +1325,10 @@ mod tests {
         };
         // Sanitize: χρηστης -> g__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_
         // Capitalize: g_... -> G_...
-        assert_eq!(to_rust_type(&ty), "G__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_");
+        assert_eq!(
+            to_rust_type(&ty),
+            "G__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_"
+        );
     }
 
     // --- Rust Codegen Tests ---

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -135,8 +135,8 @@ pub(crate) fn capitalize(s: &str) -> String {
 /// use glossa::codegen::sanitize_name;
 ///
 /// // Standard transliteration (prefixed with g_ for namespace safety)
-/// assert_eq!(sanitize_name("ξ"), "g_x");
-/// assert_eq!(sanitize_name("χρηστης"), "g__u3c7_rhsths");
+/// assert_eq!(sanitize_name("ξ"), "g__u3be_");
+/// assert_eq!(sanitize_name("χρηστης"), "g__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_");
 ///
 /// // Keyword safety (even Rust keywords are safe due to g_ prefix)
 /// assert_eq!(sanitize_name("if"), "g_if");
@@ -171,50 +171,23 @@ pub fn sanitize_name(name: &str) -> String {
 /// ```rust
 /// use glossa::codegen::transliterate;
 ///
-/// assert_eq!(transliterate("λογος"), "logos");
-/// assert_eq!(transliterate("φιλοσοφια"), "_u3c6_iloso_u3c6_ia");
+/// assert_eq!(transliterate("λογος"), "_u3bb__u3bf__u3b3__u3bf__u3c2_");
+/// assert_eq!(transliterate("φιλοσοφια"), "_u3c6__u3b9__u3bb__u3bf__u3c3__u3bf__u3c6__u3b9__u3b1_");
 /// ```
 pub fn transliterate(greek: &str) -> String {
     let mut result = String::new();
 
     for c in greek.chars() {
-        let trans = match c {
-            'α' => "a",
-            'β' => "b",
-            'γ' => "g",
-            'δ' => "d",
-            'ε' => "e",
-            'ζ' => "z",
-            'η' => "h", // Distinct from 'e' (epsilon)
-            'ι' => "i",
-            'κ' => "k",
-            'λ' => "l",
-            'μ' => "m",
-            'ν' => "n",
-            'ξ' => "x",
-            'ο' => "o",
-            'π' => "p",
-            'ρ' => "r",
-            'σ' | 'ς' => "s",
-            'τ' => "t",
-            'υ' => "u",
-            'ω' => "w", // Distinct from 'o' (omicron)
-            // Digraphs and other characters are hex-encoded to prevent collisions
-            // θ, φ, χ, ψ map to _u..._ because th, ph, ch, ps collide with sequences
-            _ => {
-                // Keep only ASCII alphanumeric characters and underscore
-                if c.is_ascii_alphanumeric() || c == '_' {
-                    result.push(c);
-                } else {
-                    // Replace invalid characters with unique hex code to prevent collisions
-                    // e.g. ϟ -> _u3df_
-                    use std::fmt::Write;
-                    write!(result, "_u{:x}_", c as u32).unwrap();
-                }
-                continue;
-            }
-        };
-        result.push_str(trans);
+        // We now hex-encode ALL Greek characters to avoid collisions with ASCII.
+        // Previously, 'ξ' mapped to 'x', causing collision with ASCII 'x'.
+        // Now, 'ξ' maps to '_u3be_', which is distinct from 'x' (which stays 'x').
+        if c.is_ascii_alphanumeric() || c == '_' {
+            result.push(c);
+        } else {
+            // Replace invalid characters with unique hex code to prevent collisions
+            use std::fmt::Write;
+            write!(result, "_u{:x}_", c as u32).unwrap();
+        }
     }
 
     // Ensure it starts with a letter or underscore (valid Rust identifier)
@@ -1229,20 +1202,21 @@ mod tests {
 
     #[test]
     fn test_sanitize_greek_letter() {
-        assert_eq!(sanitize_name("ξ"), "g_x");
-        assert_eq!(sanitize_name("α"), "g_a");
-        assert_eq!(sanitize_name("ω"), "g_w");
+        assert_eq!(sanitize_name("ξ"), "g__u3be_");
+        assert_eq!(sanitize_name("α"), "g__u3b1_");
+        assert_eq!(sanitize_name("ω"), "g__u3c9_");
     }
 
     #[test]
     fn test_transliterate() {
-        // χ (chi) -> hex, ρ -> r, η -> h, σ -> s, τ -> t, ο -> o, ς -> s
-        // χ is 0x3c7
-        assert_eq!(transliterate("χρηστος"), "_u3c7_rhstos");
-        assert_eq!(transliterate("λογος"), "logos");
-        // φ (phi) -> hex
-        // φ is 0x3c6
-        assert_eq!(transliterate("φιλοσοφια"), "_u3c6_iloso_u3c6_ia");
+        // All Greek characters are now hex encoded to avoid ASCII collisions
+        // χ (chi) -> _u3c7_
+        // ρ -> _u3c1_
+        // η -> _u3b7_
+        // ...
+        assert_eq!(transliterate("χρηστος"), "_u3c7__u3c1__u3b7__u3c3__u3c4__u3bf__u3c2_");
+        assert_eq!(transliterate("λογος"), "_u3bb__u3bf__u3b3__u3bf__u3c2_");
+        assert_eq!(transliterate("φιλοσοφια"), "_u3c6__u3b9__u3bb__u3bf__u3c3__u3bf__u3c6__u3b9__u3b1_");
     }
 
     #[test]
@@ -1265,9 +1239,12 @@ mod tests {
     #[test]
     fn test_transliterate_mixed_valid_invalid() {
         // Test mixing valid and invalid characters
+        // α -> _u3b1_
+        // ϟ -> _u3df_
+        // β -> _u3b2_
         let input = "αϟβ";
         let output = transliterate(input);
-        assert_eq!(output, "a_u3df_b");
+        assert_eq!(output, "_u3b1__u3df__u3b2_");
     }
 
     #[test]
@@ -1340,9 +1317,9 @@ mod tests {
             gender: crate::morphology::Gender::Masculine,
             fields: vec![],
         };
-        // Sanitize: χρηστης -> g__u3c7_rhsths
-        // Capitalize: g__u3c7_rhsths -> G__u3c7_rhsths
-        assert_eq!(to_rust_type(&ty), "G__u3c7_rhsths");
+        // Sanitize: χρηστης -> g__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_
+        // Capitalize: g_... -> G_...
+        assert_eq!(to_rust_type(&ty), "G__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_");
     }
 
     // --- Rust Codegen Tests ---
@@ -1364,8 +1341,8 @@ mod tests {
     #[test]
     fn test_generate_binding() {
         let code = compile("ξ πέντε ἔστω.");
-        // Variables are now prefixed with g_
-        assert!(code.contains("let g_x"));
+        // Variables are now prefixed with g_ and hex encoded
+        assert!(code.contains("let g__u3be_"));
         assert!(code.contains("5"));
     }
 
@@ -1379,9 +1356,9 @@ mod tests {
     #[test]
     fn test_generate_full_program() {
         let code = compile("ξ πέντε ἔστω. ξ λέγε.");
-        // Variables are now prefixed with g_
+        // Variables are now prefixed with g_ and hex encoded
         assert!(
-            code.contains("let g_x = 5"),
+            code.contains("let g__u3be_ = 5"),
             "Expected binding in: {}",
             code
         );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -641,6 +641,7 @@ pub enum ParseError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::recursion::check_recursion_depth;
 
     /// Helper to get the first expression of the first clause
     fn first_expr(stmt: &Statement) -> &Expr {

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -21,16 +21,17 @@ fn test_hello_cosmos() {
 #[test]
 fn test_variable_binding() {
     let code = compile("ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let g_x"));
+    // ξ transliterates to hex encoded string to avoid ASCII collision
+    assert!(code.contains("let g__u3be_"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_variable_binding_and_use() {
     let code = compile("ξ πέντε ἔστω. ξ λέγε.").unwrap();
-    assert!(code.contains("let g_x = 5"));
+    assert!(code.contains("let g__u3be_ = 5"));
     assert!(code.contains("println"));
-    assert!(code.contains("g_x"));
+    assert!(code.contains("g__u3be_"));
 }
 
 #[test]
@@ -42,8 +43,9 @@ fn test_number_literal() {
 #[test]
 fn test_multiple_statements() {
     let code = compile("α πέντε ἔστω. β δέκα ἔστω. α λέγε.").unwrap();
-    assert!(code.contains("let g_a = 5"));
-    assert!(code.contains("let g_b = 10"));
+    // α -> _u3b1_, β -> _u3b2_
+    assert!(code.contains("let g__u3b1_ = 5"));
+    assert!(code.contains("let g__u3b2_ = 10"));
 }
 
 #[test]
@@ -61,15 +63,15 @@ fn test_preserves_greek_in_strings() {
 #[test]
 fn test_mutable_binding() {
     let code = compile("μετά ξ πέντε ἔστω.").unwrap();
-    assert!(code.contains("let mut g_x"));
+    assert!(code.contains("let mut g__u3be_"));
     assert!(code.contains("5"));
 }
 
 #[test]
 fn test_assignment_codegen() {
     let code = compile("μετά ξ πέντε ἔστω. ξ δέκα γίγνεται.").unwrap();
-    assert!(code.contains("let mut g_x = 5"));
-    assert!(code.contains("g_x = 10"));
+    assert!(code.contains("let mut g__u3be_ = 5"));
+    assert!(code.contains("g__u3be_ = 10"));
 }
 
 #[test]
@@ -89,8 +91,8 @@ fn test_undefined_assignment_error() {
 #[test]
 fn test_mutable_binding_and_reassignment() {
     let code = compile("μετά ξ πέντε ἔστω. ξ λέγε. ξ δέκα γίγνεται. ξ λέγε.").unwrap();
-    assert!(code.contains("let mut g_x = 5"));
-    assert!(code.contains("g_x = 10"));
+    assert!(code.contains("let mut g__u3be_ = 5"));
+    assert!(code.contains("g__u3be_ = 10"));
     assert!(code.matches("println").count() >= 2);
 }
 

--- a/tests/function_tests.rs
+++ b/tests/function_tests.rs
@@ -39,8 +39,8 @@ fn test_function_with_two_params() {
     let code = compile("προσθεσις ὁρίζειν τῷ ξ τῷ ψ· δός ξ ψ ἄθροισμα.");
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("fn"));
-    // ξ -> g_x, ψ -> g__u3c8_
-    assert!(code.contains("g_x") && code.contains("g__u3c8_"));
+    // ξ -> g__u3be_, ψ -> g__u3c8_
+    assert!(code.contains("g__u3be_") && code.contains("g__u3c8_"));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_simple_return() {
     eprintln!("Generated code:\n{}", code);
     assert!(code.contains("return"));
     // Should return x * 2, not just a literal
-    assert!(code.contains("g_x") || code.contains("*") || code.contains("2"));
+    assert!(code.contains("g__u3be_") || code.contains("*") || code.contains("2"));
 }
 
 #[test]
@@ -82,10 +82,11 @@ fn test_function_call() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
-    // πρόσθεσις -> g_pros_u3b8_esis
+    // πρόσθεσις -> g__u3c0__u3c1__u3bf__u3c3__u3b8__u3b5__u3c3__u3b9__u3c2_
+    let name = "g__u3c0__u3c1__u3bf__u3c3__u3b8__u3b5__u3c3__u3b9__u3c2_";
     assert!(
-        code.contains("g_pros_u3b8_esis")
-            && (code.contains("g_pros_u3b8_esis(") || code.contains("g_pros_u3b8_esis ("))
+        code.contains(name)
+            && (code.contains(&format!("{}(", name)) || code.contains(&format!("{} (", name)))
     );
 }
 
@@ -99,8 +100,10 @@ fn test_nested_calls() {
     );
     eprintln!("Generated code:\n{}", code);
     // Check for nested diplasiasmos calls (allowing for whitespace)
+    // διπλασιασμος -> g__u3b4__u3b9__u3c0__u3bb__u3b1__u3c3__u3b9__u3b1__u3c3__u3bc__u3bf__u3c2_
+    let name = "g__u3b4__u3b9__u3c0__u3bb__u3b1__u3c3__u3b9__u3b1__u3c3__u3bc__u3bf__u3c2_";
     assert!(
-        code.matches("g_diplasiasmos").count() >= 3,
+        code.matches(name).count() >= 3,
         "Expected at least 3 occurrences of diplasiasmos (fn def + 2 calls)"
     );
     assert!(code.contains("5i64"), "Expected literal 5 as argument");
@@ -120,7 +123,8 @@ fn test_function_local_variables() {
     ",
     );
     eprintln!("Generated code:\n{}", code);
-    assert!(code.contains("let g_topikon"));
+    // τοπικον -> g__u3c4__u3bf__u3c0__u3b9__u3ba__u3bf__u3bd_
+    assert!(code.contains("let g__u3c4__u3bf__u3c0__u3b9__u3ba__u3bf__u3bd_"));
 }
 
 #[test]

--- a/tests/havoc_transliteration.rs
+++ b/tests/havoc_transliteration.rs
@@ -31,5 +31,8 @@ fn test_type_identifier_collision() {
 
     // We expect this to SUCCEED now, because 'x' maps to 'G_x' and 'Ξ' maps to 'G__u3be_' (hex encoded).
     // No collision occurs.
-    assert!(result.is_ok(), "Should succeed as identifier collision is fixed");
+    assert!(
+        result.is_ok(),
+        "Should succeed as identifier collision is fixed"
+    );
 }

--- a/tests/havoc_transliteration.rs
+++ b/tests/havoc_transliteration.rs
@@ -1,0 +1,35 @@
+use glossa::tools::runner::run_file;
+use std::fs::File;
+use std::io::Write;
+use tempfile::tempdir;
+
+#[test]
+fn test_type_identifier_collision() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("collision.gl");
+
+    // "x" (ASCII) and "Ξ" (Greek Xi) both transliterate to "x" -> "g_x" -> "G_x" (Capitalized for struct).
+    // This causes a name collision in the generated Rust code (two structs named G_x).
+    let code = r#"
+        εἶδος x ὁρίζειν { }.
+        εἶδος Ξ ὁρίζειν { }.
+    "#;
+
+    let mut f = File::create(&file_path).unwrap();
+    f.write_all(code.as_bytes()).unwrap();
+
+    // Debug: check generated Rust code
+    use glossa::codegen::generate_rust_file;
+    use glossa::parser::parse;
+    use glossa::semantic::analyze_program;
+    let ast = parse(code).unwrap();
+    let analyzed = analyze_program(&ast).unwrap();
+    let rust = generate_rust_file(&analyzed);
+    println!("Generated Rust:\n{}", rust);
+
+    let result = run_file(&file_path);
+
+    // We expect this to SUCCEED now, because 'x' maps to 'G_x' and 'Ξ' maps to 'G__u3be_' (hex encoded).
+    // No collision occurs.
+    assert!(result.is_ok(), "Should succeed as identifier collision is fixed");
+}

--- a/tests/trait_tests.rs
+++ b/tests/trait_tests.rs
@@ -582,7 +582,8 @@ fn test_standalone_method_call() {
     let code = compile(source);
 
     // Should contain the method call
-    assert!(code.contains("g_p . g_show") || code.contains("g_p.g_show"));
+    // π -> g__u3c0_
+    assert!(code.contains("g__u3c0_ . g_show") || code.contains("g__u3c0_.g_show"));
 }
 
 // ============================================================================

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -43,8 +43,8 @@ fn test_instantiation() {
         π νέον σημεῖον πέντε ἔστω.
     "#;
     let code = compile(source);
-    // σημεῖον -> G_shmeion
-    assert!(code.contains("G_shmeion"));
+    // σημεῖον -> G__u3c3__u3b7__u3bc__u3b5__u3b9__u3bf__u3bd_
+    assert!(code.contains("G__u3c3__u3b7__u3bc__u3b5__u3b9__u3bf__u3bd_"));
     assert!(code.contains("5"));
 }
 
@@ -55,7 +55,8 @@ fn test_instantiation_multiple_fields() {
         π νέον σημεῖον πέντε τρία ἔστω.
     "#;
     let code = compile(source);
-    assert!(code.contains("G_shmeion"));
+    // σημεῖον -> G__u3c3__u3b7__u3bc__u3b5__u3b9__u3bf__u3bd_
+    assert!(code.contains("G__u3c3__u3b7__u3bc__u3b5__u3b9__u3bf__u3bd_"));
 }
 
 // Cycle 5: Field Access
@@ -68,8 +69,8 @@ fn test_field_access() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    // ξ -> g_x
-    assert!(code.contains(".g_x") || code.contains(". g_x"));
+    // ξ -> g__u3be_
+    assert!(code.contains(".g__u3be_") || code.contains(". g__u3be_"));
 }
 
 #[test]
@@ -82,8 +83,8 @@ fn test_field_access_multiple_fields() {
     "#;
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
-    // ξ -> g_x
-    assert!(code.contains(". g_x") || code.contains(".g_x"));
+    // ξ -> g__u3be_
+    assert!(code.contains(". g__u3be_") || code.contains(".g__u3be_"));
     // ψ -> g__u3c8_
     assert!(code.contains(". g__u3c8_") || code.contains(".g__u3c8_"));
 }
@@ -97,9 +98,12 @@ fn test_instantiation_with_literals() {
     let code = compile(source);
     eprintln!("Generated code:\n{}", code);
     // It should generate struct instantiation, not string assignment
-    // Χρήστης -> G__u3c7_rhsths
-    assert!(code.contains("struct G__u3c7_rhsths"));
-    assert!(code.contains("let g__u3c7_rhsths = G__u3c7_rhsths"));
+    // Χρήστης -> G__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_
+    let name = "G__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_";
+    assert!(code.contains(&format!("struct {}", name)));
+    // Variable name lower case g_...
+    let var_name = "g__u3c7__u3c1__u3b7__u3c3__u3c4__u3b7__u3c2_";
+    assert!(code.contains(&format!("let {} = {}", var_name, name)));
     assert!(code.contains("Σωκράτης"));
     assert!(code.contains("70"));
 }

--- a/tests/warden_exploit.rs
+++ b/tests/warden_exploit.rs
@@ -20,18 +20,15 @@ fn test_exploit_unicode_panic() {
     let rust = generate_rust(&analyzed);
 
     // Verify sanitization
-    // ᾽ (U+1FBD) should be replaced by _, and α becomes a
-    // So "᾽α" -> "_a"
-    // And since it starts with _, it stays "_a" (or maybe "__a" if prefixing logic applies)
-    // sanitize_name calls transliterate.
-    // transliterate("᾽α") -> "_" + "a" = "_a"
-    // sanitize_name then checks if it starts with digit. It starts with _.
-    // So it returns "_a".
-    // format_ident!("_a") is valid.
+    // ᾽ (U+1FBD) is NOT stripped by normalize_greek (it's a modifier letter, not combining mark).
+    // ᾽ -> _u1fbd_ (hex encoded).
+    // α -> _u3b1_ (hex encoded).
+    // sanitize_name adds "g_".
+    // So "᾽α" -> "g__u1fbd__u3b1_"
 
     assert!(
-        rust.contains("_a"),
-        "Generated code should contain sanitized identifier '_a'. Code: {}",
+        rust.contains("g__u1fbd__u3b1_"),
+        "Generated code should contain sanitized identifier 'g__u1fbd__u3b1_'. Code: {}",
         rust
     );
 }

--- a/tests/word_order_tests.rs
+++ b/tests/word_order_tests.rs
@@ -23,7 +23,8 @@ fn test_binding_word_order_independence() {
     let sov = compile_to_rust("ξ πέντε ἔστω.");
 
     // These should all produce equivalent output
-    assert!(sov.contains("let g_x"));
+    // ξ -> g__u3be_
+    assert!(sov.contains("let g__u3be_"));
     assert!(sov.contains("5i64") || sov.contains("5 "));
 }
 
@@ -44,7 +45,8 @@ fn test_variable_binding_and_reference() {
     let output = compile_to_rust(source);
 
     // Should have binding
-    assert!(output.contains("let g_x"));
+    // ξ -> g__u3be_
+    assert!(output.contains("let g__u3be_"));
     // Should have print
     assert!(output.contains("println"));
 }
@@ -54,12 +56,12 @@ fn test_variable_binding_and_reference() {
 fn test_number_binding_variations() {
     // Arabic numeral
     let arabic = compile_to_rust("ξ 42 ἔστω.");
-    assert!(arabic.contains("let g_x"));
+    assert!(arabic.contains("let g__u3be_"));
     assert!(arabic.contains("42"));
 
     // Greek numeral word
     let greek_word = compile_to_rust("ξ πέντε ἔστω.");
-    assert!(greek_word.contains("let g_x"));
+    assert!(greek_word.contains("let g__u3be_"));
     assert!(greek_word.contains("5"));
 }
 
@@ -104,8 +106,9 @@ fn test_multiple_statement_scope() {
     let output = compile_to_rust(source);
 
     // Both bindings should exist
-    assert!(output.contains("let g_a"));
-    assert!(output.contains("let g_b"));
+    // α -> g__u3b1_, β -> g__u3b2_
+    assert!(output.contains("let g__u3b1_"));
+    assert!(output.contains("let g__u3b2_"));
 }
 
 /// Test that queries produce output


### PR DESCRIPTION
This PR addresses a critical vulnerability identified by Havoc testing where Greek identifiers (e.g., `ξ`) were transliterated to ASCII characters (e.g., `x`), causing name collisions with existing ASCII identifiers in the generated Rust code. This could lead to duplicate definition errors or shadowing bugs.

The fix involves modifying `src/codegen.rs` to remove the lossy ASCII mapping for Greek characters and strictly hex-encode all non-ASCII characters in identifiers (e.g., `ξ` -> `_u3be_`). All tests (`compile_tests.rs`, `function_tests.rs`, `trait_tests.rs`, `type_tests.rs`, `word_order_tests.rs`, `warden_exploit.rs`) and doctests have been updated to reflect this change.

A regression test `tests/havoc_transliteration.rs` has been added to verify that ASCII `x` and Greek `Ξ` no longer collide.

---
*PR created automatically by Jules for task [8751596381355469493](https://jules.google.com/task/8751596381355469493) started by @madmax983*