### PR TITLE
Refactor: Inline trivial error formatting helpers to reduce abstraction

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -82,3 +82,8 @@
 **Bloat:** `src/semantic/traits.rs` defined a `StatementAnalyzer` trait that was only ever implemented once by `Analyzer` in `src/semantic/analyzer.rs`.
 **Cut:** Deleted the trait and file entirely, calling `Analyzer::analyze` concretely.
 **Saved:** 1 file, reduced indirection, simplified function signatures in `control_flow.rs` and `declarations.rs`.
+
+## [Reduction]
+**Bloat:** Trivial string-formatting helper functions (`undefined_variable`, `immutable_assignment`, `gender_mismatch`, `number_mismatch`, `case_mismatch`) in `src/errors.rs` added unnecessary abstraction and boilerplate. Four of these functions were actually unused dead code.
+**Cut:** Inlined the single active usage (`immutable_assignment`) directly at its call site and deleted all 5 functions from `src/errors.rs` entirely.
+**Saved:** Removed 5 trivial functions, 4 of which were dead code, and their associated tests, reducing line count by ~70 lines and improving clarity.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,7 +39,7 @@
 
 #![allow(unused_assignments)]
 
-use crate::morphology::{Case, Gender, Number, Person};
+use crate::morphology::{Gender, Number, Person};
 use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 
@@ -274,101 +274,6 @@ pub enum AssemblyError {
     LimitExceeded { resource: String, max: usize },
 }
 
-/// Get a Greek message for an undefined variable
-///
-/// Returns: "Οὐκ οἶδα τὸ ὄνομα «{name}»"
-///
-/// # Examples
-///
-/// ```
-/// use glossa::errors::undefined_variable;
-///
-/// let msg = undefined_variable("ξ");
-/// assert_eq!(msg, "Οὐκ οἶδα τὸ ὄνομα «ξ»");
-/// ```
-pub fn undefined_variable(name: &str) -> String {
-    format!("Οὐκ οἶδα τὸ ὄνομα «{}»", name)
-}
-
-/// Get a Greek message for assignment to immutable variable
-///
-/// Returns: "Τὸ «{name}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ"
-///
-/// # Examples
-///
-/// ```
-/// use glossa::errors::immutable_assignment;
-///
-/// let msg = immutable_assignment("π");
-/// assert!(msg.contains("ἀμετάβλητόν ἐστιν"));
-/// ```
-pub fn immutable_assignment(name: &str) -> String {
-    format!(
-        "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-        name
-    )
-}
-
-/// Get a Greek message for gender mismatch
-///
-/// Returns: "Τὸ «{word1}» ({gender1}) οὐ συμφωνεῖ τῷ «{word2}» ({gender2})"
-///
-/// # Examples
-///
-/// ```
-/// use glossa::errors::gender_mismatch;
-/// use glossa::morphology::Gender;
-///
-/// let msg = gender_mismatch("καλός", Gender::Masculine, "γυνή", Gender::Feminine);
-/// assert!(msg.contains("οὐ συμφωνεῖ"));
-/// ```
-pub fn gender_mismatch(word1: &str, gender1: Gender, word2: &str, gender2: Gender) -> String {
-    format!(
-        "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
-        word1, gender1, word2, gender2
-    )
-}
-
-/// Get a Greek message for number mismatch
-///
-/// Returns: "Τὸ «{word1}» ({num1}) οὐ συμφωνεῖ τῷ «{word2}» ({num2})"
-///
-/// # Examples
-///
-/// ```
-/// use glossa::errors::number_mismatch;
-/// use glossa::morphology::Number;
-///
-/// let msg = number_mismatch("ἄνθρωπος", Number::Singular, "λέγουσι", Number::Plural);
-/// assert!(msg.contains("οὐ συμφωνεῖ"));
-/// ```
-pub fn number_mismatch(word1: &str, num1: Number, word2: &str, num2: Number) -> String {
-    format!(
-        "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
-        word1, num1, word2, num2
-    )
-}
-
-/// Get a Greek message for case mismatch
-///
-/// Returns: "Τὸ «{word1}» ({case1}) οὐ συμφωνεῖ τῷ «{word2}» ({case2})"
-///
-/// # Examples
-///
-/// ```
-/// use glossa::errors::case_mismatch;
-/// use glossa::morphology::Case;
-///
-/// let msg = case_mismatch("ἄνθρωπος", Case::Nominative, "λόγον", Case::Accusative);
-/// assert!(msg.contains("οὐ συμφωνεῖ"));
-/// ```
-pub fn case_mismatch(word1: &str, case1: Case, word2: &str, case2: Case) -> String {
-    format!(
-        "Τὸ «{}» ({}) οὐ συμφωνεῖ τῷ «{}» ({})",
-        word1, case1, word2, case2
-    )
-}
-
 /// Help messages in Greek
 pub mod help {
     /// Help for the binding construct
@@ -408,18 +313,5 @@ mod tests {
     fn test_category_greek() {
         let err = GlossaError::semantic("test");
         assert_eq!(err.category_greek(), "Σημασία");
-    }
-
-    #[test]
-    fn test_undefined_variable_message() {
-        let msg = undefined_variable("ξ");
-        assert!(msg.contains("Οὐκ οἶδα"));
-        assert!(msg.contains("ξ"));
-    }
-
-    #[test]
-    fn test_gender_mismatch_message() {
-        let msg = gender_mismatch("μεγάλη", Gender::Feminine, "χρήστος", Gender::Masculine);
-        assert!(msg.contains("οὐ συμφωνεῖ"));
     }
 }

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -405,8 +405,9 @@ fn classify_assignment(
                 }
                 Some(b) if !b.mutable => {
                     let _b = b; // Silence unused variable warning while keeping guard
-                    return Err(GlossaError::semantic(crate::errors::immutable_assignment(
-                        &var_name,
+                    return Err(GlossaError::semantic(format!(
+                        "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
+                        &var_name
                     )));
                 }
                 Some(_b) => {

--- a/tests/razor_coverage.rs
+++ b/tests/razor_coverage.rs
@@ -3,10 +3,7 @@
 //! This file aims to exercise the code paths that were moved during refactoring
 //! to ensure high code coverage.
 
-use glossa::errors::{
-    AssemblyError, GlossaError, case_mismatch, gender_mismatch, immutable_assignment,
-    number_mismatch, undefined_variable,
-};
+use glossa::errors::{AssemblyError, GlossaError};
 use glossa::morphology::{Case, Gender, Number, Person, Tense, Voice};
 use glossa::semantic::{
     AssembledStatement, Constituent, Literal, ParticipleConstituent, VerbConstituent,
@@ -88,17 +85,6 @@ fn test_assembly_errors_display_impls() {
         max: 5,
     };
     assert!(format!("{}", err).contains("Ὑπέρβασις ὁρίου"));
-}
-
-#[test]
-fn test_errors_helper_functions() {
-    assert!(undefined_variable("x").contains("Οὐκ οἶδα"));
-    assert!(immutable_assignment("x").contains("ἀμετάβλητόν"));
-    assert!(
-        gender_mismatch("w1", Gender::Masculine, "w2", Gender::Feminine).contains("οὐ συμφωνεῖ")
-    );
-    assert!(number_mismatch("w1", Number::Singular, "w2", Number::Plural).contains("οὐ συμφωνεῖ"));
-    assert!(case_mismatch("w1", Case::Nominative, "w2", Case::Accusative).contains("οὐ συμφωνεῖ"));
 }
 
 #[test]


### PR DESCRIPTION
Removed trivial error-formatting helper functions from `src/errors.rs` to enforce KISS principles. Inlined the only active usage (`immutable_assignment`) into `src/semantic/conversion.rs` and deleted the other 4 as dead code, improving codebase clarity and reducing unnecessary abstraction.

---
*PR created automatically by Jules for task [16314401246443113653](https://jules.google.com/task/16314401246443113653) started by @madmax983*