### PR TITLE
🎨 Mosaic: UI Polish for CLI Tools

### DIFF
--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -195,7 +195,7 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
         Cell::new(verb),
         Cell::new(object),
         Cell::new(indirect),
-        Cell::new(other.join(", ")),
+        Cell::new(other.join(", ")).fg(Color::DarkGrey),
     ]);
 }
 

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -117,7 +117,9 @@ fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result
             }
             Err(e) => {
                 // Use default error formatting but ensure it's visible
-                writeln!(output, "{}", format!("× Σφάλμα: {}", e).red()).into_diagnostic()?;
+                // The '×' symbol provides visual indication of error, so we don't need
+                // to prefix with "Σφάλμα: " which often leads to redundancy.
+                writeln!(output, "{}", format!("× {}", e).red()).into_diagnostic()?;
             }
         }
     }

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -599,4 +599,32 @@ mod tests {
         let output_str = String::from_utf8(output).unwrap();
         assert!(output_str.contains("Χαῖρε"));
     }
+
+    #[test]
+    fn test_run_repl_inner_error_output() {
+        // Test that the error output is formatted correctly (with '×')
+        // Using invalid syntax to trigger a ParseError
+        let input_data = "invalid syntax\n.exit\n";
+        let mut input = std::io::Cursor::new(input_data);
+        let mut output = Vec::new();
+
+        let result = run_repl_inner(&mut input, &mut output);
+        assert!(result.is_ok());
+
+        let output_str = String::from_utf8(output).unwrap();
+        // Should contain the error indicator
+        assert!(
+            output_str.contains("×"),
+            "Output should contain error indicator '×'"
+        );
+        // Should contain the error message content
+        assert!(
+            output_str.contains("Parse error"),
+            "Output should contain 'Parse error'"
+        );
+        // Should NOT contain the redundant "Σφάλμα: " prefix if the error itself starts with it
+        // The error message from GlossaError::ParseError starts with "Σφάλμα συντάξεως: ..."
+        // Our formatting prints "× error_string".
+        // We just want to ensure it printed.
+    }
 }

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -208,7 +208,9 @@ pub fn run_file(input: &Path) -> Result<()> {
         let error_msg = format!(
             "\n{}\n{}\n{}\n",
             "╔══════════════════════════════════════════════════════════════╗".red(),
-            "║  INTERNAL COMPILER ERROR (Codegen Failed)                    ║".red().bold(),
+            "║  INTERNAL COMPILER ERROR (Codegen Failed)                    ║"
+                .red()
+                .bold(),
             "╚══════════════════════════════════════════════════════════════╝".red()
         );
 

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -203,7 +203,28 @@ pub fn run_file(input: &Path) -> Result<()> {
     if !rustc_output.status.success() {
         let stderr = String::from_utf8_lossy(&rustc_output.stderr);
         status.error("Σφάλμα κώδικος (Codegen Error)");
-        return Err(miette::miette!("{}\n{}", "Rustc Error:".red(), stderr));
+
+        // Format the error nicely
+        let error_msg = format!(
+            "\n{}\n{}\n{}\n",
+            "╔══════════════════════════════════════════════════════════════╗".red(),
+            "║  INTERNAL COMPILER ERROR (Codegen Failed)                    ║".red().bold(),
+            "╚══════════════════════════════════════════════════════════════╝".red()
+        );
+
+        let help_msg = format!(
+            "{}\n{}",
+            "This indicates a bug in the Glossa compiler's code generation.",
+            "Please report this issue with the following details:"
+        )
+        .yellow();
+
+        return Err(miette::miette!(
+            "{}\n{}\n\n{}",
+            error_msg,
+            help_msg,
+            stderr.dim()
+        ));
     }
 
     status.success();
@@ -438,7 +459,7 @@ mod tests {
         let result = run_file(&input_path);
         assert!(result.is_err());
         // Verify it hits the rustc error path
-        assert!(result.unwrap_err().to_string().contains("Rustc Error"));
+        assert!(result.unwrap_err().to_string().contains("Codegen Failed"));
     }
 
     #[test]


### PR DESCRIPTION
This PR polishes the UI/UX of the Glossa CLI tools based on the "Mosaic" persona guidelines.

Changes:
- `src/tools/repl.rs`: Improved error formatting to avoid redundant prefixes like "Σφάλμα: Σφάλμα συντάξεως".
- `src/tools/runner.rs`: Implemented a formatted display for `rustc` errors during the build process, framing them as internal codegen errors rather than crashing the tool with raw stderr.
- `src/tools/mosaic.rs`: Adjusted the table style to dim less critical information, improving scanability.

These changes ensure a more professional and user-friendly experience for developers using the Glossa toolchain.

---
*PR created automatically by Jules for task [4387611937812849922](https://jules.google.com/task/4387611937812849922) started by @madmax983*