### PR TITLE
fix: Prevent stack overflow in semantic analysis via recursion depth limit

### DIFF
--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -10,7 +10,7 @@
 use super::expressions::get_first_word;
 use super::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, analyze_statement,
-    assemble_statement, convert_assembled_to_analyzed,
+    assemble_statement, convert_assembled_to_analyzed, MAX_SEMANTIC_RECURSION_DEPTH,
 };
 use crate::ast::{Clause, Expr, Statement};
 use crate::errors::GlossaError;
@@ -21,6 +21,7 @@ use crate::morphology::lexicon;
 pub fn analyze_control_flow(
     stmt: &Statement,
     scope: &mut Scope,
+    depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     // Note: Function definitions are handled in `mod.rs` before calling this.
 
@@ -33,22 +34,22 @@ pub fn analyze_control_flow(
 
     // Conditional: εἰ/ἐάν condition, body [, εἰ δὲ μή, else_body]
     if lexicon::is_conditional_particle(&normalized) {
-        return parse_conditional(stmt, scope, 0);
+        return parse_conditional(stmt, scope, depth);
     }
 
     // While loop: ἕως condition, body
     if normalized == "εως" {
-        return parse_while_loop(stmt, scope);
+        return parse_while_loop(stmt, scope, depth);
     }
 
     // For loop with range: ἀπὸ start μέχρι/ἕως end, body
     if normalized == "απο" {
-        return parse_for_range_loop(stmt, scope);
+        return parse_for_range_loop(stmt, scope, depth);
     }
 
     // For loop with iteration: διὰ collection, body
     if normalized == "δια" {
-        return parse_for_iteration_loop(stmt, scope);
+        return parse_for_iteration_loop(stmt, scope, depth);
     }
 
     if lexicon::is_loop_particle(&normalized) {
@@ -57,7 +58,7 @@ pub fn analyze_control_flow(
     }
 
     if lexicon::is_match_particle(&normalized) {
-        return parse_match_expression(stmt, scope);
+        return parse_match_expression(stmt, scope, depth);
     }
 
     // Return: δός (give)
@@ -84,6 +85,7 @@ pub fn analyze_control_flow(
 fn parse_while_loop(
     stmt: &Statement,
     scope: &mut Scope,
+    depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -105,7 +107,7 @@ fn parse_while_loop(
     };
 
     // Analyze body using unified helper
-    let body_analyzed = analyze_statement(&body_stmt, scope)?;
+    let body_analyzed = analyze_statement(&body_stmt, scope, depth + 1)?;
 
     Ok(Some(AnalyzedStatement::While {
         condition: Box::new(condition_expr),
@@ -118,6 +120,7 @@ fn parse_while_loop(
 fn parse_for_range_loop(
     stmt: &Statement,
     scope: &mut Scope,
+    depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -242,7 +245,7 @@ fn parse_for_range_loop(
         let mut loop_scope = scope.enter_scope();
         loop_scope.define(variable.clone(), GlossaType::Number);
 
-        analyze_statement(&body_stmt, &mut loop_scope)?
+        analyze_statement(&body_stmt, &mut loop_scope, depth + 1)?
     };
 
     Ok(Some(AnalyzedStatement::For {
@@ -258,6 +261,7 @@ fn parse_for_range_loop(
 fn parse_for_iteration_loop(
     stmt: &Statement,
     scope: &mut Scope,
+    depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -328,7 +332,7 @@ fn parse_for_iteration_loop(
         // TODO: Infer element type from collection type
         loop_scope.define(variable.clone(), GlossaType::String);
 
-        analyze_statement(&body_stmt, &mut loop_scope)?
+        analyze_statement(&body_stmt, &mut loop_scope, depth + 1)?
     };
 
     Ok(Some(AnalyzedStatement::For {
@@ -344,6 +348,7 @@ fn parse_for_iteration_loop(
 fn parse_match_expression(
     stmt: &Statement,
     scope: &mut Scope,
+    depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().is_empty() {
         return Err(GlossaError::semantic(
@@ -391,7 +396,7 @@ fn parse_match_expression(
                 is_query: false,
                 is_propagate: false,
             };
-            let body_analyzed = analyze_statement(&body_stmt, scope)?;
+            let body_analyzed = analyze_statement(&body_stmt, scope, depth + 1)?;
 
             arms.push((pattern, body_analyzed));
         }
@@ -566,18 +571,16 @@ fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, G
     Err(GlossaError::semantic("Invalid match pattern"))
 }
 
-const MAX_CONTROL_FLOW_DEPTH: usize = 100;
-
 /// Parse a conditional statement (εἰ/ἐάν)
 fn parse_conditional(
     stmt: &Statement,
     scope: &mut Scope,
     depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if depth > MAX_CONTROL_FLOW_DEPTH {
+    if depth > MAX_SEMANTIC_RECURSION_DEPTH {
         return Err(GlossaError::LimitExceeded {
             resource: "Control flow depth".into(),
-            max: MAX_CONTROL_FLOW_DEPTH,
+            max: MAX_SEMANTIC_RECURSION_DEPTH,
         });
     }
 
@@ -605,7 +608,7 @@ fn parse_conditional(
             is_query: false,
             is_propagate: false,
         };
-        analyze_statement(&stmt, scope)?
+        analyze_statement(&stmt, scope, depth + 1)?
     };
 
     // Check for else/elif clause
@@ -619,7 +622,7 @@ fn parse_conditional(
                 is_query: false,
                 is_propagate: false,
             };
-            Some(analyze_statement(&stmt, scope)?)
+            Some(analyze_statement(&stmt, scope, depth + 1)?)
         }
         // Check if it's "εἰ" or "ἐάν" (elif)
         else if check_conditional_start(second_expr) {

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -124,7 +124,8 @@ pub fn analyze_trait_definition(
                     }
                     // Properly analyze statements in the body using unified helper
                     for body_stmt in body_stmts {
-                        analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
+                        // Start depth at 0 for new method scope context
+                        analyzed_body.extend(analyze_statement(body_stmt, &mut scope, 0)?);
                     }
                 }
                 Some(analyzed_body)
@@ -218,7 +219,8 @@ pub fn analyze_trait_impl(
 
             // Analyze the method body using unified helper
             for body_stmt in &method.body {
-                analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
+                // Start depth at 0 for new method scope
+                analyzed_body.extend(analyze_statement(body_stmt, &mut scope, 0)?);
             }
         }
 
@@ -288,6 +290,7 @@ pub fn resolve_type_name(name: &str, scope: &Scope) -> Result<GlossaType, Glossa
 pub fn parse_function_definition(
     stmt: &Statement,
     scope: &mut Scope,
+    depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     // The middle dot (·) separates expressions within a clause
     // Structure: expr1 · expr2 where expr1 is "name ὁρίζειν [params]" and expr2 is the body
@@ -339,7 +342,7 @@ pub fn parse_function_definition(
             };
 
             // Analyze each body expression using unified helper
-            body_statements.extend(analyze_statement(&clause_stmt, &mut function_scope)?);
+            body_statements.extend(analyze_statement(&clause_stmt, &mut function_scope, depth + 1)?);
         }
     }
 
@@ -492,7 +495,7 @@ pub fn analyze_test_declaration(
         let mut test_scope = scope.enter_scope();
 
         for body_stmt in &test_decl.body {
-            analyzed_body.extend(analyze_statement(body_stmt, &mut test_scope)?);
+            analyzed_body.extend(analyze_statement(body_stmt, &mut test_scope, 0)?);
         }
     }
 

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -100,7 +100,7 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
         }
 
         // Use the unified analyze_statement helper for all other statements
-        analyzed_statements.extend(analyze_statement(stmt, &mut scope)?);
+        analyzed_statements.extend(analyze_statement(stmt, &mut scope, 0)?);
     }
 
     let analyzed = AnalyzedProgram {
@@ -114,6 +114,7 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
 }
 
 const MAX_EXPRESSION_DEPTH: usize = 200;
+pub const MAX_SEMANTIC_RECURSION_DEPTH: usize = 100;
 
 fn check_program_depth(program: &AnalyzedProgram) -> Result<(), GlossaError> {
     for stmt in &program.statements {
@@ -267,11 +268,19 @@ fn check_expr_depth(expr: &AnalyzedExpr, depth: usize) -> Result<(), GlossaError
 pub fn analyze_statement(
     stmt: &Statement,
     scope: &mut Scope,
+    depth: usize,
 ) -> Result<Vec<AnalyzedStatement>, GlossaError> {
+    if depth > MAX_SEMANTIC_RECURSION_DEPTH {
+        return Err(GlossaError::LimitExceeded {
+            resource: "semantic recursion depth".into(),
+            max: MAX_SEMANTIC_RECURSION_DEPTH,
+        });
+    }
+
     // 1. Check for function definitions (moved from control flow)
     // This allows function definitions to appear in any statement block
     if contains_function_definition_verb(stmt)
-        && let Some(func_def) = parse_function_definition(stmt, scope)?
+        && let Some(func_def) = parse_function_definition(stmt, scope, depth)?
     {
         // Register the function in the scope
         if let AnalyzedStatement::FunctionDef {
@@ -291,7 +300,7 @@ pub fn analyze_statement(
     }
 
     // 2. Check for control flow (if, while, etc.)
-    if let Some(control_flow) = analyze_control_flow(stmt, scope)? {
+    if let Some(control_flow) = analyze_control_flow(stmt, scope, depth)? {
         return Ok(vec![control_flow]);
     }
 
@@ -312,7 +321,7 @@ pub fn analyze_statement(
         // This ensures variables defined inside the block don't leak out
         let mut block_scope = scope.enter_scope();
         for s in block_stmts {
-            analyzed.extend(analyze_statement(s, &mut block_scope)?);
+            analyzed.extend(analyze_statement(s, &mut block_scope, depth + 1)?);
         }
         return Ok(analyzed);
     }

--- a/tests/havoc_elif_overflow.rs
+++ b/tests/havoc_elif_overflow.rs
@@ -43,7 +43,7 @@ fn test_elif_chain_stack_overflow() {
             println!("Got expected error: {:?}", e);
             match e {
                 glossa::errors::GlossaError::LimitExceeded { resource, max } => {
-                    assert_eq!(resource, "Control flow depth");
+                    assert_eq!(resource, "semantic recursion depth");
                     assert_eq!(max, 100);
                 }
                 _ => panic!("Expected LimitExceeded, got {:?}", e),

--- a/tests/havoc_nested_while.rs
+++ b/tests/havoc_nested_while.rs
@@ -1,0 +1,52 @@
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_nested_while_stack_overflow() {
+    // Generate a massive nested While loop: ἕως 1, ἕως 1, ... 1.
+    // Each "ἕως 1," adds a level of recursion in parse_while_loop -> analyze_statement.
+    // 5,000 iterations -> Depth 5,000.
+    // Parser sees a flat list of clauses (no recursion limit).
+    // Semantic analysis recurses.
+
+    // We need enough depth to overflow the stack.
+    // Default stack is usually 2MB.
+    // 5000 frames * ~1KB/frame = ~5MB -> Should crash.
+    let n = 5_000;
+    let mut s = String::with_capacity(n * 20);
+
+    // Build the string: "ἕως 1, ἕως 1, ... 1."
+    for _ in 0..n {
+        s.push_str("ἕως 1, ");
+    }
+    s.push_str("1.");
+
+    println!("Parsing {} nested while loops...", n);
+    // Parsing should succeed (flat structure of clauses separated by commas)
+    let ast = parse(&s).expect("Failed to parse");
+    println!(
+        "Parsed {} statements. First statement has {} clauses.",
+        ast.statements.len(),
+        ast.statements[0].clauses().len()
+    );
+
+    println!("Analyzing...");
+    // This should Stack Overflow (crash).
+    // If it doesn't, we failed (or stack is huge).
+    let result = analyze_program(&ast);
+
+    // If we reach here, we check if it failed gracefully
+    match result {
+        Ok(_) => panic!("Analysis succeeded unexpectedly! Should have crashed or returned LimitExceeded."),
+        Err(e) => {
+             // If we fixed it, it should be LimitExceeded.
+             // If we haven't, it crashed before here.
+             match e {
+                glossa::errors::GlossaError::LimitExceeded { resource, max } => {
+                    println!("Caught recursion limit: {} (max {})", resource, max);
+                }
+                _ => panic!("Expected LimitExceeded, got {:?}", e),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduces a recursion depth check in the Semantic Analyzer to prevent stack overflows caused by deeply nested control flow structures (e.g., nested 'While' loops or 'If' statements). This addresses a vulnerability where the parser's recursion check could be bypassed using constructs that don't require parentheses/braces.

- Adds `MAX_SEMANTIC_RECURSION_DEPTH = 100` in `src/semantic/mod.rs`.
- Updates `analyze_statement`, `analyze_control_flow`, and related parsers to propagate a `depth` parameter.
- Adds `tests/havoc_nested_while.rs` to verify the fix.

---
*PR created automatically by Jules for task [13038084994820942496](https://jules.google.com/task/13038084994820942496) started by @madmax983*