### PR TITLE
👺 Havoc: Fuzzing the Compilation Pipeline

### DIFF
--- a/tests/havoc_pipeline.rs
+++ b/tests/havoc_pipeline.rs
@@ -1,0 +1,31 @@
+use glossa::codegen::generate_rust;
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    // Fuzz the entire compilation pipeline
+    // This catches panics in the analyzer or codegen if the parser happens to produce
+    // a valid or seemingly-valid AST from garbage data.
+    #[test]
+    fn fuzz_entire_pipeline(s in "\\PC*") {
+        if let Ok(ast) = parse(&s) {
+            if let Ok(analyzed) = analyze_program(&ast) {
+                // If it passes analysis, codegen MUST NOT PANIC!
+                let _ = generate_rust(&analyzed);
+            }
+        }
+    }
+
+    // A more structured fuzzer targeting valid-looking syntax that might bypass initial parser rejections
+    #[test]
+    fn fuzz_pipeline_structured(s in "[a-zA-Z0-9_\\s\\.\\(\\)\\{\\}\\[\\]«»α-ωΑ-Ωἀ-ὥ]+") {
+        if let Ok(ast) = parse(&s) {
+            if let Ok(analyzed) = analyze_program(&ast) {
+                let _ = generate_rust(&analyzed);
+            }
+        }
+    }
+}


### PR DESCRIPTION
👺 Havoc: Fuzzing the Compilation Pipeline

🧨 **The Trigger:** Fuzzing the entire compiler pipeline with arbitrary Unicode (`\PC*`) and semi-structured payloads.
📉 **The Stack Trace:** (None yet; test proves system currently handles these cases gracefully, establishing a baseline for chaos engineering.)
🧪 **Reproduction:** Run `cargo test --test havoc_pipeline`.
😈 **Comment:** "You assumed your parser limits were ironclad. Let's see what happens when the fuzzer hits a structural loophole."

---
*PR created automatically by Jules for task [8219600100954531326](https://jules.google.com/task/8219600100954531326) started by @madmax983*