### PR TITLE
docs: Add ADR 012 and update architecture diagrams

### DIFF
--- a/docs/adr/012-consolidate-compiler-tools.md
+++ b/docs/adr/012-consolidate-compiler-tools.md
@@ -1,0 +1,37 @@
+# 12. Consolidate Compiler Tools
+
+Date: 2025-02-12
+Status: Accepted
+
+## Context
+
+As the ΓΛΩΣΣΑ compiler grew, the root source directory (`src/`) became cluttered with auxiliary tool modules that were distinct from the core compilation pipeline (Parsing -> Semantic Analysis -> Code Generation). These modules included:
+- `highlight` (Syntax highlighting)
+- `report` (Compilation reports)
+- `repl` (Interactive playground)
+- `cli` (Command-line interface)
+- `runner` (Compilation pipeline orchestration)
+- `cache` (Incremental compilation)
+
+Keeping these modules at the top level made it harder to distinguish between the core compiler logic and the tooling ecosystem built around it. It also obscured the dependency graph, as tools naturally depend on the core compiler components.
+
+## Decision
+
+We have consolidated all auxiliary tool modules into a dedicated `src/tools/` directory.
+
+- `src/tools/mod.rs`: Serves as the new entry point for the toolset.
+- `src/highlight.rs` -> `src/tools/highlight.rs`
+- `src/report.rs` -> `src/tools/report.rs`
+- `src/repl.rs` -> `src/tools/repl.rs`
+- `src/cli.rs` -> `src/tools/cli.rs`
+- `src/runner.rs` -> `src/tools/runner.rs`
+- `src/cache.rs` -> `src/tools/cache.rs`
+
+(Note: `narrator` was previously moved to `src/tools/narrator.rs` in ADR 010, establishing the precedent for this consolidation.)
+
+## Consequences
+
+- **Structural Clarity**: The root `src/` directory now clearly separates core compiler modules (`parser`, `morphology`, `semantic`, `codegen`) from the tooling ecosystem (`tools`).
+- **Module Organization**: The `tools` module acts as a namespace for all user-facing utilities.
+- **Improved DX**: Developers can easily locate tool-specific logic in one place.
+- **Documentation**: Architecture diagrams must be updated to reflect the new paths.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,14 +27,14 @@ The compiler is organized as a pipeline of modules, transforming source text int
 C4Container
     title Container Diagram for ΓΛΩΣΣΑ Compiler
 
-    Container(lexer, "Lexer", "src/grammar.rs", "Tokenizes source, handling Unicode normalization")
+    Container(lexer, "Lexer", "src/parser/grammar.rs", "Tokenizes source, handling Unicode normalization")
     Container(parser, "Parser", "src/parser", "Constructs AST, enforcing recursion limits (max depth 500)")
     Container(morphology, "Declension Resolver", "src/morphology", "Analyzes case, gender, number, and resolves agreement")
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
     Container(highlight, "Highlighter", "src/tools/highlight.rs", "Semantic syntax highlighting")
     Container(narrator, "Narrator", "src/tools/narrator.rs", "Generates English narrative from AST")
-    Container(report, "Reporter", "src/report.rs", "Generates statistics and structured reports")
-    Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
+    Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+    Container(codegen, "Code Generator", "src/codegen/mod.rs", "Generates Rust source code")
 
     Rel(lexer, parser, "Stream<Token>")
     Rel(parser, morphology, "AST (Unresolved)")


### PR DESCRIPTION
This PR adds ADR 012 to formally document the consolidation of compiler tools (CLI, REPL, Highlight, Report, etc.) into the `src/tools/` directory. It also updates the Architecture Container Diagram in `docs/architecture.md` to correct outdated file paths for the Lexer, Reporter, and Code Generator, ensuring the documentation reflects the actual codebase structure.

---
*PR created automatically by Jules for task [7150362819068220089](https://jules.google.com/task/7150362819068220089) started by @madmax983*