### PR TITLE
🔒 Warden: Secure Array Indexing against 32-bit Truncation

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1195,7 +1195,8 @@ fn generate_collection_index(array: &AnalyzedExpr, index: &AnalyzedExpr) -> Toke
             if idx < 0 {
                 panic!("Negative index access: {}", idx);
             }
-            #array_tokens[idx as usize]
+            let u_idx = usize::try_from(idx).expect("Index too large for platform memory");
+            #array_tokens[u_idx]
         }
     }
 }

--- a/tests/collection_tests.rs
+++ b/tests/collection_tests.rs
@@ -70,7 +70,7 @@ fn test_numeric_index() {
     let code = compile("ξ [1, 2, 3] ἔστω. ξ[0] λέγε.");
     // Should have index cast to usize
     assert!(
-        code.contains("as usize"),
+        code.contains("try_from"),
         "Expected index cast to usize in: {}",
         code
     );
@@ -166,7 +166,7 @@ fn test_ordinal_index_first() {
     let code = compile("ξ [10, 20, 30] ἔστω. ξ πρῶτον λέγε.");
     // First element = index 0, cast to usize
     assert!(
-        code.contains("as usize"),
+        code.contains("try_from"),
         "Expected usize cast in: {}",
         code
     );
@@ -191,7 +191,7 @@ fn test_ordinal_index_third() {
     let code = compile("ξ [10, 20, 30] ἔστω. ξ τρίτον λέγε.");
     // Third element = index 2 (0-indexed), cast to usize
     assert!(
-        code.contains("as usize"),
+        code.contains("try_from"),
         "Expected usize cast in: {}",
         code
     );

--- a/tests/warden_index_overflow.rs
+++ b/tests/warden_index_overflow.rs
@@ -1,4 +1,3 @@
-
 //! Warden Exploit Test: Index Truncation
 //!
 //! This test demonstrates the vulnerability where large `i64` indices are truncated
@@ -20,7 +19,7 @@ fn test_index_truncation_simulation() {
     assert_eq!(truncated_index, 1);
 
     // If we had an array of size 2, this would access index 1 instead of panicking!
-    let arr = vec![10, 20];
+    let arr = [10, 20];
     assert_eq!(arr[truncated_index], 20); // Should have panicked!
 
     // The Fix: using try_from

--- a/tests/warden_index_overflow.rs
+++ b/tests/warden_index_overflow.rs
@@ -1,0 +1,41 @@
+
+//! Warden Exploit Test: Index Truncation
+//!
+//! This test demonstrates the vulnerability where large `i64` indices are truncated
+//! when cast to `usize` on 32-bit platforms, potentially allowing out-of-bounds access.
+
+#[test]
+fn test_index_truncation_simulation() {
+    // Simulate a 32-bit environment
+    // Max u32 is 4,294,967,295
+
+    // A large index that wraps to 1 in 32-bit
+    // 2^32 + 1 = 4,294,967,297
+    let large_index: i64 = 4_294_967_297;
+
+    // The vulnerable pattern: `idx as usize` (simulated as cast to u32 then to usize)
+    let truncated_index = (large_index as u32) as usize;
+
+    // Demonstrate that truncation happens
+    assert_eq!(truncated_index, 1);
+
+    // If we had an array of size 2, this would access index 1 instead of panicking!
+    let arr = vec![10, 20];
+    assert_eq!(arr[truncated_index], 20); // Should have panicked!
+
+    // The Fix: using try_from
+    let safe_index = usize::try_from(large_index);
+
+    if cfg!(target_pointer_width = "32") {
+        // On actual 32-bit system, this should fail
+        assert!(safe_index.is_err());
+    } else {
+        // On 64-bit system, it might succeed if memory allows, but try_from is still correct.
+        // However, standard `as usize` on 64-bit preserves value, so no truncation there.
+        // The point is that on 32-bit, `try_from` returns Err, while `as usize` returns junk.
+
+        // Let's simulate the check we want to insert
+        let check = u32::try_from(large_index); // Simulate checking against 32-bit limit
+        assert!(check.is_err());
+    }
+}


### PR DESCRIPTION
Identified and fixed a potential integer truncation vulnerability in array index generation. On 32-bit platforms, casting a large `i64` index to `usize` using `as` would silently truncate the upper bits, potentially allowing out-of-bounds access logic bypass. Replaced this with `usize::try_from` which panics safely on overflow. Added a reproduction test case.

---
*PR created automatically by Jules for task [8252710256837696596](https://jules.google.com/task/8252710256837696596) started by @madmax983*