### PR TITLE
📜 Codex: ADR 013 & Architecture Diagram Update

### DIFF
--- a/docs/adr/013-nova-experience.md
+++ b/docs/adr/013-nova-experience.md
@@ -1,0 +1,30 @@
+# 13. The Nova Experience
+
+Date: 2025-02-23
+Status: Accepted
+
+## Context
+
+The ΓΛΩΣΣΑ compiler introduces several novel concepts that can be challenging for new developers:
+1.  **Ancient Greek Grammar**: Using case endings (Nominative, Accusative, Dative) instead of word order.
+2.  **Architectural Complexity**: Understanding how types and traits interact in large codebases.
+3.  **Unique Syntax**: Features like "The Perfect Participle" (memoized closures) and "The Optative Mood" (Optional types).
+
+Without specialized tooling, the learning curve is steep, and debugging semantic misunderstandings (e.g., "Why is my subject being parsed as an object?") is difficult.
+
+## Decision
+
+We have implemented a suite of Developer Experience (DX) tools under the codename **Nova**. These tools are integrated directly into the compiler binary but guarded by the `nova` feature flag to manage binary size.
+
+The Nova suite includes:
+
+*   **The Mentor (ὁ Μέντωρ)**: An interactive CLI tutorial that guides users through the language basics with live verification.
+*   **The Cartographer**: A visualization engine that generates Mermaid.js Class Diagrams from the analyzed program structure, revealing the relationships between Types and Traits.
+*   **The Mosaic**: A semantic assembly visualizer that deconstructs statements into their grammatical constituents (Subject, Verb, Object, Indirect Object), proving the "free word order" capabilities.
+
+## Consequences
+
+*   **Improved Learnability**: Users can interactively learn the language and visualize how the compiler "thinks".
+*   **Architectural Transparency**: Developers can generate maps of their code structure automatically.
+*   **Debugging**: The Mosaic tool provides immediate feedback on how the Assembler is interpreting complex sentences.
+*   **Binary Size**: Including these tools increases the compiler binary size. Therefore, they are opt-in via the `--features nova` flag.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,10 +31,18 @@ C4Container
     Container(parser, "Parser", "src/parser", "Constructs AST, enforcing recursion limits (max depth 500)")
     Container(morphology, "Declension Resolver", "src/morphology", "Analyzes case, gender, number, and resolves agreement")
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
-    Container(highlight, "Highlighter", "src/tools/highlight.rs", "Semantic syntax highlighting")
-    Container(narrator, "Narrator", "src/tools/narrator.rs", "Generates English narrative from AST")
-    Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
-    Container(codegen, "Code Generator", "src/codegen/mod.rs", "Generates Rust source code")
+
+    Container_Boundary(tools, "Developer Experience (Nova)") {
+        Container(highlight, "Highlighter", "src/tools/highlight.rs", "Semantic syntax highlighting")
+        Container(narrator, "Narrator", "src/tools/narrator.rs", "Generates English narrative from AST")
+        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+        Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
+        Container(mentor, "Mentor", "src/tools/mentor.rs", "Interactive Tutorial Mode")
+        Container(mosaic, "Mosaic", "src/tools/mosaic.rs", "Visualizes Semantic Assembly")
+        Container(tester, "Tester", "src/tools/tester.rs", "Runs built-in unit tests")
+    }
+
+    Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
 
     Rel(lexer, parser, "Stream<Token>")
     Rel(parser, morphology, "AST (Unresolved)")
@@ -42,6 +50,10 @@ C4Container
     Rel(morphology, semantic, "AST (Resolved Morphology)")
     Rel(semantic, report, "Analyzed Program")
     Rel(semantic, narrator, "Analyzed Program")
+    Rel(semantic, cartographer, "Analyzed Program")
+    Rel(semantic, mentor, "Analyzed Program")
+    Rel(semantic, mosaic, "Analyzed Program")
+    Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 ```
 


### PR DESCRIPTION
🧠 **Decision:** Recorded the "Nova Experience" initiative (Cartographer, Mentor, Mosaic) in `docs/adr/013-nova-experience.md`.
🗺️ **Visuals:** Updated `docs/architecture.md` C4 Container diagram to include new tools (`cartographer`, `mentor`, `mosaic`, `tester`) and fixed the `codegen` path. Confirmed C4 Component diagram matches `assembler.rs` logic.
🔗 **Link:** See `docs/adr/013-nova-experience.md`.

---
*PR created automatically by Jules for task [4993392002999134760](https://jules.google.com/task/4993392002999134760) started by @madmax983*