### PR TITLE
🎻 Bard: Comprehensive documentation pass for models and CLI

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -85,7 +85,7 @@
 //!
 //! # Architecture
 //!
-//! The codegen process uses the [`quote`] crate to construct a Rust AST (TokenStream)
+//! The codegen process uses the [`mod@quote`] crate to construct a Rust AST (TokenStream)
 //! directly from the Semantic Analysis model. This ensures that the generated code
 //! is syntactically valid Rust and avoids "stringly typed" code generation errors.
 //!

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -34,11 +34,11 @@
 //!
 //! ## How it works
 //!
-//! 1. **Feed**: You feed morphologically analyzed tokens one by one using [`Assembler::feed`].
+//! 1. **Feed**: You feed morphologically analyzed tokens one by one using `Assembler::feed`.
 //! 2. **Route**: The assembler looks at the `Case` of the token (Nominative, Accusative, etc.)
 //!    and routes it to the corresponding pending slot.
 //! 3. **Accumulate**: Modifiers like adjectives or genitives are accumulated in lists.
-//! 4. **Finalize**: When the statement ends (e.g., at a period), you call [`Assembler::finalize`].
+//! 4. **Finalize**: When the statement ends (e.g., at a period), you call `Assembler::finalize`.
 //!    This checks for validity (e.g., Subject-Verb agreement) and returns the [`AssembledStatement`].
 //!
 //! ## Word Order Independence

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! 1. **Morphological Analysis**: Raw words are analyzed for case, gender, number, etc.
 //!    (handled by the `morphology` module).
-//! 2. **Slot-Based Assembly**: The [`Assembler`] routes these words into grammatical slots
+//! 2. **Slot-Based Assembly**: The `Assembler` routes these words into grammatical slots
 //!    (Subject, Object, Verb) based on their case endings. This provides the
 //!    language's signature free word order.
 //! 3. **Pattern Recognition**: The assembled sentence is classified into a statement kind

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -20,8 +20,11 @@ pub enum AnalyzedStatement {
     /// ```
     /// -> `let g_x = 5;`
     Binding {
+        /// The identifier assigned to the memory slot.
         name: SmolStr,
+        /// The fully evaluated expression filling the memory slot.
         value: AnalyzedExpr,
+        /// Whether this value is allowed to mutate or is locked.
         mutable: bool,
     },
     /// Assignment to existing variable
@@ -31,7 +34,12 @@ pub enum AnalyzedStatement {
     /// ξ δέκα γίγνεται.
     /// ```
     /// -> `g_x = 10;`
-    Assignment { name: SmolStr, value: AnalyzedExpr },
+    Assignment {
+        /// The identifier representing the memory destination.
+        name: SmolStr,
+        /// The new value resolving into the target.
+        value: AnalyzedExpr,
+    },
     /// Print statement
     ///
     /// # Example
@@ -63,8 +71,11 @@ pub enum AnalyzedStatement {
     /// ```
     /// -> `if g_x > 5 { ... } else { ... }`
     If {
+        /// The boolean expression acting as the gatekeeper.
         condition: Box<AnalyzedExpr>,
+        /// The sequence of operations executed if the gate is opened.
         then_body: Vec<AnalyzedStatement>,
+        /// The optional sequence of operations executed if the gate is closed.
         else_body: Option<Vec<AnalyzedStatement>>,
     },
     /// While loop
@@ -75,7 +86,9 @@ pub enum AnalyzedStatement {
     /// ```
     /// -> `while g_x < 10 { ... }`
     While {
+        /// The condition that must remain true
         condition: Box<AnalyzedExpr>,
+        /// The list of statements comprising the loop body
         body: Vec<AnalyzedStatement>,
     },
     /// For loop
@@ -86,8 +99,11 @@ pub enum AnalyzedStatement {
     /// ```
     /// -> `for b in a { println!("{}", b); }`
     For {
+        /// The identifier bound to the current element in the traversal.
         variable: SmolStr,
+        /// The collection being sequentially traversed.
         iterator: Box<AnalyzedExpr>,
+        /// The block executed for each element.
         body: Vec<AnalyzedStatement>,
     },
     /// Match expression
@@ -98,7 +114,9 @@ pub enum AnalyzedStatement {
     /// ```
     /// -> `match g_x { 1 => ... }`
     Match {
+        /// The value being interrogated against the arms.
         scrutinee: Box<AnalyzedExpr>,
+        /// The potential structural destructuring arms.
         arms: Vec<(AnalyzedExpr, Vec<AnalyzedStatement>)>,
     },
     /// Break statement
@@ -124,7 +142,10 @@ pub enum AnalyzedStatement {
     /// δός 5.
     /// ```
     /// -> `return 5;`
-    Return { value: Option<Box<AnalyzedExpr>> },
+    Return {
+        /// The computed outcome carried back to the caller.
+        value: Option<Box<AnalyzedExpr>>,
+    },
     /// Function definition
     ///
     /// # Example
@@ -197,7 +218,9 @@ pub struct AnalyzedMethod {
 /// Analyzed expression with type information
 #[derive(Debug, Clone)]
 pub struct AnalyzedExpr {
+    /// The specific kind of expression (e.g., literal, operation)
     pub expr: AnalyzedExprKind,
+    /// The resolved type of the expression
     pub glossa_type: GlossaType,
 }
 
@@ -233,7 +256,9 @@ pub enum AnalyzedExprKind {
     /// # Example
     /// `user.name` -> `PropertyAccess { owner: user, property: "name" }`
     PropertyAccess {
+        /// The expression whose property is being accessed
         owner: Box<AnalyzedExpr>,
+        /// The name of the property being accessed
         property: SmolStr,
     },
 
@@ -242,7 +267,9 @@ pub enum AnalyzedExprKind {
     /// # Example
     /// `λέγει` (says) -> `VerbCall { verb: "say", args: [] }`
     VerbCall {
+        /// The name of the verb being called
         verb: SmolStr,
+        /// The arguments passed to the verb
         args: Vec<AnalyzedExpr>,
     },
 
@@ -270,8 +297,11 @@ pub enum AnalyzedExprKind {
     /// # Example
     /// `1..10`
     Range {
+        /// The starting value of the range
         start: Box<AnalyzedExpr>,
+        /// The ending value of the range
         end: Box<AnalyzedExpr>,
+        /// Whether the range includes its end value
         inclusive: bool,
     },
 
@@ -322,7 +352,9 @@ pub enum AnalyzedExprKind {
     /// # Example
     /// `arr[0]`
     IndexAccess {
+        /// The array expression being indexed
         array: Box<AnalyzedExpr>,
+        /// The index expression
         index: Box<AnalyzedExpr>,
     },
 
@@ -331,7 +363,9 @@ pub enum AnalyzedExprKind {
     /// # Example
     /// `my_func(arg)`
     FunctionCall {
+        /// The name of the function to call
         func: SmolStr,
+        /// The arguments passed to the function
         args: Vec<AnalyzedExpr>,
     },
 
@@ -340,8 +374,11 @@ pub enum AnalyzedExprKind {
     /// # Example
     /// `vec.push(1)`
     MethodCall {
+        /// The expression whose method is being called
         receiver: Box<AnalyzedExpr>,
+        /// The name of the method
         method: SmolStr,
+        /// The arguments passed to the method
         args: Vec<AnalyzedExpr>,
     },
 
@@ -350,9 +387,13 @@ pub enum AnalyzedExprKind {
     /// # Example
     /// `user.Show::print()`
     TraitMethodCall {
+        /// The expression implementing the trait
         receiver: Box<AnalyzedExpr>,
+        /// The name of the trait
         trait_name: SmolStr,
+        /// The name of the trait method
         method_name: SmolStr,
+        /// The arguments passed to the method
         args: Vec<AnalyzedExpr>,
     },
 
@@ -361,8 +402,11 @@ pub enum AnalyzedExprKind {
     /// # Example
     /// `x new User "name" 42`
     StructInstantiation {
+        /// The name of the struct type
         type_name: SmolStr,
+        /// The names of the fields in the struct definition
         fields: Vec<SmolStr>, // Field names from struct definition
+        /// The arguments corresponding to each field
         args: Vec<AnalyzedExpr>,
     },
 
@@ -371,20 +415,31 @@ pub enum AnalyzedExprKind {
     /// # Example
     /// `|x| x + 1`
     Lambda {
+        /// The parameter names for the closure
         params: Vec<SmolStr>,
+        /// The expression body of the closure
         body: Box<AnalyzedExpr>,
+        /// The capture mode defining how environment variables are handled
         capture_mode: CaptureMode,
     },
 
     /// Collection constructor (HashSet::new(), HashMap::new())
-    CollectionNew { collection_type: String },
+    CollectionNew {
+        /// The underlying collection type (e.g., "HashSet")
+        collection_type: String,
+    },
 
     /// Boolean assertion: δεῖ (condition must be true)
-    Assert { condition: Box<AnalyzedExpr> },
+    Assert {
+        /// The condition that must evaluate to true
+        condition: Box<AnalyzedExpr>,
+    },
 
     /// Equality assertion: ἰσοῦται (values must be equal)
     AssertEq {
+        /// The left-hand side value
         left: Box<AnalyzedExpr>,
+        /// The right-hand side value
         right: Box<AnalyzedExpr>,
     },
 }
@@ -414,13 +469,17 @@ pub enum CaptureMode {
 /// Trait definition for semantic analysis
 #[derive(Debug, Clone)]
 pub struct TraitDef {
+    /// The name of the trait
     pub name: SmolStr,
+    /// The list of methods defined in the trait
     pub methods: Vec<AnalyzedMethod>,
 }
 
 /// Trait implementation for a type
 #[derive(Debug, Clone)]
 pub struct TraitImpl {
+    /// The name of the trait being implemented
     pub trait_name: SmolStr,
+    /// The name of the type implementing the trait
     pub type_name: SmolStr,
 }

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -9,9 +9,13 @@ use std::collections::HashMap;
 /// A unified symbol entry in the scope
 #[derive(Debug, Clone)]
 pub enum Symbol {
+    /// A variable binding
     Variable(Binding),
+    /// A function signature
     Function(FunctionSignature),
+    /// A defined type
     Type(GlossaType),
+    /// A defined trait
     Trait(crate::semantic::model::TraitDef),
 }
 

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -87,8 +87,11 @@ pub enum GlossaType {
     ///
     /// Named types defined by the user (e.g., `εἶδος Χρήστης`).
     Struct {
+        /// The name of the struct
         name: SmolStr,
+        /// The grammatical gender of the struct
         gender: Gender,
+        /// The fields defined in the struct and their types
         fields: Vec<(SmolStr, GlossaType)>,
     },
 
@@ -96,7 +99,9 @@ pub enum GlossaType {
     ///
     /// Represents the type of a function, including parameter and return types.
     Function {
+        /// The parameter types of the function
         params: Vec<GlossaType>,
+        /// The return type of the function
         returns: Box<GlossaType>,
     },
 

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -46,11 +46,13 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+/// The main command line interface structure definition
 #[derive(Parser)]
 #[command(name = "glossa")]
 #[command(about = "ΓΛΩΣΣΑ - Ancient Greek morphology as programming semantics")]
 #[command(version)]
 pub struct Cli {
+    /// The subcommand to execute
     #[command(subcommand)]
     pub command: Option<Commands>,
 
@@ -59,6 +61,7 @@ pub struct Cli {
     pub file: Option<PathBuf>,
 }
 
+/// Supported subcommands for the ΓΛΩΣΣΑ CLI
 #[derive(Subcommand)]
 pub enum Commands {
     /// Run a .γλ file (default)

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -29,6 +29,7 @@ pub mod mosaic;
 pub mod narrator;
 pub mod repl;
 pub mod report;
+/// File runner and execution utilities
 pub mod runner;
 pub mod tester;
 pub mod ui;

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -233,12 +233,18 @@ fn print_env<W: Write>(context: &ReplContext, w: &mut W) -> Result<()> {
 pub enum ReplOutput {
     /// A new variable binding
     Binding {
+        /// The name of the bound variable
         name: String,
+        /// The resolved type of the variable
         type_: GlossaType,
+        /// Whether the variable is mutable
         mutable: bool,
     },
     /// Code execution (compilation)
-    Statement { code: String },
+    Statement {
+        /// The formatted code string of the executed statement
+        code: String,
+    },
     /// No output (e.g. empty line)
     None,
 }

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -219,6 +219,7 @@ pub struct GlossaReport<'a> {
 }
 
 impl<'a> GlossaReport<'a> {
+    /// Creates a new `GlossaReport` for the given analyzed program.
     pub fn new(program: &'a AnalyzedProgram, filename: String) -> Self {
         let stats = ProgramStats::new(program);
         Self {
@@ -333,11 +334,17 @@ impl Display for GlossaReport<'_> {
 
 /// A comprehensive report for the compilation process
 pub struct CompilationReport {
+    /// The path to the original source file
     pub input_path: PathBuf,
+    /// The path to the compiled output file
     pub output_path: PathBuf,
+    /// The size of the input file in bytes
     pub input_size: u64,
+    /// The size of the output file in bytes
     pub output_size: u64,
+    /// The duration taken to compile the file
     pub duration: Duration,
+    /// The statistics collected from the program
     pub stats: ProgramStats,
 }
 

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -237,6 +237,8 @@ pub fn run_file(input: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Checks the semantic validity of a ΓΛΩΣΣΑ file without executing it.
+/// Evaluates syntax, types, and variable bindings.
 pub fn check_file(input: &Path) -> Result<()> {
     let status = Status::start_with_symbol("Ἔλεγχος (Checking)", "🔍");
     let source = load_source(input)?;
@@ -256,6 +258,7 @@ pub fn check_file(input: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Displays the contents of a ΓΛΩΣΣΑ file with semantic syntax highlighting.
 pub fn highlight_file(input: &Path) -> Result<()> {
     let status = Status::start_with_symbol("Χρωματισμός (Highlighting)", "🎨");
     let source = load_source(input)?;
@@ -267,6 +270,7 @@ pub fn highlight_file(input: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Generates and prints a narrative explanation (Bard) of the logic within a ΓΛΩΣΣΑ file.
 pub fn bard_file(input: &Path) -> Result<()> {
     let status = Status::start_with_symbol("Ἀφήγησις (Narrating)", "📜");
     let source = load_source(input)?;


### PR DESCRIPTION
📖 **Chapter**: Resolving missing public documentation and broken intra-doc links across the semantic analysis and CLI tool modules.
🔦 **Insight**: The codebase was missing critical documentation for internal AST node fields, CLI structure definitions, and output report fields. These have now been documented using a story-driven approach explaining *why* these structures exist and what their fields represent in the abstract machine. Broken documentation links that previously resolved to private items (e.g., `Assembler`) were fixed.
🧪 **Example**: `cargo doc --no-deps` now compiles without warnings, and structures like `AnalyzedMethod` and `Cli` provide rich, hoverable context.

---
*PR created automatically by Jules for task [11324218557169854394](https://jules.google.com/task/11324218557169854394) started by @madmax983*