### PR TITLE
🎨 Mosaic: UI Polish for Test Runner Output

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -228,13 +228,15 @@ pub fn run_tests(input: &Path) -> Result<()> {
 
     if test_output.status.success() {
         status.success();
-        println!();
-        println!(
-            "   {}",
-            "✓ Πᾶσαι αἱ δοκιμασίαι ἐπέτυχαν! (All tests passed)"
-                .green()
-                .bold()
-        );
+        if !results.is_empty() {
+            println!();
+            println!(
+                "   {}",
+                "✓ Πᾶσαι αἱ δοκιμασίαι ἐπέτυχαν! (All tests passed)"
+                    .green()
+                    .bold()
+            );
+        }
     } else {
         status.error("Ἀποτυχία (Failure)");
         println!();
@@ -312,9 +314,6 @@ pub fn run_tests(input: &Path) -> Result<()> {
                 println!("{}", String::from_utf8_lossy(&test_output.stderr).red());
             }
         }
-    } else if results.is_empty() {
-        // Fallback for empty results but success (e.g. no tests run)
-        println!("{}", stdout.dim());
     }
 
     if !test_output.status.success() {


### PR DESCRIPTION
* 🖌️ **Before:** `glossa test empty_file.γλ` would output the green "✓ All tests passed" header, followed by "No tests found.", followed by the raw rustc text (`running 0 tests...`). This was conflicting and confusing.
* ✨ **After:** `glossa test empty_file.γλ` now simply outputs the clean yellow "No tests found." warning.
* 🖼️ **Visuals:** Suppressed conflicting success messages when test count is 0. Removed raw unstyled `stdout` string dumping from the test framework. Working tests still output exactly as before.

---
*PR created automatically by Jules for task [16901914557511487384](https://jules.google.com/task/16901914557511487384) started by @madmax983*