### PR TITLE
fix(semantic): prevent silent dropping of excess operators in expressions

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -641,7 +641,6 @@ pub enum ParseError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::recursion::check_recursion_depth;
 
     /// Helper to get the first expression of the first clause
     fn first_expr(stmt: &Statement) -> &Expr {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -884,20 +884,16 @@ fn classify_expression(asm_stmt: &AssembledStatement) -> Result<AnalyzedStatemen
     // If literals < operators + 1, build_expressions_from_literals_and_ops will fail.
     // In that case, we only build literals and let the fallback logic handle operators.
 
-    let (literals_to_build, operators_to_build) =
-        if !asm_stmt.operators.is_empty() && asm_stmt.literals.len() < asm_stmt.operators.len() + 1
-        {
-            // Fallback case: operators likely depend on Subject/Object
-            (asm_stmt.literals.as_slice(), &[][..])
-        } else {
-            (
-                asm_stmt.literals.as_slice(),
-                asm_stmt.operators.as_slice(),
-            )
-        };
+    let (literals_to_build, operators_to_build) = if !asm_stmt.operators.is_empty()
+        && asm_stmt.literals.len() < asm_stmt.operators.len() + 1
+    {
+        // Fallback case: operators likely depend on Subject/Object
+        (asm_stmt.literals.as_slice(), &[][..])
+    } else {
+        (asm_stmt.literals.as_slice(), asm_stmt.operators.as_slice())
+    };
 
-    let mut exprs =
-        build_expressions_from_literals_and_ops(literals_to_build, operators_to_build)?;
+    let mut exprs = build_expressions_from_literals_and_ops(literals_to_build, operators_to_build)?;
 
     // If we have operators but couldn't build a full expression from literals alone (usually implies literals < 2),
     // we should look for Subject/Object to complete the binary expression.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -770,7 +770,7 @@ fn classify_print(
 
             // Default
             let mut args =
-                build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators);
+                build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 
             if let Some(ref subj) = asm_stmt.subject
                 && let Some(var_type) = scope.lookup(&subj.lemma)
@@ -879,8 +879,25 @@ fn classify_query(
 
 /// Helper: Default expression
 fn classify_expression(asm_stmt: &AssembledStatement) -> Result<AnalyzedStatement, GlossaError> {
+    // Determine if we should attempt to build expressions from literals+operators
+    // or if we are in a fallback scenario (using Subject/Object with operators).
+    // If literals < operators + 1, build_expressions_from_literals_and_ops will fail.
+    // In that case, we only build literals and let the fallback logic handle operators.
+
+    let (literals_to_build, operators_to_build) =
+        if !asm_stmt.operators.is_empty() && asm_stmt.literals.len() < asm_stmt.operators.len() + 1
+        {
+            // Fallback case: operators likely depend on Subject/Object
+            (asm_stmt.literals.as_slice(), &[][..])
+        } else {
+            (
+                asm_stmt.literals.as_slice(),
+                asm_stmt.operators.as_slice(),
+            )
+        };
+
     let mut exprs =
-        build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators);
+        build_expressions_from_literals_and_ops(literals_to_build, operators_to_build)?;
 
     // If we have operators but couldn't build a full expression from literals alone (usually implies literals < 2),
     // we should look for Subject/Object to complete the binary expression.
@@ -1191,7 +1208,7 @@ pub fn extract_value(
         // Check if we can build from literals alone (2+ literals)
         if asm_stmt.literals.len() >= 2 {
             let exprs =
-                build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators);
+                build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
             if let Some(expr) = exprs.into_iter().next() {
                 let ty = expr.glossa_type.clone();
                 return Ok((expr, ty));

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -572,48 +572,52 @@ pub fn build_binary_expr(
 pub fn build_expressions_from_literals_and_ops(
     literals: &[Literal],
     operators: &[crate::morphology::lexicon::BinaryOp],
-) -> Vec<AnalyzedExpr> {
+) -> Result<Vec<AnalyzedExpr>, GlossaError> {
     // If no operators, just return literals as separate expressions
     if operators.is_empty() {
-        return literals.iter().map(literal_to_analyzed_expr).collect();
+        return Ok(literals.iter().map(literal_to_analyzed_expr).collect());
     }
 
-    // If we have operators, build a binary expression
-    // Pattern: lit0 op0 lit1 op1 lit2 ... -> ((lit0 op0 lit1) op1 lit2) ...
-    if literals.len() < 2 || operators.is_empty() {
-        return literals.iter().map(literal_to_analyzed_expr).collect();
+    // Check if we have enough literals to cover operators (left-associative: op requires left and right)
+    // ops=1 -> literals>=2. ops=2 -> literals>=3.
+    // Basically literals.len() must be >= operators.len() + 1
+    if literals.len() < operators.len() + 1 {
+        return Err(GlossaError::semantic(format!(
+            "Insufficient literals for operators. Operators: {}, Literals: {}. Expected at least {} literals.",
+            operators.len(),
+            literals.len(),
+            operators.len() + 1
+        )));
     }
 
     // Build left-associative tree
     let mut result = literal_to_analyzed_expr(&literals[0]);
 
     for (i, op) in operators.iter().enumerate() {
-        if i + 1 < literals.len() {
-            let right = literal_to_analyzed_expr(&literals[i + 1]);
-            let result_type = infer_binop_type(op);
-            result = AnalyzedExpr {
-                expr: AnalyzedExprKind::BinOp {
-                    left: Box::new(result),
-                    op: *op,
-                    right: Box::new(right),
-                },
-                glossa_type: result_type,
-            };
-        }
+        // We guaranteed i+1 < literals.len() above
+        let right = literal_to_analyzed_expr(&literals[i + 1]);
+        let result_type = infer_binop_type(op);
+        result = AnalyzedExpr {
+            expr: AnalyzedExprKind::BinOp {
+                left: Box::new(result),
+                op: *op,
+                right: Box::new(right),
+            },
+            glossa_type: result_type,
+        };
     }
 
     let mut expressions = vec![result];
 
     // Append any remaining literals that weren't consumed by operators
-    // We consumed 1 (initial) + 1 for each operator that had a matching operand
-    // Effectively we consumed min(literals.len(), operators.len() + 1) literals
-    let consumed = (operators.len() + 1).min(literals.len());
+    // We consumed 1 (initial) + 1 for each operator
+    let consumed = operators.len() + 1;
 
     for literal in &literals[consumed..] {
         expressions.push(literal_to_analyzed_expr(literal));
     }
 
-    expressions
+    Ok(expressions)
 }
 
 /// Infer the result type of a binary operation
@@ -1106,7 +1110,7 @@ mod tests {
         let literals = vec![Literal::Number(1), Literal::Number(2), Literal::Number(3)];
         let operators = vec![crate::morphology::lexicon::BinaryOp::Add];
 
-        let exprs = build_expressions_from_literals_and_ops(&literals, &operators);
+        let exprs = build_expressions_from_literals_and_ops(&literals, &operators).unwrap();
 
         // This test should fail currently because the code returns [BinOp] (len 1)
         assert_eq!(

--- a/tests/expression_coverage.rs
+++ b/tests/expression_coverage.rs
@@ -104,21 +104,16 @@ fn test_dangling_propagation() {
 }
 
 #[test]
-fn test_excess_operators_ignored() {
+#[should_panic(expected = "Insufficient literals")]
+fn test_excess_operators_error() {
     // Test case with more operators than operands can consume.
     // "10 2 sum difference" -> "10 2 + -"
-    // Should consume +, but ignore -.
-    // Expect: "10 + 2" (checked_add).
+    // Previously ignored, now strictly validated.
+    // Should fail because we have 2 literals and 2 operators (need 3 literals).
 
     let source = "10 2 ἄθροισμα διαφορά λέγε.";
 
-    let output = compile_to_rust(source);
-
-    assert!(output.contains("checked_add"), "Should contain checked_add");
-    assert!(
-        !output.contains("checked_sub"),
-        "Should NOT contain checked_sub"
-    );
+    compile_to_rust(source);
 }
 
 #[test]

--- a/tests/regression_operator_drop.rs
+++ b/tests/regression_operator_drop.rs
@@ -1,0 +1,24 @@
+#[cfg(test)]
+mod tests {
+    use glossa::semantic::expressions::build_expressions_from_literals_and_ops;
+    use glossa::semantic::Literal;
+    use glossa::morphology::lexicon::BinaryOp;
+
+    #[test]
+    fn test_dropped_operator() {
+        // Case: 1 + 2 +
+        // Literals: [1, 2]
+        // Operators: [Add, Add]
+        // Expected: Should return Error due to insufficient literals
+
+        let literals = vec![Literal::Number(1), Literal::Number(2)];
+        let operators = vec![BinaryOp::Add, BinaryOp::Add];
+
+        let result = build_expressions_from_literals_and_ops(&literals, &operators);
+
+        assert!(result.is_err(), "Expected error for dangling operator, got {:?}", result);
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Insufficient literals"), "Unexpected error message: {}", err);
+    }
+}

--- a/tests/regression_operator_drop.rs
+++ b/tests/regression_operator_drop.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use glossa::semantic::expressions::build_expressions_from_literals_and_ops;
-    use glossa::semantic::Literal;
     use glossa::morphology::lexicon::BinaryOp;
+    use glossa::semantic::Literal;
+    use glossa::semantic::expressions::build_expressions_from_literals_and_ops;
 
     #[test]
     fn test_dropped_operator() {
@@ -16,9 +16,17 @@ mod tests {
 
         let result = build_expressions_from_literals_and_ops(&literals, &operators);
 
-        assert!(result.is_err(), "Expected error for dangling operator, got {:?}", result);
+        assert!(
+            result.is_err(),
+            "Expected error for dangling operator, got {:?}",
+            result
+        );
 
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("Insufficient literals"), "Unexpected error message: {}", err);
+        assert!(
+            err.to_string().contains("Insufficient literals"),
+            "Unexpected error message: {}",
+            err
+        );
     }
 }


### PR DESCRIPTION
This PR fixes a correctness issue where `build_expressions_from_literals_and_ops` silently ignored excess operators if there weren't enough literals to consume them. 

This behavior was particularly dangerous for malformed expressions like `1 2 + -`, which would be silently interpreted as `1 + 2`, ignoring the `-` operator.

The fix involves:
1.  Changing `build_expressions_from_literals_and_ops` to return `Result<Vec<AnalyzedExpr>, GlossaError>`.
2.  Adding a validation check: `if literals.len() < operators.len() + 1 { return Err(...) }`.
3.  Updating call sites (`classify_print`, `extract_value`, `classify_expression`) to propagate errors or handle fallback scenarios appropriately.
4.  Adding a regression test to verify that dangling operators now cause a compilation error.


---
*PR created automatically by Jules for task [2600860423843444062](https://jules.google.com/task/2600860423843444062) started by @madmax983*