### PR TITLE
🎻 Bard: Morphology Documentation Polish

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -617,6 +617,24 @@ pub fn analyze_verb_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
 }
 
 /// Conjugate a verb stem to a specific form
+///
+/// Reconstructs the specified form of a verb based on its stem and morphological features.
+/// This is particularly useful for generating Greek output or error messages that require
+/// correctly inflected verbs.
+///
+/// # Examples
+///
+/// ```rust
+/// use glossa::morphology::{conjugation::conjugate, Tense, Mood, Voice, Person, Number};
+///
+/// // Conjugate "λεγ" (to say) in Present Active Indicative, 1st Person Singular
+/// let result = conjugate("λεγ", Tense::Present, Mood::Indicative, Voice::Active, Person::First, Number::Singular);
+/// assert_eq!(result, "λεγω");
+///
+/// // Conjugate "λυ" (to loose) in Aorist Active Indicative, 1st Person Plural
+/// let result = conjugate("ελυ", Tense::Aorist, Mood::Indicative, Voice::Active, Person::First, Number::Plural);
+/// assert_eq!(result, "ελυσαμεν");
+/// ```
 pub fn conjugate(
     stem: &str,
     tense: Tense,
@@ -643,6 +661,23 @@ pub fn conjugate(
 }
 
 /// Get the infinitive form of a verb
+///
+/// Returns the infinitive form of a verb stem given its tense and voice.
+/// Infinitives are used as noun-equivalents or in specific syntactic constructions.
+///
+/// # Examples
+///
+/// ```rust
+/// use glossa::morphology::{conjugation::infinitive, Tense, Voice};
+///
+/// // Present Active Infinitive of "λεγ" (to say)
+/// let result = infinitive("λεγ", Tense::Present, Voice::Active);
+/// assert_eq!(result, "λεγειν");
+///
+/// // Aorist Active Infinitive of "λυ" (to loose)
+/// let result = infinitive("λυ", Tense::Aorist, Voice::Active);
+/// assert_eq!(result, "λυσαι");
+/// ```
 pub fn infinitive(stem: &str, tense: Tense, voice: Voice) -> String {
     match (tense, voice) {
         (Tense::Present, Voice::Active) => format!("{}{}", stem, PRESENT_INFINITIVE),

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -152,6 +152,19 @@ const DECLENSION_PATTERNS: &[DeclensionPattern] = &[
 ];
 
 /// Try to analyze a word as a noun by matching declension endings
+///
+/// This function attempts to identify the morphological properties of a noun
+/// (case, number, gender, and lemma) based on its declension endings.
+///
+/// # Examples
+/// ```
+/// use glossa::morphology::declension::analyze_noun;
+/// use glossa::morphology::{Case, Number, Gender};
+///
+/// let analysis = analyze_noun("λογον").unwrap();
+/// assert_eq!(analysis.lemma, "λογος"); // Fallback matches masculine -ος type mostly
+/// assert_eq!(analysis.case, Some(Case::Accusative)); // Because "ον" can be accusative
+/// ```
 pub fn analyze_noun(word: &str) -> Option<MorphAnalysis> {
     let mut analyses = analyze_noun_all(word);
 
@@ -273,6 +286,18 @@ pub fn analyze_noun_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
 }
 
 /// Extract stem from a word given its nominative form and declension
+///
+/// Removes the standard nominative ending for the specified declension class
+/// to isolate the noun's stem. This stem can then be used to generate other forms.
+///
+/// # Examples
+/// ```
+/// use glossa::morphology::declension::{get_stem, Declension};
+///
+/// assert_eq!(get_stem("λογος", Declension::Second), "λογ");
+/// assert_eq!(get_stem("τιμη", Declension::First), "τιμ");
+/// assert_eq!(get_stem("ονομα", Declension::Third), "ονο");
+/// ```
 pub fn get_stem(nominative: &str, declension: Declension) -> String {
     match declension {
         Declension::Second => {
@@ -304,6 +329,23 @@ pub fn get_stem(nominative: &str, declension: Declension) -> String {
 }
 
 /// Decline a noun to a specific case and number
+///
+/// Reconstructs the specified form of a noun by appending the correct ending
+/// to its stem based on its declension class, gender, case, and number.
+///
+/// # Examples
+/// ```
+/// use glossa::morphology::declension::{decline, Declension};
+/// use glossa::morphology::{Case, Gender, Number};
+///
+/// // Decline "λογ" (word) to Accusative Plural
+/// let result = decline("λογ", Declension::Second, Gender::Masculine, Case::Accusative, Number::Plural);
+/// assert_eq!(result, "λογους");
+///
+/// // Decline "τιμ" (honor) to Genitive Singular
+/// let result = decline("τιμ", Declension::First, Gender::Feminine, Case::Genitive, Number::Singular);
+/// assert_eq!(result, "τιμης");
+/// ```
 pub fn decline(
     stem: &str,
     declension: Declension,

--- a/src/morphology/disambiguation.rs
+++ b/src/morphology/disambiguation.rs
@@ -30,11 +30,30 @@ pub struct DisambiguationContext {
 }
 
 impl DisambiguationContext {
+    /// Creates a new, empty context.
+    ///
+    /// # Examples
+    /// ```
+    /// use glossa::morphology::DisambiguationContext;
+    /// let ctx = DisambiguationContext::new();
+    /// assert!(ctx.expected_case.is_none());
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Create context from a preceding article
+    ///
+    /// # Examples
+    /// ```
+    /// use glossa::morphology::{DisambiguationContext, MorphAnalysis, Case, Gender, Number, PartOfSpeech};
+    /// let mut article = MorphAnalysis::new("ο".to_string(), PartOfSpeech::Article);
+    /// article.case = Some(Case::Nominative);
+    /// article.gender = Some(Gender::Masculine);
+    /// article.number = Some(Number::Singular);
+    /// let ctx = DisambiguationContext::from_article(&article);
+    /// assert_eq!(ctx.expected_case, Some(Case::Nominative));
+    /// ```
     pub fn from_article(article: &MorphAnalysis) -> Self {
         DisambiguationContext {
             expected_case: article.case,
@@ -45,6 +64,17 @@ impl DisambiguationContext {
     }
 
     /// Create context from a verb (for subject agreement)
+    ///
+    /// # Examples
+    /// ```
+    /// use glossa::morphology::{DisambiguationContext, MorphAnalysis, Number, Person, PartOfSpeech, Case};
+    /// let mut verb = MorphAnalysis::new("λεγω".to_string(), PartOfSpeech::Verb);
+    /// verb.number = Some(Number::Singular);
+    /// verb.person = Some(Person::First);
+    /// let ctx = DisambiguationContext::from_verb(&verb);
+    /// assert_eq!(ctx.expected_case, Some(Case::Nominative));
+    /// assert_eq!(ctx.expected_person, Some(Person::First));
+    /// ```
     pub fn from_verb(verb: &MorphAnalysis) -> Self {
         DisambiguationContext {
             expected_case: Some(Case::Nominative), // Subject is nominative
@@ -55,6 +85,13 @@ impl DisambiguationContext {
     }
 
     /// Create context expecting a specific case (e.g., after preposition)
+    ///
+    /// # Examples
+    /// ```
+    /// use glossa::morphology::{DisambiguationContext, Case};
+    /// let ctx = DisambiguationContext::expecting_case(Case::Dative);
+    /// assert_eq!(ctx.expected_case, Some(Case::Dative));
+    /// ```
     pub fn expecting_case(case: Case) -> Self {
         DisambiguationContext {
             expected_case: Some(case),
@@ -71,6 +108,16 @@ impl DisambiguationContext {
 /// The first element is the best match.
 ///
 /// Optimization: Sorts in-place to avoid intermediate vector allocations.
+///
+/// # Examples
+/// ```
+/// use glossa::morphology::{disambiguate, analyze_all, DisambiguationContext, Case, Gender, Number};
+/// let analyses = analyze_all("λογου");
+/// let mut ctx = DisambiguationContext::new();
+/// ctx.expected_case = Some(Case::Genitive);
+/// let mut resolved = disambiguate(analyses, &ctx);
+/// assert_eq!(resolved[0].case, Some(Case::Genitive));
+/// ```
 pub fn disambiguate(
     mut analyses: Vec<MorphAnalysis>,
     context: &DisambiguationContext,
@@ -168,6 +215,15 @@ fn score_analysis(analysis: &MorphAnalysis, context: &DisambiguationContext) -> 
 /// context matches.
 ///
 /// Optimization: Takes ownership of analyses vector to avoid cloning.
+///
+/// # Examples
+/// ```
+/// use glossa::morphology::{resolve_best, analyze_all, DisambiguationContext, Case};
+/// let analyses = analyze_all("λογον");
+/// let ctx = DisambiguationContext::expecting_case(Case::Accusative);
+/// let best = resolve_best(analyses, &ctx);
+/// assert_eq!(best.case, Some(Case::Accusative));
+/// ```
 pub fn resolve_best(
     analyses: Vec<MorphAnalysis>,
     context: &DisambiguationContext,
@@ -184,6 +240,15 @@ pub fn resolve_best(
 /// Known Greek articles for context building
 /// Uses ORIGINAL forms with diacritics to distinguish from homographs
 /// e.g., ἡ (article) vs ἤ (or) - differ only in breathing/accent
+///
+/// # Examples
+/// ```
+/// use glossa::morphology::{analyze_article, Case, Gender, Number};
+/// let ctx = analyze_article("τῆς").unwrap();
+/// assert_eq!(ctx.expected_case, Some(Case::Genitive));
+/// assert_eq!(ctx.expected_gender, Some(Gender::Feminine));
+/// assert_eq!(ctx.expected_number, Some(Number::Singular));
+/// ```
 pub fn analyze_article(word: &str) -> Option<DisambiguationContext> {
     // Match on original polytonic forms - diacritics matter!
     match word {

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -256,8 +256,8 @@ impl Assembler {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// use glossa::semantic::Assembler;
+    /// ```rust
+    /// use glossa::semantic::assembly::Assembler;
     ///
     /// let mut asm = Assembler::new();
     /// asm.feed_number(42).unwrap();
@@ -277,8 +277,8 @@ impl Assembler {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// use glossa::semantic::Assembler;
+    /// ```rust
+    /// use glossa::semantic::assembly::Assembler;
     ///
     /// let mut asm = Assembler::new();
     /// asm.feed_boolean(true).unwrap();


### PR DESCRIPTION
📖 Chapter: The `morphology` module (conjugation, declension, disambiguation)
🔦 Insight: Explained the "why" and utility behind morphological tools (e.g., how to use context to disambiguate tokens, how to properly extract noun stems without trailing endings). Fixed ignored doc tests so that all examples compile.
🧪 Example: Added 8+ executable doctests across `src/morphology/`.
🖼️ Preview: `cargo doc --no-deps` generates a beautiful scroll for these modules.

---
*PR created automatically by Jules for task [15116212043547822281](https://jules.google.com/task/15116212043547822281) started by @madmax983*