### PR TITLE
🌟 Nova: The Herald (Test Runner)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 description = "ΓΛΩΣΣΑ - A compiler where Ancient Greek morphology encodes programming semantics"
 
+[features]
+nova = []
+
 [dependencies]
 crossterm = "0.29"
 dirs-next = "2"
@@ -20,9 +23,9 @@ rustc-hash = "2"
 comfy-table = "7.2.2"
 sha2 = "0.10"
 hex = "0.4"
+tempfile = "3.24.0"
 
 [dev-dependencies]
 insta = "1"
 pretty_assertions = "1"
 proptest = "1.9.0"
-tempfile = "3.24.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,11 @@ fn main() -> Result<()> {
             lookup_word(&word)?;
         }
 
+        #[cfg(feature = "nova")]
+        Some(Commands::Test { input }) => {
+            glossa::tools::tester::run_tests(&input)?;
+        }
+
         Some(Commands::Repl) | None => {
             run_repl()?;
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -641,6 +641,7 @@ pub enum ParseError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::recursion::check_recursion_depth;
 
     /// Helper to get the first expression of the first clause
     fn first_expr(stmt: &Statement) -> &Expr {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -58,4 +58,11 @@ pub enum Commands {
         /// The Greek word to analyze
         word: String,
     },
+
+    /// Run tests defined in a .γλ file (Requires "nova" feature)
+    #[cfg(feature = "nova")]
+    Test {
+        /// Input file (.γλ)
+        input: PathBuf,
+    },
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -5,4 +5,5 @@ pub mod highlight;
 pub mod narrator;
 pub mod repl;
 pub mod runner;
+pub mod tester;
 pub mod ui;

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -1,0 +1,110 @@
+use crate::codegen::generate_rust_file;
+use crate::parser::parse;
+use crate::semantic::analyze_program;
+use crate::tools::ui::Status;
+use crossterm::style::Stylize;
+use miette::{IntoDiagnostic, Result};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+use tempfile::Builder;
+
+/// Run tests defined in a Glossa file
+///
+/// This tool compiles the Glossa source to Rust, but instead of building a regular binary,
+/// it compiles it with `rustc --test`. This creates a test harness that runs all functions
+/// marked with `#[test]` (which `codegen` generates for `TestDeclaration` nodes).
+pub fn run_tests(input: &Path) -> Result<()> {
+    // 1. Validation
+    if !input.exists() {
+        return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
+    }
+
+    let mut status = Status::start("Δοκιμασία (Testing)");
+
+    // 2. Compilation (Lex -> Parse -> Analyze -> Codegen)
+    let source = fs::read_to_string(input).into_diagnostic()?;
+    let ast = parse(&source).map_err(|e| miette::miette!("{}", e))?;
+    let analyzed = analyze_program(&ast).map_err(|e| miette::miette!("{}", e))?;
+    let rust_code = generate_rust_file(&analyzed);
+
+    // 3. Create temporary file for Rust source
+    let mut temp_file = Builder::new()
+        .prefix("glossa_test_")
+        .suffix(".rs")
+        .tempfile()
+        .into_diagnostic()?;
+
+    write!(temp_file, "{}", rust_code).into_diagnostic()?;
+    let temp_path = temp_file.path().to_owned();
+
+    // 4. Determine output path for the test binary
+    // We use the temp directory to avoid polluting the user's workspace
+    // Use the temp file name to ensure uniqueness
+    let exe_name = temp_path
+        .file_stem()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    let exe_path = temp_path.parent().unwrap().join(if cfg!(windows) {
+        format!("{}.exe", exe_name)
+    } else {
+        exe_name
+    });
+
+    // 5. Compile with rustc --test
+    let rustc_output = Command::new("rustc")
+        .arg("--test")
+        .arg(&temp_path)
+        .arg("-o")
+        .arg(&exe_path)
+        .output()
+        .into_diagnostic()?;
+
+    if !rustc_output.status.success() {
+        let stderr = String::from_utf8_lossy(&rustc_output.stderr);
+        status.error("Σφάλμα μεταγλωττίσεως δοκιμῶν (Test Compilation Error)");
+        return Err(miette::miette!("{}\n{}", "Rustc Error:".red(), stderr));
+    }
+
+    // 6. Run the test binary
+    status.update("Ἐκτέλεσις (Running)");
+
+    let test_output = Command::new(&exe_path)
+        .output() // Capture output to display it nicely
+        .into_diagnostic()?;
+
+    // Cleanup: The temp_file (source) is auto-deleted when dropped.
+    // The executable must be deleted manually.
+    let _ = fs::remove_file(&exe_path);
+
+    // 7. Report results
+    if test_output.status.success() {
+        status.success();
+        println!();
+        println!(
+            "{}",
+            "✓ Πᾶσαι αἱ δοκιμασίαι ἐπέτυχαν! (All tests passed)"
+                .green()
+                .bold()
+        );
+        println!("{}", String::from_utf8_lossy(&test_output.stdout));
+    } else {
+        status.error("Ἀποτυχία (Failure)");
+        println!();
+        println!(
+            "{}",
+            "✕ Τινὲς δοκιμασίαι ἀπέτυχαν (Some tests failed)"
+                .red()
+                .bold()
+        );
+        println!("{}", String::from_utf8_lossy(&test_output.stdout));
+        if !test_output.stderr.is_empty() {
+            println!("{}", String::from_utf8_lossy(&test_output.stderr).red());
+        }
+        return Err(miette::miette!("Tests failed"));
+    }
+
+    Ok(())
+}

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -3,6 +3,7 @@
 use glossa::tools::tester::run_tests;
 use std::io::Write;
 use tempfile::Builder;
+use std::path::PathBuf;
 
 #[test]
 fn test_run_tests_success() {
@@ -56,4 +57,44 @@ fn test_run_tests_failure() {
     assert!(result.is_err(), "Test runner should have failed");
     let err_msg = result.unwrap_err().to_string();
     assert!(err_msg.contains("Tests failed"));
+}
+
+#[test]
+fn test_run_tests_file_not_found() {
+    let path = PathBuf::from("non_existent_file.gl");
+    let result = run_tests(&path);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("Ἀρχεῖον οὐχ εὑρέθη"));
+}
+
+#[test]
+fn test_run_tests_syntax_error() {
+    let mut temp_file = Builder::new()
+        .suffix(".gl")
+        .tempfile()
+        .expect("Failed to create temp file");
+
+    write!(temp_file, "invalid syntax").expect("Failed to write");
+
+    let result = run_tests(temp_file.path());
+    assert!(result.is_err());
+    // Error could be from parser or analyzer, but it should fail
+}
+
+#[test]
+fn test_run_tests_rustc_error() {
+    let mut temp_file = Builder::new()
+        .suffix(".gl")
+        .tempfile()
+        .expect("Failed to create temp file");
+
+    // This creates valid Glossa code that produces invalid Rust code (redefining String)
+    // "εἶδος String ὁρίζειν { }." -> "struct String { }" -> conflicts with std::string::String
+    let source = "εἶδος String ὁρίζειν { }. τέλος.";
+    write!(temp_file, "{}", source).expect("Failed to write");
+
+    let result = run_tests(temp_file.path());
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("Rustc Error"));
 }

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -2,8 +2,8 @@
 
 use glossa::tools::tester::run_tests;
 use std::io::Write;
-use tempfile::Builder;
 use std::path::PathBuf;
+use tempfile::Builder;
 
 #[test]
 fn test_run_tests_success() {
@@ -64,7 +64,12 @@ fn test_run_tests_file_not_found() {
     let path = PathBuf::from("non_existent_file.gl");
     let result = run_tests(&path);
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("Ἀρχεῖον οὐχ εὑρέθη"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Ἀρχεῖον οὐχ εὑρέθη")
+    );
 }
 
 #[test]

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -1,0 +1,59 @@
+#![cfg(feature = "nova")]
+
+use glossa::tools::tester::run_tests;
+use std::io::Write;
+use tempfile::Builder;
+
+#[test]
+fn test_run_tests_success() {
+    // Create a temporary Glossa file
+    let mut temp_file = Builder::new()
+        .suffix(".gl")
+        .tempfile()
+        .expect("Failed to create temp file");
+
+    // Write a passing test
+    // Test: Let x be 5. Assert x equals 5.
+    let source = "
+    δοκιμή «test_simple».
+       ξ πέντε ἔστω.
+       ξ πέντε ἰσοῦται.
+    τέλος.
+    ";
+
+    write!(temp_file, "{}", source).expect("Failed to write to temp file");
+
+    // Run the tester
+    let result = run_tests(temp_file.path());
+
+    // Should succeed
+    assert!(result.is_ok(), "Test runner failed: {:?}", result.err());
+}
+
+#[test]
+fn test_run_tests_failure() {
+    // Create a temporary Glossa file
+    let mut temp_file = Builder::new()
+        .suffix(".gl")
+        .tempfile()
+        .expect("Failed to create temp file");
+
+    // Write a failing test
+    // Test: Let x be 4. Assert x equals 5.
+    let source = "
+    δοκιμή «test_fail».
+       ξ τέσσαρα ἔστω.
+       ξ πέντε ἰσοῦται.
+    τέλος.
+    ";
+
+    write!(temp_file, "{}", source).expect("Failed to write to temp file");
+
+    // Run the tester
+    let result = run_tests(temp_file.path());
+
+    // Should fail
+    assert!(result.is_err(), "Test runner should have failed");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("Tests failed"));
+}


### PR DESCRIPTION
🌟 **Nova: The Herald (ὁ Κήρυξ)**

### 💡 The Spark
"We have `TestDeclaration` in the grammar, but no way to run them!"
The language supports defining tests (`δοκιμή ... τέλος.`), but the CLI only had `run` (for main) and `build` (for codegen). A language without a test runner is like a ship without a compass.

### 🚀 The Feature
Implemented `glossa test <FILE>` (The Herald).
This tool:
1. Compiles the Glossa source to Rust.
2. Invokes `rustc --test` on the generated code.
3. Runs the resulting test binary.
4. Reports pass/fail status with standard output.

It effectively brings TDD (Test-Driven Development) to Ancient Greek programming.

### 🔮 The Potential
This enables developers to write self-testing Glossa libraries and ensures that the "ancient logic" holds true.

### ⚠️ Risk
Low. The feature is additive and gated behind the `nova` feature flag.
I also fixed a minor issue in `src/parser.rs` where tests were missing an import.


---
*PR created automatically by Jules for task [15112702842839864348](https://jules.google.com/task/15112702842839864348) started by @madmax983*