### PR TITLE
Refine documentation for CLI, Types, Assembly, and Dictionary

### DIFF
--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -51,6 +51,17 @@
 //!
 //! The assembler handles all of these correctly, producing the same assembled semantic representation.
 //!
+//! # Security & Limits
+//!
+//! To prevent Denial of Service (DoS) attacks via resource exhaustion (e.g., stack overflow or excessive memory usage),
+//! the assembler enforces strict limits on the number of components in a single statement.
+//!
+//! * **Adjectives**: Max 1024
+//! * **Literals**: Max 1024
+//! * **Nested Structures**: Max 256 (Arrays, Blocks, Phrases)
+//!
+//! See [`model`] for the full list of limits.
+//!
 //! ## The Hero's Journey: A Sentence's Path
 //!
 //! Consider the sentence: `ὁ ἄνθρωπος τὸν λόγον λέγει` (The man says the word).

--- a/src/semantic/assembly/model.rs
+++ b/src/semantic/assembly/model.rs
@@ -10,17 +10,31 @@ use crate::morphology::{Case, Gender, Mood, Number, Person, Tense, Voice};
 use smol_str::SmolStr;
 
 // Constants for resource limits to prevent DoS
+// These limits are enforced to prevent malicious code from exhausting memory or stack space
+// by creating excessively long lists of adjectives, literals, or nested structures.
+/// Maximum number of adjectives allowed per statement
 pub(crate) const MAX_ADJECTIVES: usize = 1024;
+/// Maximum number of literals (strings/numbers) allowed per statement
 pub(crate) const MAX_LITERALS: usize = 1024;
+/// Maximum number of nominatives (subjects/function names) allowed per statement
 pub(crate) const MAX_NOMINATIVES: usize = 256;
+/// Maximum number of genitives (possessors) allowed per statement
 pub(crate) const MAX_GENITIVES: usize = 256;
+/// Maximum number of array literals allowed per statement
 pub(crate) const MAX_ARRAYS: usize = 256;
+/// Maximum number of index accesses allowed per statement
 pub(crate) const MAX_INDEX_ACCESSES: usize = 256;
+/// Maximum number of property accesses allowed per statement
 pub(crate) const MAX_PROPERTY_ACCESSES: usize = 256;
+/// Maximum number of nested phrases (parenthesized calls) allowed per statement
 pub(crate) const MAX_NESTED_PHRASES: usize = 256;
+/// Maximum number of participles (lambdas) allowed per statement
 pub(crate) const MAX_PARTICIPLES: usize = 256;
+/// Maximum number of unwrap operations allowed per statement
 pub(crate) const MAX_UNWRAPS: usize = 256;
+/// Maximum number of binary operators allowed per statement
 pub(crate) const MAX_OPERATORS: usize = 256;
+/// Maximum number of block expressions allowed per statement
 pub(crate) const MAX_BLOCKS: usize = 256;
 
 /// A fully assembled statement with all grammatical roles filled

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -1,14 +1,16 @@
 //! Type system for ΓΛΩΣΣΑ
 //!
-//! Types in GLOSSA are derived from Greek nouns:
-//! - ἀριθμός (arithmos) → Number (i64)
-//! - ὄνομα (onoma) → String
-//! - ἀληθές/ψεῦδος → Boolean
-//! - λίστη (liste) → List/Vec
+//! This module defines the [`GlossaType`] enum, which represents the type system of the language.
 //!
-//! Special types from Greek morphology:
-//! - Optative mood → `Option<T>` (value that "might be")
-//! - ἀποτέλεσμα (apotelasma) → `Result<T,E>` (outcome/result)
+//! # Philosophy
+//!
+//! ΓΛΩΣΣΑ maps programming concepts to Ancient Greek philosophical and grammatical constructs:
+//!
+//! * **Nouns as Types**: Basic types are derived from Greek nouns (e.g., `ἀριθμός` for Number, `ὄνομα` for Name/String).
+//! * **Moods as Wrappers**:
+//!     * The **Optative Mood** (expressing wish/possibility) maps to `Option<T>` (a value that "might be").
+//!     * The **Noun `Ἀποτέλεσμα`** (outcome/result) maps to `Result<T, E>`.
+//! * **Free Word Order**: Type compatibility is determined by structure, not just name (though nominal typing is used for structs).
 
 use crate::morphology::Gender;
 use smol_str::SmolStr;
@@ -110,6 +112,20 @@ pub enum GlossaType {
 }
 
 impl std::fmt::Display for GlossaType {
+    /// Formats the type using its Greek name.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use glossa::semantic::GlossaType;
+    ///
+    /// assert_eq!(format!("{}", GlossaType::Number), "Ἀριθμός");
+    /// assert_eq!(format!("{}", GlossaType::String), "Ὄνομα");
+    /// assert_eq!(
+    ///     format!("{}", GlossaType::List(Box::new(GlossaType::Number))),
+    ///     "Λίστη<Ἀριθμός>"
+    /// );
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             GlossaType::Number => write!(f, "Ἀριθμός"),

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -9,10 +9,20 @@
 //! The CLI supports several distinct workflows:
 //!
 //! * **Execution**: `run` (default) compiles and executes a program.
+//! * **Testing**: `test` runs unit tests defined in the source file.
 //! * **Compilation**: `build` only compiles to a binary.
 //! * **Development**: `check` verifies syntax/semantics, `highlight` shows colors.
 //! * **Learning**: `lookup` explains words, `bard` tells the story of the code.
 //! * **Interactive**: `repl` starts the Read-Eval-Print Loop.
+//!
+//! ## Experimental Tools (Nova Feature)
+//!
+//! Some advanced visualization tools require the `nova` feature flag to be enabled
+//! during compilation of the compiler itself.
+//!
+//! * **Mentor**: `mentor` starts an interactive tutorial.
+//! * **Mosaic**: `mosaic` visualizes the sentence structure assembly.
+//! * **Map**: `map` generates architecture diagrams.
 //!
 //! # Example Usage
 //!
@@ -20,11 +30,17 @@
 //! # Run a file
 //! glossa run main.gl
 //!
+//! # Run tests
+//! glossa test main.gl
+//!
 //! # Just check for errors
 //! glossa check main.gl
 //!
 //! # Look up a word
 //! glossa lookup "λόγον"
+//!
+//! # Visualize sentence structure (requires feature 'nova')
+//! glossa mosaic main.gl
 //! ```
 
 use clap::{Parser, Subcommand};

--- a/src/tools/dictionary.rs
+++ b/src/tools/dictionary.rs
@@ -228,4 +228,10 @@ mod tests {
     fn test_lookup_verb() {
         lookup_word("λέγε").unwrap();
     }
+
+    #[test]
+    fn test_lookup_word_without_rust_equiv() {
+        // "εγω" (I) has rust_equiv: None in the lexicon
+        lookup_word("εγω").unwrap();
+    }
 }

--- a/src/tools/dictionary.rs
+++ b/src/tools/dictionary.rs
@@ -94,14 +94,18 @@ pub fn lookup_word(word: &str) -> Result<()> {
             Cell::new(entry.meaning).fg(Color::Yellow),
         ]);
 
-        if let Some(rust) = entry.rust_equiv {
-            table.add_row(vec![
-                Cell::new("Rust Equivalent"),
-                Cell::new(rust)
-                    .fg(Color::Red)
-                    .add_attribute(Attribute::Bold),
-            ]);
-        }
+        // Clarify rust_equiv semantics: None means user-defined or no direct mapping
+        let rust_equiv_display = entry.rust_equiv.unwrap_or("(none/user-defined)");
+        table.add_row(vec![
+            Cell::new("Rust Equivalent"),
+            Cell::new(rust_equiv_display)
+                .fg(if entry.rust_equiv.is_some() {
+                    Color::Red
+                } else {
+                    Color::DarkGrey
+                })
+                .add_attribute(Attribute::Bold),
+        ]);
 
         // Add grammatical details if present
         if let Some(c) = entry.case {

--- a/tests/mosaic_coverage.rs
+++ b/tests/mosaic_coverage.rs
@@ -1,6 +1,7 @@
+#![cfg(feature = "nova")]
+
 use glossa::tools::mosaic::run_mosaic_inner;
 
-#[cfg(feature = "nova")]
 #[test]
 fn test_mosaic_comprehensive_coverage() {
     // Corrected test string with valid syntax


### PR DESCRIPTION
This PR enhances the documentation and user experience of the Glossa compiler tools and core semantic modules.

### Key Changes
1.  **CLI Documentation (`src/tools/cli.rs`)**:
    *   Added detailed descriptions for `test`, `mosaic`, `map`, and `mentor` commands.
    *   Explicitly documented the requirement for the `nova` feature flag for experimental tools.
    *   Added usage examples for these commands.

2.  **Type System Philosophy (`src/semantic/types.rs`)**:
    *   Added a "Philosophy" section explaining the rationale behind mapping Ancient Greek grammatical constructs to Rust types (e.g., Optative Mood -> `Option<T>`, `Ἀποτέλεσμα` -> `Result<T, E>`).
    *   Added executable doctests for `GlossaType` display formatting.

3.  **Security Limits (`src/semantic/assembly/mod.rs`, `src/semantic/assembly/model.rs`)**:
    *   Documented the purpose of resource limits (e.g., `MAX_ADJECTIVES`, `MAX_LITERALS`) in `model.rs` as a defense against Denial of Service (DoS) attacks via resource exhaustion.
    *   Added a "Security & Limits" section to the `assembly` module documentation.

4.  **Dictionary Tool Polish (`src/tools/dictionary.rs`)**:
    *   Improved the output of the `glossa lookup` command to explicitly state `(none/user-defined)` when a word has no direct Rust equivalent, rather than showing a confusing empty or misleading value.

### Verification
*   `cargo test` passed.
*   `cargo clippy` passed.
*   `cargo doc` generated successfully (verified visually via source inspection and warning checks).

---
*PR created automatically by Jules for task [6101298449217664940](https://jules.google.com/task/6101298449217664940) started by @madmax983*