### PR TITLE
🛡️ Sentry: [AST Builder panic point removal]

### DIFF
--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -34,10 +34,7 @@ pub(crate) fn build_type_definition(pair: Pair<'_, Rule>) -> Result<TypeDef, Par
         ));
     };
 
-    Ok(TypeDef {
-        name,
-        fields,
-    })
+    Ok(TypeDef { name, fields })
 }
 
 fn build_field_declaration(pair: Pair<'_, Rule>) -> Result<FieldDecl, ParseError> {
@@ -96,10 +93,7 @@ pub(crate) fn build_trait_definition(pair: Pair<'_, Rule>) -> Result<TraitDef, P
         ));
     };
 
-    Ok(TraitDef {
-        name,
-        methods,
-    })
+    Ok(TraitDef { name, methods })
 }
 
 fn parse_method_parameters(words: &[Word]) -> Vec<FieldDecl> {
@@ -261,10 +255,7 @@ pub(crate) fn build_test_declaration(pair: Pair<'_, Rule>) -> Result<TestDecl, P
         ));
     };
 
-    Ok(TestDecl {
-        name,
-        body,
-    })
+    Ok(TestDecl { name, body })
 }
 
 fn build_impl_method(pair: Pair<'_, Rule>) -> Result<ImplMethodDef, ParseError> {

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -28,14 +28,14 @@ pub(crate) fn build_type_definition(pair: Pair<'_, Rule>) -> Result<TypeDef, Par
         }
     }
 
-    if type_name.is_none() {
+    let Some(name) = type_name else {
         return Err(ParseError::UnexpectedRule(
             "Type definition needs a name".to_string(),
         ));
-    }
+    };
 
     Ok(TypeDef {
-        name: type_name.unwrap(),
+        name,
         fields,
     })
 }
@@ -90,14 +90,14 @@ pub(crate) fn build_trait_definition(pair: Pair<'_, Rule>) -> Result<TraitDef, P
         }
     }
 
-    if trait_name.is_none() {
+    let Some(name) = trait_name else {
         return Err(ParseError::UnexpectedRule(
             "Trait definition needs a name".to_string(),
         ));
-    }
+    };
 
     Ok(TraitDef {
-        name: trait_name.unwrap(),
+        name,
         methods,
     })
 }
@@ -207,15 +207,15 @@ pub(crate) fn build_trait_impl(pair: Pair<'_, Rule>) -> Result<TraitImplDef, Par
         }
     }
 
-    if type_name.is_none() || trait_name.is_none() {
+    let (Some(type_n), Some(trait_n)) = (type_name, trait_name) else {
         return Err(ParseError::UnexpectedRule(
             "Trait impl needs type and trait names".to_string(),
         ));
-    }
+    };
 
     Ok(TraitImplDef {
-        type_name: type_name.unwrap(),
-        trait_name: trait_name.unwrap(),
+        type_name: type_n,
+        trait_name: trait_n,
         methods,
     })
 }
@@ -255,14 +255,14 @@ pub(crate) fn build_test_declaration(pair: Pair<'_, Rule>) -> Result<TestDecl, P
         }
     }
 
-    if test_name.is_none() {
+    let Some(name) = test_name else {
         return Err(ParseError::UnexpectedRule(
             "Test declaration needs a name".to_string(),
         ));
-    }
+    };
 
     Ok(TestDecl {
-        name: test_name.unwrap(),
+        name,
         body,
     })
 }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -15,10 +15,10 @@ pub(crate) fn build_expression(pair: Pair<'_, Rule>) -> Result<Expr, ParseError>
 
     // If there's only one term, return it directly
     if terms.len() == 1 {
-        Ok(terms.into_iter().next().unwrap())
+        Ok(terms.into_iter().next().ok_or(ParseError::EmptyTerm)?)
     } else {
         // Multiple terms form a phrase (e.g., "χαῖρε κόσμε λέγε")
-        Ok(Expr::Phrase(terms))
+        Ok(Expr::Phrase(terms)) // Empty terms vector returns an empty Phrase
     }
 }
 

--- a/tests/parser_error_tests.rs
+++ b/tests/parser_error_tests.rs
@@ -1,0 +1,24 @@
+use glossa::parser::parse;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Since `parse` goes through the PEG grammar, the `type_definition` rule
+    // explicitly requires `eidos_keyword ~ greek_word`. If `greek_word` is missing,
+    // the parser falls back to the `clause_list` rule.
+    // So "εἶδος ὁρίζειν { }." becomes a `Regular` statement with three terms.
+    // Therefore, the `is_none()` branches we changed are essentially unreachable
+    // from valid strings, but replacing `unwrap()` prevents potential panics if
+    // the grammar is manually constructed or relaxed in the future.
+
+    // We can at least test that `parse` rejects truly invalid tokens completely.
+    #[test]
+    fn test_empty_term_handling() {
+        let result = parse("().");
+        assert!(result.is_err());
+    }
+
+    // Since we cannot construct `Pair` manually to trigger those specific errors,
+    // we document that these branches are unreachable via string parsing but act as safety guards.
+}


### PR DESCRIPTION
🎯 Target: `src/parser/declarations.rs` and `src/parser/expressions.rs`
💣 Risk: `unwrap()` calls on Option types during AST construction could panic if the grammar is modified or if `Pair` trees are constructed programmatically. 
🧪 Strategy: Replaced `unwrap()` with idiomatic `let Some(...) = ... else` pattern returning `ParseError::UnexpectedRule`. In `expressions.rs`, replaced `unwrap()` with `ok_or(ParseError::EmptyTerm)?`.
🔬 Verification: Run `cargo test --test parser_error_tests` to verify parser gracefully rejects malformed inputs without panicking.

---
*PR created automatically by Jules for task [4523771876856709591](https://jules.google.com/task/4523771876856709591) started by @madmax983*