### PR TITLE
🔒 Warden: Fix DoS via nested test declarations

### DIFF
--- a/src/parser/recursion.rs
+++ b/src/parser/recursion.rs
@@ -3,7 +3,8 @@ use super::ParseError;
 /// Check recursion depth to prevent stack overflows
 ///
 /// This function performs a fast linear scan of the source code to ensure that
-/// parentheses, braces, and brackets are not nested deeper than `MAX_DEPTH` (500).
+/// parentheses, braces, brackets, AND keywords that induce nesting (like `δοκιμή`)
+/// are not nested deeper than `MAX_DEPTH` (500).
 /// This prevents stack overflows during the recursive parsing phase.
 pub(crate) fn check_recursion_depth(source: &str) -> Result<(), ParseError> {
     const MAX_DEPTH: usize = 500;
@@ -13,7 +14,8 @@ pub(crate) fn check_recursion_depth(source: &str) -> Result<(), ParseError> {
     let mut i = 0;
 
     // Optimization: Iterate bytes directly to avoid expensive UTF-8 decoding of Greek characters.
-    // We only care about structural characters which are ASCII (except for « and »).
+    // We only care about structural characters which are ASCII (except for « and »)
+    // and specific keywords (`δοκιμή`, `τέλος`) that affect nesting.
     // « is [0xC2, 0xAB]
     // » is [0xC2, 0xBB]
     while i < bytes.len() {
@@ -27,6 +29,27 @@ pub(crate) fn check_recursion_depth(source: &str) -> Result<(), ParseError> {
                 i += 1;
             }
         } else {
+            // Check for keywords first if byte matches start of UTF-8 sequence
+            // δοκιμή (test): starts with \xCE\xB4 (δ)
+            // τέλος (end): starts with \xCF\x84 (τ)
+
+            // Check for "δοκιμή" (test declaration start)
+            if b == 0xCE && source[i..].starts_with("δοκιμή") {
+                depth += 1;
+                if depth > MAX_DEPTH {
+                    return Err(ParseError::RecursionLimitExceeded(MAX_DEPTH));
+                }
+                i += "δοκιμή".len();
+                continue;
+            }
+
+            // Check for "τέλος" (test declaration end)
+            if b == 0xCF && source[i..].starts_with("τέλος") {
+                depth = depth.saturating_sub(1);
+                i += "τέλος".len();
+                continue;
+            }
+
             match b {
                 // Check for « [0xC2, 0xAB]
                 0xC2 => {

--- a/tests/havoc_nested_tests.rs
+++ b/tests/havoc_nested_tests.rs
@@ -1,4 +1,3 @@
-
 #[cfg(test)]
 mod tests {
     use glossa::parser::parse;
@@ -27,11 +26,18 @@ mod tests {
         // Now this should fail with RecursionLimitExceeded
         let result = parse(&source);
 
-        assert!(result.is_err(), "Expected parsing to fail due to recursion limit");
+        assert!(
+            result.is_err(),
+            "Expected parsing to fail due to recursion limit"
+        );
 
         let err = result.unwrap_err();
         let msg = err.to_string();
 
-        assert!(msg.contains("Recursion limit exceeded"), "Unexpected error message: {}", msg);
+        assert!(
+            msg.contains("Recursion limit exceeded"),
+            "Unexpected error message: {}",
+            msg
+        );
     }
 }

--- a/tests/havoc_nested_tests.rs
+++ b/tests/havoc_nested_tests.rs
@@ -1,0 +1,37 @@
+
+#[cfg(test)]
+mod tests {
+    use glossa::parser::parse;
+
+    #[test]
+    fn test_deeply_nested_tests_dos() {
+        // Generate 20000 nested test declarations to ensure stack overflow if unchecked
+        // δοκιμή "1" δοκιμή "2" ... τέλος τέλος
+        let mut source = String::new();
+        let depth = 20000;
+
+        // Use a loop to avoid stack overflow during string construction if we used recursion
+        source.reserve(depth * 30);
+
+        for i in 0..depth {
+            source.push_str(&format!("δοκιμή \"t{}\". ", i));
+        }
+
+        // Add a body to the innermost test
+        source.push_str("ξ 1 ἔστω. ");
+
+        for _ in 0..depth {
+            source.push_str("τέλος. ");
+        }
+
+        // Now this should fail with RecursionLimitExceeded
+        let result = parse(&source);
+
+        assert!(result.is_err(), "Expected parsing to fail due to recursion limit");
+
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+
+        assert!(msg.contains("Recursion limit exceeded"), "Unexpected error message: {}", msg);
+    }
+}


### PR DESCRIPTION
This PR addresses a Denial of Service (DoS) vulnerability where deeply nested test declarations (`δοκιμή ... τέλος`) could bypass the recursion depth check and cause a stack overflow.

**Changes:**
- Modified `check_recursion_depth` in `src/parser/recursion.rs` to explicitly count `δοκιμή` (start) and `τέλος` (end) keywords towards the recursion limit.
- Implemented a fast linear scan that respects UTF-8 boundaries for these Greek keywords.
- Added a regression test `tests/havoc_nested_tests.rs` that verifies the fix by attempting to parse 20,000 nested test declarations.

**Security Impact:**
- Prevents attackers (or accidents) from crashing the compiler/parser with malformed or excessive source code.
- Enforces the "Defense in Depth" principle by catching recursion early in the parsing pipeline.

---
*PR created automatically by Jules for task [728139008119162699](https://jules.google.com/task/728139008119162699) started by @madmax983*