### PR TITLE
🎻 Bard: Add module-level documentation to tools

### DIFF
--- a/src/tools/dictionary.rs
+++ b/src/tools/dictionary.rs
@@ -1,3 +1,50 @@
+//! The Lexicon (Dictionary) Tool
+//!
+//! This module implements the dictionary lookup and morphological analysis interface.
+//! It serves as "The Lexicon" in the compiler's toolset, allowing users to query
+//! word meanings, grammatical properties, and etymology.
+//!
+//! # The Dual Approach
+//!
+//! The Lexicon uses a two-tiered approach to analyze words:
+//!
+//! 1.  **Static Lexicon Lookup (Definitive)**:
+//!     First, it checks a built-in static dictionary of common words. If found, this provides
+//!     definitive information (lemma, part of speech, definition). This is fast and accurate
+//!     for core vocabulary.
+//!
+//! 2.  **Dynamic Morphological Analysis (Probabilistic)**:
+//!     If the word is not in the static lexicon (or even if it is), the tool performs
+//!     a dynamic morphological analysis. It decomposes the word into stem and ending,
+//!     applying grammatical rules to guess its properties (Case, Number, Gender, etc.).
+//!     This allows the compiler to understand words it has never seen before!
+//!
+//! # CLI Usage
+//!
+//! This tool powers the `glossa lookup` command:
+//!
+//! ```bash
+//! glossa lookup λόγον
+//! ```
+//!
+//! Output:
+//!
+//! ```text
+//!    Γ Λ Ω Σ Σ Α   L E X I C O N
+//!    Analyzing: λόγον
+//!
+//!    📚 Lexicon Entry (Definitive)
+//!    Property        Value
+//!    Lemma           λόγος
+//!    Part of Speech  Noun
+//!    Meaning         word, reason, logic
+//!    ...
+//!
+//!    🔬 Morphological Analysis (All Possibilities)
+//!    Lemma  PoS   Grammar                        Confidence
+//!    λόγος  Noun  Accusative, Singular, Masculine  1.00
+//! ```
+
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -1,3 +1,44 @@
+//! The Judge (Test Runner) Tool
+//!
+//! This module implements the `glossa test` command, allowing developers to write and run
+//! unit tests directly in ΓΛΩΣΣΑ.
+//!
+//! # The Strategy: Harness Generation
+//!
+//! Unlike interpreted languages that run tests in a VM, or compiled languages that need
+//! complex test discovery, ΓΛΩΣΣΑ leverages the existing Rust test infrastructure.
+//!
+//! 1.  **Parse & Analyze**: The source file is parsed and analyzed as usual.
+//! 2.  **Generate Test Harness**: The `codegen` module produces a Rust file where
+//!     `δοκιμή` (test) declarations are converted to `#[test]` functions.
+//! 3.  **Compile with `--test`**: The generated Rust file is compiled using `rustc --test`.
+//!     This produces a standalone test executable.
+//! 4.  **Execute & Capture**: The executable is run, and its output (stdout/stderr) is captured.
+//! 5.  **Parse & Report**: The raw output is parsed to provide a stylized, emoji-rich report.
+//!
+//! # Writing Tests
+//!
+//! Tests are declared using the `δοκιμή` keyword:
+//!
+//! ```glossa
+//! δοκιμή "Addition works" {
+//!     ξ 10 ἔστω.
+//!     ψ 20 ἔστω.
+//!     assert_eq(ξ + ψ, 30).
+//! }
+//! ```
+//!
+//! This compiles to:
+//!
+//! ```rust
+//! #[test]
+//! fn test_addition_works() {
+//!     let g_x = 10;
+//!     let g_y = 20;
+//!     assert_eq!(g_x + g_y, 30);
+//! }
+//! ```
+
 use crate::codegen::generate_rust_file;
 use crate::parser::parse;
 use crate::semantic::analyze_program;

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -30,7 +30,7 @@
 //!
 //! This compiles to:
 //!
-//! ```rust
+//! ```rust,ignore
 //! #[test]
 //! fn test_addition_works() {
 //!     let g_x = 10;

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -1,3 +1,24 @@
+//! The Stage (UI) Tool
+//!
+//! This module provides terminal user interface components for the CLI.
+//! It handles status indicators, spinners, and stylized output.
+//!
+//! # The Philosophy: "The Show Must Go On"
+//!
+//! A compiler should not be a black box that hangs silently. It should provide
+//! feedback on what it's doing.
+//!
+//! # Key Components
+//!
+//! *   **[`Status`]**: A context manager for long-running operations. It displays a
+//!     spinner or status message and handles cleanup (success/failure) automatically.
+//!
+//! # CI Friendliness
+//!
+//! The module detects if it is running in a TTY (interactive terminal).
+//! *   **TTY**: Uses animated spinners and rewriting lines (`\r`).
+//! *   **No-TTY (CI)**: Uses simple log lines to avoid cluttering build logs with escape codes.
+
 use crossterm::{ExecutableCommand, cursor, style::Stylize, terminal};
 use std::io::{self, IsTerminal, Write};
 use std::time::Instant;


### PR DESCRIPTION
This PR improves the documentation of the `tools` module by adding module-level docstrings (`//!`) to `dictionary.rs`, `tester.rs`, and `ui.rs`. These docstrings explain the high-level purpose of each tool using the project's "Bard" persona (storytelling style), including architectural decisions (e.g., TTY handling, harness generation) and usage examples. This addresses the "Black Box" documentation gap.

---
*PR created automatically by Jules for task [4277720506991950615](https://jules.google.com/task/4277720506991950615) started by @madmax983*