### PR TITLE
🎻 Bard: Documentation Polish & Identity Resolution

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -89,7 +89,7 @@
 //! directly from the Semantic Analysis model. This ensures that the generated code
 //! is syntactically valid Rust and avoids "stringly typed" code generation errors.
 //!
-//! 1. **Semantic Analysis**: Produces an [`AnalyzedProgram`](crate::semantic::AnalyzedProgram).
+//! 1. **Semantic Analysis**: Produces an [`AnalyzedProgram`].
 //! 2. **Code Generation**: [`generate_rust`] takes the program and produces a Rust source string.
 
 #![allow(clippy::needless_doctest_main)]

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -58,6 +58,11 @@ pub enum GlossaError {
     /// **Syntax Error**: The parser failed to understand the code structure.
     ///
     /// This usually means a missing period `.`, unmatched braces `{}`, or invalid characters.
+    ///
+    /// # Example Output
+    /// ```text
+    /// Σφάλμα συντάξεως: expected statement
+    /// ```
     #[error("Σφάλμα συντάξεως: {message}")]
     #[diagnostic(code(glossa::parse))]
     ParseError {
@@ -73,6 +78,11 @@ pub enum GlossaError {
     /// **Semantic Error**: The code is syntactically valid but semantically meaningless.
     ///
     /// Examples include invalid type conversions, recursion limits, or logical paradoxes.
+    ///
+    /// # Example Output
+    /// ```text
+    /// Σφάλμα σημασίας: Τὸ «x» οὐχ ὡρίσθη
+    /// ```
     #[error("Σφάλμα σημασίας: {message}")]
     #[diagnostic(code(glossa::semantic))]
     SemanticError { message: String },
@@ -80,6 +90,11 @@ pub enum GlossaError {
     /// **Undefined Name**: You tried to use a variable or function that doesn't exist.
     ///
     /// Remember to define variables with `ἔστω` (let be) before using them.
+    ///
+    /// # Example Output
+    /// ```text
+    /// Ἄγνωστον ὄνομα: ξ
+    /// ```
     #[error("Ἄγνωστον ὄνομα: {name}")]
     #[diagnostic(code(glossa::undefined))]
     UndefinedName { name: String },
@@ -88,6 +103,11 @@ pub enum GlossaError {
     ///
     /// In Greek, the Subject must agree with the Verb in Person and Number.
     /// Adjectives must agree with Nouns in Gender, Number, and Case.
+    ///
+    /// # Example Output
+    /// ```text
+    /// Σφάλμα συμφωνίας: ὑποκείμενον (Singular) ἀλλὰ ῥῆμα (Plural)
+    /// ```
     #[error("Σφάλμα συμφωνίας: {message}")]
     #[diagnostic(code(glossa::agreement))]
     AgreementError { message: String },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,10 +96,11 @@
 //! * [`codegen`]: **The Translator** - Logic that turns Greek semantics into Rust code.
 //! * [`errors`]: **The Oracle** - Greek-native error messages and diagnostics using `miette`.
 //! * [`parser::grammar`]: **The Gatekeeper** - PEG parser that defines the valid syntax.
-//! * [`highlight`]: **The Scribe** - Semantic syntax highlighting for the CLI.
+//! * [`highlight`]: **The Painter** - Semantic syntax highlighting for the CLI.
 //! * [`morphology`]: **The Analyst** - Word analysis, lexicon lookup, and participle parsing.
 //! * [`parser`]: **The Builder** - Constructs the AST from the raw parse tree.
-//! * [`tools::report`]: **The Chronicler** - Report generation and statistics.
+//! * [`tools::report`]: **The Scribe** - Report generation and statistics.
+//! * [`tools::narrator`]: **The Bard** - Code-to-story translator for debugging and learning.
 //! * [`semantic`]: **The Assembler** - The slot-based engine that assembles sentences from words.
 //! * [`text`]: **The Sizer** - Text utilities and normalization (polytonic -> monotonic).
 

--- a/src/tools/cache.rs
+++ b/src/tools/cache.rs
@@ -66,9 +66,16 @@ impl Cache {
     ///
     /// # Why hash the path?
     ///
-    /// We hash the path instead of the content for speed. The content change
-    /// detection is handled by the filesystem timestamp check in [`is_valid`](Cache::is_valid).
-    /// This allows the key generation to be extremely fast (no file reading).
+    /// We hash the path instead of the content for speed. The cache key serves to identify
+    /// *which* file we are talking about, while [`is_valid`](Cache::is_valid) checks
+    /// *if* it has changed.
+    ///
+    /// This separation allows:
+    /// 1. Fast key generation (O(1) path operation vs O(N) file read).
+    /// 2. Simple dependency tracking (path is stable identifier).
+    ///
+    /// The content change detection relies on filesystem timestamps, which is standard practice
+    /// for build tools (like `make` or `cargo`).
     pub fn key(&self, input: &Path) -> String {
         use sha2::{Digest, Sha256};
 
@@ -109,9 +116,15 @@ impl Cache {
     ///
     /// # Logic
     ///
+    /// The cache is valid if and only if the cached executable exists AND
+    /// is newer than the source file.
+    ///
     /// ```text
-    /// Valid = Exists(Binary) AND Modified(Binary) > Modified(Source)
+    /// is_valid = exists(exe) && mtime(exe) > mtime(source)
     /// ```
+    ///
+    /// If the source file has been modified *after* the executable was built,
+    /// `mtime(source)` will be greater, making the condition false (invalid).
     pub fn is_valid(&self, input: &Path, cached_exe: &Path) -> bool {
         let source_modified = fs::metadata(input)
             .and_then(|m| m.modified())

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -1,11 +1,11 @@
-//! The Bard (ὁ Ῥαψῳδός) - Semantic Syntax Highlighter
+//! The Painter (ὁ Ζωγράφος) - Semantic Syntax Highlighter
 //!
 //! This module implements a semantic syntax highlighter that colors the source code
 //! based on the grammatical role of each word (Subject, Object, Verb, etc.).
 //!
 //! # Philosophy
 //!
-//! Unlike traditional syntax highlighters that use regexes, The Bard uses the
+//! Unlike traditional syntax highlighters that use regexes, The Painter uses the
 //! compiler's own morphological analysis to understand the code. It doesn't just
 //! know that a word is a noun; it knows if it's the **Subject** or the **Object**.
 //!

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -291,42 +291,51 @@ impl ReplContext {
     }
 
     fn execute(&mut self, input: &str) -> std::result::Result<ReplOutput, GlossaError> {
-        // Check binding count limit
+        // Safety: Prevent memory exhaustion from infinite binding history
+        // The REPL re-compiles the entire history on every line, so we must limit it.
         if self.bindings.len() > MAX_REPL_BINDINGS {
             return Err(GlossaError::semantic(
                 "REPL binding limit exceeded (50). Please use .καθαρός (.clear)",
             ));
         }
 
-        // Build full program with previous bindings
+        // 1. Construct the Virtual Source File
+        // We simulate a single persistent file by concatenating previous valid bindings
+        // with the new input. This allows variable references to resolve correctly.
         let mut full_source = self.bindings.join("\n");
         if !full_source.is_empty() {
             full_source.push('\n');
         }
         full_source.push_str(input);
 
-        // Check total size limit
+        // Safety: Check total size limit
         if full_source.len() > MAX_REPL_SOURCE_LEN {
             return Err(GlossaError::semantic(
                 "REPL source size limit exceeded (50KB). Please use .καθαρός (.clear)",
             ));
         }
 
-        // Try to compile
+        // 2. Compile the Virtual File
+        // If this fails (parse error, type error), the history remains unchanged.
         let ast = parse(&full_source)?;
         let analyzed = analyze_program(&ast)?;
 
+        // 3. Detect New Activity
+        // If the new input didn't add any executable statements (e.g. it was just a comment),
+        // we don't need to do anything.
         let new_count = analyzed.statements.len();
         if new_count <= self.statement_count {
             return Ok(ReplOutput::None);
         }
 
-        // Update scope and count
+        // 4. Update State
+        // The compilation succeeded, so we update our snapshot of the scope and statement count.
         self.last_scope = Some(analyzed.scope.clone());
         self.statement_count = new_count;
 
-        // Analyze what happened in the last statement
-        // We know it exists because new_count > old_count >= 0
+        // 5. Analyze Result
+        // We only care about the *last* statement, because previous statements have already
+        // been executed/processed in previous turns.
         let last_stmt = analyzed.statements.last().unwrap();
         match last_stmt {
             AnalyzedStatement::Binding { name, mutable, .. } => {
@@ -337,7 +346,8 @@ impl ReplContext {
                     .cloned()
                     .unwrap_or(GlossaType::Unknown);
 
-                // Add to bindings list so it persists
+                // Persistence: Variable definitions MUST be saved to history
+                // so they can be referenced in future lines.
                 self.bindings.push(input.to_string());
 
                 Ok(ReplOutput::Binding {
@@ -347,9 +357,10 @@ impl ReplContext {
                 })
             }
             _ => {
-                // For non-binding statements, we don't save them to bindings list
-                // because we don't want to re-execute side effects (print) every time.
-                // BUT: If the user defines a function or type, we SHOULD save it.
+                // Persistence Logic:
+                // - Side effects (print, expressions) are NOT saved. We don't want to
+                //   print "Hello" 50 times just because we defined a variable later.
+                // - Structural definitions (Types, Functions, Traits) MUST be saved.
                 if matches!(
                     last_stmt,
                     AnalyzedStatement::FunctionDef { .. }

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -1,4 +1,4 @@
-//! Report generation for ΓΛΩΣΣΑ
+//! The Scribe (ὁ Γραμματεύς) - Report generation for ΓΛΩΣΣΑ
 //!
 //! This module provides tools to generate human-readable reports and statistics
 //! for analyzed programs.


### PR DESCRIPTION
This PR addresses documentation gaps and naming inconsistencies in the tools module.

1.  **Resolved "The Bard" Identity Crisis**:
    *   Renamed `highlight` tool title to "The Painter" (was conflicting with "The Bard").
    *   Renamed `report` tool title to "The Scribe".
    *   Updated `lib.rs` module guide to match.
    *   `narrator` remains "The Bard".

2.  **Enhanced Cache Documentation**:
    *   Corrected the logic explanation in `src/tools/cache.rs` for `is_valid`.
    *   Added context on why path hashing is used.

3.  **Clarified REPL Logic**:
    *   Added internal comments to `ReplContext::execute` in `src/tools/repl.rs` to explain the "Virtual Source File" strategy and safety limits.

4.  **Visualized Errors**:
    *   Added Greek example output to `GlossaError` variants in `src/errors/mod.rs` to help developers understand the "Strict Grammaticus" persona.

Verified with `cargo doc --no-deps` and `cargo test tools`.

---
*PR created automatically by Jules for task [5144371987396012954](https://jules.google.com/task/5144371987396012954) started by @madmax983*