### PR TITLE
🎻 Bard: Enhance tools documentation with narrative style

### DIFF
--- a/src/tools/cache.rs
+++ b/src/tools/cache.rs
@@ -1,8 +1,31 @@
+//! The Cache System - "The Vault"
+//!
+//! This module implements incremental compilation for ΓΛΩΣΣΑ.
+//!
+//! # The Vault Philosophy
+//!
+//! Compiling code takes time. To be fast, we must avoid doing work we've already done.
+//! "The Vault" stores the results of previous compilations and retrieves them
+//! if the source code hasn't changed.
+//!
+//! # How it works
+//!
+//! 1. **Key Generation**: A unique fingerprint (SHA-256 hash) is generated from the
+//!    canonical path of the source file. This ensures that `src/main.gl` and `./main.gl`
+//!    map to the same cache entry.
+//! 2. **Storage**: The compiler stores two artifacts in the cache directory (`~/.glossa/cache`):
+//!    - `{hash}.rs`: The generated Rust source code.
+//!    - `{hash}` (or `{hash}.exe`): The compiled binary.
+//! 3. **Validation**: Before running, we check if the cached binary is newer than the source file.
+//!    If it is, we skip compilation and run the cached binary directly (The "Hot Path").
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 /// Manages the build cache for compiled programs.
+///
+/// Handles path resolution, key generation, and validity checking for cached binaries.
 pub struct Cache {
     base_dir: PathBuf,
 }
@@ -14,7 +37,10 @@ impl Default for Cache {
 }
 
 impl Cache {
-    /// Create a new Cache manager, resolving the cache directory.
+    /// Create a new Cache manager
+    ///
+    /// Resolves the cache directory to the system standard (e.g. `~/.cache` or `%LOCALAPPDATA%`)
+    /// appended with `.glossa/cache`.
     pub fn new() -> Self {
         let base_dir = dirs_next::cache_dir()
             .or_else(dirs_next::home_dir)
@@ -24,12 +50,25 @@ impl Cache {
         Self { base_dir }
     }
 
-    /// Ensure the cache directory exists.
+    /// Ensure the cache directory exists
+    ///
+    /// Creates the directory structure if it doesn't already exist.
+    /// Should be called before writing any files.
     pub fn init(&self) -> std::io::Result<()> {
         fs::create_dir_all(&self.base_dir)
     }
 
-    /// Generate a cache key from the source file path.
+    /// Generate a unique cache key for a source file
+    ///
+    /// The key is a SHA-256 hash of the **canonical path** of the input file.
+    /// This ensures that the same file always maps to the same cache entry,
+    /// regardless of how it was referenced (relative vs absolute path).
+    ///
+    /// # Why hash the path?
+    ///
+    /// We hash the path instead of the content for speed. The content change
+    /// detection is handled by the filesystem timestamp check in [`is_valid`](Cache::is_valid).
+    /// This allows the key generation to be extremely fast (no file reading).
     pub fn key(&self, input: &Path) -> String {
         use sha2::{Digest, Sha256};
 
@@ -47,7 +86,11 @@ impl Cache {
         hex::encode(result)
     }
 
-    /// Get the paths for the cached Rust source and executable.
+    /// Get the paths for the cached artifacts
+    ///
+    /// Returns a tuple of:
+    /// 1. Path to the generated Rust source (`{hash}.rs`)
+    /// 2. Path to the compiled executable (`{hash}` or `{hash}.exe`)
     pub fn get_paths(&self, input: &Path) -> (PathBuf, PathBuf) {
         let key = self.key(input);
         let cached_rs = self.base_dir.join(format!("{}.rs", key));
@@ -59,7 +102,16 @@ impl Cache {
         (cached_rs, cached_exe)
     }
 
-    /// Check if the cached binary is still valid (source not modified since compile).
+    /// Check if the cached binary is still valid
+    ///
+    /// Returns `true` if the cached executable exists and is newer than the source file.
+    /// This implements the standard "timestamp-based" incremental build logic.
+    ///
+    /// # Logic
+    ///
+    /// ```text
+    /// Valid = Exists(Binary) AND Modified(Binary) > Modified(Source)
+    /// ```
     pub fn is_valid(&self, input: &Path, cached_exe: &Path) -> bool {
         let source_modified = fs::metadata(input)
             .and_then(|m| m.modified())

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -6,7 +6,12 @@
 //! # Philosophy
 //!
 //! Unlike traditional syntax highlighters that use regexes, The Bard uses the
-//! compiler's own morphological analysis to understand the code.
+//! compiler's own morphological analysis to understand the code. It doesn't just
+//! know that a word is a noun; it knows if it's the **Subject** or the **Object**.
+//!
+//! # Color Scheme
+//!
+//! The colors are chosen to represent the function of the word:
 //!
 //! * **Nominative (Subject)**: Blue (The agent/foundation)
 //! * **Accusative (Object)**: Red (The target of action)
@@ -40,6 +45,13 @@ use crate::morphology::{
 use crate::parser::parse;
 
 /// Highlight the source code with semantic colors
+///
+/// This function parses the source code into an AST and then walks the AST to
+/// apply ANSI color codes based on the semantic role of each element.
+///
+/// # Errors
+///
+/// Returns a [`GlossaError`] if the source code cannot be parsed.
 pub fn highlight(source: &str) -> Result<String, GlossaError> {
     let program = parse(source)?;
     let mut highlighter = Highlighter::new();

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -2,6 +2,17 @@
 //!
 //! This module implements the "Mentor" tool, which guides users through learning
 //! the ΓΛΩΣΣΑ language with interactive lessons and challenges.
+//!
+//! # The Mentor Philosophy
+//!
+//! Learning a new language (especially one based on Ancient Greek) can be daunting.
+//! The Mentor provides a safe, guided environment where users can practice concepts
+//! one by one.
+//!
+//! Each lesson consists of:
+//! 1. **The Concept**: A brief explanation of a language feature.
+//! 2. **The Challenge**: A specific coding task to perform.
+//! 3. **The Verification**: Real-time analysis of the user's code to ensure they met the goal.
 
 use crate::parser::parse;
 use crate::semantic::{AnalyzedProgram, AnalyzedStatement, GlossaType, analyze_program};
@@ -68,6 +79,10 @@ const LESSONS: &[Lesson] = &[
     },
 ];
 
+/// Start the interactive Mentor session
+///
+/// This function enters a loop where it presents lessons to the user and waits
+/// for them to type code that satisfies the lesson's requirements.
 pub fn run_mentor() -> Result<()> {
     let stdin = std::io::stdin();
     let mut stdout = std::io::stdout();

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -5,14 +5,25 @@
 //!
 //! # Purpose
 //!
-//! This tool helps developers and users understand how the "free word order" of Ancient Greek
-//! is interpreted by the compiler's `Assembler`. It shows which words land in which
-//! grammatical slot (Subject, Object, Verb, etc.).
+//! Ancient Greek is a language of "free word order". The meaning is determined by
+//! case endings, not position.
 //!
-//! # The Mosaic
+//! "Mosaic" reveals how the compiler's [`Assembler`](crate::semantic::Assembler)
+//! deconstructs this freedom. It shows exactly which words land in which grammatical
+//! slot (Subject, Object, Verb, etc.), proving that `SOV`, `VSO`, and `OVS` all map
+//! to the same semantic structure.
 //!
-//! The output is a table where each row represents a statement, and columns represent
-//! the grammatical slots.
+//! # The Output
+//!
+//! The output is a table where each row represents a single statement.
+//!
+//! | Slot | Color | Role |
+//! |------|-------|------|
+//! | **Subject** | Cyan | The Agent (Nominative case) |
+//! | **Verb** | Yellow | The Action |
+//! | **Object** | Green | The Patient (Accusative case) |
+//! | **Indirect** | Magenta | The Recipient (Dative case) |
+//! | **Other** | Grey | Modifiers, Genitives, Literals |
 
 use crate::parser::parse;
 use crate::semantic::{AssembledStatement, Constituent, assemble_statement};
@@ -21,11 +32,17 @@ use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table};
 use miette::{IntoDiagnostic, Result};
 use std::path::PathBuf;
 
+/// Run the Mosaic tool on a file
+///
+/// Reads the source file, parses it, and prints the semantic assembly table to stdout.
 pub fn run_mosaic(input_path: &PathBuf) -> Result<()> {
     let source = std::fs::read_to_string(input_path).into_diagnostic()?;
     run_mosaic_inner(&source, &mut std::io::stdout())
 }
 
+/// Internal implementation of Mosaic logic
+///
+/// Separated for testing purposes (allows injecting a writer).
 pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Result<()> {
     let program = parse(source)?;
 

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -1,3 +1,28 @@
+//! The REPL (Read-Eval-Print Loop) - "The Playground"
+//!
+//! This module implements the interactive shell for ΓΛΩΣΣΑ.
+//! It allows users to experiment with the language, test snippets, and explore
+//! the type system in real-time.
+//!
+//! # The Playground Philosophy
+//!
+//! The REPL is designed to be forgiving and helpful. It maintains a persistent
+//! session state, allowing users to define variables and functions incrementally.
+//!
+//! # Features
+//!
+//! * **Persistence**: Variables defined with `ἔστω` stay in scope.
+//! * **Incremental Compilation**: Each line is compiled with the previous context.
+//! * **Safety Limits**: Prevents memory exhaustion with strict binding and size limits.
+//! * **Commands**: Built-in commands for managing the environment.
+//!
+//! # Commands
+//!
+//! * `.βοήθεια` / `.help` - Show available commands.
+//! * `.ἔξοδος` / `.exit` - Exit the REPL.
+//! * `.καθαρός` / `.clear` - Clear the session history (reset scope).
+//! * `.περιβάλλον` / `.env` - Show all defined variables and their types.
+
 use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
@@ -14,6 +39,24 @@ const MAX_REPL_BINDINGS: usize = 50;
 const MAX_REPL_SOURCE_LEN: usize = 50_000;
 
 /// Entry point for the REPL using stdin/stdout
+///
+/// Starts the interactive loop, reading from standard input and writing to standard output.
+///
+/// # Example Usage
+///
+/// ```text
+/// $ glossa repl
+///
+///    Γ Λ Ω Σ Σ Α
+///    Code as the ancients intended.
+///    v0.1.0
+///
+/// γλ> ξ πέντε ἔστω.
+/// ✓ ξ: Ἀριθμός
+/// γλ> ξ λέγε.
+/// ✓ Ἐκτελέσθη
+///   println!("{}", ξ);
+/// ```
 pub fn run_repl() -> Result<()> {
     print_banner();
     let stdin = std::io::stdin();


### PR DESCRIPTION
This PR updates the documentation for the `tools` module to align with the "Bard" persona guidelines. It introduces narrative-driven module documentation, explains the "why" behind features, and ensures all public items have clear, actionable doc comments with examples where appropriate.

Specifically:
- `src/tools/repl.rs`: Documented the REPL philosophy, features, and available commands.
- `src/tools/cache.rs`: Explained the incremental compilation strategy and hashing mechanism.
- `src/tools/mosaic.rs`: Documented the visualization tool's purpose and output format.
- `src/tools/mentor.rs`: Explained the interactive tutorial's structure.
- `src/tools/highlight.rs`: Documented the semantic highlighting philosophy and color scheme.

Verified by running `cargo doc --no-deps` and `cargo test`.

---
*PR created automatically by Jules for task [16925380104070151625](https://jules.google.com/task/16925380104070151625) started by @madmax983*