### PR TITLE
🌟 Nova: Mosaic - The Semantic Assembler Visualizer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,11 @@ fn main() -> Result<()> {
             glossa::tools::tester::run_tests(&input)?;
         }
 
+        #[cfg(feature = "nova")]
+        Some(Commands::Mosaic { input }) => {
+            glossa::tools::mosaic::run_mosaic(&input)?;
+        }
+
         Some(Commands::Repl) | None => {
             run_repl()?;
         }

--- a/src/semantic/assembly_model.rs
+++ b/src/semantic/assembly_model.rs
@@ -15,7 +15,7 @@ use smol_str::SmolStr;
 /// It contains all the semantic components (subject, verb, object, etc.)
 /// extracted from the input stream.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct AssembledStatement {
+pub struct AssembledStatement {
     /// The subject (nominative) - the agent/doer
     pub subject: Option<Constituent>,
 
@@ -86,7 +86,7 @@ pub(crate) struct AssembledStatement {
 /// A noun/pronoun constituent with its grammatical info
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub(crate) struct Constituent {
+pub struct Constituent {
     /// The dictionary form
     pub lemma: SmolStr,
 
@@ -109,7 +109,7 @@ pub(crate) struct Constituent {
 /// A verb constituent with its grammatical info
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub(crate) struct VerbConstituent {
+pub struct VerbConstituent {
     /// The dictionary form
     pub lemma: SmolStr,
 
@@ -135,7 +135,7 @@ pub(crate) struct VerbConstituent {
 /// A participle constituent (used for lambdas/closures)
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub(crate) struct ParticipleConstituent {
+pub struct ParticipleConstituent {
     /// The verb stem extracted from the participle
     pub verb_lemma: SmolStr,
     /// Original text as it appeared
@@ -154,7 +154,7 @@ pub(crate) struct ParticipleConstituent {
 
 /// A literal value
 #[derive(Debug, Clone)]
-pub(crate) enum Literal {
+pub enum Literal {
     String(String),
     Number(i64),
     Boolean(bool),

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -48,7 +48,7 @@ mod types;
 pub use crate::morphology::{DisambiguationContext, analyze_article, disambiguate, resolve_best};
 pub(crate) use assembler::Assembler;
 pub use assembler::AssemblyError;
-pub(crate) use assembly_model::{AssembledStatement, Constituent, Literal};
+pub use assembly_model::{AssembledStatement, Constituent, Literal};
 pub use model::*;
 pub use resolver::*;
 pub use types::*;
@@ -325,7 +325,7 @@ fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
 }
 
 /// Analyze a single statement using the slot-based assembler
-pub(crate) fn assemble_statement(stmt: &Statement) -> Result<AssembledStatement, GlossaError> {
+pub fn assemble_statement(stmt: &Statement) -> Result<AssembledStatement, GlossaError> {
     let mut asm = Assembler::new();
     asm.set_query(stmt.is_query());
     asm.set_propagate(stmt.is_propagate());

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -65,4 +65,11 @@ pub enum Commands {
         /// Input file (.γλ)
         input: PathBuf,
     },
+
+    /// Visualize the assembled sentence structure (Requires "nova" feature)
+    #[cfg(feature = "nova")]
+    Mosaic {
+        /// Input file (.γλ)
+        input: PathBuf,
+    },
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -8,3 +8,5 @@ pub mod report;
 pub mod runner;
 pub mod tester;
 pub mod ui;
+#[cfg(feature = "nova")]
+pub mod mosaic;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,11 +2,11 @@ pub mod cache;
 pub mod cli;
 pub mod dictionary;
 pub mod highlight;
+#[cfg(feature = "nova")]
+pub mod mosaic;
 pub mod narrator;
 pub mod repl;
 pub mod report;
 pub mod runner;
 pub mod tester;
 pub mod ui;
-#[cfg(feature = "nova")]
-pub mod mosaic;

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -1,0 +1,181 @@
+//! The Mosaic Tool ("Mosaic")
+//!
+//! This module implements the "Mosaic" functionality, which visualizes the internal
+//! "Assembled Statement" structure of a ΓΛΩΣΣΑ program.
+//!
+//! # Purpose
+//!
+//! This tool helps developers and users understand how the "free word order" of Ancient Greek
+//! is interpreted by the compiler's `Assembler`. It shows which words land in which
+//! grammatical slot (Subject, Object, Verb, etc.).
+//!
+//! # The Mosaic
+//!
+//! The output is a table where each row represents a statement, and columns represent
+//! the grammatical slots.
+
+#[cfg(feature = "nova")]
+use crate::parser::parse;
+#[cfg(feature = "nova")]
+use crate::semantic::{AssembledStatement, Constituent, assemble_statement};
+#[cfg(feature = "nova")]
+use comfy_table::presets::UTF8_FULL;
+#[cfg(feature = "nova")]
+use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table};
+#[cfg(feature = "nova")]
+use miette::{IntoDiagnostic, Result};
+#[cfg(feature = "nova")]
+use std::path::PathBuf;
+
+#[cfg(feature = "nova")]
+pub fn run_mosaic(input_path: &PathBuf) -> Result<()> {
+    let source = std::fs::read_to_string(input_path).into_diagnostic()?;
+    run_mosaic_inner(&source, &mut std::io::stdout())
+}
+
+#[cfg(feature = "nova")]
+pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Result<()> {
+    let program = parse(source)?;
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec![
+            Cell::new("Line").add_attribute(Attribute::Bold),
+            Cell::new("Subject (Nom)").add_attribute(Attribute::Bold).fg(Color::Cyan),
+            Cell::new("Verb (Action)").add_attribute(Attribute::Bold).fg(Color::Yellow),
+            Cell::new("Object (Acc)").add_attribute(Attribute::Bold).fg(Color::Green),
+            Cell::new("Indirect (Dat)").add_attribute(Attribute::Bold).fg(Color::Magenta),
+            Cell::new("Other").add_attribute(Attribute::Bold).fg(Color::DarkGrey),
+        ]);
+
+    for (i, stmt) in program.statements.iter().enumerate() {
+        // Only assemble regular statements (others like TypeDef don't go through Assembler in the same way)
+        // Check if it's a regular statement
+        if let crate::ast::Statement::Regular { .. } = stmt {
+            match assemble_statement(stmt) {
+                Ok(assembled) => {
+                    add_row(&mut table, i + 1, &assembled);
+                }
+                Err(e) => {
+                    table.add_row(vec![
+                        Cell::new(format!("{}", i + 1)),
+                        Cell::new(format!("Error: {}", e)).fg(Color::Red),
+                        Cell::new(""),
+                        Cell::new(""),
+                        Cell::new(""),
+                        Cell::new(""),
+                    ]);
+                }
+            }
+        } else {
+             // For non-regular statements, just print the type
+             let type_name = match stmt {
+                 crate::ast::Statement::TypeDefinition(_) => "Type Definition",
+                 crate::ast::Statement::TraitDefinition(_) => "Trait Definition",
+                 crate::ast::Statement::TraitImpl(_) => "Trait Implementation",
+                 crate::ast::Statement::TestDeclaration(_) => "Test Declaration",
+                 _ => "Unknown",
+             };
+             table.add_row(vec![
+                 Cell::new(format!("{}", i + 1)),
+                 Cell::new(type_name).fg(Color::Blue).add_attribute(Attribute::Italic),
+                 Cell::new(""),
+                 Cell::new(""),
+                 Cell::new(""),
+                 Cell::new(""),
+             ]);
+        }
+    }
+
+    writeln!(writer, "{}", table).into_diagnostic()?;
+    Ok(())
+}
+
+#[cfg(feature = "nova")]
+fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
+    let subject = asm.subject.as_ref().map(fmt_constituent).unwrap_or_default();
+
+    // Combine nominatives if subject is present or if there are multiple
+    let extra_noms = asm.nominatives.iter().map(fmt_constituent).collect::<Vec<_>>().join(", ");
+    let full_subject = if !extra_noms.is_empty() {
+        if !subject.is_empty() {
+            format!("{} (+ {})", subject, extra_noms)
+        } else {
+            extra_noms
+        }
+    } else {
+        subject
+    };
+
+    let verb = asm.verb.as_ref().map(|v| v.original.to_string()).unwrap_or_default();
+    let object = asm.object.as_ref().map(fmt_constituent).unwrap_or_default();
+    let indirect = asm.indirect.as_ref().map(fmt_constituent).unwrap_or_default();
+
+    // Collect other interesting things
+    let mut other = Vec::new();
+    if !asm.literals.is_empty() {
+        other.push(format!("Literals: {}", asm.literals.len()));
+    }
+    if !asm.operators.is_empty() {
+        other.push(format!("Ops: {:?}", asm.operators));
+    }
+    if !asm.genitives.is_empty() {
+        let gens = asm.genitives.iter().map(fmt_constituent).collect::<Vec<_>>().join(", ");
+        other.push(format!("Gen: [{}]", gens));
+    }
+    if !asm.adjectives.is_empty() {
+        let adjs = asm.adjectives.iter().map(fmt_constituent).collect::<Vec<_>>().join(", ");
+        other.push(format!("Adj: [{}]", adjs));
+    }
+    if !asm.participles.is_empty() {
+        let parts = asm.participles.iter().map(|p| p.original.to_string()).collect::<Vec<_>>().join(", ");
+        other.push(format!("Participles: [{}]", parts));
+    }
+    if asm.is_query {
+        other.push("Query (?)".to_string());
+    }
+
+    table.add_row(vec![
+        Cell::new(format!("{}", line)),
+        Cell::new(full_subject),
+        Cell::new(verb),
+        Cell::new(object),
+        Cell::new(indirect),
+        Cell::new(other.join(", ")),
+    ]);
+}
+
+#[cfg(feature = "nova")]
+fn fmt_constituent(c: &Constituent) -> String {
+    c.original.to_string()
+}
+
+#[cfg(test)]
+#[cfg(feature = "nova")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mosaic_output() {
+        let source = "ὁ ἄνθρωπος τὸν λόγον λέγει.";
+        let mut buffer = Vec::new();
+        run_mosaic_inner(source, &mut buffer).unwrap();
+        let output = String::from_utf8(buffer).unwrap();
+
+        assert!(output.contains("ἄνθρωπος")); // Subject
+        assert!(output.contains("λόγον"));    // Object
+        assert!(output.contains("λέγει"));    // Verb
+    }
+
+    #[test]
+    fn test_mosaic_non_regular() {
+        let source = "εἶδος Χ ὁρίζειν { x ἀριθμοῦ. }.";
+        let mut buffer = Vec::new();
+        run_mosaic_inner(source, &mut buffer).unwrap();
+        let output = String::from_utf8(buffer).unwrap();
+
+        assert!(output.contains("Type Definition"));
+    }
+}

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -14,26 +14,18 @@
 //! The output is a table where each row represents a statement, and columns represent
 //! the grammatical slots.
 
-#[cfg(feature = "nova")]
 use crate::parser::parse;
-#[cfg(feature = "nova")]
 use crate::semantic::{AssembledStatement, Constituent, assemble_statement};
-#[cfg(feature = "nova")]
 use comfy_table::presets::UTF8_FULL;
-#[cfg(feature = "nova")]
 use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table};
-#[cfg(feature = "nova")]
 use miette::{IntoDiagnostic, Result};
-#[cfg(feature = "nova")]
 use std::path::PathBuf;
 
-#[cfg(feature = "nova")]
 pub fn run_mosaic(input_path: &PathBuf) -> Result<()> {
     let source = std::fs::read_to_string(input_path).into_diagnostic()?;
     run_mosaic_inner(&source, &mut std::io::stdout())
 }
 
-#[cfg(feature = "nova")]
 pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Result<()> {
     let program = parse(source)?;
 
@@ -43,11 +35,21 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
         .set_content_arrangement(ContentArrangement::Dynamic)
         .set_header(vec![
             Cell::new("Line").add_attribute(Attribute::Bold),
-            Cell::new("Subject (Nom)").add_attribute(Attribute::Bold).fg(Color::Cyan),
-            Cell::new("Verb (Action)").add_attribute(Attribute::Bold).fg(Color::Yellow),
-            Cell::new("Object (Acc)").add_attribute(Attribute::Bold).fg(Color::Green),
-            Cell::new("Indirect (Dat)").add_attribute(Attribute::Bold).fg(Color::Magenta),
-            Cell::new("Other").add_attribute(Attribute::Bold).fg(Color::DarkGrey),
+            Cell::new("Subject (Nom)")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+            Cell::new("Verb (Action)")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Yellow),
+            Cell::new("Object (Acc)")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Green),
+            Cell::new("Indirect (Dat)")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Magenta),
+            Cell::new("Other")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::DarkGrey),
         ]);
 
     for (i, stmt) in program.statements.iter().enumerate() {
@@ -70,22 +72,24 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
                 }
             }
         } else {
-             // For non-regular statements, just print the type
-             let type_name = match stmt {
-                 crate::ast::Statement::TypeDefinition(_) => "Type Definition",
-                 crate::ast::Statement::TraitDefinition(_) => "Trait Definition",
-                 crate::ast::Statement::TraitImpl(_) => "Trait Implementation",
-                 crate::ast::Statement::TestDeclaration(_) => "Test Declaration",
-                 _ => "Unknown",
-             };
-             table.add_row(vec![
-                 Cell::new(format!("{}", i + 1)),
-                 Cell::new(type_name).fg(Color::Blue).add_attribute(Attribute::Italic),
-                 Cell::new(""),
-                 Cell::new(""),
-                 Cell::new(""),
-                 Cell::new(""),
-             ]);
+            // For non-regular statements, just print the type
+            let type_name = match stmt {
+                crate::ast::Statement::TypeDefinition(_) => "Type Definition",
+                crate::ast::Statement::TraitDefinition(_) => "Trait Definition",
+                crate::ast::Statement::TraitImpl(_) => "Trait Implementation",
+                crate::ast::Statement::TestDeclaration(_) => "Test Declaration",
+                _ => "Unknown",
+            };
+            table.add_row(vec![
+                Cell::new(format!("{}", i + 1)),
+                Cell::new(type_name)
+                    .fg(Color::Blue)
+                    .add_attribute(Attribute::Italic),
+                Cell::new(""),
+                Cell::new(""),
+                Cell::new(""),
+                Cell::new(""),
+            ]);
         }
     }
 
@@ -93,12 +97,20 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
     Ok(())
 }
 
-#[cfg(feature = "nova")]
 fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
-    let subject = asm.subject.as_ref().map(fmt_constituent).unwrap_or_default();
+    let subject = asm
+        .subject
+        .as_ref()
+        .map(fmt_constituent)
+        .unwrap_or_default();
 
     // Combine nominatives if subject is present or if there are multiple
-    let extra_noms = asm.nominatives.iter().map(fmt_constituent).collect::<Vec<_>>().join(", ");
+    let extra_noms = asm
+        .nominatives
+        .iter()
+        .map(fmt_constituent)
+        .collect::<Vec<_>>()
+        .join(", ");
     let full_subject = if !extra_noms.is_empty() {
         if !subject.is_empty() {
             format!("{} (+ {})", subject, extra_noms)
@@ -109,9 +121,17 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
         subject
     };
 
-    let verb = asm.verb.as_ref().map(|v| v.original.to_string()).unwrap_or_default();
+    let verb = asm
+        .verb
+        .as_ref()
+        .map(|v| v.original.to_string())
+        .unwrap_or_default();
     let object = asm.object.as_ref().map(fmt_constituent).unwrap_or_default();
-    let indirect = asm.indirect.as_ref().map(fmt_constituent).unwrap_or_default();
+    let indirect = asm
+        .indirect
+        .as_ref()
+        .map(fmt_constituent)
+        .unwrap_or_default();
 
     // Collect other interesting things
     let mut other = Vec::new();
@@ -122,15 +142,30 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
         other.push(format!("Ops: {:?}", asm.operators));
     }
     if !asm.genitives.is_empty() {
-        let gens = asm.genitives.iter().map(fmt_constituent).collect::<Vec<_>>().join(", ");
+        let gens = asm
+            .genitives
+            .iter()
+            .map(fmt_constituent)
+            .collect::<Vec<_>>()
+            .join(", ");
         other.push(format!("Gen: [{}]", gens));
     }
     if !asm.adjectives.is_empty() {
-        let adjs = asm.adjectives.iter().map(fmt_constituent).collect::<Vec<_>>().join(", ");
+        let adjs = asm
+            .adjectives
+            .iter()
+            .map(fmt_constituent)
+            .collect::<Vec<_>>()
+            .join(", ");
         other.push(format!("Adj: [{}]", adjs));
     }
     if !asm.participles.is_empty() {
-        let parts = asm.participles.iter().map(|p| p.original.to_string()).collect::<Vec<_>>().join(", ");
+        let parts = asm
+            .participles
+            .iter()
+            .map(|p| p.original.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
         other.push(format!("Participles: [{}]", parts));
     }
     if asm.is_query {
@@ -147,13 +182,11 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
     ]);
 }
 
-#[cfg(feature = "nova")]
 fn fmt_constituent(c: &Constituent) -> String {
     c.original.to_string()
 }
 
 #[cfg(test)]
-#[cfg(feature = "nova")]
 mod tests {
     use super::*;
 
@@ -165,8 +198,8 @@ mod tests {
         let output = String::from_utf8(buffer).unwrap();
 
         assert!(output.contains("ἄνθρωπος")); // Subject
-        assert!(output.contains("λόγον"));    // Object
-        assert!(output.contains("λέγει"));    // Verb
+        assert!(output.contains("λόγον")); // Object
+        assert!(output.contains("λέγει")); // Verb
     }
 
     #[test]


### PR DESCRIPTION
🌟 **Nova: Mosaic**

**Concept:** A visualization tool that displays the "Assembled Statement" - the internal representation of the Greek sentence structure (Subject, Object, Verb, etc.) before it is compiled to Rust.

**The Spark:** "We have `AssembledStatement` which shows how words are slotted into Subject/Object/Verb, but users can only see the final `AnalyzedStatement` via `narrator`. I want to see the *process* of assembly."

**The Feature:**
- Adds `glossa mosaic <file.gl>` command.
- Renders a beautiful CLI table showing:
  - Subject (Nominative)
  - Verb (Action)
  - Object (Accusative)
  - Indirect Object (Dative)
  - Modifiers (Adjectives, Genitives, Participles)
- Helps debug ambiguity (e.g., seeing that `λόγον` is classified as a participle).

**Safety:**
- Implemented behind `#[cfg(feature = "nova")]`.
- Does not modify core logic behavior (only visibility of some internal structs).
- Verified with tests.


---
*PR created automatically by Jules for task [3629862893358703072](https://jules.google.com/task/3629862893358703072) started by @madmax983*