### PR TITLE
docs: Fix broken examples in README and Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ We define the shape of our world with `εἶδος` (form/type).
 We guide the flow of fate with `εἰ` (if) and `διὰ` (through/for).
 
 ```glossa
+// Let age be 80
+ἡλικία 80 ἔστω.
+
 // If age is greater than 50...
 εἰ ἡλικία 50 μεῖζον ᾖ,
     «σοφός» λέγε.

--- a/examples/quickstart.γλ
+++ b/examples/quickstart.γλ
@@ -15,10 +15,26 @@
 // Say the name
 ὄνομα λέγε.
 
-// Chapter 4: Logic
-// If x is greater than 5...
-εἰ ξ 5 μεῖζον ᾖ,
-    «μέγας» λέγε.
+// Chapter 3: The Structure (Types)
+// Define a User type
+εἶδος Χρήστης ὁρίζειν {
+    ὄνομα ὀνόματος.    // String
+    ἡλικία ἀριθμοῦ. // i64
+}.
+
+// Create an instance
+χρήστης νέον Χρήστης
+    «Πλάτων»
+    80
+ἔστω.
+
+// Chapter 4: The Logic (Control Flow)
+// If age is greater than 50...
+// (We define a variable for the comparison)
+ἡλικία 80 ἔστω.
+
+εἰ ἡλικία 50 μεῖζον ᾖ,
+    «σοφός» λέγε.
 
 // Loops
 // Create a list of numbers


### PR DESCRIPTION
Fixed broken examples in README.md and examples/quickstart.γλ to ensure they compile and run correctly. Addressed issues with undefined variables and unsupported struct field access in control flow.

---
*PR created automatically by Jules for task [7933619177694139054](https://jules.google.com/task/7933619177694139054) started by @madmax983*