### PR TITLE
DX: Improve error messages for missing 'nova' feature commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,16 @@ fn main() -> Result<()> {
             run_file(&input)?;
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Mentor) => {
+            #[cfg(feature = "nova")]
             glossa::tools::mentor::run_mentor()?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                eprintln!("⚠️  The 'Mentor' feature is not enabled.");
+                eprintln!("   Please run with: cargo run --release --features nova -- mentor");
+                std::process::exit(1);
+            }
         }
 
         Some(Commands::Build { input, output }) => {
@@ -52,14 +59,30 @@ fn main() -> Result<()> {
             glossa::tools::tester::run_tests(&input)?;
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Mosaic { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::mosaic::run_mosaic(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input; // Suppress unused variable warning
+                eprintln!("⚠️  The 'Mosaic' feature is not enabled.");
+                eprintln!("   Please run with: cargo run --release --features nova -- mosaic <FILE>");
+                std::process::exit(1);
+            }
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::cartographer::run_map(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input; // Suppress unused variable warning
+                eprintln!("⚠️  The 'Map' feature is not enabled.");
+                eprintln!("   Please run with: cargo run --release --features nova -- map <FILE>");
+                std::process::exit(1);
+            }
         }
 
         Some(Commands::Repl) | None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,9 @@ fn main() -> Result<()> {
             {
                 let _ = input; // Suppress unused variable warning
                 eprintln!("⚠️  The 'Mosaic' feature is not enabled.");
-                eprintln!("   Please run with: cargo run --release --features nova -- mosaic <FILE>");
+                eprintln!(
+                    "   Please run with: cargo run --release --features nova -- mosaic <FILE>"
+                );
                 std::process::exit(1);
             }
         }

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -52,7 +52,6 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -99,14 +98,12 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Map {
         /// Input file (.γλ)
         input: PathBuf,

--- a/tests/mosaic_coverage.rs
+++ b/tests/mosaic_coverage.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "nova")]
 use glossa::tools::mosaic::run_mosaic_inner;
 
 #[cfg(feature = "nova")]


### PR DESCRIPTION
Improved CLI error handling for optional 'nova' feature commands. Instead of 'File not found', users now see a helpful message instructing them to enable the feature flag.

---
*PR created automatically by Jules for task [6449277047699798060](https://jules.google.com/task/6449277047699798060) started by @madmax983*