### PR TITLE
Detect and block infinite size recursive structs

### DIFF
--- a/src/semantic/statements.rs
+++ b/src/semantic/statements.rs
@@ -1246,3 +1246,61 @@ pub fn analyze_test_declaration(
         body: analyzed_body,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_recursive_type() {
+        let target = "Target";
+
+        // Direct recursion: Target == Target
+        let direct = GlossaType::Struct {
+            name: "Target".into(),
+            gender: crate::morphology::Gender::Neuter,
+            fields: vec![],
+        };
+        assert!(check_recursive_type(target, &direct));
+
+        // Non-recursive struct
+        let other = GlossaType::Struct {
+            name: "Other".into(),
+            gender: crate::morphology::Gender::Neuter,
+            fields: vec![],
+        };
+        assert!(!check_recursive_type(target, &other));
+
+        // Option recursion: Option<Target>
+        let opt_rec = GlossaType::Option(Box::new(direct.clone()));
+        assert!(check_recursive_type(target, &opt_rec));
+
+        // Option non-recursion: Option<Other>
+        let opt_non_rec = GlossaType::Option(Box::new(other.clone()));
+        assert!(!check_recursive_type(target, &opt_non_rec));
+
+        // Result recursion (Ok): Result<Target, Other>
+        let res_ok_rec = GlossaType::Result(Box::new(direct.clone()), Box::new(other.clone()));
+        assert!(check_recursive_type(target, &res_ok_rec));
+
+        // Result recursion (Err): Result<Other, Target>
+        let res_err_rec = GlossaType::Result(Box::new(other.clone()), Box::new(direct.clone()));
+        assert!(check_recursive_type(target, &res_err_rec));
+
+        // Result non-recursion: Result<Other, Other>
+        let res_non_rec = GlossaType::Result(Box::new(other.clone()), Box::new(other.clone()));
+        assert!(!check_recursive_type(target, &res_non_rec));
+
+        // List breaks recursion: List<Target> -> Safe (Vec is heap allocated)
+        let list_rec = GlossaType::List(Box::new(direct.clone()));
+        assert!(!check_recursive_type(target, &list_rec));
+
+        // Set breaks recursion
+        let set_rec = GlossaType::Set(Box::new(direct.clone()));
+        assert!(!check_recursive_type(target, &set_rec));
+
+        // Map breaks recursion
+        let map_rec = GlossaType::Map(Box::new(direct.clone()), Box::new(other.clone()));
+        assert!(!check_recursive_type(target, &map_rec));
+    }
+}

--- a/src/semantic/statements.rs
+++ b/src/semantic/statements.rs
@@ -770,6 +770,16 @@ pub fn analyze_type_definition(
     // Extract type name
     let type_name = type_def.name.normalized.clone();
 
+    // Define placeholder to allow recursive reference
+    scope.define_type(
+        type_name.clone(),
+        GlossaType::Struct {
+            name: type_name.clone(),
+            gender: crate::morphology::Gender::Neuter,
+            fields: vec![],
+        },
+    );
+
     // Analyze fields
     let mut fields = Vec::new();
     for field in &type_def.fields {
@@ -778,6 +788,15 @@ pub fn analyze_type_definition(
 
         // Map genitive type names to GlossaType
         let field_type = resolve_type_name(type_name_gen, scope);
+
+        // Check for infinite recursion
+        if check_recursive_type(&type_name, &field_type) {
+            return Err(GlossaError::semantic(format!(
+                "Recursive type detected: field '{}' uses type '{}' directly. Use a collection (List) or Box for indirection.",
+                field_name, type_name
+            )));
+        }
+
         fields.push((field_name, field_type));
     }
 
@@ -788,13 +807,26 @@ pub fn analyze_type_definition(
         fields: fields.clone(),
     };
 
-    // Store the type in scope
+    // Store the type in scope (update placeholder)
     scope.define_type(type_name.clone(), struct_type);
 
     Ok(AnalyzedStatement::TypeDefinition {
         name: type_name,
         fields,
     })
+}
+
+/// Check if a type contains the target type recursively without indirection
+fn check_recursive_type(target_name: &str, ty: &GlossaType) -> bool {
+    match ty {
+        GlossaType::Struct { name, .. } => name == target_name,
+        GlossaType::Option(inner) => check_recursive_type(target_name, inner),
+        GlossaType::Result(ok, err) => {
+            check_recursive_type(target_name, ok) || check_recursive_type(target_name, err)
+        }
+        // List, Set, Map break recursion
+        _ => false,
+    }
 }
 
 /// Analyze a trait definition statement

--- a/tests/warden_recursive_struct.rs
+++ b/tests/warden_recursive_struct.rs
@@ -1,0 +1,29 @@
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_recursive_struct_fails() {
+    // Define a recursive struct: struct A { a: A }
+    // Syntax:
+    // εἶδος Α ὁρίζειν {
+    //     α Α.
+    // }.
+    let code = "εἶδος Α ὁρίζειν { α Α. }.";
+
+    let ast = parse(code).expect("Failed to parse");
+    let result = analyze_program(&ast);
+
+    // Assert that semantic analysis fails
+    assert!(
+        result.is_err(),
+        "Expected semantic analysis error for recursive struct, but got Ok"
+    );
+
+    let err = result.unwrap_err();
+    let err_msg = err.to_string().to_lowercase();
+    assert!(
+        err_msg.contains("recursive"),
+        "Expected error message to contain 'recursive', got: {}",
+        err
+    );
+}


### PR DESCRIPTION
# Description
This PR addresses a vulnerability where defining a recursive struct (e.g., `struct A { a: A }`) would bypass semantic analysis and cause `rustc` to fail with an "infinite size" error during code generation. This behavior is now caught early in the semantic analysis phase, providing a clear and helpful error message to the user.

# Changes
- Modified `src/semantic/statements.rs`:
  - Added `check_recursive_type` helper function to detect direct recursion in `Struct`, `Option`, and `Result` types.
  - Updated `analyze_type_definition` to define a placeholder struct in the scope *before* analyzing fields. This allows the type to be referenced within its own definition.
  - Added a check within the field analysis loop to call `check_recursive_type`. If a recursive type is detected without indirection (like `List`, `Set`, or `Map`), a semantic error is returned.
- Added `tests/warden_recursive_struct.rs`:
  - A regression test that defines a recursive struct and verifies that `analyze_program` returns the expected semantic error.

# Verification
- Ran `cargo test --test warden_recursive_struct` to confirm the fix works.
- Ran `cargo test` to ensure no regressions.
- Verified that `Option` and `Result` wrappers (which do not break recursion in Rust) are correctly flagged as recursive.
- Verified that `List` (mapped to `Vec`) breaks the recursion and is allowed.

---
*PR created automatically by Jules for task [17576656291994357432](https://jules.google.com/task/17576656291994357432) started by @madmax983*