### PR TITLE
🎻 Bard: Report and Runner documentation update

### DIFF
--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -49,6 +49,22 @@ pub struct ProgramStats {
 
 impl ProgramStats {
     /// Analyze a program and collect statistics
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use glossa::parser::parse;
+    /// use glossa::semantic::analyze_program;
+    /// use glossa::tools::report::ProgramStats;
+    ///
+    /// let source = "ξ πέντε ἔστω.";
+    /// let ast = parse(source).unwrap();
+    /// let program = analyze_program(&ast).unwrap();
+    /// let stats = ProgramStats::new(&program);
+    ///
+    /// assert_eq!(stats.statement_count, 1);
+    /// assert_eq!(stats.binding_count, 1);
+    /// ```
     pub fn new(program: &AnalyzedProgram) -> Self {
         let mut stats = ProgramStats {
             function_count: program.scope.functions().count(),
@@ -219,6 +235,24 @@ pub struct GlossaReport<'a> {
 }
 
 impl<'a> GlossaReport<'a> {
+    /// Creates a new GlossaReport.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use glossa::parser::parse;
+    /// use glossa::semantic::analyze_program;
+    /// use glossa::tools::report::GlossaReport;
+    ///
+    /// let source = "ξ πέντε ἔστω.";
+    /// let ast = parse(source).unwrap();
+    /// let program = analyze_program(&ast).unwrap();
+    /// let report = GlossaReport::new(&program, "main.γλ".to_string());
+    ///
+    /// let output = format!("{}", report);
+    /// assert!(output.contains("main.γλ"));
+    /// assert!(output.contains("1")); // Statement count
+    /// ```
     pub fn new(program: &'a AnalyzedProgram, filename: String) -> Self {
         let stats = ProgramStats::new(program);
         Self {
@@ -332,6 +366,34 @@ impl Display for GlossaReport<'_> {
 }
 
 /// A comprehensive report for the compilation process
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::parser::parse;
+/// use glossa::semantic::analyze_program;
+/// use glossa::tools::report::{CompilationReport, ProgramStats};
+/// use std::path::PathBuf;
+/// use std::time::Duration;
+///
+/// let source = "ξ πέντε ἔστω.";
+/// let ast = parse(source).unwrap();
+/// let program = analyze_program(&ast).unwrap();
+/// let stats = ProgramStats::new(&program);
+///
+/// let report = CompilationReport {
+///     input_path: PathBuf::from("main.γλ"),
+///     output_path: PathBuf::from("main.rs"),
+///     input_size: 15,
+///     output_size: 150,
+///     duration: Duration::from_millis(10),
+///     stats,
+/// };
+///
+/// let output = format!("{}", report);
+/// assert!(output.contains("main.γλ"));
+/// assert!(output.contains("15 bytes"));
+/// ```
 pub struct CompilationReport {
     pub input_path: PathBuf,
     pub output_path: PathBuf,

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -97,6 +97,24 @@ fn load_source(input: &Path) -> Result<String> {
 /// 3. **Codegen**: Generates valid Rust code.
 /// 4. **Write**: Saves the Rust code to the output path.
 /// 5. **Report**: Prints a compilation report with statistics.
+///
+/// ## Errors
+///
+/// Returns an error if the input file does not exist, exceeds the size limit,
+/// or contains syntax/semantic errors. Also returns an error if writing to
+/// the output path fails.
+///
+/// ## Examples
+///
+/// ```no_run
+/// use glossa::tools::runner::build_file;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// let output = Path::new("main.rs");
+/// // Compiles main.γλ to main.rs
+/// build_file(input, Some(output)).unwrap();
+/// ```
 pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
     let status = Status::start_with_symbol("Μεταγλώττισις (Compiling)", "🏗️");
     let start = std::time::Instant::now();
@@ -148,6 +166,23 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 ///    This inherits Rust's optimizations (set to `-O` level).
 /// 5. **Execution**: Spawns the resulting binary as a child process, inheriting
 ///    stdin/stdout/stderr so it feels like a native script.
+///
+/// ## Errors
+///
+/// Returns an error if the input file does not exist, exceeds the size limit,
+/// or contains syntax/semantic errors. Also returns an error if `rustc` fails to
+/// compile the generated code.
+///
+/// ## Examples
+///
+/// ```no_run
+/// use glossa::tools::runner::run_file;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// // Compiles and immediately executes the file
+/// run_file(input).unwrap();
+/// ```
 pub fn run_file(input: &Path) -> Result<()> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
@@ -237,6 +272,27 @@ pub fn run_file(input: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Verifies the syntax and semantics of a ΓΛΩΣΣΑ file.
+///
+/// This function loads the source code, parses it, and performs semantic analysis
+/// without generating any output code or binaries. It prints a [`GlossaReport`]
+/// summarizing the program's statistics if successful.
+///
+/// ## Errors
+///
+/// Returns an error if the input file does not exist, exceeds the size limit,
+/// or contains any syntax or semantic errors.
+///
+/// ## Examples
+///
+/// ```no_run
+/// use glossa::tools::runner::check_file;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// // Checks the file for errors without compiling it
+/// check_file(input).unwrap();
+/// ```
 pub fn check_file(input: &Path) -> Result<()> {
     let status = Status::start_with_symbol("Ἔλεγχος (Checking)", "🔍");
     let source = load_source(input)?;
@@ -256,6 +312,27 @@ pub fn check_file(input: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Semantically highlights a ΓΛΩΣΣΑ file and prints it to the terminal.
+///
+/// Uses the [`highlight`] function to parse
+/// and colorize the source code based on grammatical roles (e.g., Subjects are blue,
+/// Objects are red, Verbs are green).
+///
+/// ## Errors
+///
+/// Returns an error if the input file does not exist, exceeds the size limit,
+/// or contains syntax errors that prevent highlighting.
+///
+/// ## Examples
+///
+/// ```no_run
+/// use glossa::tools::runner::highlight_file;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// // Prints the highlighted source code to stdout
+/// highlight_file(input).unwrap();
+/// ```
 pub fn highlight_file(input: &Path) -> Result<()> {
     let status = Status::start_with_symbol("Χρωματισμός (Highlighting)", "🎨");
     let source = load_source(input)?;
@@ -267,6 +344,26 @@ pub fn highlight_file(input: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Narrates the logic of a ΓΛΩΣΣΑ file in plain English.
+///
+/// Uses the "Bard" tool to parse, analyze, and translate the semantic
+/// meaning of the program into a readable English narrative ("The Scroll of Logic").
+///
+/// ## Errors
+///
+/// Returns an error if the input file does not exist, exceeds the size limit,
+/// or contains syntax/semantic errors.
+///
+/// ## Examples
+///
+/// ```no_run
+/// use glossa::tools::runner::bard_file;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// // Prints the English narrative of the program's logic
+/// bard_file(input).unwrap();
+/// ```
 pub fn bard_file(input: &Path) -> Result<()> {
     let status = Status::start_with_symbol("Ἀφήγησις (Narrating)", "📜");
     let source = load_source(input)?;


### PR DESCRIPTION
📖 Chapter: The `report` and `runner` modules
🔦 Insight: Explained how to use statistics structures and runner utilities with actionable examples and error documentation.
🧪 Example: Added 8 executable (or `no_run`) doctests.

---
*PR created automatically by Jules for task [18360461610009517171](https://jules.google.com/task/18360461610009517171) started by @madmax983*