### PR TITLE
🛡️ Sentry: Fix PropertyAccess assembly for non-Subject owners

### DIFF
--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -479,10 +479,12 @@ fn feed_expr_recursive(
                 }
             }
         }
-        Expr::PropertyAccess { owner, property } => {
-            // Owner is genitive, property is what it attaches to
-            feed_expr_recursive(asm, owner, context, depth + 1)?;
-            feed_expr_recursive(asm, property, context, depth + 1)?;
+        Expr::PropertyAccess { .. } => {
+            // Property access expression (e.g. x.len)
+            // We feed this as a nested phrase so it's treated as a single unit (value)
+            // and analyzed later by analyze_argument_expr, rather than being split
+            // into constituent words which might be misassembled.
+            asm.feed_nested_phrase(vec![expr.clone()])?;
         }
         Expr::Call { verb, arguments } => {
             // Feed the verb - verbs can set context for subjects

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -552,7 +552,9 @@ fn feed_expr_recursive(
 /// Recursively check expression depth to prevent stack overflow during cloning
 fn check_cloning_depth_safety(expr: &Expr, limit: usize) -> Result<(), GlossaError> {
     if limit == 0 {
-        return Err(GlossaError::semantic("Recursion limit exceeded in nested phrase analysis"));
+        return Err(GlossaError::semantic(
+            "Recursion limit exceeded in nested phrase analysis",
+        ));
     }
 
     match expr {

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -484,6 +484,10 @@ fn feed_expr_recursive(
             // We feed this as a nested phrase so it's treated as a single unit (value)
             // and analyzed later by analyze_argument_expr, rather than being split
             // into constituent words which might be misassembled.
+
+            // SECURITY: Ensure we don't clone excessively deep structures, which would stack overflow.
+            check_cloning_depth_safety(expr, MAX_RECURSION_DEPTH)?;
+
             asm.feed_nested_phrase(vec![expr.clone()])?;
         }
         Expr::Call { verb, arguments } => {
@@ -541,6 +545,49 @@ fn feed_expr_recursive(
             // Feed index access to assembler
             asm.feed_index_access(array.as_ref().clone(), index.as_ref().clone())?;
         }
+    }
+    Ok(())
+}
+
+/// Recursively check expression depth to prevent stack overflow during cloning
+fn check_cloning_depth_safety(expr: &Expr, limit: usize) -> Result<(), GlossaError> {
+    if limit == 0 {
+        return Err(GlossaError::semantic("Recursion limit exceeded in nested phrase analysis"));
+    }
+
+    match expr {
+        Expr::PropertyAccess { owner, property } => {
+            check_cloning_depth_safety(owner, limit - 1)?;
+            check_cloning_depth_safety(property, limit - 1)?;
+        }
+        Expr::Phrase(terms) | Expr::ArrayLiteral(terms) => {
+            for term in terms {
+                check_cloning_depth_safety(term, limit - 1)?;
+            }
+        }
+        Expr::IndexAccess { array, index } => {
+            check_cloning_depth_safety(array, limit - 1)?;
+            check_cloning_depth_safety(index, limit - 1)?;
+        }
+        Expr::BinOp { left, right, .. } => {
+            check_cloning_depth_safety(left, limit - 1)?;
+            check_cloning_depth_safety(right, limit - 1)?;
+        }
+        Expr::UnaryOp { operand, .. } | Expr::Binding { value: operand, .. } => {
+            check_cloning_depth_safety(operand, limit - 1)?;
+        }
+        Expr::Call { arguments, .. } => {
+            for arg in arguments {
+                check_cloning_depth_safety(arg, limit - 1)?;
+            }
+        }
+        // Block is tricky because it contains Statements, which contain Clauses, which contain Exprs.
+        // For now, we don't deeply check Blocks here as they are typically top-level recursion boundaries
+        // or handled by analyze_block which has checks. But if we are CLONING, we should be careful.
+        // Assuming Blocks don't usually cause infinite recursion in PropertyAccess contexts.
+        Expr::Block(_) => {}
+
+        _ => {}
     }
     Ok(())
 }

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -46,6 +46,8 @@ pub(crate) mod model;
 pub(crate) mod patterns;
 #[cfg(test)]
 mod property_access_tests;
+#[cfg(test)]
+mod recursion_safety_tests;
 mod resolver;
 mod types;
 

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -44,6 +44,8 @@ pub(crate) mod declarations;
 pub(crate) mod expressions;
 pub(crate) mod model;
 pub(crate) mod patterns;
+#[cfg(test)]
+mod property_access_tests;
 mod resolver;
 mod types;
 

--- a/src/semantic/property_access_tests.rs
+++ b/src/semantic/property_access_tests.rs
@@ -1,0 +1,75 @@
+use crate::ast::Expr;
+use crate::semantic::expressions::feed_expr_to_assembler_with_context;
+use crate::semantic::{Assembler, DisambiguationContext};
+
+#[test]
+fn test_property_access_on_accusative_owner() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+
+    let owner = Expr::Word(crate::ast::Word::new("λόγον"));
+    let property = Expr::Word(crate::ast::Word::new("μῆκος"));
+    let expr = Expr::PropertyAccess {
+        owner: Box::new(owner),
+        property: Box::new(property),
+    };
+
+    feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx).unwrap();
+    let stmt = asm.finalize().unwrap();
+
+    // EXPECTATION: The Property Access should be preserved as a nested phrase
+    // This allows extract_value to handle it correctly later
+    assert!(
+        !stmt.nested_phrases.is_empty(),
+        "Should have nested phrase containing property access"
+    );
+
+    // Verify content of nested phrase
+    let phrase = &stmt.nested_phrases[0];
+    assert_eq!(phrase.len(), 1);
+    match &phrase[0] {
+        Expr::PropertyAccess { .. } => {} // Success
+        _ => panic!(
+            "Nested phrase should contain PropertyAccess, found {:?}",
+            phrase[0]
+        ),
+    }
+}
+
+#[test]
+fn test_nested_property_access() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+
+    let inner_phrase = Expr::Phrase(vec![
+        Expr::NumberLiteral(1),
+        Expr::Word(crate::ast::Word::new("+")),
+        Expr::NumberLiteral(2),
+    ]);
+    let nested_phrase = Expr::Phrase(vec![inner_phrase]);
+
+    let property = Expr::Word(crate::ast::Word::new("μῆκος"));
+    let expr = Expr::PropertyAccess {
+        owner: Box::new(nested_phrase),
+        property: Box::new(property),
+    };
+
+    feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx).unwrap();
+    let stmt = asm.finalize().unwrap();
+
+    // EXPECTATION: The Property Access should be preserved as a nested phrase
+    assert!(
+        !stmt.nested_phrases.is_empty(),
+        "Should have nested phrase containing property access"
+    );
+
+    let phrase = &stmt.nested_phrases[0];
+    assert_eq!(phrase.len(), 1);
+    match &phrase[0] {
+        Expr::PropertyAccess { .. } => {} // Success
+        _ => panic!(
+            "Nested phrase should contain PropertyAccess, found {:?}",
+            phrase[0]
+        ),
+    }
+}

--- a/src/semantic/recursion_safety_tests.rs
+++ b/src/semantic/recursion_safety_tests.rs
@@ -1,0 +1,148 @@
+
+use crate::ast::{Expr, Word};
+use crate::semantic::expressions::{MAX_RECURSION_DEPTH, feed_expr_to_assembler_with_context};
+use crate::semantic::{Assembler, DisambiguationContext};
+
+// Helper to create a nested structure of a specific type
+fn make_nested_expr(depth: usize, constructor: impl Fn(Expr) -> Expr) -> Expr {
+    let mut expr = Expr::Word(Word::new("x"));
+    for _ in 0..depth {
+        expr = constructor(expr);
+    }
+    // Wrap in PropertyAccess to trigger the check_cloning_depth_safety
+    Expr::PropertyAccess {
+        owner: Box::new(expr),
+        property: Box::new(Expr::Word(Word::new("len"))),
+    }
+}
+
+#[test]
+fn test_check_safety_phrase_recursion() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+    let depth = MAX_RECURSION_DEPTH + 10;
+
+    let expr = make_nested_expr(depth, |e| Expr::Phrase(vec![e]));
+
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+    assert!(result.is_err(), "Should catch recursion in Phrase");
+}
+
+#[test]
+fn test_check_safety_array_recursion() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+    let depth = MAX_RECURSION_DEPTH + 10;
+
+    let expr = make_nested_expr(depth, |e| Expr::ArrayLiteral(vec![e]));
+
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+    assert!(result.is_err(), "Should catch recursion in ArrayLiteral");
+}
+
+#[test]
+fn test_check_safety_index_access_recursion_array() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+    let depth = MAX_RECURSION_DEPTH + 10;
+
+    let expr = make_nested_expr(depth, |e| Expr::IndexAccess {
+        array: Box::new(e),
+        index: Box::new(Expr::NumberLiteral(0)),
+    });
+
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+    assert!(result.is_err(), "Should catch recursion in IndexAccess (array)");
+}
+
+#[test]
+fn test_check_safety_index_access_recursion_index() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+    let depth = MAX_RECURSION_DEPTH + 10;
+
+    let expr = make_nested_expr(depth, |e| Expr::IndexAccess {
+        array: Box::new(Expr::ArrayLiteral(vec![])),
+        index: Box::new(e),
+    });
+
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+    assert!(result.is_err(), "Should catch recursion in IndexAccess (index)");
+}
+
+#[test]
+fn test_check_safety_binop_recursion_left() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+    let depth = MAX_RECURSION_DEPTH + 10;
+
+    let expr = make_nested_expr(depth, |e| Expr::BinOp {
+        left: Box::new(e),
+        op: crate::ast::BinOperator::Add,
+        right: Box::new(Expr::NumberLiteral(1)),
+    });
+
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+    assert!(result.is_err(), "Should catch recursion in BinOp (left)");
+}
+
+#[test]
+fn test_check_safety_binop_recursion_right() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+    let depth = MAX_RECURSION_DEPTH + 10;
+
+    let expr = make_nested_expr(depth, |e| Expr::BinOp {
+        left: Box::new(Expr::NumberLiteral(1)),
+        op: crate::ast::BinOperator::Add,
+        right: Box::new(e),
+    });
+
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+    assert!(result.is_err(), "Should catch recursion in BinOp (right)");
+}
+
+#[test]
+fn test_check_safety_unary_op_recursion() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+    let depth = MAX_RECURSION_DEPTH + 10;
+
+    let expr = make_nested_expr(depth, |e| Expr::UnaryOp {
+        op: crate::ast::UnaryOperator::Not,
+        operand: Box::new(e),
+    });
+
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+    assert!(result.is_err(), "Should catch recursion in UnaryOp");
+}
+
+#[test]
+fn test_check_safety_binding_recursion() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+    let depth = MAX_RECURSION_DEPTH + 10;
+
+    let expr = make_nested_expr(depth, |e| Expr::Binding {
+        name: Word::new("x"),
+        value: Box::new(e),
+    });
+
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+    assert!(result.is_err(), "Should catch recursion in Binding");
+}
+
+#[test]
+fn test_check_safety_call_recursion() {
+    let mut asm = Assembler::new();
+    let mut ctx = DisambiguationContext::new();
+    let depth = MAX_RECURSION_DEPTH + 10;
+
+    let expr = make_nested_expr(depth, |e| Expr::Call {
+        verb: Word::new("f"),
+        arguments: vec![e],
+    });
+
+    let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
+    assert!(result.is_err(), "Should catch recursion in Call");
+}

--- a/src/semantic/recursion_safety_tests.rs
+++ b/src/semantic/recursion_safety_tests.rs
@@ -1,4 +1,3 @@
-
 use crate::ast::{Expr, Word};
 use crate::semantic::expressions::{MAX_RECURSION_DEPTH, feed_expr_to_assembler_with_context};
 use crate::semantic::{Assembler, DisambiguationContext};
@@ -52,7 +51,10 @@ fn test_check_safety_index_access_recursion_array() {
     });
 
     let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
-    assert!(result.is_err(), "Should catch recursion in IndexAccess (array)");
+    assert!(
+        result.is_err(),
+        "Should catch recursion in IndexAccess (array)"
+    );
 }
 
 #[test]
@@ -67,7 +69,10 @@ fn test_check_safety_index_access_recursion_index() {
     });
 
     let result = feed_expr_to_assembler_with_context(&mut asm, &expr, &mut ctx);
-    assert!(result.is_err(), "Should catch recursion in IndexAccess (index)");
+    assert!(
+        result.is_err(),
+        "Should catch recursion in IndexAccess (index)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
🛡️ Sentry: Fix PropertyAccess assembly for non-Subject owners

🎯 Target: `src/semantic/expressions.rs`

💣 Risk: Previously, `Expr::PropertyAccess` (e.g., `x.len`) was split into `x` and `len` during assembly. If `x` resolved to an Object (Accusative case) or was a complex expression, the Assembler failed to associate `len` with it, leading to incorrect parsing or "Subject not found" errors for the property.

🧪 Strategy: Changed `feed_expr_recursive` to wrap `Expr::PropertyAccess` in a `nested_phrase`. This treats it as an atomic semantic unit (like a parenthesized expression), ensuring it is passed intact to `analyze_argument_expr`, which correctly handles property access logic.

🔬 Verification: Added `src/semantic/property_access_tests.rs` covering:
- Property access on Accusative owner (Object).
- Property access on nested phrase owner (e.g., `(1+2).len`).

---
*PR created automatically by Jules for task [16812375020444727905](https://jules.google.com/task/16812375020444727905) started by @madmax983*