### PR TITLE
🗺️ Atlas: Extract morphology models to break dependency cycle

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -7,8 +7,8 @@
 
 use std::borrow::Cow;
 
-use super::{Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice};
 use crate::morphology::matcher::match_suffix;
+use crate::morphology::models::{Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice};
 use crate::text::normalize_greek;
 
 /// Present Active Indicative endings (ω-conjugation)

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -7,8 +7,8 @@
 
 use std::borrow::Cow;
 
-use super::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
 use crate::morphology::matcher::match_suffix;
+use crate::morphology::models::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
 
 /// Declension pattern
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/morphology/disambiguation.rs
+++ b/src/morphology/disambiguation.rs
@@ -14,7 +14,7 @@
 //!
 //! If preceded by "ἡ" (feminine nominative article), we know it's nominative.
 
-use crate::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech, Person};
+use crate::morphology::models::{Case, Gender, MorphAnalysis, Number, PartOfSpeech, Person};
 
 /// A disambiguation context built from surrounding words
 #[derive(Debug, Clone, Default)]

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -53,7 +53,9 @@
 //! * **Function Mappings**: Mapping `λέγε` directly to `println!`.
 //! * **Keywords**: `εἰ` (if), `ἕως` (while).
 
-use super::{Case, Gender, Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice};
+use crate::morphology::models::{
+    Case, Gender, Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice,
+};
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::sync::LazyLock;

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -24,79 +24,19 @@ pub mod declension;
 pub mod disambiguation;
 pub mod lexicon;
 pub mod matcher;
+pub mod models;
 pub mod participle;
 
 pub use conjugation::*;
 pub use declension::*;
 pub use disambiguation::*;
 pub use lexicon::*;
+pub use models::*;
 pub use participle::*;
 
 use std::borrow::Cow;
 
 use crate::text::normalize_greek;
-
-/// Result of morphological analysis
-#[derive(Debug, Clone, PartialEq)]
-pub struct MorphAnalysis {
-    /// The dictionary form (lemma)
-    ///
-    /// Optimization: Uses `Cow<'static, str>` to avoid allocations for lexicon entries
-    /// which are `&'static str`. Only dynamically generated lemmas (e.g. from
-    /// suffix stripping) use heap allocation.
-    pub lemma: Cow<'static, str>,
-    pub part_of_speech: PartOfSpeech,
-    pub case: Option<Case>,
-    pub number: Option<Number>,
-    pub gender: Option<Gender>,
-    pub person: Option<Person>,
-    pub tense: Option<Tense>,
-    pub mood: Option<Mood>,
-    pub voice: Option<Voice>,
-    /// Confidence score (0.0 - 1.0). Higher = more likely.
-    /// Lexicon entries get 1.0, pattern matches get lower scores.
-    pub confidence: f32,
-}
-
-impl MorphAnalysis {
-    /// Create a new analysis with default confidence
-    pub fn new(lemma: String, pos: PartOfSpeech) -> Self {
-        MorphAnalysis {
-            lemma: Cow::Owned(lemma),
-            part_of_speech: pos,
-            case: None,
-            number: None,
-            gender: None,
-            person: None,
-            tense: None,
-            mood: None,
-            voice: None,
-            confidence: 0.5,
-        }
-    }
-
-    /// Set confidence score
-    pub fn with_confidence(mut self, confidence: f32) -> Self {
-        self.confidence = confidence;
-        self
-    }
-}
-
-/// Part of speech
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PartOfSpeech {
-    Noun,
-    Verb,
-    Adjective,
-    Pronoun,
-    Article,
-    Particle,
-    Numeral,
-    Preposition,
-    Conjunction,
-    Adverb,
-    Unknown,
-}
 
 /// Analyze a Greek word and return the most likely morphological analysis
 pub fn analyze(word: &str) -> MorphAnalysis {
@@ -224,171 +164,6 @@ fn is_single_greek_letter(word: &str) -> bool {
     ('\u{0391}'..='\u{03A9}').contains(&c) ||   // Uppercase
     ('\u{03B1}'..='\u{03C9}').contains(&c) ||   // Lowercase
     c == '\u{03C2}' // Final sigma
-}
-
-/// Check if two analyses are compatible (could refer to the same word in context)
-///
-/// Returns `true` if the analyses do not have conflicting grammatical features.
-/// Used during disambiguation to check if a word's potential analysis fits
-/// with the surrounding context (e.g., article agreement).
-///
-/// # Examples
-///
-/// ```
-/// use glossa::morphology::{analyses_compatible, MorphAnalysis, PartOfSpeech, Case};
-///
-/// let mut a = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
-/// a.case = Some(Case::Nominative);
-///
-/// let mut b = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
-/// b.case = Some(Case::Accusative);
-///
-/// assert!(!analyses_compatible(&a, &b));
-/// ```
-pub fn analyses_compatible(a: &MorphAnalysis, b: &MorphAnalysis) -> bool {
-    // Check case agreement if both have cases
-    if let (Some(case_a), Some(case_b)) = (a.case, b.case)
-        && case_a != case_b
-    {
-        return false;
-    }
-
-    // Check number agreement if both have numbers
-    if let (Some(num_a), Some(num_b)) = (a.number, b.number)
-        && num_a != num_b
-    {
-        return false;
-    }
-
-    // Check gender agreement if both have genders
-    if let (Some(gen_a), Some(gen_b)) = (a.gender, b.gender)
-        && gen_a != gen_b
-    {
-        return false;
-    }
-
-    true
-}
-
-/// Grammatical case - determines semantic role
-///
-/// In ΓΛΩΣΣΑ:
-/// - Nominative: the subject/agent
-/// - Genitive: possession, property access, borrow (&T)
-/// - Dative: indirect object, recipient, mutable borrow (&mut T)
-/// - Accusative: direct object, function argument, move/ownership
-/// - Vocative: direct address (for error messages)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum Case {
-    Nominative,
-    Genitive,
-    Dative,
-    Accusative,
-    Vocative,
-}
-
-/// Grammatical number
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum Number {
-    Singular,
-    Plural,
-    // Dual omitted for MVP
-}
-
-/// Grammatical gender
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum Gender {
-    Masculine,
-    Feminine,
-    Neuter,
-}
-
-/// Person (for verbs)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum Person {
-    First,
-    Second,
-    Third,
-}
-
-/// Tense - encodes aspect/time
-///
-/// In ΓΛΩΣΣΑ:
-/// - Present: streaming/iterative operations
-/// - Aorist: one-shot/complete operations
-/// - Perfect: completed with lasting result
-/// - Imperfect: ongoing past (for async?)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum Tense {
-    Present,
-    Imperfect,
-    Future,
-    Aorist,
-    Perfect,
-    Pluperfect,
-}
-
-/// Mood - encodes modality
-///
-/// In ΓΛΩΣΣΑ:
-/// - Indicative: statements of fact, regular execution
-/// - Imperative: commands, top-level expressions
-/// - Subjunctive: conditionals, possibility
-/// - Optative: wishes, optional execution
-/// - Infinitive: non-finite verb form
-/// - Participle: verbal adjective, used for lambdas/closures
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum Mood {
-    Indicative,
-    Imperative,
-    Subjunctive,
-    Optative,
-    Infinitive,
-    Participle,
-}
-
-/// Voice - active, middle, passive
-///
-/// In ΓΛΩΣΣΑ:
-/// - Active: regular function calls
-/// - Middle: reflexive/self-affecting (method on self)
-/// - Passive: subject receives action (callback/event handler)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Voice {
-    Active,
-    Middle,
-    Passive,
-}
-
-impl std::fmt::Display for Case {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Case::Nominative => write!(f, "ὀνομαστική"),
-            Case::Genitive => write!(f, "γενική"),
-            Case::Dative => write!(f, "δοτική"),
-            Case::Accusative => write!(f, "αἰτιατική"),
-            Case::Vocative => write!(f, "κλητική"),
-        }
-    }
-}
-
-impl std::fmt::Display for Number {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Number::Singular => write!(f, "ἑνικός"),
-            Number::Plural => write!(f, "πληθυντικός"),
-        }
-    }
-}
-
-impl std::fmt::Display for Gender {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Gender::Masculine => write!(f, "ἀρσενικόν"),
-            Gender::Feminine => write!(f, "θηλυκόν"),
-            Gender::Neuter => write!(f, "οὐδέτερον"),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/morphology/models.rs
+++ b/src/morphology/models.rs
@@ -1,0 +1,233 @@
+//! Core morphology types and models
+//!
+//! This module contains the foundational types for morphological analysis,
+//! extracted to break circular dependencies between `morphology` submodules.
+
+use std::borrow::Cow;
+
+/// Result of morphological analysis
+#[derive(Debug, Clone, PartialEq)]
+pub struct MorphAnalysis {
+    /// The dictionary form (lemma)
+    ///
+    /// Optimization: Uses `Cow<'static, str>` to avoid allocations for lexicon entries
+    /// which are `&'static str`. Only dynamically generated lemmas (e.g. from
+    /// suffix stripping) use heap allocation.
+    pub lemma: Cow<'static, str>,
+    pub part_of_speech: PartOfSpeech,
+    pub case: Option<Case>,
+    pub number: Option<Number>,
+    pub gender: Option<Gender>,
+    pub person: Option<Person>,
+    pub tense: Option<Tense>,
+    pub mood: Option<Mood>,
+    pub voice: Option<Voice>,
+    /// Confidence score (0.0 - 1.0). Higher = more likely.
+    /// Lexicon entries get 1.0, pattern matches get lower scores.
+    pub confidence: f32,
+}
+
+impl MorphAnalysis {
+    /// Create a new analysis with default confidence
+    pub fn new(lemma: String, pos: PartOfSpeech) -> Self {
+        MorphAnalysis {
+            lemma: Cow::Owned(lemma),
+            part_of_speech: pos,
+            case: None,
+            number: None,
+            gender: None,
+            person: None,
+            tense: None,
+            mood: None,
+            voice: None,
+            confidence: 0.5,
+        }
+    }
+
+    /// Set confidence score
+    pub fn with_confidence(mut self, confidence: f32) -> Self {
+        self.confidence = confidence;
+        self
+    }
+}
+
+/// Part of speech
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PartOfSpeech {
+    Noun,
+    Verb,
+    Adjective,
+    Pronoun,
+    Article,
+    Particle,
+    Numeral,
+    Preposition,
+    Conjunction,
+    Adverb,
+    Unknown,
+}
+
+/// Grammatical case - determines semantic role
+///
+/// In ΓΛΩΣΣΑ:
+/// - Nominative: the subject/agent
+/// - Genitive: possession, property access, borrow (&T)
+/// - Dative: indirect object, recipient, mutable borrow (&mut T)
+/// - Accusative: direct object, function argument, move/ownership
+/// - Vocative: direct address (for error messages)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Case {
+    Nominative,
+    Genitive,
+    Dative,
+    Accusative,
+    Vocative,
+}
+
+/// Grammatical number
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Number {
+    Singular,
+    Plural,
+    // Dual omitted for MVP
+}
+
+/// Grammatical gender
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Gender {
+    Masculine,
+    Feminine,
+    Neuter,
+}
+
+/// Person (for verbs)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Person {
+    First,
+    Second,
+    Third,
+}
+
+/// Tense - encodes aspect/time
+///
+/// In ΓΛΩΣΣΑ:
+/// - Present: streaming/iterative operations
+/// - Aorist: one-shot/complete operations
+/// - Perfect: completed with lasting result
+/// - Imperfect: ongoing past (for async?)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Tense {
+    Present,
+    Imperfect,
+    Future,
+    Aorist,
+    Perfect,
+    Pluperfect,
+}
+
+/// Mood - encodes modality
+///
+/// In ΓΛΩΣΣΑ:
+/// - Indicative: statements of fact, regular execution
+/// - Imperative: commands, top-level expressions
+/// - Subjunctive: conditionals, possibility
+/// - Optative: wishes, optional execution
+/// - Infinitive: non-finite verb form
+/// - Participle: verbal adjective, used for lambdas/closures
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Mood {
+    Indicative,
+    Imperative,
+    Subjunctive,
+    Optative,
+    Infinitive,
+    Participle,
+}
+
+/// Voice - active, middle, passive
+///
+/// In ΓΛΩΣΣΑ:
+/// - Active: regular function calls
+/// - Middle: reflexive/self-affecting (method on self)
+/// - Passive: subject receives action (callback/event handler)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Voice {
+    Active,
+    Middle,
+    Passive,
+}
+
+impl std::fmt::Display for Case {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Case::Nominative => write!(f, "ὀνομαστική"),
+            Case::Genitive => write!(f, "γενική"),
+            Case::Dative => write!(f, "δοτική"),
+            Case::Accusative => write!(f, "αἰτιατική"),
+            Case::Vocative => write!(f, "κλητική"),
+        }
+    }
+}
+
+impl std::fmt::Display for Number {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Number::Singular => write!(f, "ἑνικός"),
+            Number::Plural => write!(f, "πληθυντικός"),
+        }
+    }
+}
+
+impl std::fmt::Display for Gender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Gender::Masculine => write!(f, "ἀρσενικόν"),
+            Gender::Feminine => write!(f, "θηλυκόν"),
+            Gender::Neuter => write!(f, "οὐδέτερον"),
+        }
+    }
+}
+
+/// Check if two analyses are compatible (could refer to the same word in context)
+///
+/// Returns `true` if the analyses do not have conflicting grammatical features.
+/// Used during disambiguation to check if a word's potential analysis fits
+/// with the surrounding context (e.g., article agreement).
+///
+/// # Examples
+///
+/// ```
+/// use glossa::morphology::models::{analyses_compatible, MorphAnalysis, PartOfSpeech, Case};
+///
+/// let mut a = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
+/// a.case = Some(Case::Nominative);
+///
+/// let mut b = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
+/// b.case = Some(Case::Accusative);
+///
+/// assert!(!analyses_compatible(&a, &b));
+/// ```
+pub fn analyses_compatible(a: &MorphAnalysis, b: &MorphAnalysis) -> bool {
+    // Check case agreement if both have cases
+    if let (Some(case_a), Some(case_b)) = (a.case, b.case)
+        && case_a != case_b
+    {
+        return false;
+    }
+
+    // Check number agreement if both have numbers
+    if let (Some(num_a), Some(num_b)) = (a.number, b.number)
+        && num_a != num_b
+    {
+        return false;
+    }
+
+    // Check gender agreement if both have genders
+    if let (Some(gen_a), Some(gen_b)) = (a.gender, b.gender)
+        && gen_a != gen_b
+    {
+        return false;
+    }
+
+    true
+}

--- a/src/morphology/participle.rs
+++ b/src/morphology/participle.rs
@@ -24,8 +24,8 @@
 //! assert_eq!(p.tense, Tense::Present);
 //! ```
 
-use super::{Case, Gender, Number, Tense, Voice};
 use crate::morphology::matcher::match_suffix;
+use crate::morphology::models::{Case, Gender, Number, Tense, Voice};
 use std::sync::LazyLock;
 
 /// Result of participle morphological analysis

--- a/tests/morphology_models_test.rs
+++ b/tests/morphology_models_test.rs
@@ -1,0 +1,102 @@
+use glossa::morphology::models::*;
+
+#[test]
+fn test_morph_analysis_creation() {
+    let analysis = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
+    assert_eq!(analysis.lemma, "λογος");
+    assert_eq!(analysis.part_of_speech, PartOfSpeech::Noun);
+    assert_eq!(analysis.confidence, 0.5); // Default confidence
+}
+
+#[test]
+fn test_morph_analysis_with_confidence() {
+    let analysis = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun).with_confidence(0.9);
+    assert_eq!(analysis.confidence, 0.9);
+}
+
+#[test]
+fn test_analyses_compatible() {
+    // Compatible: Same case
+    let mut a = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
+    a.case = Some(Case::Nominative);
+    let mut b = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
+    b.case = Some(Case::Nominative);
+    assert!(analyses_compatible(&a, &b));
+
+    // Incompatible: Different case
+    b.case = Some(Case::Accusative);
+    assert!(!analyses_compatible(&a, &b));
+
+    // Compatible: One has no case
+    b.case = None;
+    assert!(analyses_compatible(&a, &b));
+
+    // Incompatible: Different number
+    a.number = Some(Number::Singular);
+    b.number = Some(Number::Plural);
+    assert!(!analyses_compatible(&a, &b));
+
+    // Incompatible: Different gender
+    a.number = None;
+    b.number = None;
+    a.gender = Some(Gender::Masculine);
+    b.gender = Some(Gender::Feminine);
+    assert!(!analyses_compatible(&a, &b));
+}
+
+#[test]
+fn test_display_impls() {
+    assert_eq!(Case::Nominative.to_string(), "ὀνομαστική");
+    assert_eq!(Case::Genitive.to_string(), "γενική");
+    assert_eq!(Case::Dative.to_string(), "δοτική");
+    assert_eq!(Case::Accusative.to_string(), "αἰτιατική");
+    assert_eq!(Case::Vocative.to_string(), "κλητική");
+
+    assert_eq!(Number::Singular.to_string(), "ἑνικός");
+    assert_eq!(Number::Plural.to_string(), "πληθυντικός");
+
+    assert_eq!(Gender::Masculine.to_string(), "ἀρσενικόν");
+    assert_eq!(Gender::Feminine.to_string(), "θηλυκόν");
+    assert_eq!(Gender::Neuter.to_string(), "οὐδέτερον");
+}
+
+#[test]
+fn test_enum_variants() {
+    // Verify PartOfSpeech variants
+    let _ = PartOfSpeech::Verb;
+    let _ = PartOfSpeech::Adjective;
+    let _ = PartOfSpeech::Pronoun;
+    let _ = PartOfSpeech::Article;
+    let _ = PartOfSpeech::Particle;
+    let _ = PartOfSpeech::Numeral;
+    let _ = PartOfSpeech::Preposition;
+    let _ = PartOfSpeech::Conjunction;
+    let _ = PartOfSpeech::Adverb;
+    let _ = PartOfSpeech::Unknown;
+
+    // Verify Person variants
+    let _ = Person::First;
+    let _ = Person::Second;
+    let _ = Person::Third;
+
+    // Verify Tense variants
+    let _ = Tense::Present;
+    let _ = Tense::Imperfect;
+    let _ = Tense::Future;
+    let _ = Tense::Aorist;
+    let _ = Tense::Perfect;
+    let _ = Tense::Pluperfect;
+
+    // Verify Mood variants
+    let _ = Mood::Indicative;
+    let _ = Mood::Imperative;
+    let _ = Mood::Subjunctive;
+    let _ = Mood::Optative;
+    let _ = Mood::Infinitive;
+    let _ = Mood::Participle;
+
+    // Verify Voice variants
+    let _ = Voice::Active;
+    let _ = Voice::Middle;
+    let _ = Voice::Passive;
+}


### PR DESCRIPTION
This PR refactors the `morphology` module to align with "Atlas" architectural principles.

🕸️ **Tangle**: The `morphology` module had a circular dependency structure where `mod.rs` defined types used by submodules, but also imported submodules to expose their functionality. This "Parent depends on Children, Children depend on Parent" pattern makes the module fragile and hard to reason about.

📐 **Blueprint**:
1.  Extracted core domain models (`MorphAnalysis`, `Case`, `Gender`, etc.) into a new leaf module `src/morphology/models.rs`.
2.  Updated `src/morphology/mod.rs` to re-export these types, maintaining backward compatibility.
3.  Refactored all submodules (`lexicon`, `declension`, `conjugation`, `participle`, `disambiguation`) to import types from `crate::morphology::models` instead of `super`.

🧱 **Stability**:
*   The dependency graph is now a Directed Acyclic Graph (DAG): `mod` -> `lexicon` -> `models`.
*   Zero logic changes; this is a pure structural refactor.
*   Backward compatibility is preserved via re-exports.

🔬 **Verification**:
*   `cargo check` passes.
*   `cargo test` passes (existing unrelated failure in `mosaic` coverage noted and ignored).

---
*PR created automatically by Jules for task [9547126163791241455](https://jules.google.com/task/9547126163791241455) started by @madmax983*