### PR TITLE
🗺️ Atlas: Enforce semantic module boundaries

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -39,10 +39,11 @@ use super::expressions::{
     literal_to_analyzed_expr, literal_to_type,
 };
 use super::patterns::detect_iterator_pattern;
-use super::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, AssembledStatement, GlossaType, Scope,
-};
 use crate::ast::Expr;
+use crate::semantic::assembly_model::AssembledStatement;
+use crate::semantic::model::{AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement};
+use crate::semantic::resolver::Scope;
+use crate::semantic::types::GlossaType;
 use crate::errors::GlossaError;
 use crate::morphology::{self};
 use crate::semantic::{Constituent, Literal};

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -40,12 +40,12 @@ use super::expressions::{
 };
 use super::patterns::detect_iterator_pattern;
 use crate::ast::Expr;
+use crate::errors::GlossaError;
+use crate::morphology::{self};
 use crate::semantic::assembly_model::AssembledStatement;
 use crate::semantic::model::{AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement};
 use crate::semantic::resolver::Scope;
 use crate::semantic::types::GlossaType;
-use crate::errors::GlossaError;
-use crate::morphology::{self};
 use crate::semantic::{Constituent, Literal};
 
 /// Convert an AssembledStatement to an AnalyzedStatement

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -12,8 +12,12 @@
 //! 2. **Recursive Analysis**: Nested expressions (args inside a function call) are analyzed
 //!    recursively to produce an [`AnalyzedExpr`]. See [`analyze_argument_expr`].
 
-use super::{AnalyzedExpr, AnalyzedExprKind, Assembler, GlossaType, Literal, Scope};
 use crate::ast::{Expr, Statement};
+use crate::semantic::assembler::Assembler;
+use crate::semantic::assembly_model::Literal;
+use crate::semantic::model::{AnalyzedExpr, AnalyzedExprKind};
+use crate::semantic::resolver::Scope;
+use crate::semantic::types::GlossaType;
 use crate::errors::GlossaError;
 use crate::morphology::{self, DisambiguationContext, analyze_article, disambiguate, resolve_best};
 
@@ -25,7 +29,7 @@ use crate::morphology::{self, DisambiguationContext, analyze_article, disambigua
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use glossa::semantic::{Scope, AnalyzedExprKind, GlossaType};
 /// use glossa::semantic::expressions::analyze_argument_expr;
 /// use glossa::ast::{Expr, Word};
@@ -45,7 +49,7 @@ use crate::morphology::{self, DisambiguationContext, analyze_article, disambigua
 /// let var_analyzed = analyze_argument_expr(&var_expr, &scope_with_var).unwrap();
 /// assert!(matches!(var_analyzed.expr, AnalyzedExprKind::Variable(name) if name == "x"));
 /// ```
-pub fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr, GlossaError> {
+pub(crate) fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr, GlossaError> {
     analyze_argument_expr_recursive(expr, scope, 0)
 }
 

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -13,13 +13,13 @@
 //!    recursively to produce an [`AnalyzedExpr`]. See [`analyze_argument_expr`].
 
 use crate::ast::{Expr, Statement};
+use crate::errors::GlossaError;
+use crate::morphology::{self, DisambiguationContext, analyze_article, disambiguate, resolve_best};
 use crate::semantic::assembler::Assembler;
 use crate::semantic::assembly_model::Literal;
 use crate::semantic::model::{AnalyzedExpr, AnalyzedExprKind};
 use crate::semantic::resolver::Scope;
 use crate::semantic::types::GlossaType;
-use crate::errors::GlossaError;
-use crate::morphology::{self, DisambiguationContext, analyze_article, disambiguate, resolve_best};
 
 /// Analyze an argument expression (could be literal, variable, or nested call)
 ///
@@ -49,7 +49,10 @@ use crate::morphology::{self, DisambiguationContext, analyze_article, disambigua
 /// let var_analyzed = analyze_argument_expr(&var_expr, &scope_with_var).unwrap();
 /// assert!(matches!(var_analyzed.expr, AnalyzedExprKind::Variable(name) if name == "x"));
 /// ```
-pub(crate) fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> Result<AnalyzedExpr, GlossaError> {
+pub(crate) fn analyze_argument_expr(
+    expr: &Expr,
+    scope: &Scope,
+) -> Result<AnalyzedExpr, GlossaError> {
     analyze_argument_expr_recursive(expr, scope, 0)
 }
 

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -38,7 +38,7 @@ pub(crate) mod assembly_model;
 pub(crate) mod conversion;
 #[cfg(test)]
 mod conversion_tests;
-pub mod expressions;
+pub(crate) mod expressions;
 pub(crate) mod model;
 pub(crate) mod patterns;
 mod resolver;


### PR DESCRIPTION
This PR refactors the `semantic` module to improve architectural boundaries and prevent circular dependencies.

**Changes:**
- **Encapsulation:** `src/semantic/expressions.rs` is now `pub(crate)` instead of `pub`, hiding internal implementation details.
- **Import Cleanup:** Explicit absolute imports (`crate::semantic::...`) are used in `expressions.rs` and `conversion.rs` instead of relative `super::` imports. This breaks the dependency on `mod.rs` re-exports and prevents "The Knot" (circular coupling).
- **Doc Tests:** Internal doc tests in `expressions.rs` are marked `ignore` as they cannot run from outside the crate.

**Verification:**
- `cargo check` passes.
- `cargo test` passes (all unit tests).
- Code review approved the architectural improvements.

---
*PR created automatically by Jules for task [1260648360561539158](https://jules.google.com/task/1260648360561539158) started by @madmax983*