### PR TITLE
Echo DX Audit: Document Nova feature flag and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,42 @@ To run the Quick Start example:
 cargo run --release -- examples/quickstart.γλ
 ```
 
+## The Nova Toolset (Experimental)
+
+Unlock advanced developer tools by enabling the `nova` feature.
+
+> ⚠️ **REQUIRES FEATURE NOVA**
+>
+> To use these tools, you must add `--features nova` to your command.
+
+### 1. The Mentor (Interactive Tutorial)
+Learn ΓΛΩΣΣΑ step-by-step.
+
+```bash
+cargo run --release --features nova -- mentor
+```
+
+### 2. The Cartographer (Architecture Map)
+Generate a Mermaid.js class diagram of your code.
+
+```bash
+cargo run --release --features nova -- map examples/quickstart.γλ
+```
+
+### 3. The Mosaic (Sentence Structure)
+Visualize how the compiler assembles your sentences.
+
+```bash
+cargo run --release --features nova -- mosaic examples/quickstart.γλ
+```
+
+### 4. The Bard (Scroll of Logic)
+Translate your code into an English narrative (available without `nova`).
+
+```bash
+cargo run --release -- bard examples/quickstart.γλ
+```
+
 ## Features
 
 - **Greek Syntax**: Write code using authentic Ancient Greek grammatical constructs


### PR DESCRIPTION
Echo DX Audit: The user (Echo) encountered friction when trying to use 'Nova' features (specifically a 'story' feature, likely Bard or Mentor) because they were gated behind a feature flag without documentation.

Changes:
- Added "The Nova Toolset (Experimental)" section to `README.md`.
- Explicitly documented that `mentor`, `mosaic`, and `map` require `--features nova`.
- Provided copy-pasteable example commands for each tool.
- Added a prominent warning about the feature flag requirement.

Verification:
- Manually verified that `map` and `mosaic` commands work with `--features nova`.
- Verified that `cargo test` passes both with and without the `nova` feature.
- Confirmed `README.md` rendering and content correctness.

---
*PR created automatically by Jules for task [8304977105215976425](https://jules.google.com/task/8304977105215976425) started by @madmax983*