### PR TITLE
👺 Havoc: Enforce strict length limits on strings and identifiers

### DIFF
--- a/src/semantic/assembler.rs
+++ b/src/semantic/assembler.rs
@@ -116,6 +116,8 @@ pub(crate) const MAX_PARTICIPLES: usize = 256;
 pub(crate) const MAX_UNWRAPS: usize = 256;
 pub(crate) const MAX_OPERATORS: usize = 256;
 pub(crate) const MAX_BLOCKS: usize = 256;
+pub(crate) const MAX_STRING_LITERAL_LENGTH: usize = 65536;
+pub(crate) const MAX_IDENTIFIER_LENGTH: usize = 256;
 
 /// The slot-based assembler
 ///
@@ -199,6 +201,13 @@ impl Assembler {
         original: &str,
         normalized: &str,
     ) -> Result<(), AssemblyError> {
+        if original.len() > MAX_IDENTIFIER_LENGTH {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Identifier Length".to_string(),
+                max: MAX_IDENTIFIER_LENGTH,
+            });
+        }
+
         if self.check_special_markers(normalized, original) {
             return Ok(());
         }
@@ -244,6 +253,12 @@ impl Assembler {
     /// asm.feed_string("χαῖρε".to_string()).unwrap();
     /// ```
     pub fn feed_string(&mut self, value: String) -> Result<(), AssemblyError> {
+        if value.len() > MAX_STRING_LITERAL_LENGTH {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "String Literal Length".to_string(),
+                max: MAX_STRING_LITERAL_LENGTH,
+            });
+        }
         if self.state.literals.len() >= MAX_LITERALS {
             return Err(AssemblyError::LimitExceeded {
                 resource: "Literals".to_string(),
@@ -443,6 +458,12 @@ impl Assembler {
         analysis: &crate::morphology::ParticipleAnalysis,
         original: &str,
     ) -> Result<(), AssemblyError> {
+        if original.len() > MAX_IDENTIFIER_LENGTH {
+            return Err(AssemblyError::LimitExceeded {
+                resource: "Identifier Length".to_string(),
+                max: MAX_IDENTIFIER_LENGTH,
+            });
+        }
         if self.state.participles.len() >= MAX_PARTICIPLES {
             return Err(AssemblyError::LimitExceeded {
                 resource: "Participles".to_string(),

--- a/tests/havoc_identifier_dos.rs
+++ b/tests/havoc_identifier_dos.rs
@@ -1,6 +1,6 @@
 use glossa::ast::{Clause, Expr, Statement, Word};
 use glossa::errors::GlossaError;
-use glossa::semantic::{assemble_statement, AssemblyError};
+use glossa::semantic::{AssemblyError, assemble_statement};
 
 #[test]
 fn test_identifier_length_limit() {

--- a/tests/havoc_identifier_dos.rs
+++ b/tests/havoc_identifier_dos.rs
@@ -1,0 +1,33 @@
+use glossa::ast::{Statement, Clause, Expr, Word};
+use glossa::semantic::{assemble_statement, AssemblyError};
+use glossa::errors::GlossaError;
+
+#[test]
+fn test_identifier_length_limit() {
+    let limit = 256;
+    let huge_ident = "a".repeat(limit + 1);
+
+    // Create a statement: huge_ident.
+    let stmt = Statement::Regular {
+        clauses: vec![Clause {
+            expressions: vec![
+                Expr::Word(Word::new(huge_ident)),
+            ]
+        }],
+        is_query: false,
+        is_propagate: false,
+    };
+
+    // This should fail with LimitExceeded
+    let result = assemble_statement(&stmt);
+
+    assert!(result.is_err(), "Assembler accepted identifier longer than limit");
+
+    match result {
+        Err(GlossaError::AssemblyError(AssemblyError::LimitExceeded { resource, max })) => {
+            assert_eq!(resource, "Identifier Length");
+            assert_eq!(max, 256);
+        }
+        _ => panic!("Expected LimitExceeded error, got {:?}", result),
+    }
+}

--- a/tests/havoc_identifier_dos.rs
+++ b/tests/havoc_identifier_dos.rs
@@ -1,6 +1,6 @@
-use glossa::ast::{Statement, Clause, Expr, Word};
-use glossa::semantic::{assemble_statement, AssemblyError};
+use glossa::ast::{Clause, Expr, Statement, Word};
 use glossa::errors::GlossaError;
+use glossa::semantic::{assemble_statement, AssemblyError};
 
 #[test]
 fn test_identifier_length_limit() {
@@ -10,9 +10,7 @@ fn test_identifier_length_limit() {
     // Create a statement: huge_ident.
     let stmt = Statement::Regular {
         clauses: vec![Clause {
-            expressions: vec![
-                Expr::Word(Word::new(huge_ident)),
-            ]
+            expressions: vec![Expr::Word(Word::new(huge_ident))],
         }],
         is_query: false,
         is_propagate: false,
@@ -21,7 +19,50 @@ fn test_identifier_length_limit() {
     // This should fail with LimitExceeded
     let result = assemble_statement(&stmt);
 
-    assert!(result.is_err(), "Assembler accepted identifier longer than limit");
+    assert!(
+        result.is_err(),
+        "Assembler accepted identifier longer than limit"
+    );
+
+    match result {
+        Err(GlossaError::AssemblyError(AssemblyError::LimitExceeded { resource, max })) => {
+            assert_eq!(resource, "Identifier Length");
+            assert_eq!(max, 256);
+        }
+        _ => panic!("Expected LimitExceeded error, got {:?}", result),
+    }
+}
+
+#[test]
+fn test_participle_length_limit() {
+    let limit = 256;
+    // Create a huge participle: "aaaa..." + "μενος"
+    // It must effectively fail the length check in feed_participle
+    // But first, we need to ensure it IS detected as a participle.
+    // The suffix "μενος" (passive participle) usually triggers detection.
+    let suffix = "μενος";
+    let prefix_len = limit + 1 - suffix.len() + 10; // Ensure it's comfortably over the limit
+    let huge_participle = "α".repeat(prefix_len) + suffix;
+
+    // Verify it is indeed over the limit
+    assert!(huge_participle.len() > limit);
+
+    // Create a statement: huge_participle.
+    let stmt = Statement::Regular {
+        clauses: vec![Clause {
+            expressions: vec![Expr::Word(Word::new(huge_participle))],
+        }],
+        is_query: false,
+        is_propagate: false,
+    };
+
+    // This should fail with LimitExceeded
+    let result = assemble_statement(&stmt);
+
+    assert!(
+        result.is_err(),
+        "Assembler accepted participle longer than limit"
+    );
 
     match result {
         Err(GlossaError::AssemblyError(AssemblyError::LimitExceeded { resource, max })) => {

--- a/tests/havoc_string_dos.rs
+++ b/tests/havoc_string_dos.rs
@@ -1,6 +1,6 @@
-use glossa::ast::{Statement, Clause, Expr};
-use glossa::semantic::{assemble_statement, AssemblyError};
+use glossa::ast::{Clause, Expr, Statement};
 use glossa::errors::GlossaError;
+use glossa::semantic::{AssemblyError, assemble_statement};
 
 #[test]
 fn test_string_literal_length_limit() {
@@ -11,9 +11,7 @@ fn test_string_literal_length_limit() {
     // Note: assemble_statement processes expressions. A string literal is a valid expression.
     let stmt = Statement::Regular {
         clauses: vec![Clause {
-            expressions: vec![
-                Expr::StringLiteral(huge_string),
-            ]
+            expressions: vec![Expr::StringLiteral(huge_string)],
         }],
         is_query: false,
         is_propagate: false,
@@ -22,7 +20,10 @@ fn test_string_literal_length_limit() {
     // This should fail with LimitExceeded
     let result = assemble_statement(&stmt);
 
-    assert!(result.is_err(), "Assembler accepted string literal longer than limit");
+    assert!(
+        result.is_err(),
+        "Assembler accepted string literal longer than limit"
+    );
 
     match result {
         Err(GlossaError::AssemblyError(AssemblyError::LimitExceeded { resource, max })) => {

--- a/tests/havoc_string_dos.rs
+++ b/tests/havoc_string_dos.rs
@@ -1,0 +1,34 @@
+use glossa::ast::{Statement, Clause, Expr};
+use glossa::semantic::{assemble_statement, AssemblyError};
+use glossa::errors::GlossaError;
+
+#[test]
+fn test_string_literal_length_limit() {
+    let limit = 65536;
+    let huge_string = "a".repeat(limit + 1);
+
+    // Create a statement: "huge_string" λέγε.
+    // Note: assemble_statement processes expressions. A string literal is a valid expression.
+    let stmt = Statement::Regular {
+        clauses: vec![Clause {
+            expressions: vec![
+                Expr::StringLiteral(huge_string),
+            ]
+        }],
+        is_query: false,
+        is_propagate: false,
+    };
+
+    // This should fail with LimitExceeded
+    let result = assemble_statement(&stmt);
+
+    assert!(result.is_err(), "Assembler accepted string literal longer than limit");
+
+    match result {
+        Err(GlossaError::AssemblyError(AssemblyError::LimitExceeded { resource, max })) => {
+            assert_eq!(resource, "String Literal Length");
+            assert_eq!(max, 65536);
+        }
+        _ => panic!("Expected LimitExceeded error, got {:?}", result),
+    }
+}


### PR DESCRIPTION
Implemented strict length limits for string literals (65,536 bytes) and identifiers (256 bytes) in the semantic Assembler to prevent Denial of Service (DoS) via memory exhaustion. 

Added regression tests:
- `tests/havoc_string_dos.rs`
- `tests/havoc_identifier_dos.rs`

These tests verify that the Assembler rejects inputs exceeding the limits with `AssemblyError::LimitExceeded`.

---
*PR created automatically by Jules for task [118830920362082909](https://jules.google.com/task/118830920362082909) started by @madmax983*