### PR TITLE
⚒️ Forge: Refactor semantic analysis modules

### DIFF
--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -482,69 +482,85 @@ impl Assembler {
         };
 
         match analysis.case {
-            Some(Case::Nominative) => {
-                // If we already have a verb, check agreement immediately!
-                if let Some(verb) = &self.state.verb {
-                    // Don't check agreement if we already have a subject (this is an extra nominative)
-                    if self.state.subject.is_none() {
-                        self.check_agreement(&constituent, verb)?;
-                    }
-                }
+            Some(Case::Nominative) => self.handle_nominative(constituent),
+            Some(Case::Accusative) => self.handle_accusative(constituent),
+            Some(Case::Dative) => self.handle_dative(constituent),
+            Some(Case::Genitive) => self.handle_genitive(constituent),
+            Some(Case::Vocative) => self.handle_vocative(constituent),
+            None => self.handle_unknown_case(constituent),
+        }
+    }
 
-                if self.state.subject.is_some() {
-                    // Additional nominatives stored separately for function call patterns
-                    if self.state.nominatives.len() >= MAX_NOMINATIVES {
-                        return Err(AssemblyError::LimitExceeded {
-                            resource: "Nominatives".to_string(),
-                            max: MAX_NOMINATIVES,
-                        });
-                    }
-                    self.state.nominatives.push(constituent);
-                } else {
-                    self.state.subject = Some(constituent);
-                }
-            }
-            Some(Case::Accusative) => {
-                if self.state.object.is_some() {
-                    return Err(AssemblyError::DoubleObject);
-                }
-                self.state.object = Some(constituent);
-            }
-            Some(Case::Dative) => {
-                // Dative can stack (multiple recipients) but for simplicity, one for now
-                if self.state.indirect.is_some() {
-                    return Err(AssemblyError::DoubleIndirect);
-                }
-                self.state.indirect = Some(constituent);
-            }
-            Some(Case::Genitive) => {
-                // Genitives attach to other constituents (possession, etc.)
-                if self.state.genitives.len() >= MAX_GENITIVES {
-                    return Err(AssemblyError::LimitExceeded {
-                        resource: "Genitives".to_string(),
-                        max: MAX_GENITIVES,
-                    });
-                }
-                self.state.genitives.push(constituent);
-            }
-            Some(Case::Vocative) => {
-                // Vocative is direct address - treat as subject for now
-                if self.state.subject.is_none() {
-                    self.state.subject = Some(constituent);
-                }
-            }
-            None => {
-                // Unknown case - try to infer from context
-                // Default to accusative (object) if we have no object
-                if self.state.object.is_none() {
-                    self.state.object = Some(constituent);
-                } else {
-                    return Err(AssemblyError::DoubleObject);
-                }
+    fn handle_nominative(&mut self, constituent: Constituent) -> Result<(), AssemblyError> {
+        // If we already have a verb, check agreement immediately!
+        if let Some(verb) = &self.state.verb {
+            // Don't check agreement if we already have a subject (this is an extra nominative)
+            if self.state.subject.is_none() {
+                self.check_agreement(&constituent, verb)?;
             }
         }
 
+        if self.state.subject.is_some() {
+            // Additional nominatives stored separately for function call patterns
+            if self.state.nominatives.len() >= MAX_NOMINATIVES {
+                return Err(AssemblyError::LimitExceeded {
+                    resource: "Nominatives".to_string(),
+                    max: MAX_NOMINATIVES,
+                });
+            }
+            self.state.nominatives.push(constituent);
+        } else {
+            self.state.subject = Some(constituent);
+        }
         Ok(())
+    }
+
+    fn handle_accusative(&mut self, constituent: Constituent) -> Result<(), AssemblyError> {
+        if self.state.object.is_some() {
+            return Err(AssemblyError::DoubleObject);
+        }
+        self.state.object = Some(constituent);
+        Ok(())
+    }
+
+    fn handle_dative(&mut self, constituent: Constituent) -> Result<(), AssemblyError> {
+        // Dative can stack (multiple recipients) but for simplicity, one for now
+        if self.state.indirect.is_some() {
+            return Err(AssemblyError::DoubleIndirect);
+        }
+        self.state.indirect = Some(constituent);
+        Ok(())
+    }
+
+    fn handle_genitive(&mut self, constituent: Constituent) -> Result<(), AssemblyError> {
+        // Genitives attach to other constituents (possession, etc.)
+        if self.state.genitives.len() >= MAX_GENITIVES {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Genitives".to_string(),
+                max: MAX_GENITIVES,
+            });
+        }
+        self.state.genitives.push(constituent);
+        Ok(())
+    }
+
+    fn handle_vocative(&mut self, constituent: Constituent) -> Result<(), AssemblyError> {
+        // Vocative is direct address - treat as subject for now
+        if self.state.subject.is_none() {
+            self.state.subject = Some(constituent);
+        }
+        Ok(())
+    }
+
+    fn handle_unknown_case(&mut self, constituent: Constituent) -> Result<(), AssemblyError> {
+        // Unknown case - try to infer from context
+        // Default to accusative (object) if we have no object
+        if self.state.object.is_none() {
+            self.state.object = Some(constituent);
+            Ok(())
+        } else {
+            Err(AssemblyError::DoubleObject)
+        }
     }
 
     /// Handle a verb

--- a/src/semantic/classification_tests.rs
+++ b/src/semantic/classification_tests.rs
@@ -1,0 +1,183 @@
+use super::conversion::classify_assembled_statement;
+use crate::morphology::Case;
+use crate::semantic::assembly_model::{ParticipleConstituent, VerbConstituent};
+use crate::semantic::{
+    AnalyzedExprKind, AnalyzedStatement, AssembledStatement, Constituent, GlossaType, Literal, Scope,
+};
+use crate::text::normalize_greek;
+use crate::morphology::lexicon::BinaryOp;
+
+fn make_constituent(original: &str, lemma: &str) -> Constituent {
+    Constituent {
+        lemma: lemma.into(),
+        original: original.into(),
+        normalized: normalize_greek(original),
+        case: Case::Nominative,
+        number: None,
+        gender: None,
+        person: None,
+    }
+}
+
+fn make_verb(original: &str, lemma: &str) -> VerbConstituent {
+    VerbConstituent {
+        lemma: lemma.into(),
+        original: original.into(),
+        normalized: normalize_greek(original),
+        person: None,
+        number: None,
+        tense: None,
+        mood: None,
+        voice: None,
+    }
+}
+
+#[test]
+fn test_classify_simple_binding() {
+    let mut scope = Scope::new();
+
+    // "x 5 let"
+    let mut asm_stmt = AssembledStatement::default();
+    asm_stmt.subject = Some(make_constituent("x", "x"));
+    asm_stmt.literals = vec![Literal::Number(5)];
+    asm_stmt.verb = Some(make_verb("let", "εστω")); // "ἔστω" is a binding verb
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope)
+        .expect("Classification failed");
+
+    if let AnalyzedStatement::Binding { name, value, .. } = result {
+        assert_eq!(name, "x");
+        if let AnalyzedExprKind::NumberLiteral(n) = value.expr {
+            assert_eq!(n, 5);
+        } else {
+            panic!("Expected NumberLiteral");
+        }
+    } else {
+        panic!("Expected Binding, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_classify_binding_subject_object_swap() {
+    let mut scope = Scope::new();
+    scope.define("val", GlossaType::Number);
+
+    // "val x let" -> Should bind x to val, because val is defined and x is not.
+    // Original: Subject=val, Object=x (because of word order/case, usually)
+    // Here we simulate the assembler putting "val" in Subject and "x" in Object.
+    let mut asm_stmt = AssembledStatement::default();
+    asm_stmt.subject = Some(make_constituent("val", "val"));
+    asm_stmt.object = Some(make_constituent("x", "x"));
+    asm_stmt.verb = Some(make_verb("let", "εστω"));
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope)
+        .expect("Classification failed");
+
+    if let AnalyzedStatement::Binding { name, value, .. } = result {
+        assert_eq!(name, "x"); // Should be swapped to x
+        if let AnalyzedExprKind::Variable(v) = value.expr {
+            assert_eq!(v, "val");
+        } else {
+            panic!("Expected Variable val");
+        }
+    } else {
+        panic!("Expected Binding, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_classify_binding_false_participle() {
+    let mut scope = Scope::new();
+
+    // "x 5 written let" -> "written" is a participle but not a real one in this context (it's the variable name essentially or part of the phrase)
+    // The logic checks if the participle lemma exists in lexicon. If not, it treats it as the variable name.
+
+    let mut asm_stmt = AssembledStatement::default();
+    asm_stmt.literals = vec![Literal::Number(5)];
+    asm_stmt.verb = Some(make_verb("let", "εστω"));
+
+    // Add a "false" participle (lemma not in lexicon)
+    asm_stmt.participles.push(ParticipleConstituent {
+        verb_lemma: "unknown_verb".into(),
+        original: "written".into(),
+        normalized: "written".into(),
+        tense: crate::morphology::Tense::Present, // Dummy values
+        voice: crate::morphology::Voice::Active,
+        case: Case::Nominative,
+        gender: crate::morphology::Gender::Neuter,
+        number: crate::morphology::Number::Singular,
+    });
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope)
+        .expect("Classification failed");
+
+    if let AnalyzedStatement::Binding { name, .. } = result {
+        assert_eq!(name, "written"); // Should bind to the participle's normalized form
+    } else {
+        panic!("Expected Binding, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_classify_print_binary_op() {
+    let mut scope = Scope::new();
+    scope.define("x", GlossaType::Number);
+
+    // "x + 5 print"
+    let mut asm_stmt = AssembledStatement::default();
+    asm_stmt.subject = Some(make_constituent("x", "x"));
+    asm_stmt.literals = vec![Literal::Number(5)];
+    asm_stmt.operators = vec![BinaryOp::Add];
+    asm_stmt.verb = Some(make_verb("print", "λεγε"));
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope)
+        .expect("Classification failed");
+
+    if let AnalyzedStatement::Print(exprs) = result {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::BinOp { left, op, right } = &exprs[0].expr {
+            assert_eq!(*op, BinaryOp::Add);
+            // check left is variable x
+             if let AnalyzedExprKind::Variable(v) = &left.expr {
+                assert_eq!(v, "x");
+            } else {
+                panic!("Expected Variable x");
+            }
+        } else {
+            panic!("Expected BinOp");
+        }
+    } else {
+        panic!("Expected Print, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_classify_print_property_access() {
+    let mut scope = Scope::new();
+    scope.define("user", GlossaType::Unknown); // Type doesn't matter much for lookup unless it fails
+
+    // "user.name print"
+    // Assembler represents this as property_accesses: [("user", "name")]
+    let mut asm_stmt = AssembledStatement::default();
+    asm_stmt.property_accesses.push(("user".into(), "name".into()));
+    asm_stmt.verb = Some(make_verb("print", "λεγε"));
+
+    let result = classify_assembled_statement(&asm_stmt, &mut scope)
+        .expect("Classification failed");
+
+    if let AnalyzedStatement::Print(exprs) = result {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::MethodCall { receiver, method, .. } = &exprs[0].expr {
+            assert_eq!(method, "name");
+            if let AnalyzedExprKind::Variable(v) = &receiver.expr {
+                assert_eq!(v, "user");
+            } else {
+                panic!("Expected Variable user");
+            }
+        } else {
+            panic!("Expected MethodCall (property access is often lowered to method call or specific enum)");
+        }
+    } else {
+        panic!("Expected Print, got {:?}", result);
+    }
+}

--- a/src/semantic/classification_tests.rs
+++ b/src/semantic/classification_tests.rs
@@ -1,11 +1,13 @@
 use super::conversion::classify_assembled_statement;
+use crate::ast::Expr;
 use crate::morphology::Case;
+use crate::morphology::lexicon::BinaryOp;
 use crate::semantic::assembly_model::{ParticipleConstituent, VerbConstituent};
 use crate::semantic::{
-    AnalyzedExprKind, AnalyzedStatement, AssembledStatement, Constituent, GlossaType, Literal, Scope,
+    AnalyzedExprKind, AnalyzedStatement, AssembledStatement, Constituent, GlossaType, Literal,
+    Scope,
 };
 use crate::text::normalize_greek;
-use crate::morphology::lexicon::BinaryOp;
 
 fn make_constituent(original: &str, lemma: &str) -> Constituent {
     Constituent {
@@ -37,13 +39,15 @@ fn test_classify_simple_binding() {
     let mut scope = Scope::new();
 
     // "x 5 let"
-    let mut asm_stmt = AssembledStatement::default();
-    asm_stmt.subject = Some(make_constituent("x", "x"));
-    asm_stmt.literals = vec![Literal::Number(5)];
-    asm_stmt.verb = Some(make_verb("let", "εστω")); // "ἔστω" is a binding verb
+    let asm_stmt = AssembledStatement {
+        subject: Some(make_constituent("x", "x")),
+        literals: vec![Literal::Number(5)],
+        verb: Some(make_verb("let", "εστω")), // "ἔστω" is a binding verb
+        ..Default::default()
+    };
 
-    let result = classify_assembled_statement(&asm_stmt, &mut scope)
-        .expect("Classification failed");
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Classification failed");
 
     if let AnalyzedStatement::Binding { name, value, .. } = result {
         assert_eq!(name, "x");
@@ -65,13 +69,15 @@ fn test_classify_binding_subject_object_swap() {
     // "val x let" -> Should bind x to val, because val is defined and x is not.
     // Original: Subject=val, Object=x (because of word order/case, usually)
     // Here we simulate the assembler putting "val" in Subject and "x" in Object.
-    let mut asm_stmt = AssembledStatement::default();
-    asm_stmt.subject = Some(make_constituent("val", "val"));
-    asm_stmt.object = Some(make_constituent("x", "x"));
-    asm_stmt.verb = Some(make_verb("let", "εστω"));
+    let asm_stmt = AssembledStatement {
+        subject: Some(make_constituent("val", "val")),
+        object: Some(make_constituent("x", "x")),
+        verb: Some(make_verb("let", "εστω")),
+        ..Default::default()
+    };
 
-    let result = classify_assembled_statement(&asm_stmt, &mut scope)
-        .expect("Classification failed");
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Classification failed");
 
     if let AnalyzedStatement::Binding { name, value, .. } = result {
         assert_eq!(name, "x"); // Should be swapped to x
@@ -89,30 +95,77 @@ fn test_classify_binding_subject_object_swap() {
 fn test_classify_binding_false_participle() {
     let mut scope = Scope::new();
 
-    // "x 5 written let" -> "written" is a participle but not a real one in this context (it's the variable name essentially or part of the phrase)
+    // "x 5 written let" -> "written" is a participle but not a real one in this context
+    // (it's the variable name essentially or part of the phrase)
     // The logic checks if the participle lemma exists in lexicon. If not, it treats it as the variable name.
 
-    let mut asm_stmt = AssembledStatement::default();
-    asm_stmt.literals = vec![Literal::Number(5)];
-    asm_stmt.verb = Some(make_verb("let", "εστω"));
+    let asm_stmt = AssembledStatement {
+        literals: vec![Literal::Number(5)],
+        verb: Some(make_verb("let", "εστω")),
+        // Add a "false" participle (lemma not in lexicon)
+        participles: vec![ParticipleConstituent {
+            verb_lemma: "unknown_verb".into(),
+            original: "written".into(),
+            normalized: "written".into(),
+            tense: crate::morphology::Tense::Present, // Dummy values
+            voice: crate::morphology::Voice::Active,
+            case: Case::Nominative,
+            gender: crate::morphology::Gender::Neuter,
+            number: crate::morphology::Number::Singular,
+        }],
+        ..Default::default()
+    };
 
-    // Add a "false" participle (lemma not in lexicon)
-    asm_stmt.participles.push(ParticipleConstituent {
-        verb_lemma: "unknown_verb".into(),
-        original: "written".into(),
-        normalized: "written".into(),
-        tense: crate::morphology::Tense::Present, // Dummy values
-        voice: crate::morphology::Voice::Active,
-        case: Case::Nominative,
-        gender: crate::morphology::Gender::Neuter,
-        number: crate::morphology::Number::Singular,
-    });
-
-    let result = classify_assembled_statement(&asm_stmt, &mut scope)
-        .expect("Classification failed");
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Classification failed");
 
     if let AnalyzedStatement::Binding { name, .. } = result {
         assert_eq!(name, "written"); // Should bind to the participle's normalized form
+    } else {
+        panic!("Expected Binding, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_classify_binding_fallback_participle() {
+    let mut scope = Scope::new();
+
+    // Case where we bind to a participle when no subject/object is present
+    // and it IS a real participle (or at least we want to hit the fallback path)
+    // Note: The logic prioritizes "false participles" first.
+    // If the participle IS in the lexicon, `has_false_participle` is false.
+    // Then it falls through subject/object checks.
+    // Finally it hits the fallback `if !asm_stmt.participles.is_empty()`.
+
+    // We need a verb lemma that IS in the lexicon for this test to hit the fallback path,
+    // OR we just rely on `resolve_binding_target` falling through.
+    // Let's use a dummy one but ensure `has_false_participle` would be false if we could control the lexicon.
+    // Since we can't easily mock the lexicon here, we might just assume "unknown_verb" triggers false participle.
+    // Wait, if "unknown_verb" is NOT in lexicon, `lookup` returns None, so `has_false_participle` is TRUE.
+    // So to hit the fallback, we need `lookup` to return SOME.
+    // "λεγω" (speak) is definitely in the lexicon.
+
+    let asm_stmt = AssembledStatement {
+        literals: vec![Literal::Number(5)],
+        verb: Some(make_verb("let", "εστω")),
+        participles: vec![ParticipleConstituent {
+            verb_lemma: "λεγω".into(), // Should be in lexicon
+            original: "legomenon".into(),
+            normalized: "legomenon".into(),
+            tense: crate::morphology::Tense::Present,
+            voice: crate::morphology::Voice::Passive,
+            case: Case::Nominative,
+            gender: crate::morphology::Gender::Neuter,
+            number: crate::morphology::Number::Singular,
+        }],
+        ..Default::default()
+    };
+
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Classification failed");
+
+    if let AnalyzedStatement::Binding { name, .. } = result {
+        assert_eq!(name, "legomenon");
     } else {
         panic!("Expected Binding, got {:?}", result);
     }
@@ -124,21 +177,23 @@ fn test_classify_print_binary_op() {
     scope.define("x", GlossaType::Number);
 
     // "x + 5 print"
-    let mut asm_stmt = AssembledStatement::default();
-    asm_stmt.subject = Some(make_constituent("x", "x"));
-    asm_stmt.literals = vec![Literal::Number(5)];
-    asm_stmt.operators = vec![BinaryOp::Add];
-    asm_stmt.verb = Some(make_verb("print", "λεγε"));
+    let asm_stmt = AssembledStatement {
+        subject: Some(make_constituent("x", "x")),
+        literals: vec![Literal::Number(5)],
+        operators: vec![BinaryOp::Add],
+        verb: Some(make_verb("print", "λεγε")),
+        ..Default::default()
+    };
 
-    let result = classify_assembled_statement(&asm_stmt, &mut scope)
-        .expect("Classification failed");
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Classification failed");
 
     if let AnalyzedStatement::Print(exprs) = result {
         assert_eq!(exprs.len(), 1);
-        if let AnalyzedExprKind::BinOp { left, op, right } = &exprs[0].expr {
+        if let AnalyzedExprKind::BinOp { left, op, right: _ } = &exprs[0].expr {
             assert_eq!(*op, BinaryOp::Add);
             // check left is variable x
-             if let AnalyzedExprKind::Variable(v) = &left.expr {
+            if let AnalyzedExprKind::Variable(v) = &left.expr {
                 assert_eq!(v, "x");
             } else {
                 panic!("Expected Variable x");
@@ -158,16 +213,21 @@ fn test_classify_print_property_access() {
 
     // "user.name print"
     // Assembler represents this as property_accesses: [("user", "name")]
-    let mut asm_stmt = AssembledStatement::default();
-    asm_stmt.property_accesses.push(("user".into(), "name".into()));
-    asm_stmt.verb = Some(make_verb("print", "λεγε"));
+    let asm_stmt = AssembledStatement {
+        property_accesses: vec![("user".into(), "name".into())],
+        verb: Some(make_verb("print", "λεγε")),
+        ..Default::default()
+    };
 
-    let result = classify_assembled_statement(&asm_stmt, &mut scope)
-        .expect("Classification failed");
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Classification failed");
 
     if let AnalyzedStatement::Print(exprs) = result {
         assert_eq!(exprs.len(), 1);
-        if let AnalyzedExprKind::MethodCall { receiver, method, .. } = &exprs[0].expr {
+        if let AnalyzedExprKind::MethodCall {
+            receiver, method, ..
+        } = &exprs[0].expr
+        {
             assert_eq!(method, "name");
             if let AnalyzedExprKind::Variable(v) = &receiver.expr {
                 assert_eq!(v, "user");
@@ -175,9 +235,113 @@ fn test_classify_print_property_access() {
                 panic!("Expected Variable user");
             }
         } else {
-            panic!("Expected MethodCall (property access is often lowered to method call or specific enum)");
+            panic!(
+                "Expected MethodCall (property access is often lowered to method call or specific enum)"
+            );
         }
     } else {
         panic!("Expected Print, got {:?}", result);
+    }
+}
+
+#[test]
+fn test_classify_print_index_access() {
+    let mut scope = Scope::new();
+    // array[0] print
+    let asm_stmt = AssembledStatement {
+        index_accesses: vec![(
+            Expr::Word(crate::ast::Word {
+                original: "arr".into(),
+                normalized: "arr".into(),
+            }),
+            Expr::NumberLiteral(0),
+        )],
+        verb: Some(make_verb("print", "λεγε")),
+        ..Default::default()
+    };
+
+    // Define "arr" so it can be resolved
+    scope.define("arr", GlossaType::List(Box::new(GlossaType::Number)));
+
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Classification failed");
+
+    if let AnalyzedStatement::Print(exprs) = result {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::IndexAccess { array, index } = &exprs[0].expr {
+            if let AnalyzedExprKind::Variable(v) = &array.expr {
+                assert_eq!(v, "arr");
+            } else {
+                panic!("Expected array variable");
+            }
+            if let AnalyzedExprKind::NumberLiteral(n) = &index.expr {
+                assert_eq!(*n, 0);
+            } else {
+                panic!("Expected index literal 0");
+            }
+        } else {
+            panic!("Expected IndexAccess");
+        }
+    } else {
+        panic!("Expected Print");
+    }
+}
+
+#[test]
+fn test_classify_print_unwrap() {
+    let mut scope = Scope::new();
+    // x! print
+    let asm_stmt = AssembledStatement {
+        unwraps: vec![Expr::Word(crate::ast::Word {
+            original: "x".into(),
+            normalized: "x".into(),
+        })],
+        verb: Some(make_verb("print", "λεγε")),
+        ..Default::default()
+    };
+
+    scope.define("x", GlossaType::Option(Box::new(GlossaType::Number)));
+
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Classification failed");
+
+    if let AnalyzedStatement::Print(exprs) = result {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::Unwrap(inner) = &exprs[0].expr {
+            if let AnalyzedExprKind::Variable(v) = &inner.expr {
+                assert_eq!(v, "x");
+            } else {
+                panic!("Expected variable x");
+            }
+        } else {
+            panic!("Expected Unwrap");
+        }
+    } else {
+        panic!("Expected Print");
+    }
+}
+
+#[test]
+fn test_classify_print_default() {
+    let mut scope = Scope::new();
+    // "hello" print
+    let asm_stmt = AssembledStatement {
+        literals: vec![Literal::String("hello".into())],
+        verb: Some(make_verb("print", "λεγε")),
+        ..Default::default()
+    };
+
+    let result =
+        classify_assembled_statement(&asm_stmt, &mut scope).expect("Classification failed");
+
+    if let AnalyzedStatement::Print(exprs) = result {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::StringLiteral(s) = &exprs[0].expr {
+            assert_eq!(s, "hello");
+        } else {
+            panic!("Expected StringLiteral");
+        }
+    } else {
+        panic!("Expected Print");
     }
 }

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -293,6 +293,53 @@ fn classify_subjunctive_comparison(
     Ok(None)
 }
 
+/// Helper: Resolve the target variable name and the effective assembled statement for binding
+fn resolve_binding_target(
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<(String, AssembledStatement), GlossaError> {
+    // Check for "false participles" (nouns misclassified as participles)
+    let has_false_participle = !asm_stmt.participles.is_empty()
+        && morphology::lexicon::lookup(&asm_stmt.participles[0].verb_lemma).is_none();
+
+    if has_false_participle {
+        let first_participle = &asm_stmt.participles[0];
+        let mut fixed_asm = asm_stmt.clone();
+        fixed_asm.participles = asm_stmt.participles[1..].to_vec();
+        return Ok((first_participle.normalized.to_string(), fixed_asm));
+    }
+
+    // Check for Subject/Object swap (if Subject is defined and Object is not, bind to Object)
+    if let (Some(subject), Some(object)) = (&asm_stmt.subject, &asm_stmt.object) {
+        let subject_name = &subject.normalized;
+        let object_name = &object.normalized;
+
+        if scope.is_defined(&subject.lemma) && !scope.is_defined(&object.lemma) {
+            let mut swapped = asm_stmt.clone();
+            swapped.subject = Some(object.clone());
+            swapped.object = Some(subject.clone());
+            return Ok((object_name.to_string(), swapped));
+        } else {
+            return Ok((subject_name.to_string(), asm_stmt.clone()));
+        }
+    }
+
+    // Default case: Bind to Subject
+    if let Some(subject) = &asm_stmt.subject {
+        return Ok((subject.normalized.to_string(), asm_stmt.clone()));
+    }
+
+    // Fallback: Bind to first participle (if any remain)
+    if !asm_stmt.participles.is_empty() {
+        let first_participle = &asm_stmt.participles[0];
+        let mut fixed_asm = asm_stmt.clone();
+        fixed_asm.participles = asm_stmt.participles[1..].to_vec();
+        return Ok((first_participle.normalized.to_string(), fixed_asm));
+    }
+
+    Err(GlossaError::semantic("Binding without subject"))
+}
+
 /// Helper: Detect variable binding (let x = ...)
 fn classify_variable_binding(
     asm_stmt: &AssembledStatement,
@@ -302,36 +349,7 @@ fn classify_variable_binding(
         let verb_lemma = &verb.lemma;
 
         if crate::morphology::lexicon::is_binding_verb(verb_lemma) {
-            let has_false_participle = !asm_stmt.participles.is_empty()
-                && morphology::lexicon::lookup(&asm_stmt.participles[0].verb_lemma).is_none();
-
-            let (var_name, actual_asm) = if has_false_participle {
-                let first_participle = &asm_stmt.participles[0];
-                let mut fixed_asm = asm_stmt.clone();
-                fixed_asm.participles = asm_stmt.participles[1..].to_vec();
-                (first_participle.normalized.clone(), fixed_asm)
-            } else if let (Some(subject), Some(object)) = (&asm_stmt.subject, &asm_stmt.object) {
-                let subject_name = &subject.normalized;
-                let object_name = &object.normalized;
-
-                if scope.is_defined(&subject.lemma) && !scope.is_defined(&object.lemma) {
-                    let mut swapped = asm_stmt.clone();
-                    swapped.subject = Some(object.clone());
-                    swapped.object = Some(subject.clone());
-                    (object_name.clone(), swapped)
-                } else {
-                    (subject_name.clone(), asm_stmt.clone())
-                }
-            } else if let Some(subject) = &asm_stmt.subject {
-                (subject.normalized.clone(), asm_stmt.clone())
-            } else if !asm_stmt.participles.is_empty() {
-                let first_participle = &asm_stmt.participles[0];
-                let mut fixed_asm = asm_stmt.clone();
-                fixed_asm.participles = asm_stmt.participles[1..].to_vec();
-                (first_participle.normalized.clone(), fixed_asm)
-            } else {
-                return Err(GlossaError::semantic("Binding without subject"));
-            };
+            let (var_name, actual_asm) = resolve_binding_target(asm_stmt, scope)?;
 
             let (value_expr, value_type) = extract_value(&actual_asm, scope)?;
 
@@ -352,7 +370,7 @@ fn classify_variable_binding(
             }
 
             return Ok(Some(AnalyzedStatement::Binding {
-                name: var_name.clone(),
+                name: var_name.into(),
                 value: final_value_expr,
                 mutable: is_mutable,
             }));
@@ -670,6 +688,145 @@ fn classify_equality_assertion(
     Ok(None)
 }
 
+fn try_print_binary_op(
+    asm_stmt: &AssembledStatement,
+    scope: &mut Scope,
+) -> Option<Vec<AnalyzedExpr>> {
+    if !asm_stmt.operators.is_empty() {
+        let left = if let Some(ref subj) = asm_stmt.subject {
+            scope.lookup(&subj.lemma).map(|var_type| AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                glossa_type: var_type.clone(),
+            })
+        } else {
+            None
+        };
+
+        let right = asm_stmt.literals.first().map(literal_to_analyzed_expr);
+
+        if let (Some(left_expr), Some(right_expr)) = (left, right) {
+            let op = asm_stmt.operators[0];
+            let bin_expr = build_binary_expr(left_expr, op, right_expr);
+            return Some(vec![bin_expr]);
+        }
+    }
+    None
+}
+
+fn try_print_property_access(
+    asm_stmt: &AssembledStatement,
+    scope: &mut Scope,
+) -> Option<Vec<AnalyzedExpr>> {
+    if !asm_stmt.property_accesses.is_empty() {
+        let mut args = Vec::new();
+        for (owner, method) in &asm_stmt.property_accesses {
+            let receiver = AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(owner.clone().into()),
+                glossa_type: scope.lookup(owner).cloned().unwrap_or(GlossaType::Unknown),
+            };
+            let method_args = if let Some((ref meth, ref delim)) = asm_stmt.string_method {
+                if meth == method {
+                    vec![AnalyzedExpr {
+                        expr: AnalyzedExprKind::StringLiteral(delim.clone()),
+                        glossa_type: GlossaType::String,
+                    }]
+                } else {
+                    vec![]
+                }
+            } else {
+                vec![]
+            };
+            let return_type = match method.as_str() {
+                "len" => GlossaType::Number,
+                "split" => GlossaType::List(Box::new(GlossaType::String)),
+                "join" => GlossaType::String,
+                _ => GlossaType::Unknown,
+            };
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::MethodCall {
+                    receiver: Box::new(receiver),
+                    method: method.clone().into(),
+                    args: method_args,
+                },
+                glossa_type: return_type,
+            });
+        }
+        return Some(args);
+    }
+    None
+}
+
+fn try_print_index_access(
+    asm_stmt: &AssembledStatement,
+    scope: &mut Scope,
+) -> Result<Option<Vec<AnalyzedExpr>>, GlossaError> {
+    if !asm_stmt.index_accesses.is_empty() {
+        let mut args = Vec::new();
+        for (array_expr, index_expr) in &asm_stmt.index_accesses {
+            let array_analyzed = analyze_argument_expr(array_expr, scope)?;
+            let index_analyzed = analyze_argument_expr(index_expr, scope)?;
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::IndexAccess {
+                    array: Box::new(array_analyzed),
+                    index: Box::new(index_analyzed),
+                },
+                glossa_type: GlossaType::Unknown,
+            });
+        }
+        return Ok(Some(args));
+    }
+    Ok(None)
+}
+
+fn try_print_unwrap(
+    asm_stmt: &AssembledStatement,
+    scope: &mut Scope,
+) -> Result<Option<Vec<AnalyzedExpr>>, GlossaError> {
+    if !asm_stmt.unwraps.is_empty() {
+        let mut args = Vec::new();
+        for unwrap_expr in &asm_stmt.unwraps {
+            let inner_analyzed = analyze_argument_expr(unwrap_expr, scope)?;
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::Unwrap(Box::new(inner_analyzed)),
+                glossa_type: GlossaType::Unknown,
+            });
+        }
+        return Ok(Some(args));
+    }
+    Ok(None)
+}
+
+fn try_print_default(
+    asm_stmt: &AssembledStatement,
+    scope: &mut Scope,
+) -> Result<Vec<AnalyzedExpr>, GlossaError> {
+    let mut args =
+        build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
+
+    if let Some(ref subj) = asm_stmt.subject
+        && let Some(var_type) = scope.lookup(&subj.lemma)
+    {
+        args.insert(
+            0,
+            AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                glossa_type: var_type.clone(),
+            },
+        );
+    }
+
+    if let Some(ref obj) = asm_stmt.object
+        && let Some(var_type) = scope.lookup(&obj.lemma)
+    {
+        args.push(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+            glossa_type: var_type.clone(),
+        });
+    }
+
+    Ok(args)
+}
+
 /// Helper: Detect print statement
 fn classify_print(
     asm_stmt: &AssembledStatement,
@@ -679,119 +836,23 @@ fn classify_print(
         let verb_lemma = &verb.lemma;
 
         if crate::morphology::lexicon::is_print_verb(verb_lemma) {
-            // Binary expr with operator
-            if !asm_stmt.operators.is_empty() {
-                let left = if let Some(ref subj) = asm_stmt.subject {
-                    scope.lookup(&subj.lemma).map(|var_type| AnalyzedExpr {
-                        expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                        glossa_type: var_type.clone(),
-                    })
-                } else {
-                    None
-                };
-
-                let right = asm_stmt.literals.first().map(literal_to_analyzed_expr);
-
-                if let (Some(left_expr), Some(right_expr)) = (left, right) {
-                    let op = asm_stmt.operators[0];
-                    let bin_expr = build_binary_expr(left_expr, op, right_expr);
-                    return Ok(Some(AnalyzedStatement::Print(vec![bin_expr])));
-                }
-            }
-
-            // Property access
-            if !asm_stmt.property_accesses.is_empty() {
-                let mut args = Vec::new();
-                for (owner, method) in &asm_stmt.property_accesses {
-                    let receiver = AnalyzedExpr {
-                        expr: AnalyzedExprKind::Variable(owner.clone().into()),
-                        glossa_type: scope.lookup(owner).cloned().unwrap_or(GlossaType::Unknown),
-                    };
-                    let method_args = if let Some((ref meth, ref delim)) = asm_stmt.string_method {
-                        if meth == method {
-                            vec![AnalyzedExpr {
-                                expr: AnalyzedExprKind::StringLiteral(delim.clone()),
-                                glossa_type: GlossaType::String,
-                            }]
-                        } else {
-                            vec![]
-                        }
-                    } else {
-                        vec![]
-                    };
-                    let return_type = match method.as_str() {
-                        "len" => GlossaType::Number,
-                        "split" => GlossaType::List(Box::new(GlossaType::String)),
-                        "join" => GlossaType::String,
-                        _ => GlossaType::Unknown,
-                    };
-                    args.push(AnalyzedExpr {
-                        expr: AnalyzedExprKind::MethodCall {
-                            receiver: Box::new(receiver),
-                            method: method.clone().into(),
-                            args: method_args,
-                        },
-                        glossa_type: return_type,
-                    });
-                }
+            if let Some(args) = try_print_binary_op(asm_stmt, scope) {
                 return Ok(Some(AnalyzedStatement::Print(args)));
             }
 
-            // Index access
-            if !asm_stmt.index_accesses.is_empty() {
-                let mut args = Vec::new();
-                for (array_expr, index_expr) in &asm_stmt.index_accesses {
-                    let array_analyzed = analyze_argument_expr(array_expr, scope)?;
-                    let index_analyzed = analyze_argument_expr(index_expr, scope)?;
-                    args.push(AnalyzedExpr {
-                        expr: AnalyzedExprKind::IndexAccess {
-                            array: Box::new(array_analyzed),
-                            index: Box::new(index_analyzed),
-                        },
-                        glossa_type: GlossaType::Unknown,
-                    });
-                }
+            if let Some(args) = try_print_property_access(asm_stmt, scope) {
                 return Ok(Some(AnalyzedStatement::Print(args)));
             }
 
-            // Unwrap
-            if !asm_stmt.unwraps.is_empty() {
-                let mut args = Vec::new();
-                for unwrap_expr in &asm_stmt.unwraps {
-                    let inner_analyzed = analyze_argument_expr(unwrap_expr, scope)?;
-                    args.push(AnalyzedExpr {
-                        expr: AnalyzedExprKind::Unwrap(Box::new(inner_analyzed)),
-                        glossa_type: GlossaType::Unknown,
-                    });
-                }
+            if let Some(args) = try_print_index_access(asm_stmt, scope)? {
                 return Ok(Some(AnalyzedStatement::Print(args)));
             }
 
-            // Default
-            let mut args =
-                build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
-
-            if let Some(ref subj) = asm_stmt.subject
-                && let Some(var_type) = scope.lookup(&subj.lemma)
-            {
-                args.insert(
-                    0,
-                    AnalyzedExpr {
-                        expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                        glossa_type: var_type.clone(),
-                    },
-                );
+            if let Some(args) = try_print_unwrap(asm_stmt, scope)? {
+                return Ok(Some(AnalyzedStatement::Print(args)));
             }
 
-            if let Some(ref obj) = asm_stmt.object
-                && let Some(var_type) = scope.lookup(&obj.lemma)
-            {
-                args.push(AnalyzedExpr {
-                    expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                    glossa_type: var_type.clone(),
-                });
-            }
-
+            let args = try_print_default(asm_stmt, scope)?;
             return Ok(Some(AnalyzedStatement::Print(args)));
         }
     }

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -38,6 +38,8 @@ pub(crate) mod assembly_model;
 pub(crate) mod conversion;
 #[cfg(test)]
 mod conversion_tests;
+#[cfg(test)]
+mod classification_tests;
 pub mod expressions;
 pub(crate) mod model;
 pub(crate) mod patterns;

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -35,11 +35,11 @@ pub mod assembler;
 #[cfg(test)]
 mod assembler_tests;
 pub(crate) mod assembly_model;
+#[cfg(test)]
+mod classification_tests;
 pub(crate) mod conversion;
 #[cfg(test)]
 mod conversion_tests;
-#[cfg(test)]
-mod classification_tests;
 pub mod expressions;
 pub(crate) mod model;
 pub(crate) mod patterns;


### PR DESCRIPTION
🚮 Smell:
- `classify_variable_binding` in `src/semantic/conversion.rs` had complex inline logic for determining binding targets (false participles, subject/object swapping).
- `classify_print` in `src/semantic/conversion.rs` was a long function with multiple `if` blocks for different print types.
- `Assembler::handle_nominal` in `src/semantic/assembler.rs` was a large `match` block handling all grammatical cases.

✨ Solution:
- Extracted `resolve_binding_target` helper from `classify_variable_binding`.
- Extracted `try_print_binary_op`, `try_print_property_access`, `try_print_index_access`, `try_print_unwrap`, and `try_print_default` from `classify_print`.
- Split `Assembler::handle_nominal` into `handle_nominative`, `handle_accusative`, etc.
- Added `src/semantic/classification_tests.rs` to unit test the extracted logic and ensure no regressions.

🧼 Benefit:
- Improved readability by reducing function length and complexity.
- "Happy path" is clearer in `classify_print` due to guard clause pattern.
- Logic for resolving binding targets is now isolated and easier to test.
- `Assembler` logic is more modular.

🛡️ Verification:
- Added comprehensive unit tests in `src/semantic/classification_tests.rs` covering edge cases.
- Ran `cargo test semantic::assembler` and `cargo test semantic::classification_tests` successfully.

---
*PR created automatically by Jules for task [4857534362781304487](https://jules.google.com/task/4857534362781304487) started by @madmax983*