### PR TITLE
🎨 Mosaic: UI Polish for CLI Runner

### DIFF
--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -162,8 +162,13 @@ pub fn run_file(input: &Path) -> Result<()> {
 
     // Check if we can use cached binary
     if cache.is_valid(input, &cached_exe) && cached_exe.exists() {
+        println!();
+        println!("{}", "--- Ἐκτέλεσις (Execution) ---".dim());
+
         // Run cached binary directly
         let exit_status = Command::new(&cached_exe).status().into_diagnostic()?;
+
+        println!("{}", "--- Τέλος (End) ---".dim());
 
         if !exit_status.success() {
             std::process::exit(exit_status.code().unwrap_or(1));
@@ -227,8 +232,13 @@ pub fn run_file(input: &Path) -> Result<()> {
 
     status.success();
 
+    println!();
+    println!("{}", "--- Ἐκτέλεσις (Execution) ---".dim());
+
     // Run the compiled program
     let exit_status = Command::new(&cached_exe).status().into_diagnostic()?;
+
+    println!("{}", "--- Τέλος (End) ---".dim());
 
     if !exit_status.success() {
         std::process::exit(exit_status.code().unwrap_or(1));


### PR DESCRIPTION
🖌️ **Before:** `glossa run` would compile the program, print `Οἰκοδόμησις (Building)`, check success, and immediately start printing the executed program's output. If the program simply prints a single number or runs a long process, it was indistinguishable from the compiler logs, leading to confusing CLI experiences and violating the "Feedback Loops" rule.

✨ **After:** Visual boundaries (`--- Ἐκτέλεσις (Execution) ---` and `--- Τέλος (End) ---`) are now cleanly placed around the executed process's output.

🖼️ **Visuals:** The boundaries use `.dim()` styling. This provides strong "Visual Hierarchy", letting debug info recede so the actual application output remains the focal point of the execution phase.

---
*PR created automatically by Jules for task [13116869427922490778](https://jules.google.com/task/13116869427922490778) started by @madmax983*