### PR TITLE
feat(semantic): enforce strict type definition to prevent mutual recursion

### DIFF
--- a/src/semantic/statements.rs
+++ b/src/semantic/statements.rs
@@ -797,7 +797,7 @@ pub fn analyze_type_definition(
         let type_name_gen = &field.type_name.normalized;
 
         // Map genitive type names to GlossaType
-        let field_type = resolve_type_name(type_name_gen, scope);
+        let field_type = resolve_type_name(type_name_gen, scope)?;
 
         // Check for infinite recursion
         if check_recursive_type(&type_name, &field_type) {
@@ -1019,22 +1019,25 @@ pub fn analyze_trait_impl(
 }
 
 /// Map a genitive type name to a GlossaType
-pub fn resolve_type_name(name: &str, scope: &Scope) -> GlossaType {
+pub fn resolve_type_name(name: &str, scope: &Scope) -> Result<GlossaType, GlossaError> {
     match name {
         // ἀριθμοῦ (genitive of ἀριθμός) → Number
-        "αριθμου" => GlossaType::Number,
+        "αριθμου" => Ok(GlossaType::Number),
         // ὀνόματος (genitive of ὄνομα) → String
-        "ονοματος" => GlossaType::String,
+        "ονοματος" => Ok(GlossaType::String),
         // λιστης (genitive of λίστα) → List
-        "λιστης" => GlossaType::List(Box::new(GlossaType::Unknown)),
+        "λιστης" => Ok(GlossaType::List(Box::new(GlossaType::Unknown))),
         _ => {
             // Check for user-defined types
             // Strip genitive ending and look up the nominative form
             // For now, just try the name as-is
             if let Some(ty) = scope.lookup_type(name) {
-                ty.clone()
+                Ok(ty.clone())
             } else {
-                GlossaType::Unknown
+                Err(GlossaError::semantic(format!(
+                    "Undefined type: '{}'. Ensure the type is defined before use.",
+                    name
+                )))
             }
         }
     }
@@ -1187,7 +1190,8 @@ fn extract_parameters_from_expr(
                     if next_analysis.case == Some(morphology::Case::Genitive) {
                         // Map genitive type to GlossaType
                         let type_name = &next_word.normalized;
-                        param_type = Some(resolve_type_name(type_name, scope));
+                        // If it looks like a type annotation (genitive), it MUST be a valid type
+                        param_type = Some(resolve_type_name(type_name, scope)?);
                         i += 1; // Skip the type annotation
                     }
                 }

--- a/tests/type_tests.rs
+++ b/tests/type_tests.rs
@@ -111,19 +111,6 @@ fn test_instantiation_with_literals() {
 #[test]
 fn test_instantiation_with_boolean() {
     let source = r#"
-        εἶδος Κατάστασις ὁρίζειν { ενεργός κενόν. }. // Using κενόν as placeholder for boolean if not available? No, let's use valid bool check.
-        // Actually there isn't a "boolean" type keyword in the lexicon explicitly mapped to GlossaType::Boolean yet?
-        // Wait, 'αληθες' maps to true.
-        // Let's assume there is no explicit boolean type name in lexicon yet, but we can verify BooleanLiteral handling.
-        // Or wait, is there a boolean type?
-        // In src/semantic/declarations.rs: map_greek_type_to_glossa only handles Number, String, List.
-        // So we can't define a struct with a boolean field yet properly?
-        // Let's check lexicon.
-        // "αριθμου", "ονοματος", "λιστης".
-        // But the parser supports Expr::BooleanLiteral.
-        // If I use "ἀριθμοῦ" it expects Number.
-        // If I pass a boolean literal to a field expecting Number, it might fail type check later, but here we test PARSING/AST construction.
-
         // Let's try to pass a boolean literal. Even if type doesn't match, we want to exercise the code path in patterns.rs.
         εἶδος Δοκιμή ὁρίζειν { τιμή ἀριθμοῦ. }.
         δ νέον Δοκιμή ἀληθές ἔστω.

--- a/tests/warden_recursive_struct_mutual.rs
+++ b/tests/warden_recursive_struct_mutual.rs
@@ -1,0 +1,43 @@
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_mutual_recursive_struct_fails() {
+    // Define mutual recursive structs:
+    // εἶδος A { b: B }
+    // εἶδος B { a: A }
+    //
+    // In a safe language, this should either:
+    // 1. Fail because B is undefined when defining A.
+    // 2. Fail because of infinite size (recursion) if B was somehow known.
+
+    let code = r#"
+        εἶδος Α ὁρίζειν { β Β. }.
+        εἶδος Β ὁρίζειν { α Α. }.
+    "#;
+
+    let ast = parse(code).expect("Failed to parse");
+    let result = analyze_program(&ast);
+
+    // We expect this to fail.
+    assert!(
+        result.is_err(),
+        "Expected semantic analysis error (Undefined Type or Recursion), but got Ok"
+    );
+}
+
+#[test]
+fn test_unknown_type_fails() {
+    // Defining a struct with a non-existent type should fail
+    let code = r#"
+        εἶδος Α ὁρίζειν { β Φάντασμα. }.
+    "#;
+
+    let ast = parse(code).expect("Failed to parse");
+    let result = analyze_program(&ast);
+
+    assert!(
+        result.is_err(),
+        "Expected error for undefined type, but got Ok"
+    );
+}


### PR DESCRIPTION
This PR addresses a vulnerability where undefined types were silently treated as `Unknown`, allowing for the creation of mutually recursive structs that could lead to stack overflows or infinite loops during later compilation phases.

### Changes
- **`src/semantic/statements.rs`**: `resolve_type_name` now returns a `Result`. If a type is not found, it returns a semantic error instead of `GlossaType::Unknown`.
- **`tests/warden_recursive_struct_mutual.rs`**: Added a new test file to verify that mutual recursion (e.g., `A { b: B }`, `B { a: A }`) is rejected because `B` is undefined when `A` is analyzed.
- **`tests/type_tests.rs`**: Removed a line in `test_instantiation_with_boolean` that used an undefined type `κενόν`, which now correctly triggers an error.

### Verification
- Ran `cargo test --test warden_recursive_struct_mutual` - Passed.
- Ran `cargo test --test type_tests` - Passed.
- Ran full `cargo test` suite - Passed.

This enforces a "define-before-use" policy for types, which effectively prevents mutual recursion cycles in the current single-pass compiler architecture.

---
*PR created automatically by Jules for task [8926454846858247708](https://jules.google.com/task/8926454846858247708) started by @madmax983*