### PR TITLE
⚒️ Forge: Refactor semantic conversion logic

### DIFF
--- a/src/semantic/classification_tests.rs
+++ b/src/semantic/classification_tests.rs
@@ -1,0 +1,178 @@
+use super::conversion::classify_assembled_statement;
+use crate::semantic::assembly_model::{
+    AssembledStatement, Constituent, ParticipleConstituent, VerbConstituent,
+};
+use crate::semantic::{
+    AnalyzedExprKind, AnalyzedStatement, GlossaType, Literal, Scope,
+};
+use crate::morphology::{Case, Gender, Number, Tense, Voice};
+
+fn make_constituent(original: &str, lemma: &str) -> Constituent {
+    Constituent {
+        lemma: lemma.into(),
+        original: original.into(),
+        case: Case::Nominative,
+        number: None,
+        gender: None,
+        person: None,
+    }
+}
+
+fn make_verb(original: &str, lemma: &str) -> VerbConstituent {
+    VerbConstituent {
+        lemma: lemma.into(),
+        original: original.into(),
+        person: None,
+        number: None,
+        tense: None,
+        mood: None,
+        voice: None,
+    }
+}
+
+fn make_participle(original: &str, verb_lemma: &str) -> ParticipleConstituent {
+    ParticipleConstituent {
+        verb_lemma: verb_lemma.into(),
+        original: original.into(),
+        tense: Tense::Present,
+        voice: Voice::Active,
+        case: Case::Nominative,
+        gender: Gender::Neuter,
+        number: Number::Singular,
+    }
+}
+
+#[test]
+fn test_classify_variable_binding_simple() {
+    let mut scope = Scope::new();
+    // "x 5 let"
+    let asm_stmt = AssembledStatement {
+        subject: Some(make_constituent("x", "x")),
+        literals: vec![Literal::Number(5)],
+        verb: Some(make_verb("ἔστω", "ειμι")),
+        ..Default::default()
+    };
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify binding");
+
+    if let AnalyzedStatement::Binding { name, value, .. } = result {
+        assert_eq!(name, "x");
+        if let AnalyzedExprKind::NumberLiteral(n) = value.expr {
+            assert_eq!(n, 5);
+        } else {
+            panic!("Expected NumberLiteral");
+        }
+    } else {
+        panic!("Expected Binding statement");
+    }
+}
+
+#[test]
+fn test_classify_variable_binding_swap_subject_object() {
+    let mut scope = Scope::new();
+    scope.define("y", GlossaType::Number); // y is defined
+
+    // "x y let" (x is new, y is existing)
+    // If assembler puts x in Subject and y in Object (or vice versa), logic should handle it.
+    // Logic: if subject is defined and object is not, swap.
+
+    // Case 1: Subject=y (defined), Object=x (undefined) -> Should bind x to y
+    let asm_stmt = AssembledStatement {
+        subject: Some(make_constituent("y", "y")),
+        object: Some(make_constituent("x", "x")),
+        verb: Some(make_verb("ἔστω", "ειμι")),
+        ..Default::default()
+    };
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify binding with swap");
+
+    if let AnalyzedStatement::Binding { name, value, .. } = result {
+        assert_eq!(name, "x"); // Bound variable
+        if let AnalyzedExprKind::Variable(v) = value.expr {
+            assert_eq!(v, "y"); // Value source
+        } else {
+            panic!("Expected Variable value");
+        }
+    } else {
+        panic!("Expected Binding statement");
+    }
+}
+
+#[test]
+fn test_classify_variable_binding_false_participle() {
+    let mut scope = Scope::new();
+
+    // "variable called x let"
+    // "called" (participle) might be treated as part of the name if it's not a known verb?
+    // The logic checks for "false participle" (not in lexicon) and treats it as the name.
+
+    let asm_stmt = AssembledStatement {
+        participles: vec![make_participle("x", "x_lemma")], // "x" as participle?
+        literals: vec![Literal::Number(10)],
+        verb: Some(make_verb("ἔστω", "ειμι")),
+        ..Default::default()
+    };
+
+    // x_lemma is not in lexicon (hopefully), so it should be treated as the variable name
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify binding with false participle");
+
+    if let AnalyzedStatement::Binding { name, .. } = result {
+        assert_eq!(name, "x");
+    } else {
+        panic!("Expected Binding statement");
+    }
+}
+
+#[test]
+fn test_classify_print_binary() {
+    let mut scope = Scope::new();
+
+    // "1 + 2 print"
+    let asm_stmt = AssembledStatement {
+        literals: vec![Literal::Number(1), Literal::Number(2)],
+        operators: vec![crate::morphology::lexicon::BinaryOp::Add],
+        verb: Some(make_verb("λέγε", "λεγω")),
+        ..Default::default()
+    };
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify print binary");
+
+    if let AnalyzedStatement::Print(exprs) = result {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::BinOp { op, .. } = exprs[0].expr {
+             assert_eq!(op, crate::morphology::lexicon::BinaryOp::Add);
+        } else {
+            panic!("Expected BinOp");
+        }
+    } else {
+        panic!("Expected Print statement");
+    }
+}
+
+#[test]
+fn test_classify_print_property() {
+    let mut scope = Scope::new();
+    scope.define("list", GlossaType::List(Box::new(GlossaType::Number)));
+
+    // "list length print" (property access)
+    // property accesses are pre-calculated by assembler usually, but classify_print checks asm_stmt.property_accesses
+    let asm_stmt = AssembledStatement {
+        property_accesses: vec![("list".into(), "len".into())],
+        verb: Some(make_verb("λέγε", "λεγω")),
+        ..Default::default()
+    };
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify print property");
+
+    if let AnalyzedStatement::Print(exprs) = result {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::MethodCall { method, .. } = &exprs[0].expr {
+             assert_eq!(method, "len");
+        } else {
+            panic!("Expected MethodCall for property access");
+        }
+    } else {
+        panic!("Expected Print statement");
+    }
+}

--- a/src/semantic/classification_tests.rs
+++ b/src/semantic/classification_tests.rs
@@ -1,11 +1,9 @@
 use super::conversion::classify_assembled_statement;
+use crate::morphology::{Case, Gender, Number, Tense, Voice};
 use crate::semantic::assembly_model::{
     AssembledStatement, Constituent, ParticipleConstituent, VerbConstituent,
 };
-use crate::semantic::{
-    AnalyzedExprKind, AnalyzedStatement, GlossaType, Literal, Scope,
-};
-use crate::morphology::{Case, Gender, Number, Tense, Voice};
+use crate::semantic::{AnalyzedExprKind, AnalyzedStatement, GlossaType, Literal, Scope};
 
 fn make_constituent(original: &str, lemma: &str) -> Constituent {
     Constituent {
@@ -53,7 +51,8 @@ fn test_classify_variable_binding_simple() {
         ..Default::default()
     };
 
-    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify binding");
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify binding");
 
     if let AnalyzedStatement::Binding { name, value, .. } = result {
         assert_eq!(name, "x");
@@ -84,7 +83,8 @@ fn test_classify_variable_binding_swap_subject_object() {
         ..Default::default()
     };
 
-    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify binding with swap");
+    let result = classify_assembled_statement(&asm_stmt, &mut scope)
+        .expect("Should classify binding with swap");
 
     if let AnalyzedStatement::Binding { name, value, .. } = result {
         assert_eq!(name, "x"); // Bound variable
@@ -115,7 +115,8 @@ fn test_classify_variable_binding_false_participle() {
 
     // x_lemma is not in lexicon (hopefully), so it should be treated as the variable name
 
-    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify binding with false participle");
+    let result = classify_assembled_statement(&asm_stmt, &mut scope)
+        .expect("Should classify binding with false participle");
 
     if let AnalyzedStatement::Binding { name, .. } = result {
         assert_eq!(name, "x");
@@ -136,12 +137,13 @@ fn test_classify_print_binary() {
         ..Default::default()
     };
 
-    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify print binary");
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify print binary");
 
     if let AnalyzedStatement::Print(exprs) = result {
         assert_eq!(exprs.len(), 1);
         if let AnalyzedExprKind::BinOp { op, .. } = exprs[0].expr {
-             assert_eq!(op, crate::morphology::lexicon::BinaryOp::Add);
+            assert_eq!(op, crate::morphology::lexicon::BinaryOp::Add);
         } else {
             panic!("Expected BinOp");
         }
@@ -163,12 +165,13 @@ fn test_classify_print_property() {
         ..Default::default()
     };
 
-    let result = classify_assembled_statement(&asm_stmt, &mut scope).expect("Should classify print property");
+    let result = classify_assembled_statement(&asm_stmt, &mut scope)
+        .expect("Should classify print property");
 
     if let AnalyzedStatement::Print(exprs) = result {
         assert_eq!(exprs.len(), 1);
         if let AnalyzedExprKind::MethodCall { method, .. } = &exprs[0].expr {
-             assert_eq!(method, "len");
+            assert_eq!(method, "len");
         } else {
             panic!("Expected MethodCall for property access");
         }

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -294,6 +294,50 @@ fn classify_subjunctive_comparison(
     Ok(None)
 }
 
+/// Helper: Resolve the target variable name and the effective assembled statement for binding
+fn resolve_binding_target(
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<(smol_str::SmolStr, AssembledStatement), GlossaError> {
+    let has_false_participle = !asm_stmt.participles.is_empty()
+        && morphology::lexicon::lookup(&asm_stmt.participles[0].verb_lemma).is_none();
+
+    if has_false_participle {
+        let first_participle = &asm_stmt.participles[0];
+        let mut fixed_asm = asm_stmt.clone();
+        fixed_asm.participles = asm_stmt.participles[1..].to_vec();
+        return Ok((normalize_greek(&first_participle.original), fixed_asm));
+    }
+
+    if let (Some(subject), Some(object)) = (&asm_stmt.subject, &asm_stmt.object) {
+        let subject_name = normalize_greek(&subject.original);
+        let object_name = normalize_greek(&object.original);
+
+        // Swap subject/object if subject is already defined (value) and object is new (target)
+        if scope.is_defined(&subject.lemma) && !scope.is_defined(&object.lemma) {
+            let mut swapped = asm_stmt.clone();
+            swapped.subject = Some(object.clone());
+            swapped.object = Some(subject.clone());
+            return Ok((object_name, swapped));
+        } else {
+            return Ok((subject_name, asm_stmt.clone()));
+        }
+    }
+
+    if let Some(subject) = &asm_stmt.subject {
+        return Ok((normalize_greek(&subject.original), asm_stmt.clone()));
+    }
+
+    if !asm_stmt.participles.is_empty() {
+        let first_participle = &asm_stmt.participles[0];
+        let mut fixed_asm = asm_stmt.clone();
+        fixed_asm.participles = asm_stmt.participles[1..].to_vec();
+        return Ok((normalize_greek(&first_participle.original), fixed_asm));
+    }
+
+    Err(GlossaError::semantic("Binding without subject"))
+}
+
 /// Helper: Detect variable binding (let x = ...)
 fn classify_variable_binding(
     asm_stmt: &AssembledStatement,
@@ -303,36 +347,7 @@ fn classify_variable_binding(
         let verb_lemma = normalize_greek(&verb.lemma);
 
         if crate::morphology::lexicon::is_binding_verb(&verb_lemma) {
-            let has_false_participle = !asm_stmt.participles.is_empty()
-                && morphology::lexicon::lookup(&asm_stmt.participles[0].verb_lemma).is_none();
-
-            let (var_name, actual_asm) = if has_false_participle {
-                let first_participle = &asm_stmt.participles[0];
-                let mut fixed_asm = asm_stmt.clone();
-                fixed_asm.participles = asm_stmt.participles[1..].to_vec();
-                (normalize_greek(&first_participle.original), fixed_asm)
-            } else if let (Some(subject), Some(object)) = (&asm_stmt.subject, &asm_stmt.object) {
-                let subject_name = normalize_greek(&subject.original);
-                let object_name = normalize_greek(&object.original);
-
-                if scope.is_defined(&subject.lemma) && !scope.is_defined(&object.lemma) {
-                    let mut swapped = asm_stmt.clone();
-                    swapped.subject = Some(object.clone());
-                    swapped.object = Some(subject.clone());
-                    (object_name, swapped)
-                } else {
-                    (subject_name, asm_stmt.clone())
-                }
-            } else if let Some(subject) = &asm_stmt.subject {
-                (normalize_greek(&subject.original), asm_stmt.clone())
-            } else if !asm_stmt.participles.is_empty() {
-                let first_participle = &asm_stmt.participles[0];
-                let mut fixed_asm = asm_stmt.clone();
-                fixed_asm.participles = asm_stmt.participles[1..].to_vec();
-                (normalize_greek(&first_participle.original), fixed_asm)
-            } else {
-                return Err(GlossaError::semantic("Binding without subject"));
-            };
+            let (var_name, actual_asm) = resolve_binding_target(asm_stmt, scope)?;
 
             let (value_expr, value_type) = extract_value(&actual_asm, scope)?;
 
@@ -671,6 +686,145 @@ fn classify_equality_assertion(
     Ok(None)
 }
 
+fn try_print_binary_op(
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    if !asm_stmt.operators.is_empty() {
+        let left = if let Some(ref subj) = asm_stmt.subject {
+            scope.lookup(&subj.lemma).map(|var_type| AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                glossa_type: var_type.clone(),
+            })
+        } else {
+            None
+        };
+
+        let right = asm_stmt.literals.first().map(literal_to_analyzed_expr);
+
+        if let (Some(left_expr), Some(right_expr)) = (left, right) {
+            let op = asm_stmt.operators[0];
+            let bin_expr = build_binary_expr(left_expr, op, right_expr);
+            return Ok(Some(AnalyzedStatement::Print(vec![bin_expr])));
+        }
+    }
+    Ok(None)
+}
+
+fn try_print_property_access(
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    if !asm_stmt.property_accesses.is_empty() {
+        let mut args = Vec::new();
+        for (owner, method) in &asm_stmt.property_accesses {
+            let receiver = AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(owner.clone().into()),
+                glossa_type: scope.lookup(owner).cloned().unwrap_or(GlossaType::Unknown),
+            };
+            let method_args = if let Some((ref meth, ref delim)) = asm_stmt.string_method {
+                if meth == method {
+                    vec![AnalyzedExpr {
+                        expr: AnalyzedExprKind::StringLiteral(delim.clone()),
+                        glossa_type: GlossaType::String,
+                    }]
+                } else {
+                    vec![]
+                }
+            } else {
+                vec![]
+            };
+            let return_type = match method.as_str() {
+                "len" => GlossaType::Number,
+                "split" => GlossaType::List(Box::new(GlossaType::String)),
+                "join" => GlossaType::String,
+                _ => GlossaType::Unknown,
+            };
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::MethodCall {
+                    receiver: Box::new(receiver),
+                    method: method.clone().into(),
+                    args: method_args,
+                },
+                glossa_type: return_type,
+            });
+        }
+        return Ok(Some(AnalyzedStatement::Print(args)));
+    }
+    Ok(None)
+}
+
+fn try_print_index_access(
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    if !asm_stmt.index_accesses.is_empty() {
+        let mut args = Vec::new();
+        for (array_expr, index_expr) in &asm_stmt.index_accesses {
+            let array_analyzed = analyze_argument_expr(array_expr, scope)?;
+            let index_analyzed = analyze_argument_expr(index_expr, scope)?;
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::IndexAccess {
+                    array: Box::new(array_analyzed),
+                    index: Box::new(index_analyzed),
+                },
+                glossa_type: GlossaType::Unknown,
+            });
+        }
+        return Ok(Some(AnalyzedStatement::Print(args)));
+    }
+    Ok(None)
+}
+
+fn try_print_unwrap(
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    if !asm_stmt.unwraps.is_empty() {
+        let mut args = Vec::new();
+        for unwrap_expr in &asm_stmt.unwraps {
+            let inner_analyzed = analyze_argument_expr(unwrap_expr, scope)?;
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::Unwrap(Box::new(inner_analyzed)),
+                glossa_type: GlossaType::Unknown,
+            });
+        }
+        return Ok(Some(AnalyzedStatement::Print(args)));
+    }
+    Ok(None)
+}
+
+fn try_print_default(
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    let mut args =
+        build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
+
+    if let Some(ref subj) = asm_stmt.subject
+        && let Some(var_type) = scope.lookup(&subj.lemma)
+    {
+        args.insert(
+            0,
+            AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                glossa_type: var_type.clone(),
+            },
+        );
+    }
+
+    if let Some(ref obj) = asm_stmt.object
+        && let Some(var_type) = scope.lookup(&obj.lemma)
+    {
+        args.push(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+            glossa_type: var_type.clone(),
+        });
+    }
+
+    Ok(Some(AnalyzedStatement::Print(args)))
+}
+
 /// Helper: Detect print statement
 fn classify_print(
     asm_stmt: &AssembledStatement,
@@ -680,120 +834,21 @@ fn classify_print(
         let verb_lemma = normalize_greek(&verb.lemma);
 
         if crate::morphology::lexicon::is_print_verb(&verb_lemma) {
-            // Binary expr with operator
-            if !asm_stmt.operators.is_empty() {
-                let left = if let Some(ref subj) = asm_stmt.subject {
-                    scope.lookup(&subj.lemma).map(|var_type| AnalyzedExpr {
-                        expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                        glossa_type: var_type.clone(),
-                    })
-                } else {
-                    None
-                };
-
-                let right = asm_stmt.literals.first().map(literal_to_analyzed_expr);
-
-                if let (Some(left_expr), Some(right_expr)) = (left, right) {
-                    let op = asm_stmt.operators[0];
-                    let bin_expr = build_binary_expr(left_expr, op, right_expr);
-                    return Ok(Some(AnalyzedStatement::Print(vec![bin_expr])));
-                }
+            if let Some(res) = try_print_binary_op(asm_stmt, scope)? {
+                return Ok(Some(res));
             }
-
-            // Property access
-            if !asm_stmt.property_accesses.is_empty() {
-                let mut args = Vec::new();
-                for (owner, method) in &asm_stmt.property_accesses {
-                    let receiver = AnalyzedExpr {
-                        expr: AnalyzedExprKind::Variable(owner.clone().into()),
-                        glossa_type: scope.lookup(owner).cloned().unwrap_or(GlossaType::Unknown),
-                    };
-                    let method_args = if let Some((ref meth, ref delim)) = asm_stmt.string_method {
-                        if meth == method {
-                            vec![AnalyzedExpr {
-                                expr: AnalyzedExprKind::StringLiteral(delim.clone()),
-                                glossa_type: GlossaType::String,
-                            }]
-                        } else {
-                            vec![]
-                        }
-                    } else {
-                        vec![]
-                    };
-                    let return_type = match method.as_str() {
-                        "len" => GlossaType::Number,
-                        "split" => GlossaType::List(Box::new(GlossaType::String)),
-                        "join" => GlossaType::String,
-                        _ => GlossaType::Unknown,
-                    };
-                    args.push(AnalyzedExpr {
-                        expr: AnalyzedExprKind::MethodCall {
-                            receiver: Box::new(receiver),
-                            method: method.clone().into(),
-                            args: method_args,
-                        },
-                        glossa_type: return_type,
-                    });
-                }
-                return Ok(Some(AnalyzedStatement::Print(args)));
+            if let Some(res) = try_print_property_access(asm_stmt, scope)? {
+                return Ok(Some(res));
             }
-
-            // Index access
-            if !asm_stmt.index_accesses.is_empty() {
-                let mut args = Vec::new();
-                for (array_expr, index_expr) in &asm_stmt.index_accesses {
-                    let array_analyzed = analyze_argument_expr(array_expr, scope)?;
-                    let index_analyzed = analyze_argument_expr(index_expr, scope)?;
-                    args.push(AnalyzedExpr {
-                        expr: AnalyzedExprKind::IndexAccess {
-                            array: Box::new(array_analyzed),
-                            index: Box::new(index_analyzed),
-                        },
-                        glossa_type: GlossaType::Unknown,
-                    });
-                }
-                return Ok(Some(AnalyzedStatement::Print(args)));
+            if let Some(res) = try_print_index_access(asm_stmt, scope)? {
+                return Ok(Some(res));
             }
-
-            // Unwrap
-            if !asm_stmt.unwraps.is_empty() {
-                let mut args = Vec::new();
-                for unwrap_expr in &asm_stmt.unwraps {
-                    let inner_analyzed = analyze_argument_expr(unwrap_expr, scope)?;
-                    args.push(AnalyzedExpr {
-                        expr: AnalyzedExprKind::Unwrap(Box::new(inner_analyzed)),
-                        glossa_type: GlossaType::Unknown,
-                    });
-                }
-                return Ok(Some(AnalyzedStatement::Print(args)));
+            if let Some(res) = try_print_unwrap(asm_stmt, scope)? {
+                return Ok(Some(res));
             }
-
-            // Default
-            let mut args =
-                build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
-
-            if let Some(ref subj) = asm_stmt.subject
-                && let Some(var_type) = scope.lookup(&subj.lemma)
-            {
-                args.insert(
-                    0,
-                    AnalyzedExpr {
-                        expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                        glossa_type: var_type.clone(),
-                    },
-                );
+            if let Some(res) = try_print_default(asm_stmt, scope)? {
+                return Ok(Some(res));
             }
-
-            if let Some(ref obj) = asm_stmt.object
-                && let Some(var_type) = scope.lookup(&obj.lemma)
-            {
-                args.push(AnalyzedExpr {
-                    expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                    glossa_type: var_type.clone(),
-                });
-            }
-
-            return Ok(Some(AnalyzedStatement::Print(args)));
         }
     }
     Ok(None)

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -38,6 +38,8 @@ pub(crate) mod assembly_model;
 pub(crate) mod conversion;
 #[cfg(test)]
 mod conversion_tests;
+#[cfg(test)]
+mod classification_tests;
 pub mod expressions;
 pub(crate) mod model;
 pub(crate) mod patterns;

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -35,11 +35,11 @@ pub mod assembler;
 #[cfg(test)]
 mod assembler_tests;
 pub(crate) mod assembly_model;
+#[cfg(test)]
+mod classification_tests;
 pub(crate) mod conversion;
 #[cfg(test)]
 mod conversion_tests;
-#[cfg(test)]
-mod classification_tests;
 pub mod expressions;
 pub(crate) mod model;
 pub(crate) mod patterns;


### PR DESCRIPTION
Refactored `src/semantic/conversion.rs` to address "God Function" smells in `classify_variable_binding` and `classify_print`. Extracted logic into smaller, named helper functions. Added comprehensive unit tests in `src/semantic/classification_tests.rs` to ensure no regression.

---
*PR created automatically by Jules for task [136431596724872977](https://jules.google.com/task/136431596724872977) started by @madmax983*