### PR TITLE
Fix operator drop bug in binary expressions with multiple variables

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -1218,7 +1218,7 @@ fn extract_array(
 
 fn extract_binary_op(
     asm_stmt: &AssembledStatement,
-    _scope: &Scope,
+    scope: &Scope,
 ) -> Result<Option<(AnalyzedExpr, GlossaType)>, GlossaError> {
     if !asm_stmt.operators.is_empty() {
         // Check if we can build from literals alone (2+ literals)
@@ -1231,16 +1231,40 @@ fn extract_binary_op(
             }
         }
 
+        let make_var = |lemma: &smol_str::SmolStr| AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(lemma.clone()),
+            glossa_type: scope.lookup(lemma).cloned().unwrap_or(GlossaType::Unknown),
+        };
+
         // Or check if we can combine object + literal with operator
         if let Some(ref obj) = asm_stmt.object
             && !asm_stmt.literals.is_empty()
         {
             // Build: object op literal
-            let left = AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                glossa_type: GlossaType::Unknown, // Will be inferred
-            };
+            let left = make_var(&obj.lemma);
             let right = literal_to_analyzed_expr(&asm_stmt.literals[0]);
+            let op = asm_stmt.operators[0];
+            let bin_expr = build_binary_expr(left, op, right);
+            let ty = bin_expr.glossa_type.clone();
+            return Ok(Some((bin_expr, ty)));
+        }
+
+        // Object + Nominative (e.g. x + y)
+        if let Some(ref obj) = asm_stmt.object
+            && let Some(nom) = asm_stmt.nominatives.first()
+        {
+            let left = make_var(&obj.lemma);
+            let right = make_var(&nom.lemma);
+            let op = asm_stmt.operators[0];
+            let bin_expr = build_binary_expr(left, op, right);
+            let ty = bin_expr.glossa_type.clone();
+            return Ok(Some((bin_expr, ty)));
+        }
+
+        // Nominative + Nominative (e.g. a + b, where both are extra nominatives)
+        if asm_stmt.nominatives.len() >= 2 {
+            let left = make_var(&asm_stmt.nominatives[0].lemma);
+            let right = make_var(&asm_stmt.nominatives[1].lemma);
             let op = asm_stmt.operators[0];
             let bin_expr = build_binary_expr(left, op, right);
             let ty = bin_expr.glossa_type.clone();

--- a/src/semantic/conversion_tests.rs
+++ b/src/semantic/conversion_tests.rs
@@ -1,6 +1,7 @@
 use super::conversion::extract_value;
 use crate::ast::Expr;
 use crate::morphology::Case;
+use crate::morphology::lexicon::BinaryOp;
 use crate::semantic::{
     AnalyzedExprKind, AssembledStatement, Constituent, GlossaType, Literal, Scope,
 };
@@ -93,6 +94,52 @@ fn test_extract_literal() {
         assert_eq!(n, 123);
     } else {
         panic!("Expected NumberLiteral");
+    }
+
+    assert_eq!(glossa_type, GlossaType::Number);
+}
+
+#[test]
+fn test_extract_binary_op_object_and_nominative() {
+    let mut scope = Scope::new();
+    scope.define("x", GlossaType::Number);
+    scope.define("y", GlossaType::Number);
+
+    // Simulate "x + y"
+    // Object: "x"
+    // Nominative: "y" (extra nominative, not subject)
+    // Operator: "+"
+    let asm_stmt = AssembledStatement {
+        object: Some(make_constituent("x", "x")),
+        nominatives: vec![make_constituent("y", "y")],
+        operators: vec![BinaryOp::Add],
+        ..Default::default()
+    };
+
+    let (analyzed, glossa_type) =
+        extract_value(&asm_stmt, &scope).expect("Should extract binary op");
+
+    match analyzed.expr {
+        AnalyzedExprKind::BinOp { left, op, right } => {
+            assert_eq!(op, BinaryOp::Add);
+            if let AnalyzedExprKind::Variable(name) = left.expr {
+                assert_eq!(name, "x");
+            } else {
+                panic!("Left operand should be variable x");
+            }
+            if let AnalyzedExprKind::Variable(name) = right.expr {
+                assert_eq!(name, "y");
+            } else {
+                panic!("Right operand should be variable y");
+            }
+        }
+        AnalyzedExprKind::Variable(name) => {
+            panic!(
+                "Expected BinOp, got Variable '{}' (Operator Drop Bug!)",
+                name
+            );
+        }
+        _ => panic!("Expected BinOp, got {:?}", analyzed.expr),
     }
 
     assert_eq!(glossa_type, GlossaType::Number);

--- a/src/semantic/conversion_tests.rs
+++ b/src/semantic/conversion_tests.rs
@@ -100,6 +100,85 @@ fn test_extract_literal() {
 }
 
 #[test]
+fn test_extract_binary_op_nominative_and_nominative() {
+    let mut scope = Scope::new();
+    scope.define("a", GlossaType::Number);
+    scope.define("b", GlossaType::Number);
+
+    // Simulate "a + b" where both are nominatives (no Object/Subject used)
+    // Object: None
+    // Nominatives: ["a", "b"]
+    // Operator: "+"
+    let asm_stmt = AssembledStatement {
+        object: None,
+        nominatives: vec![make_constituent("a", "a"), make_constituent("b", "b")],
+        operators: vec![BinaryOp::Add],
+        ..Default::default()
+    };
+
+    let (analyzed, glossa_type) =
+        extract_value(&asm_stmt, &scope).expect("Should extract binary op for nom+nom");
+
+    match analyzed.expr {
+        AnalyzedExprKind::BinOp { left, op, right } => {
+            assert_eq!(op, BinaryOp::Add);
+            if let AnalyzedExprKind::Variable(name) = left.expr {
+                assert_eq!(name, "a");
+            } else {
+                panic!("Left operand should be variable a");
+            }
+            if let AnalyzedExprKind::Variable(name) = right.expr {
+                assert_eq!(name, "b");
+            } else {
+                panic!("Right operand should be variable b");
+            }
+        }
+        _ => panic!("Expected BinOp, got {:?}", analyzed.expr),
+    }
+
+    assert_eq!(glossa_type, GlossaType::Number);
+}
+
+#[test]
+fn test_extract_binary_op_object_and_literal() {
+    let mut scope = Scope::new();
+    scope.define("x", GlossaType::Number);
+
+    // Simulate "x + 5"
+    // Object: "x"
+    // Literal: 5
+    // Operator: "+"
+    let asm_stmt = AssembledStatement {
+        object: Some(make_constituent("x", "x")),
+        literals: vec![Literal::Number(5)],
+        operators: vec![BinaryOp::Add],
+        ..Default::default()
+    };
+
+    let (analyzed, glossa_type) =
+        extract_value(&asm_stmt, &scope).expect("Should extract binary op for obj+lit");
+
+    match analyzed.expr {
+        AnalyzedExprKind::BinOp { left, op, right } => {
+            assert_eq!(op, BinaryOp::Add);
+            if let AnalyzedExprKind::Variable(name) = left.expr {
+                assert_eq!(name, "x");
+            } else {
+                panic!("Left operand should be variable x");
+            }
+            if let AnalyzedExprKind::NumberLiteral(val) = right.expr {
+                assert_eq!(val, 5);
+            } else {
+                panic!("Right operand should be literal 5");
+            }
+        }
+        _ => panic!("Expected BinOp, got {:?}", analyzed.expr),
+    }
+
+    assert_eq!(glossa_type, GlossaType::Number);
+}
+
+#[test]
 fn test_extract_binary_op_object_and_nominative() {
     let mut scope = Scope::new();
     scope.define("x", GlossaType::Number);


### PR DESCRIPTION
Fixes a logic bug in `extract_binary_op` that caused binary operators to be ignored when operands were variables (Object or Nominatives) instead of literals. Added regression test.

---
*PR created automatically by Jules for task [18310211847176539807](https://jules.google.com/task/18310211847176539807) started by @madmax983*