### PR TITLE
🎻 Bard: Enhance compiler documentation with narrative style

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -329,31 +329,47 @@ pub enum Expr {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinOperator {
     // Arithmetic
-    Add, // ἄθροισμα
-    Sub, // διαφορά
-    Mul, // γινόμενον
-    Div, // μέρος
-    Mod, // ὑπόλοιπον
+    /// Addition (sum) - `ἄθροισμα`
+    Add,
+    /// Subtraction (difference) - `διαφορά`
+    Sub,
+    /// Multiplication (product) - `γινόμενον`
+    Mul,
+    /// Division (quotient/part) - `μέρος`
+    Div,
+    /// Modulo (remainder) - `ὑπόλοιπον`
+    Mod,
 
     // Comparison
-    Eq, // ἴσον
-    Ne, // ἄνισον
-    Lt, // ἔλαττον
-    Le, // ἔλαττον ἢ ἴσον
-    Gt, // μεῖζον
-    Ge, // μεῖζον ἢ ἴσον
+    /// Equality - `ἴσον`
+    Eq,
+    /// Inequality - `ἄνισον`
+    Ne,
+    /// Less than - `ἔλαττον`
+    Lt,
+    /// Less than or equal - `ἔλαττον ἢ ἴσον`
+    Le,
+    /// Greater than - `μεῖζον`
+    Gt,
+    /// Greater than or equal - `μεῖζον ἢ ἴσον`
+    Ge,
 
     // Boolean
-    And, // καί
-    Or,  // ἤ
+    /// Logical AND - `καί`
+    And,
+    /// Logical OR - `ἤ`
+    Or,
 }
 
 /// Unary operators in GLOSSA
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnaryOperator {
-    Not,    // οὐ/οὐκ/οὐχ - logical negation
-    Neg,    // arithmetic negation
-    Unwrap, // ! - confident extraction from Option/Result
+    /// Logical Negation - `οὐ`, `οὐκ`, `οὐχ`
+    Not,
+    /// Arithmetic Negation
+    Neg,
+    /// Unwrap (Extract value) - `!` suffix
+    Unwrap,
 }
 
 /// A Greek word with original and normalized forms

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -1,3 +1,32 @@
+//! Command Line Interface (CLI) definition
+//!
+//! This module defines the structure of the command-line arguments and subcommands
+//! using the [`clap`] crate. It serves as the entry point for user interaction
+//! with the compiler.
+//!
+//! # The Interface
+//!
+//! The CLI supports several distinct workflows:
+//!
+//! * **Execution**: `run` (default) compiles and executes a program.
+//! * **Compilation**: `build` only compiles to a binary.
+//! * **Development**: `check` verifies syntax/semantics, `highlight` shows colors.
+//! * **Learning**: `lookup` explains words, `bard` tells the story of the code.
+//! * **Interactive**: `repl` starts the Read-Eval-Print Loop.
+//!
+//! # Example Usage
+//!
+//! ```bash
+//! # Run a file
+//! glossa run main.gl
+//!
+//! # Just check for errors
+//! glossa check main.gl
+//!
+//! # Look up a word
+//! glossa lookup "λόγον"
+//! ```
+
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,21 @@
+//! Compiler tools and utilities
+//!
+//! This module contains the various sub-tools that power the ΓΛΩΣΣΑ compiler ecosystem.
+//! Each submodule handles a specific aspect of the developer experience or compiler pipeline.
+//!
+//! # The Toolset
+//!
+//! * [`cli`]: **The Command Center** - Defines the command-line interface using `clap`.
+//! * [`runner`]: **The Engine Room** - Orchestrates the full compilation pipeline (load -> analyze -> compile -> run).
+//! * [`repl`]: **The Playground** - An interactive Read-Eval-Print Loop for experimentation.
+//! * [`highlight`]: **The Painter** - Syntax highlighting for terminal output.
+//! * [`report`]: **The Scribe** - Detailed compilation reports and error diagnostics.
+//! * [`cache`]: **The Vault** - Incremental compilation cache to speed up builds.
+//! * [`dictionary`]: **The Lexicon** - Word lookup utility for the built-in dictionary.
+//! * [`narrator`]: **The Bard** - Experimental "code-to-story" translator.
+//! * [`tester`]: **The Judge** - Built-in test runner for unit tests defined in ΓΛΩΣΣΑ files.
+//! * [`ui`]: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
+
 pub mod cache;
 pub mod cli;
 pub mod dictionary;

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -16,11 +16,20 @@ use std::process::{Command, Stdio};
 /// Maximum source file size (1MB) to prevent memory exhaustion
 const MAX_FILE_SIZE: u64 = 1024 * 1024;
 
+/// Parse and semantically analyze a source string
+///
+/// This helper runs the first two phases of the compiler pipeline:
+/// 1. **Parsing**: Converts source text to AST
+/// 2. **Semantic Analysis**: Resolves names, types, and statement structure
 fn analyze_source(source: &str) -> Result<AnalyzedProgram> {
     let ast = parse(source).map_err(|e| miette::miette!("{}", e))?;
     analyze_program(&ast).map_err(|e| miette::miette!("{}", e))
 }
 
+/// Compile a source string directly to Rust code
+///
+/// Runs the full pipeline: Parse -> Analyze -> Codegen.
+/// Returns the generated Rust source code as a string.
 fn compile(source: &str) -> Result<String> {
     let analyzed = analyze_source(source)?;
     Ok(generate_rust_file(&analyzed))
@@ -76,6 +85,18 @@ fn load_source(input: &Path) -> Result<String> {
     Ok(content)
 }
 
+/// Build a ΓΛΩΣΣΑ file to Rust source (without running it)
+///
+/// This function executes the compiler pipeline up to the code generation phase
+/// and writes the resulting Rust code to a file (defaulting to `input.rs`).
+///
+/// # Steps
+///
+/// 1. **Load**: Reads the source file (with size limits).
+/// 2. **Analyze**: Parses and performs semantic analysis.
+/// 3. **Codegen**: Generates valid Rust code.
+/// 4. **Write**: Saves the Rust code to the output path.
+/// 5. **Report**: Prints a compilation report with statistics.
 pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
     let status = Status::start("Μεταγλώττισις (Compiling)");
     let start = std::time::Instant::now();
@@ -114,19 +135,19 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 
 /// Compile and run a ΓΛΩΣΣΑ file
 ///
-/// This is the main entry point for the `run` command. It handles the full pipeline:
-/// 1. **Validation**: Checks file existence and size limits.
-/// 2. **Caching**: Checks if a compiled binary already exists for this source file.
-///    The cache key is based on the file path and content hash.
-/// 3. **Compilation**: If not cached, runs the full compiler pipeline (Lex -> Parse -> Analyze -> Codegen).
-/// 4. **Build**: Invokes `rustc` to compile the generated Rust code into a native binary.
-/// 5. **Execution**: Runs the resulting binary.
+/// This is the "all-in-one" command that developers use most often.
+/// It orchestrates the entire lifecycle of a program from Greek source to execution.
 ///
-/// # Caching Strategy
+/// # The Pipeline
 ///
-/// To speed up repeated runs, we cache the compiled binary in the system's cache directory
-/// (e.g., `~/.cache/glossa`). If the source file hasn't changed, we skip compilation
-/// and run the cached binary directly.
+/// 1. **Validation**: Checks file existence and strict size limits to prevent DoS.
+/// 2. **Caching**: Calculates a hash of the input. If a binary exists for this hash,
+///    compilation is skipped entirely (The "Hot Path").
+/// 3. **Compilation**: Runs the ΓΛΩΣΣΑ compiler to produce Rust source code.
+/// 4. **Build**: Invokes `rustc` (the Rust compiler) to produce a native executable.
+///    This inherits Rust's optimizations (set to `-O` level).
+/// 5. **Execution**: Spawns the resulting binary as a child process, inheriting
+///    stdin/stdout/stderr so it feels like a native script.
 pub fn run_file(input: &Path) -> Result<()> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));


### PR DESCRIPTION
This PR enhances the documentation of the ΓΛΩΣΣΑ compiler, focusing on the `tools` module and the AST. It adds narrative module-level docs to `src/tools/mod.rs` and `src/tools/cli.rs`, explaining the purpose of each component. It also documents the `BinOperator` and `UnaryOperator` enums in `src/ast/mod.rs` with their corresponding Greek keywords, making the language mapping explicit. Finally, it improves the documentation in `src/tools/runner.rs` to clearly explain the compilation pipeline steps. These changes aim to make the codebase more approachable and easier to understand for new contributors.

---
*PR created automatically by Jules for task [7375378266621976998](https://jules.google.com/task/7375378266621976998) started by @madmax983*