### PR TITLE
⚒️ Forge: Refactor semantic conversion logic

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -446,123 +446,151 @@ fn classify_collection_mutation(
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
-        // Pop
-        if crate::morphology::lexicon::is_pop_verb(verb_lemma)
-            && let Some(ref subject) = asm_stmt.subject
-        {
-            let receiver = AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
-                glossa_type: scope
-                    .lookup(&subject.lemma)
-                    .cloned()
-                    .unwrap_or(GlossaType::Unknown),
-            };
-
-            let method_call = AnalyzedExpr {
-                expr: AnalyzedExprKind::MethodCall {
-                    receiver: Box::new(receiver),
-                    method: "pop".into(),
-                    args: vec![],
-                },
-                glossa_type: GlossaType::Unknown,
-            };
-
-            return Ok(Some(AnalyzedStatement::Expression(vec![method_call])));
+        if let Some(res) = classify_pop(verb_lemma, asm_stmt, scope)? {
+            return Ok(Some(res));
         }
-
-        // Push
-        if crate::morphology::lexicon::is_push_verb(verb_lemma)
-            && let Some(ref subject) = asm_stmt.subject
-        {
-            let receiver = AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
-                glossa_type: scope
-                    .lookup(&subject.lemma)
-                    .cloned()
-                    .unwrap_or(GlossaType::Unknown),
-            };
-
-            let arg = if let Some(lit) = asm_stmt.literals.first() {
-                literal_to_analyzed_expr(lit)
-            } else if let Some(ref obj) = asm_stmt.object {
-                AnalyzedExpr {
-                    expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                    glossa_type: scope
-                        .lookup(&obj.lemma)
-                        .cloned()
-                        .unwrap_or(GlossaType::Unknown),
-                }
-            } else {
-                AnalyzedExpr {
-                    expr: AnalyzedExprKind::NumberLiteral(0),
-                    glossa_type: GlossaType::Number,
-                }
-            };
-
-            let method_call = AnalyzedExpr {
-                expr: AnalyzedExprKind::MethodCall {
-                    receiver: Box::new(receiver),
-                    method: "push".into(),
-                    args: vec![arg],
-                },
-                glossa_type: GlossaType::Unit,
-            };
-
-            return Ok(Some(AnalyzedStatement::Expression(vec![method_call])));
+        if let Some(res) = classify_push(verb_lemma, asm_stmt, scope)? {
+            return Ok(Some(res));
         }
+        if let Some(res) = classify_insert(verb_lemma, asm_stmt, scope)? {
+            return Ok(Some(res));
+        }
+    }
+    Ok(None)
+}
 
-        // Insert
-        if crate::morphology::lexicon::is_insert_verb(verb_lemma)
-            && let Some(ref subject) = asm_stmt.subject
-        {
-            let subj_name = &subject.normalized;
-            let subj_type = scope
-                .lookup(subj_name)
+fn classify_pop(
+    verb_lemma: &str,
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    if crate::morphology::lexicon::is_pop_verb(verb_lemma)
+        && let Some(ref subject) = asm_stmt.subject
+    {
+        let receiver = AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
+            glossa_type: scope
+                .lookup(&subject.lemma)
                 .cloned()
-                .unwrap_or(GlossaType::Unknown);
+                .unwrap_or(GlossaType::Unknown),
+        };
 
-            let receiver = AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj_name.clone()),
-                glossa_type: subj_type.clone(),
-            };
+        let method_call = AnalyzedExpr {
+            expr: AnalyzedExprKind::MethodCall {
+                receiver: Box::new(receiver),
+                method: "pop".into(),
+                args: vec![],
+            },
+            glossa_type: GlossaType::Unknown,
+        };
 
-            let is_map = matches!(subj_type, GlossaType::Map(_, _));
+        return Ok(Some(AnalyzedStatement::Expression(vec![method_call])));
+    }
+    Ok(None)
+}
 
-            let args = if is_map && asm_stmt.literals.len() >= 2 {
-                vec![
-                    literal_to_analyzed_expr(&asm_stmt.literals[0]),
-                    literal_to_analyzed_expr(&asm_stmt.literals[1]),
-                ]
-            } else if let Some(lit) = asm_stmt.literals.first() {
-                vec![literal_to_analyzed_expr(lit)]
-            } else if let Some(ref obj) = asm_stmt.object {
-                vec![AnalyzedExpr {
-                    expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                    glossa_type: scope
-                        .lookup(&obj.lemma)
-                        .cloned()
-                        .unwrap_or(GlossaType::Unknown),
-                }]
-            } else {
-                vec![]
-            };
+fn classify_push(
+    verb_lemma: &str,
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    if crate::morphology::lexicon::is_push_verb(verb_lemma)
+        && let Some(ref subject) = asm_stmt.subject
+    {
+        let receiver = AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
+            glossa_type: scope
+                .lookup(&subject.lemma)
+                .cloned()
+                .unwrap_or(GlossaType::Unknown),
+        };
 
-            let return_type = if is_map {
-                GlossaType::Option(Box::new(GlossaType::Unknown))
-            } else {
-                GlossaType::Boolean
-            };
-            let method_call = AnalyzedExpr {
-                expr: AnalyzedExprKind::MethodCall {
-                    receiver: Box::new(receiver),
-                    method: "insert".into(),
-                    args,
-                },
-                glossa_type: return_type,
-            };
+        let arg = if let Some(lit) = asm_stmt.literals.first() {
+            literal_to_analyzed_expr(lit)
+        } else if let Some(ref obj) = asm_stmt.object {
+            AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+                glossa_type: scope
+                    .lookup(&obj.lemma)
+                    .cloned()
+                    .unwrap_or(GlossaType::Unknown),
+            }
+        } else {
+            AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(0),
+                glossa_type: GlossaType::Number,
+            }
+        };
 
-            return Ok(Some(AnalyzedStatement::Expression(vec![method_call])));
-        }
+        let method_call = AnalyzedExpr {
+            expr: AnalyzedExprKind::MethodCall {
+                receiver: Box::new(receiver),
+                method: "push".into(),
+                args: vec![arg],
+            },
+            glossa_type: GlossaType::Unit,
+        };
+
+        return Ok(Some(AnalyzedStatement::Expression(vec![method_call])));
+    }
+    Ok(None)
+}
+
+fn classify_insert(
+    verb_lemma: &str,
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    if crate::morphology::lexicon::is_insert_verb(verb_lemma)
+        && let Some(ref subject) = asm_stmt.subject
+    {
+        let subj_name = &subject.normalized;
+        let subj_type = scope
+            .lookup(subj_name)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown);
+
+        let receiver = AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(subj_name.clone()),
+            glossa_type: subj_type.clone(),
+        };
+
+        let is_map = matches!(subj_type, GlossaType::Map(_, _));
+
+        let args = if is_map && asm_stmt.literals.len() >= 2 {
+            vec![
+                literal_to_analyzed_expr(&asm_stmt.literals[0]),
+                literal_to_analyzed_expr(&asm_stmt.literals[1]),
+            ]
+        } else if let Some(lit) = asm_stmt.literals.first() {
+            vec![literal_to_analyzed_expr(lit)]
+        } else if let Some(ref obj) = asm_stmt.object {
+            vec![AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+                glossa_type: scope
+                    .lookup(&obj.lemma)
+                    .cloned()
+                    .unwrap_or(GlossaType::Unknown),
+            }]
+        } else {
+            vec![]
+        };
+
+        let return_type = if is_map {
+            GlossaType::Option(Box::new(GlossaType::Unknown))
+        } else {
+            GlossaType::Boolean
+        };
+        let method_call = AnalyzedExpr {
+            expr: AnalyzedExprKind::MethodCall {
+                receiver: Box::new(receiver),
+                method: "insert".into(),
+                args,
+            },
+            glossa_type: return_type,
+        };
+
+        return Ok(Some(AnalyzedStatement::Expression(vec![method_call])));
     }
     Ok(None)
 }
@@ -1082,10 +1110,11 @@ fn detect_enum_variant(
     let lemma = &word.lemma;
     let original = &word.normalized;
 
+    // Helper to check if a word matches a predicate
+    let check = |pred: fn(&str) -> bool| pred(lemma) || pred(original);
+
     // None
-    if crate::morphology::lexicon::is_none_word(lemma)
-        || crate::morphology::lexicon::is_none_word(original)
-    {
+    if check(crate::morphology::lexicon::is_none_word) {
         return Some((
             AnalyzedExpr {
                 expr: AnalyzedExprKind::None,
@@ -1095,58 +1124,48 @@ fn detect_enum_variant(
         ));
     }
 
-    // Some
-    if (crate::morphology::lexicon::is_some_word(lemma)
-        || crate::morphology::lexicon::is_some_word(original))
-        && let Some(lit) = literals.first()
-    {
+    if let Some(lit) = literals.first() {
         let inner_expr = literal_to_analyzed_expr(lit);
         let inner_type = inner_expr.glossa_type.clone();
-        return Some((
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::Some(Box::new(inner_expr)),
-                glossa_type: GlossaType::Option(Box::new(inner_type.clone())),
-            },
-            GlossaType::Option(Box::new(inner_type)),
-        ));
-    }
 
-    // Ok
-    if (crate::morphology::lexicon::is_ok_word(lemma)
-        || crate::morphology::lexicon::is_ok_word(original))
-        && let Some(lit) = literals.first()
-    {
-        let inner_expr = literal_to_analyzed_expr(lit);
-        let inner_type = inner_expr.glossa_type.clone();
-        return Some((
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::Ok(Box::new(inner_expr)),
-                glossa_type: GlossaType::Result(
-                    Box::new(inner_type.clone()),
-                    Box::new(GlossaType::String),
-                ),
-            },
-            GlossaType::Result(Box::new(inner_type), Box::new(GlossaType::String)),
-        ));
-    }
+        // Some
+        if check(crate::morphology::lexicon::is_some_word) {
+            return Some((
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::Some(Box::new(inner_expr)),
+                    glossa_type: GlossaType::Option(Box::new(inner_type.clone())),
+                },
+                GlossaType::Option(Box::new(inner_type)),
+            ));
+        }
 
-    // Err
-    if (crate::morphology::lexicon::is_err_word(lemma)
-        || crate::morphology::lexicon::is_err_word(original))
-        && let Some(lit) = literals.first()
-    {
-        let inner_expr = literal_to_analyzed_expr(lit);
-        let inner_type = inner_expr.glossa_type.clone();
-        return Some((
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::Err(Box::new(inner_expr)),
-                glossa_type: GlossaType::Result(
-                    Box::new(GlossaType::Unknown),
-                    Box::new(inner_type.clone()),
-                ),
-            },
-            GlossaType::Result(Box::new(GlossaType::Unknown), Box::new(inner_type)),
-        ));
+        // Ok
+        if check(crate::morphology::lexicon::is_ok_word) {
+            return Some((
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::Ok(Box::new(inner_expr)),
+                    glossa_type: GlossaType::Result(
+                        Box::new(inner_type.clone()),
+                        Box::new(GlossaType::String),
+                    ),
+                },
+                GlossaType::Result(Box::new(inner_type), Box::new(GlossaType::String)),
+            ));
+        }
+
+        // Err
+        if check(crate::morphology::lexicon::is_err_word) {
+            return Some((
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::Err(Box::new(inner_expr)),
+                    glossa_type: GlossaType::Result(
+                        Box::new(GlossaType::Unknown),
+                        Box::new(inner_type.clone()),
+                    ),
+                },
+                GlossaType::Result(Box::new(GlossaType::Unknown), Box::new(inner_type)),
+            ));
+        }
     }
 
     None

--- a/src/semantic/conversion_tests.rs
+++ b/src/semantic/conversion_tests.rs
@@ -1,9 +1,10 @@
-use super::conversion::extract_value;
+use super::conversion::{convert_assembled_to_analyzed, extract_value};
 use crate::ast::Expr;
-use crate::morphology::Case;
 use crate::morphology::lexicon::BinaryOp;
+use crate::morphology::{Case, Number, Person, Tense};
 use crate::semantic::{
-    AnalyzedExprKind, AssembledStatement, Constituent, GlossaType, Literal, Scope,
+    AnalyzedExprKind, AnalyzedStatement, AssembledStatement, Constituent, GlossaType, Literal,
+    Scope, VerbConstituent,
 };
 use crate::text::normalize_greek;
 
@@ -16,6 +17,135 @@ fn make_constituent(original: &str, lemma: &str) -> Constituent {
         number: None,
         gender: None,
         person: None,
+    }
+}
+
+fn make_verb(original: &str, lemma: &str) -> VerbConstituent {
+    VerbConstituent {
+        lemma: lemma.into(),
+        original: original.into(),
+        normalized: normalize_greek(original),
+        person: Some(Person::Third),
+        number: Some(Number::Singular),
+        tense: Some(Tense::Present),
+        mood: None,
+        voice: None,
+    }
+}
+
+#[test]
+fn test_classify_pop() {
+    let mut scope = Scope::new();
+    scope.define("stack", GlossaType::List(Box::new(GlossaType::Number)));
+
+    // "stack pulls itself" (stack.pop())
+    let asm_stmt = AssembledStatement {
+        verb: Some(make_verb("ἕλκεται", "ελκω")),
+        subject: Some(make_constituent("stack", "stack")),
+        ..Default::default()
+    };
+
+    let analyzed =
+        convert_assembled_to_analyzed(&asm_stmt, &mut scope).expect("Should classify pop");
+
+    if let AnalyzedStatement::Expression(exprs) = analyzed {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::MethodCall {
+            receiver,
+            method,
+            args,
+        } = &exprs[0].expr
+        {
+            assert_eq!(method, "pop");
+            assert!(args.is_empty());
+            if let AnalyzedExprKind::Variable(name) = &receiver.expr {
+                assert_eq!(name, "stack");
+            } else {
+                panic!("Receiver should be variable");
+            }
+        } else {
+            panic!("Expected MethodCall");
+        }
+    } else {
+        panic!("Expected Expression statement");
+    }
+}
+
+#[test]
+fn test_classify_push_literal() {
+    let mut scope = Scope::new();
+    scope.define("stack", GlossaType::List(Box::new(GlossaType::Number)));
+
+    // "stack pushes 42"
+    let asm_stmt = AssembledStatement {
+        verb: Some(make_verb("ὠθεῖ", "ωθεω")),
+        subject: Some(make_constituent("stack", "stack")),
+        literals: vec![Literal::Number(42)],
+        ..Default::default()
+    };
+
+    let analyzed =
+        convert_assembled_to_analyzed(&asm_stmt, &mut scope).expect("Should classify push");
+
+    if let AnalyzedStatement::Expression(exprs) = analyzed {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::MethodCall {
+            method,
+            args,
+            ..
+        } = &exprs[0].expr
+        {
+            assert_eq!(method, "push");
+            assert_eq!(args.len(), 1);
+            if let AnalyzedExprKind::NumberLiteral(n) = &args[0].expr {
+                assert_eq!(*n, 42);
+            } else {
+                panic!("Arg should be literal 42");
+            }
+        } else {
+            panic!("Expected MethodCall");
+        }
+    } else {
+        panic!("Expected Expression statement");
+    }
+}
+
+#[test]
+fn test_classify_insert_map() {
+    let mut scope = Scope::new();
+    // Map<String, Number>
+    scope.define(
+        "map",
+        GlossaType::Map(Box::new(GlossaType::String), Box::new(GlossaType::Number)),
+    );
+
+    // "map puts 'key' 100"
+    let asm_stmt = AssembledStatement {
+        verb: Some(make_verb("τίθησι", "τιθημι")),
+        subject: Some(make_constituent("map", "map")),
+        literals: vec![Literal::String("key".into()), Literal::Number(100)],
+        ..Default::default()
+    };
+
+    let analyzed =
+        convert_assembled_to_analyzed(&asm_stmt, &mut scope).expect("Should classify insert");
+
+    if let AnalyzedStatement::Expression(exprs) = analyzed {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::MethodCall {
+            method,
+            args,
+            ..
+        } = &exprs[0].expr
+        {
+            assert_eq!(method, "insert");
+            assert_eq!(args.len(), 2);
+            // Verify args...
+        } else {
+            panic!("Expected MethodCall");
+        }
+    } else {
+        panic!("Expected Expression statement");
     }
 }
 

--- a/src/semantic/conversion_tests.rs
+++ b/src/semantic/conversion_tests.rs
@@ -89,18 +89,81 @@ fn test_classify_push_literal() {
 
     if let AnalyzedStatement::Expression(exprs) = analyzed {
         assert_eq!(exprs.len(), 1);
-        if let AnalyzedExprKind::MethodCall {
-            method,
-            args,
-            ..
-        } = &exprs[0].expr
-        {
+        if let AnalyzedExprKind::MethodCall { method, args, .. } = &exprs[0].expr {
             assert_eq!(method, "push");
             assert_eq!(args.len(), 1);
             if let AnalyzedExprKind::NumberLiteral(n) = &args[0].expr {
                 assert_eq!(*n, 42);
             } else {
                 panic!("Arg should be literal 42");
+            }
+        } else {
+            panic!("Expected MethodCall");
+        }
+    } else {
+        panic!("Expected Expression statement");
+    }
+}
+
+#[test]
+fn test_classify_push_object() {
+    let mut scope = Scope::new();
+    scope.define("stack", GlossaType::List(Box::new(GlossaType::Number)));
+    scope.define("val", GlossaType::Number);
+
+    // "stack pushes val" (val is object)
+    let asm_stmt = AssembledStatement {
+        verb: Some(make_verb("ὠθεῖ", "ωθεω")),
+        subject: Some(make_constituent("stack", "stack")),
+        object: Some(make_constituent("val", "val")),
+        ..Default::default()
+    };
+
+    let analyzed =
+        convert_assembled_to_analyzed(&asm_stmt, &mut scope).expect("Should classify push object");
+
+    if let AnalyzedStatement::Expression(exprs) = analyzed {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::MethodCall { method, args, .. } = &exprs[0].expr {
+            assert_eq!(method, "push");
+            assert_eq!(args.len(), 1);
+            if let AnalyzedExprKind::Variable(name) = &args[0].expr {
+                assert_eq!(name, "val");
+            } else {
+                panic!("Arg should be variable val");
+            }
+        } else {
+            panic!("Expected MethodCall");
+        }
+    } else {
+        panic!("Expected Expression statement");
+    }
+}
+
+#[test]
+fn test_classify_push_default() {
+    let mut scope = Scope::new();
+    scope.define("stack", GlossaType::List(Box::new(GlossaType::Number)));
+
+    // "stack pushes" (no object/literal -> default 0)
+    let asm_stmt = AssembledStatement {
+        verb: Some(make_verb("ὠθεῖ", "ωθεω")),
+        subject: Some(make_constituent("stack", "stack")),
+        ..Default::default()
+    };
+
+    let analyzed =
+        convert_assembled_to_analyzed(&asm_stmt, &mut scope).expect("Should classify push default");
+
+    if let AnalyzedStatement::Expression(exprs) = analyzed {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::MethodCall { method, args, .. } = &exprs[0].expr {
+            assert_eq!(method, "push");
+            assert_eq!(args.len(), 1);
+            if let AnalyzedExprKind::NumberLiteral(n) = &args[0].expr {
+                assert_eq!(*n, 0);
+            } else {
+                panic!("Arg should be default 0");
             }
         } else {
             panic!("Expected MethodCall");
@@ -132,12 +195,7 @@ fn test_classify_insert_map() {
 
     if let AnalyzedStatement::Expression(exprs) = analyzed {
         assert_eq!(exprs.len(), 1);
-        if let AnalyzedExprKind::MethodCall {
-            method,
-            args,
-            ..
-        } = &exprs[0].expr
-        {
+        if let AnalyzedExprKind::MethodCall { method, args, .. } = &exprs[0].expr {
             assert_eq!(method, "insert");
             assert_eq!(args.len(), 2);
             // Verify args...
@@ -147,6 +205,91 @@ fn test_classify_insert_map() {
     } else {
         panic!("Expected Expression statement");
     }
+}
+
+#[test]
+fn test_classify_insert_set() {
+    let mut scope = Scope::new();
+    // Set<String>
+    scope.define("set", GlossaType::Set(Box::new(GlossaType::String)));
+
+    // "set puts 'val'"
+    let asm_stmt = AssembledStatement {
+        verb: Some(make_verb("τίθησι", "τιθημι")),
+        subject: Some(make_constituent("set", "set")),
+        literals: vec![Literal::String("val".into())],
+        ..Default::default()
+    };
+
+    let analyzed =
+        convert_assembled_to_analyzed(&asm_stmt, &mut scope).expect("Should classify insert set");
+
+    if let AnalyzedStatement::Expression(exprs) = analyzed {
+        assert_eq!(exprs.len(), 1);
+        if let AnalyzedExprKind::MethodCall { method, args, .. } = &exprs[0].expr {
+            assert_eq!(method, "insert");
+            assert_eq!(args.len(), 1);
+            if let AnalyzedExprKind::StringLiteral(s) = &args[0].expr {
+                assert_eq!(s, "val");
+            } else {
+                panic!("Arg should be string literal");
+            }
+        } else {
+            panic!("Expected MethodCall");
+        }
+    } else {
+        panic!("Expected Expression statement");
+    }
+}
+
+#[test]
+fn test_extract_ok() {
+    let scope = Scope::new();
+    // Subject "ἐπιτυχία" (Ok), Literal 42
+    let asm_stmt = AssembledStatement {
+        subject: Some(make_constituent("ἐπιτυχία", "επιτυχια")),
+        literals: vec![Literal::Number(42)],
+        ..Default::default()
+    };
+
+    let (analyzed, glossa_type) = extract_value(&asm_stmt, &scope).expect("Should extract Ok");
+
+    if let AnalyzedExprKind::Ok(inner) = analyzed.expr {
+        if let AnalyzedExprKind::NumberLiteral(n) = inner.expr {
+            assert_eq!(n, 42);
+        } else {
+            panic!("Expected number inside Ok");
+        }
+    } else {
+        panic!("Expected Ok expression");
+    }
+
+    assert!(matches!(glossa_type, GlossaType::Result(_, _)));
+}
+
+#[test]
+fn test_extract_err() {
+    let scope = Scope::new();
+    // Subject "σφάλμα" (Err), Literal 1 (error code)
+    let asm_stmt = AssembledStatement {
+        subject: Some(make_constituent("σφάλμα", "σφαλμα")),
+        literals: vec![Literal::Number(1)],
+        ..Default::default()
+    };
+
+    let (analyzed, glossa_type) = extract_value(&asm_stmt, &scope).expect("Should extract Err");
+
+    if let AnalyzedExprKind::Err(inner) = analyzed.expr {
+        if let AnalyzedExprKind::NumberLiteral(n) = inner.expr {
+            assert_eq!(n, 1);
+        } else {
+            panic!("Expected number inside Err");
+        }
+    } else {
+        panic!("Expected Err expression");
+    }
+
+    assert!(matches!(glossa_type, GlossaType::Result(_, _)));
 }
 
 #[test]


### PR DESCRIPTION
* 🚮 Smell: Deeply nested if/else blocks in `classify_collection_mutation` and repetitive code in `detect_enum_variant`.
* ✨ Solution: Extracted `classify_pop`, `classify_push`, and `classify_insert` helper functions. Introduced `check` helper in `detect_enum_variant`.
* 🧼 Benefit: Reduces cognitive load, flattens structure, and adheres to single responsibility principle.
* 🛡️ Verification: Added unit tests `test_classify_pop`, `test_classify_push_literal`, `test_classify_insert_map` in `src/semantic/conversion_tests.rs`. All tests passed.

---
*PR created automatically by Jules for task [12252649045445260333](https://jules.google.com/task/12252649045445260333) started by @madmax983*