### PR TITLE
🌟 Nova: The Simulator and The Weaver

### DIFF
--- a/src/experimental/interpreter.rs
+++ b/src/experimental/interpreter.rs
@@ -40,6 +40,41 @@ impl fmt::Display for Value {
     }
 }
 
+use crate::tools::runner::{analyze_source, load_source};
+use crate::tools::ui::Status;
+use std::path::Path;
+
+/// Run a file in the simulator directly
+pub fn run_simulate(input: &Path) -> miette::Result<()> {
+    let mut status = Status::start_with_symbol("Ὑποκριτής (Simulating)", "🎭");
+
+    // 1. Load and Analyze
+    let source = load_source(input)?;
+    let program = analyze_source(&source)?;
+    status.update("Ἐκτέλεσις (Running)");
+
+    // 2. Interpret
+    let mut interpreter = Interpreter::new();
+    let result = interpreter.run(&program);
+
+    // 3. Cleanup & Report
+    status.clear(); // We don't want the spinner mixing with print output
+
+    match result {
+        Ok(_) => {
+            // Success
+            Ok(())
+        }
+        Err(e) => {
+            // Map EvalError to a miette error
+            Err(miette::miette!(
+                "Σφάλμα ὑποκριτοῦ (Simulation error):\n{}",
+                e
+            ))
+        }
+    }
+}
+
 /// Evaluation Error
 #[derive(Debug, thiserror::Error)]
 pub enum EvalError {

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -4,3 +4,4 @@
 //! These features are hidden behind the `nova` feature flag.
 
 pub mod interpreter;
+pub mod weaver;

--- a/src/experimental/weaver.rs
+++ b/src/experimental/weaver.rs
@@ -1,0 +1,101 @@
+//! The Weaver (ὁ Ὑφάντης) - Schema Generator
+//!
+//! This module converts simple English struct schemas into ΓΛΩΣΣΑ `εἶδος` definitions.
+//! It maps common programming types to their corresponding Ancient Greek genitives.
+
+use miette::{Diagnostic, Report};
+use thiserror::Error;
+
+/// Errors that can occur during weaving
+#[derive(Debug, Error, Diagnostic)]
+pub enum WeaveError {
+    #[error("Invalid schema format")]
+    #[diagnostic(help("Expected format: struct Name {{ field: Type, ... }}"))]
+    InvalidFormat,
+}
+
+/// Parse a simple English struct schema and generate ΓΛΩΣΣΑ code.
+///
+/// Example input: `struct User { name: String, age: Number }`
+pub fn weave_schema(input: &str) -> Result<String, Report> {
+    let input = input.trim();
+
+    // Basic validation: "struct Name { ... }"
+    if !input.starts_with("struct ") || !input.ends_with('}') {
+        return Err(WeaveError::InvalidFormat.into());
+    }
+
+    let without_struct = input.trim_start_matches("struct ").trim();
+
+    // Find the opening brace
+    let brace_idx = without_struct.find('{').ok_or(WeaveError::InvalidFormat)?;
+
+    let struct_name = without_struct[..brace_idx].trim();
+    if struct_name.is_empty() {
+        return Err(WeaveError::InvalidFormat.into());
+    }
+
+    // Extract fields
+    let fields_str = &without_struct[brace_idx + 1..without_struct.len() - 1];
+
+    let mut fields = Vec::new();
+    for field_decl in fields_str.split(',') {
+        let field_decl = field_decl.trim();
+        if field_decl.is_empty() {
+            continue;
+        }
+
+        let mut parts = field_decl.split(':');
+        let field_name = parts.next().ok_or(WeaveError::InvalidFormat)?.trim();
+        let field_type = parts.next().ok_or(WeaveError::InvalidFormat)?.trim();
+
+        fields.push((field_name, field_type));
+    }
+
+    // Generate output
+    let mut out = String::new();
+    out.push_str(&format!("εἶδος {} ὁρίζειν {{\n", struct_name));
+
+    for (name, ty) in fields {
+        let glossa_type = match ty {
+            "String" => "ὀνόματος",
+            "Number" => "ἀριθμα", // From memory instruction
+            "Bool" => "ἀληθοῦς",
+            "List" => "λίστης",
+            _ => "ἀγνώστου", // Fallback for unknown
+        };
+        out.push_str(&format!("    {} {}.\n", name, glossa_type));
+    }
+
+    out.push_str("}.\n");
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_weave_schema() {
+        let input = "struct User { name: String, age: Number }";
+        let expected = "εἶδος User ὁρίζειν {\n    name ὀνόματος.\n    age ἀριθμα.\n}.\n";
+
+        let output = weave_schema(input).unwrap();
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_weave_invalid_format() {
+        let input = "User { name: String }";
+        assert!(weave_schema(input).is_err());
+    }
+
+    #[test]
+    fn test_weave_all_types() {
+        let input = "struct Data { s: String, n: Number, b: Bool, l: List }";
+        let expected = "εἶδος Data ὁρίζειν {\n    s ὀνόματος.\n    n ἀριθμα.\n    b ἀληθοῦς.\n    l λίστης.\n}.\n";
+        let output = weave_schema(input).unwrap();
+        assert_eq!(output, expected);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,17 @@ fn main() -> Result<()> {
             glossa::tools::cartographer::run_map(&input)?;
         }
 
+        #[cfg(feature = "nova")]
+        Some(Commands::Simulate { input }) => {
+            glossa::experimental::interpreter::run_simulate(&input)?;
+        }
+
+        #[cfg(feature = "nova")]
+        Some(Commands::Weave { schema }) => {
+            let output = glossa::experimental::weaver::weave_schema(&schema)?;
+            println!("{}", output);
+        }
+
         Some(Commands::Repl) | None => {
             run_repl()?;
         }

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -127,4 +127,18 @@ pub enum Commands {
         /// Input file (.γλ)
         input: PathBuf,
     },
+
+    /// Execute a .γλ file directly in the tree-walk interpreter (Requires "nova" feature)
+    #[cfg(feature = "nova")]
+    Simulate {
+        /// Input file (.γλ)
+        input: PathBuf,
+    },
+
+    /// Weave a simple English struct schema into ΓΛΩΣΣΑ `εἶδος` code (Requires "nova" feature)
+    #[cfg(feature = "nova")]
+    Weave {
+        /// Schema string (e.g., "struct User { name: String }")
+        schema: String,
+    },
 }

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -21,7 +21,7 @@ const MAX_FILE_SIZE: u64 = 1024 * 1024;
 /// This helper runs the first two phases of the compiler pipeline:
 /// 1. **Parsing**: Converts source text to AST
 /// 2. **Semantic Analysis**: Resolves names, types, and statement structure
-fn analyze_source(source: &str) -> Result<AnalyzedProgram> {
+pub fn analyze_source(source: &str) -> Result<AnalyzedProgram> {
     let ast = parse(source).map_err(|e| miette::miette!("{}", e))?;
     analyze_program(&ast).map_err(|e| miette::miette!("{}", e))
 }
@@ -61,7 +61,7 @@ fn check_file_size(input: &Path) -> Result<()> {
 /// - The file does not exist.
 /// - The file metadata indicates it is too large.
 /// - The file content exceeds the 1MB limit.
-fn load_source(input: &Path) -> Result<String> {
+pub fn load_source(input: &Path) -> Result<String> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
     }

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -57,6 +57,16 @@ impl Status {
         status
     }
 
+    /// Clear the status line
+    pub fn clear(&mut self) {
+        if self.is_tty {
+            let mut stderr = io::stderr();
+            eprint!("\r");
+            let _ = stderr.execute(terminal::Clear(terminal::ClearType::UntilNewLine));
+        }
+        self.active = false;
+    }
+
     /// Update the status message
     pub fn update(&mut self, message: impl Into<String>) {
         if !self.active {


### PR DESCRIPTION
🌟 **The Spark:** The memories mention a `Simulate` command and a `Weaver` tool, but both were missing from the CLI and the codebase. The `Interpreter` existed but couldn't be invoked via the CLI! Furthermore, an English-to-Greek schema generator (`Weaver`) would be a great bridge for new users.

🚀 **The Feature:**
- Added `glossa simulate <file>` to directly execute `.γλ` files without compilation to Rust.
- Created `glossa weave <schema>` which parses string-based English struct definitions and auto-generates `εἶδος` structs using the correct Greek genitive cases (e.g. `String` -> `ὀνόματος`, `Number` -> `ἀριθμα`).

🔮 **The Potential:** `Simulate` brings us closer to a full web/WASM playground, and `Weave` allows English-speaking users to bootstrap projects immediately.

⚠️ **Risk:** Low. Isolated in `src/experimental/` and guarded by `#[cfg(feature = "nova")]`.

---
*PR created automatically by Jules for task [3386301618980491902](https://jules.google.com/task/3386301618980491902) started by @madmax983*