### PR TITLE
📜 Codex: ADR 011 Update & Architecture Diagram Sync

### DIFF
--- a/docs/adr/011-consolidate-semantic-analysis.md
+++ b/docs/adr/011-consolidate-semantic-analysis.md
@@ -4,7 +4,7 @@ Date: 2024-10-27
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -18,15 +18,20 @@ However, as the language evolved, several issues emerged:
 
 ## Decision
 
-We have decided to consolidate the semantic analysis structure:
+We have decided to consolidate the semantic analysis structure, with some modifications to the initial proposal:
 
-1.  **Merge Declarations into Statements:** The `src/semantic/declarations.rs` module is removed. Its logic is merged into `src/semantic/statements.rs`, which now handles all high-level statement analysis, including Control Flow (If, While) and Declarations (Type, Trait, Function, Test).
-2.  **Extract Expression Analysis:** Recursive descent logic for nested expressions (function calls, arithmetic) is formalized in `src/semantic/expressions.rs`. This module is used by both `statements.rs` (for conditions, initializers) and `assembler.rs` (for feeding arguments).
-3.  **Formalize Resolver:** Scope management and name resolution logic is centralized in `src/semantic/resolver.rs`. This module manages the symbol table, scope stack, and type/trait lookups.
+1.  **Orchestrator Pattern:** Instead of a monolithic `statements.rs`, the `src/semantic/mod.rs` module acts as the orchestrator (via `analyze_statement`), delegating to specialized modules.
+2.  **Specialized Modules:**
+    -   `declarations.rs` is **retained** to handle Type, Trait, Function, and Test definitions.
+    -   `control_flow.rs` handles If, While, Match logic.
+    -   `conversion.rs` handles the conversion of assembled statements.
+3.  **Extract Expression Analysis:** Recursive descent logic for nested expressions (function calls, arithmetic) is formalized in `src/semantic/expressions.rs`. This module is used by `declarations`, `control_flow`, and `assembly`.
+4.  **Formalize Resolver:** Scope management and name resolution logic is centralized in `src/semantic/resolver.rs`. This module manages the symbol table, scope stack, and type/trait lookups.
 
 ## Consequences
 
-*   **Simplified Structure:** The semantic analysis module is more cohesive, with `statements.rs` acting as the primary orchestrator for non-assembler constructs.
+*   **Modular Orchestration:** The `mod.rs` orchestrator keeps the high-level logic clean while delegating complexity to specialized submodules.
 *   **Centralized Logic:** Expression parsing and scope management are centralized, reducing duplication and bugs.
-*   **Explicit Dependencies:** The relationships between modules are clearer: `Statements` depends on `Expressions` and `Resolver`; `Assembler` depends on `Expressions`.
-*   **Documentation Update:** Architecture diagrams must be updated to reflect the removal of `declarations` and the prominence of `statements`, `expressions`, and `resolver`.
+*   **Explicit Dependencies:** The relationships between modules are clearer: `mod.rs` depends on `declarations`, `control_flow`, and `conversion`; these depend on `expressions` and `resolver`.
+*   **Documentation Update:** Architecture diagrams have been updated to reflect the retention of `declarations`, the addition of `control_flow`, and the central role of `mod.rs`.
+*   **Note:** This implementation diverges from the original proposal (which suggested merging everything into `statements.rs`) to maintain better file-level separation of concerns.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,13 +33,19 @@ C4Container
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
-        Container(highlight, "Highlighter", "src/tools/highlight.rs", "Semantic syntax highlighting")
-        Container(narrator, "Narrator", "src/tools/narrator.rs", "Generates English narrative from AST")
-        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
+        Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
+        Container(dictionary, "Dictionary", "src/tools/dictionary.rs", "Lexicon lookup utility")
+        Container(highlight, "Highlighter", "src/tools/highlight.rs", "Semantic syntax highlighting")
         Container(mentor, "Mentor", "src/tools/mentor.rs", "Interactive Tutorial Mode")
         Container(mosaic, "Mosaic", "src/tools/mosaic.rs", "Visualizes Semantic Assembly")
+        Container(narrator, "Narrator", "src/tools/narrator.rs", "Generates English narrative from AST")
+        Container(repl, "REPL", "src/tools/repl.rs", "Interactive Read-Eval-Print Loop")
+        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+        Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "Tester", "src/tools/tester.rs", "Runs built-in unit tests")
+        Container(ui, "UI", "src/tools/ui.rs", "Terminal UI helpers")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -66,31 +72,41 @@ C4Component
     title Component Diagram for Semantic Analysis
 
     Container_Boundary(semantic, "Semantic Analysis") {
-        Component(statements, "Statements", "src/semantic/statements.rs", "Analyzes Control Flow and Declarations")
+        Component(orchestrator, "Orchestrator", "src/semantic/mod.rs", "Coordinates analysis pipeline")
+        Component(declarations, "Declarations", "src/semantic/declarations.rs", "Analyzes Types, Traits, Functions")
+        Component(control_flow, "Control Flow", "src/semantic/control_flow.rs", "Analyzes If, While, Match")
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
-        Component(assembler, "Assembler", "src/semantic/assembler.rs", "Routes words to slots based on Case (Nom, Acc, Dat)")
-        Component(converter, "Converter", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
-        Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs (Iterators, Structs)")
+        Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
+        Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
+        Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")
+        Component(types, "Type System", "src/semantic/types.rs", "GlossaType definitions and utilities")
     }
 
     Container(morphology, "Morphology", "src/morphology", "Provides Case/Gender/Number analysis")
 
-    Rel(statements, model, "Produces AnalyzedStatement")
-    Rel(statements, expressions, "Analyzes conditions")
-    Rel(statements, resolver, "Defines Symbols")
+    Rel(orchestrator, declarations, "Delegates to")
+    Rel(orchestrator, control_flow, "Delegates to")
+    Rel(orchestrator, conversion, "Delegates to")
 
-    Rel(morphology, assembler, "Feeds MorphAnalysis")
+    Rel(declarations, resolver, "Defines Symbols")
+    Rel(declarations, types, "Uses")
+    Rel(declarations, model, "Produces")
 
-    Rel(assembler, expressions, "Feeds sub-expressions")
-    Rel(assembler, converter, "Produces AssembledStatement")
+    Rel(control_flow, expressions, "Analyzes conditions")
+    Rel(control_flow, model, "Produces")
 
-    Rel(converter, patterns, "Delegates complex patterns")
-    Rel(converter, resolver, "Lookups Symbols")
-    Rel(converter, model, "Produces AnalyzedStatement")
+    Rel(conversion, assembly, "Uses Assembler")
+    Rel(assembly, morphology, "Uses")
+    Rel(assembly, expressions, "Feeds sub-expressions")
+
+    Rel(conversion, patterns, "Delegates complex patterns")
+    Rel(conversion, resolver, "Lookups Symbols")
+    Rel(conversion, model, "Produces")
 
     Rel(expressions, resolver, "Lookups Symbols")
+    Rel(expressions, types, "Uses")
 
-    Rel(patterns, model, "Produces AnalyzedStatement")
+    Rel(model, types, "Uses")
 ```


### PR DESCRIPTION
🧠 **Decision:** Finalized ADR 011 to reflect the actual semantic analysis structure (Declarations kept separate, Expressions/Resolver extracted).
🗺️ **Visuals:** Updated `docs/architecture.md` to include all tools and correct semantic components.
🔗 **Link:** See `docs/adr/011-consolidate-semantic-analysis.md`.

---
*PR created automatically by Jules for task [1850158900468033727](https://jules.google.com/task/1850158900468033727) started by @madmax983*