### PR TITLE
👺 Havoc: Fix Stack Overflow in Nested Conditionals

### DIFF
--- a/src/semantic/statements.rs
+++ b/src/semantic/statements.rs
@@ -38,7 +38,7 @@ pub fn analyze_control_flow(
 
     // Conditional: εἰ/ἐάν condition, body [, εἰ δὲ μή, else_body]
     if lexicon::is_conditional_particle(&normalized) {
-        return parse_conditional(stmt, scope);
+        return parse_conditional(stmt, scope, 0);
     }
 
     // While loop: ἕως condition, body
@@ -571,11 +571,21 @@ fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, G
     Err(GlossaError::semantic("Invalid match pattern"))
 }
 
+const MAX_CONTROL_FLOW_DEPTH: usize = 100;
+
 /// Parse a conditional statement (εἰ/ἐάν)
 fn parse_conditional(
     stmt: &Statement,
     scope: &mut Scope,
+    depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    if depth > MAX_CONTROL_FLOW_DEPTH {
+        return Err(GlossaError::LimitExceeded {
+            resource: "Control flow depth".into(),
+            max: MAX_CONTROL_FLOW_DEPTH,
+        });
+    }
+
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
             "Conditional needs at least 2 clauses: condition and body",
@@ -636,7 +646,7 @@ fn parse_conditional(
             };
 
             // Recursively parse as a new conditional (which becomes the else body)
-            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope)? {
+            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, depth + 1)? {
                 Some(vec![elif_analyzed])
             } else {
                 None

--- a/tests/havoc_elif_overflow.rs
+++ b/tests/havoc_elif_overflow.rs
@@ -22,14 +22,16 @@ fn test_elif_chain_stack_overflow() {
         // Else if chained with middle dot
         s.push_str(" · εἰ 1, 1");
     }
-    s.push_str(".");
+    s.push('.');
 
     println!("Parsing {} elif clauses...", n);
     // Parsing should succeed (flat structure)
     let ast = parse(&s).expect("Failed to parse");
-    println!("Parsed {} statements. First statement has {} clauses.",
-             ast.statements.len(),
-             ast.statements[0].clauses().len());
+    println!(
+        "Parsed {} statements. First statement has {} clauses.",
+        ast.statements.len(),
+        ast.statements[0].clauses().len()
+    );
 
     println!("Analyzing...");
     // This should NOT Stack Overflow anymore. It should return LimitExceeded.

--- a/tests/havoc_elif_overflow.rs
+++ b/tests/havoc_elif_overflow.rs
@@ -1,0 +1,51 @@
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_elif_chain_stack_overflow() {
+    // Generate a massive elif chain: εἰ 1, 1, εἰ 1, 1, ...
+    // Each "εἰ 1, 1," adds a level of recursion in parse_conditional.
+    // 2,000 iterations -> Depth 2,000.
+    // Parser sees a flat list of clauses (no recursion limit).
+    // Semantic analysis recurses.
+
+    let n = 2_000;
+    let mut s = String::with_capacity(n * 20);
+
+    // First if
+    s.push_str("εἰ 1, 1");
+
+    // Use middle dot (·) to chain else-if, because parse_conditional expects
+    // the else-if to be the second expression of the then-clause.
+    // Logic: if then_clause.expressions.len() > 1 ...
+    for _ in 0..n {
+        // Else if chained with middle dot
+        s.push_str(" · εἰ 1, 1");
+    }
+    s.push_str(".");
+
+    println!("Parsing {} elif clauses...", n);
+    // Parsing should succeed (flat structure)
+    let ast = parse(&s).expect("Failed to parse");
+    println!("Parsed {} statements. First statement has {} clauses.",
+             ast.statements.len(),
+             ast.statements[0].clauses().len());
+
+    println!("Analyzing...");
+    // This should NOT Stack Overflow anymore. It should return LimitExceeded.
+    let result = analyze_program(&ast);
+
+    match result {
+        Ok(_) => panic!("Expected LimitExceeded error, but analysis succeeded!"),
+        Err(e) => {
+            println!("Got expected error: {:?}", e);
+            match e {
+                glossa::errors::GlossaError::LimitExceeded { resource, max } => {
+                    assert_eq!(resource, "Control flow depth");
+                    assert_eq!(max, 100);
+                }
+                _ => panic!("Expected LimitExceeded, got {:?}", e),
+            }
+        }
+    }
+}

--- a/tests/havoc_operator_stress.rs
+++ b/tests/havoc_operator_stress.rs
@@ -18,7 +18,10 @@ fn test_stack_overflow_in_drop() {
     let ast = parse(&s).expect("Failed to parse");
 
     println!("Analyzing...");
-    println!("Size of AnalyzedExpr: {}", std::mem::size_of::<glossa::semantic::AnalyzedExpr>());
+    println!(
+        "Size of AnalyzedExpr: {}",
+        std::mem::size_of::<glossa::semantic::AnalyzedExpr>()
+    );
 
     // This should fail with LimitExceeded, but then panic during Drop
     let result = analyze_program(&ast);
@@ -29,7 +32,7 @@ fn test_stack_overflow_in_drop() {
             println!("Analysis FAILED (expected): {:?}", e);
             match e {
                 glossa::errors::GlossaError::AssemblyError(
-                    glossa::semantic::AssemblyError::LimitExceeded { resource, max }
+                    glossa::semantic::AssemblyError::LimitExceeded { resource, max },
                 ) => {
                     assert_eq!(resource, "Operators");
                     assert_eq!(*max, 256);

--- a/tests/havoc_operator_stress.rs
+++ b/tests/havoc_operator_stress.rs
@@ -1,0 +1,43 @@
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_stack_overflow_in_drop() {
+    // Generate a massive expression: 1 + 1 + 1 + ...
+    // Depth 100,000 should blow the stack during Drop
+    let n = 1_000_000;
+    let mut s = String::with_capacity(n * 15);
+    s.push('1');
+    for _ in 0..n {
+        // "ἄθροισμα" means "+" (sum)
+        s.push_str(" ἄθροισμα 1");
+    }
+    s.push_str(" λέγε.");
+
+    println!("Parsing...");
+    let ast = parse(&s).expect("Failed to parse");
+
+    println!("Analyzing...");
+    println!("Size of AnalyzedExpr: {}", std::mem::size_of::<glossa::semantic::AnalyzedExpr>());
+
+    // This should fail with LimitExceeded, but then panic during Drop
+    let result = analyze_program(&ast);
+
+    match &result {
+        Ok(_) => panic!("Analysis SUCCEEDED (unexpected)"),
+        Err(e) => {
+            println!("Analysis FAILED (expected): {:?}", e);
+            match e {
+                glossa::errors::GlossaError::AssemblyError(
+                    glossa::semantic::AssemblyError::LimitExceeded { resource, max }
+                ) => {
+                    assert_eq!(resource, "Operators");
+                    assert_eq!(*max, 256);
+                }
+                _ => panic!("Expected AssemblyError::LimitExceeded, got {:?}", e),
+            }
+        }
+    }
+    // Result is dropped here. Since analysis failed early (256 limit), the tree is shallow.
+    // No stack overflow should occur.
+}


### PR DESCRIPTION
👺 **Havoc Report: Stack Overflow Mitigation**

I successfully crashed the compiler with a stack overflow using a massive chain of 2,000 nested `else if` clauses (`εἰ ...`). The parser allows flat `clause_list` structures, but the semantic analyzer recursively transformed them into a deep tree, blowing the stack.

**The Fix:**
- Enforced `MAX_CONTROL_FLOW_DEPTH = 100` in `src/semantic/statements.rs`.
- `parse_conditional` now tracks recursion depth and errors out gracefully.

**Verification:**
- `tests/havoc_elif_overflow.rs`: Confirms `LimitExceeded` error is returned instead of crash.
- `tests/havoc_operator_stress.rs`: Confirms `Assembler` limits (256 operators) prevent similar attacks via binary expressions.

The Warden is pleased. The system is robust. 🛡️

---
*PR created automatically by Jules for task [17672890088418353315](https://jules.google.com/task/17672890088418353315) started by @madmax983*