### PR TITLE
🛡️ Sentry: Add unit tests for morphology matcher

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -25,3 +25,7 @@
 ## [Silent Token Swallowing in Assembler Fallback]
 **Learning:** In `src/semantic/assembler.rs`, the fallback logic for unknown case tokens was silently swallowing tokens if the object slot was already full. It would attempt to set `state.object`, find it occupied, and then do nothing (returning `Ok(())`), leading to data loss.
 **Action:** Changed fallback logic to return `Err(AssemblyError::DoubleObject)` when the object slot is full, ensuring no tokens are silently ignored.
+
+## [Constraint] Empty Stem in Suffix Matching
+**Learning:** `match_suffix` in `src/morphology/matcher.rs` explicitly skips matches if the resulting stem is empty. This prevents spurious matches (e.g., word "o" matching suffix "-o"), but means words that coincide with their suffix (e.g., article "o") must be handled by the lexicon or explicit checks, not morphological rules.
+**Action:** When implementing morphology rules, assume `match_suffix` requires `word.len() > suffix.len()`. Add explicit test cases for this constraint to document it as intended behavior.

--- a/src/morphology/matcher.rs
+++ b/src/morphology/matcher.rs
@@ -37,3 +37,149 @@ pub fn match_suffix<'w, 'p, T, S, F>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_match() {
+        let patterns = vec![("suffix", 1)];
+        let mut matched = false;
+
+        match_suffix(
+            "wordsuffix",
+            &patterns,
+            |p| p.0,
+            |stem, &(_, val)| {
+                assert_eq!(stem, "word");
+                assert_eq!(val, 1);
+                matched = true;
+                true
+            },
+        );
+
+        assert!(matched, "Should have matched suffix");
+    }
+
+    #[test]
+    fn test_multiple_matches() {
+        // Matches should be found in order if callback returns true
+        let patterns = vec![("ix", 1), ("fix", 2), ("suffix", 3)];
+        let mut matches = Vec::new();
+
+        match_suffix(
+            "suffix",
+            &patterns,
+            |p| p.0,
+            |stem, &(_, val)| {
+                matches.push((stem.to_string(), val));
+                true // Continue searching
+            },
+        );
+
+        // "suffix" ends with "ix" -> stem "suff", val 1
+        // "suffix" ends with "fix" -> stem "suf", val 2
+        // "suffix" ends with "suffix" -> stem "", val 3 -> SKIPPED (empty stem)
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0], ("suff".to_string(), 1));
+        assert_eq!(matches[1], ("suf".to_string(), 2));
+    }
+
+    #[test]
+    fn test_early_exit() {
+        let patterns = vec![("ix", 1), ("fix", 2)];
+        let mut matches = Vec::new();
+
+        match_suffix(
+            "suffix",
+            &patterns,
+            |p| p.0,
+            |stem, &(_, val)| {
+                matches.push((stem.to_string(), val));
+                false // Stop searching after first match
+            },
+        );
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0], ("suff".to_string(), 1));
+    }
+
+    #[test]
+    fn test_empty_stem_check() {
+        // This is a crucial constraint: match_suffix ignores matches where stem becomes empty
+        let patterns = vec![("word", 1)];
+        let mut matched = false;
+
+        match_suffix(
+            "word",
+            &patterns,
+            |p| p.0,
+            |_, _| {
+                matched = true;
+                true
+            },
+        );
+
+        assert!(!matched, "Should NOT match when stem is empty");
+    }
+
+    #[test]
+    fn test_unicode_suffix() {
+        // Test with Greek characters
+        let patterns = vec![("ος", "nominative")];
+        let mut matches = Vec::new();
+
+        match_suffix(
+            "λογος",
+            &patterns,
+            |p| p.0,
+            |stem, &(_, case)| {
+                matches.push((stem.to_string(), case));
+                true
+            },
+        );
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0], ("λογ".to_string(), "nominative"));
+    }
+
+    #[test]
+    fn test_no_match() {
+        let patterns = vec![("a", 1), ("b", 2)];
+        let mut matched = false;
+
+        match_suffix(
+            "c",
+            &patterns,
+            |p| p.0,
+            |_, _| {
+                matched = true;
+                true
+            },
+        );
+
+        assert!(!matched, "Should not match any pattern");
+    }
+
+    #[test]
+    fn test_callback_mutable_state() {
+        let patterns = vec![("a", 1), ("ba", 2)];
+        let mut count = 0;
+
+        match_suffix(
+            "aba",
+            &patterns,
+            |p| p.0,
+            |_, _| {
+                count += 1;
+                true
+            },
+        );
+
+        // "aba" ends with "a" -> stem "ab" -> match
+        // "aba" ends with "ba" -> stem "a" -> match
+        assert_eq!(count, 2);
+    }
+}


### PR DESCRIPTION
Added unit tests to `src/morphology/matcher.rs` to ensure correctness of the `match_suffix` utility.
This covers a previously untested critical path in the morphology engine.
Tests confirm that `match_suffix` correctly skips matches that result in an empty stem.
Also updated the Sentry journal with this finding.

---
*PR created automatically by Jules for task [17422863259787096884](https://jules.google.com/task/17422863259787096884) started by @madmax983*