### PR TITLE
🔒 Warden: Prevent terminal injection in syntax highlighter

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -641,7 +641,6 @@ pub enum ParseError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::recursion::check_recursion_depth;
 
     /// Helper to get the first expression of the first clause
     fn first_expr(stmt: &Statement) -> &Expr {

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -837,9 +837,15 @@ mod tests {
         let result = highlight(source).unwrap();
 
         // Should NOT contain raw escape code (vulnerable behavior)
-        assert!(!result.contains("\x1b[31m"), "Raw escape code should be sanitized");
+        assert!(
+            !result.contains("\x1b[31m"),
+            "Raw escape code should be sanitized"
+        );
 
         // Should contain escaped form
-        assert!(result.contains("\\u{1b}[31m"), "Escaped control char should be present");
+        assert!(
+            result.contains("\\u{1b}[31m"),
+            "Escaped control char should be present"
+        );
     }
 }

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -113,7 +113,9 @@ impl Highlighter {
     fn highlight_expr(&mut self, expr: &Expr) -> Result<(), GlossaError> {
         match expr {
             Expr::StringLiteral(s) => {
-                write!(self.output, "«{}»", s.as_str().italic()).unwrap();
+                // Sanitize string to prevent terminal injection
+                let sanitized: String = s.chars().flat_map(|c| c.escape_debug()).collect();
+                write!(self.output, "«{}»", sanitized.as_str().italic()).unwrap();
             }
             Expr::NumberLiteral(n) => {
                 write!(self.output, "{}", n.to_string().italic()).unwrap();
@@ -826,5 +828,18 @@ mod tests {
         let source = "«unclosed string";
         let result = highlight(source);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_highlight_string_injection() {
+        // Inject RED color code into string literal
+        let source = "«\x1b[31mRED» λέγε.";
+        let result = highlight(source).unwrap();
+
+        // Should NOT contain raw escape code (vulnerable behavior)
+        assert!(!result.contains("\x1b[31m"), "Raw escape code should be sanitized");
+
+        // Should contain escaped form
+        assert!(result.contains("\\u{1b}[31m"), "Escaped control char should be present");
     }
 }


### PR DESCRIPTION
* 🦠 Threat: Terminal Injection (CWE-150) in `src/tools/highlight.rs`. String literals containing ANSI escape codes (e.g., `\x1b[31m`) were rendered raw, allowing malicious source code to manipulate the user's terminal output.
* 🛡️ Defense: Sanitized string literals using `s.chars().flat_map(|c| c.escape_debug())` before printing. This ensures escape sequences are displayed safely (e.g., `\u{1b}`) instead of executed.
* 💥 Severity: Moderate (Client-side display manipulation).
* 🧪 Verification: Added `test_highlight_string_injection` to verify that raw escape codes are absent and escaped versions are present.

---
*PR created automatically by Jules for task [3441923351156371637](https://jules.google.com/task/3441923351156371637) started by @madmax983*