### PR TITLE
📜 Codex: ADR 015 & Architecture Diagram Update

### DIFF
--- a/docs/adr/015-remove-statement-analyzer-trait.md
+++ b/docs/adr/015-remove-statement-analyzer-trait.md
@@ -1,0 +1,24 @@
+# 15. Remove StatementAnalyzer Trait
+
+Date: 2026-02-28
+
+## Status
+
+Accepted
+
+## Context
+
+In the earlier architecture, the `StatementAnalyzer` trait was introduced to break circular dependencies between the main semantic orchestrator (`src/semantic/mod.rs` and its internal logic) and the specialized submodules (`control_flow.rs`, `declarations.rs`). This allowed the submodules to receive a generic reference to an orchestrator (`&mut impl StatementAnalyzer`) without tightly coupling them to the concrete `Analyzer` implementation.
+
+However, over time, `Analyzer` became the sole and exclusive implementer of this trait. Following the "Razor" persona's philosophy of essentialism and YAGNI (You Aren't Gonna Need It), maintaining a single-implementation interface added unnecessary abstraction overhead and decreased architectural clarity without providing any tangible benefit.
+
+## Decision
+
+We have decided to remove the `StatementAnalyzer` trait entirely (`src/semantic/traits.rs` was deleted). The trait's methods have been flattened directly into the concrete `Analyzer` struct. Function signatures in submodules (`control_flow.rs`, `declarations.rs`) were updated to accept a concrete `&mut Analyzer` reference instead of `&mut impl StatementAnalyzer`.
+
+## Consequences
+
+*   **Simplicity:** The semantic analysis pipeline is simpler and easier to understand, with fewer layers of abstraction.
+*   **Performance:** While minimal, removing dynamic trait boundaries or monomorphization overhead can marginally improve compile times.
+*   **Clarity:** The relationship between the orchestrator (`Analyzer`) and its delegates is now explicit and direct.
+*   **Documentation:** Architecture diagrams and module-level comments have been updated to reflect `Analyzer` as the concrete orchestrator, removing references to the legacy trait.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,7 +76,7 @@ C4Component
     title Component Diagram for Semantic Analysis
 
     Container_Boundary(semantic, "Semantic Analysis") {
-        Component(orchestrator, "Orchestrator", "src/semantic/mod.rs", "Coordinates analysis pipeline")
+        Component(orchestrator, "Analyzer (Orchestrator)", "src/semantic/analyzer.rs", "Coordinates analysis pipeline explicitly via Analyzer")
         Component(declarations, "Declarations", "src/semantic/declarations.rs", "Analyzes Types, Traits, Functions")
         Component(control_flow, "Control Flow", "src/semantic/control_flow.rs", "Analyzes If, While, Match")
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -1,8 +1,7 @@
 //! Core Semantic Analyzer
 //!
 //! This module contains the `Analyzer` struct which orchestrates the semantic analysis
-//! process. It implements the `StatementAnalyzer` trait to break circular dependencies
-//! between control flow/declarations and the main analysis logic.
+//! process, directly coordinating between control flow, declarations, and the main analysis logic.
 
 use super::control_flow::analyze_control_flow;
 use super::conversion::convert_assembled_to_analyzed;


### PR DESCRIPTION
🧠 **Decision:** Recorded the removal of the `StatementAnalyzer` trait, flattening its logic directly into the `Analyzer` struct to reduce abstraction overhead, following the Razor/YAGNI philosophy.
🗺️ **Visuals:** Updated the "Semantic Analysis (C4 Component Level)" Mermaid diagram in `docs/architecture.md` to correctly point to `src/semantic/analyzer.rs` and reflect the direct orchestration. Removed outdated comments in code.
🔗 **Link:** See `docs/adr/015-remove-statement-analyzer-trait.md`.

---
*PR created automatically by Jules for task [15205186345701048720](https://jules.google.com/task/15205186345701048720) started by @madmax983*