### PR TITLE
🗺️ Atlas: Unify error handling with GlossaResult type

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -99,3 +99,10 @@
 3.  Updated `control_flow.rs` and `declarations.rs` to accept `&mut impl StatementAnalyzer` instead of calling a concrete function.
 4.  Re-exported the public API from `mod.rs` to maintain backward compatibility.
 **Stability:** Broken the dependency cycle. The dependency graph is now a DAG: `mod` -> `analyzer` -> `control_flow` -> `traits`. Submodules are now leaf-like with respect to the analyzer.
+
+## [Breaking The Shotgun: API Design & Unifying Error Types]
+**Tangle:** `src/errors.rs` defined a `GlossaResult<T> = Result<T, GlossaError>` which was entirely unused. Instead, many modules (especially `semantic` and `parser`) explicitly returned `Result<T, GlossaError>` everywhere. This caused inconsistent API design and made it harder to maintain a unified error boundary.
+**Blueprint:**
+1. Replaced all instances of `Result<T, GlossaError>` with `GlossaResult<T>` across the codebase.
+2. Updated imports in `src/semantic/*`, `src/parser/*`, and `src/tools/*` to use the unified `GlossaResult`.
+**Stability:** Enforces a consistent error boundary and simplifies function signatures, acting as a single source of truth for standard operations that can fail with a `GlossaError`.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod statements;
 
 use self::grammar::{Rule, parse as grammar_parse};
 use crate::ast::*;
-use crate::errors::GlossaError;
+use crate::errors::{GlossaError, GlossaResult};
 use pest::iterators::Pair;
 
 pub use common::ParseError;
@@ -56,7 +56,7 @@ impl From<ParseError> for GlossaError {
 /// let program = parse(source).unwrap();
 /// assert_eq!(program.statements.len(), 1);
 /// ```
-pub fn parse(source: &str) -> Result<Program, GlossaError> {
+pub fn parse(source: &str) -> GlossaResult<Program> {
     parse_source(source).map_err(GlossaError::from)
 }
 

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -16,7 +16,7 @@ use super::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, assemble_statement,
 };
 use crate::ast::{Expr, Program, Statement};
-use crate::errors::GlossaError;
+use crate::errors::{GlossaError, GlossaResult};
 
 /// Analyzed program with resolved names and types
 #[derive(Debug, Clone)]
@@ -45,7 +45,7 @@ impl Analyzer {
         &mut self,
         stmt: &Statement,
         scope: &mut Scope,
-    ) -> Result<Vec<AnalyzedStatement>, GlossaError> {
+    ) -> GlossaResult<Vec<AnalyzedStatement>> {
         // 1. Check for function definitions
         if contains_function_definition_verb(stmt)
             && let Some(func_def) = parse_function_definition(stmt, scope, self)?
@@ -117,7 +117,7 @@ fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
 /// Perform semantic analysis on a program
 ///
 /// This is the entry point that instantiates the Analyzer.
-pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError> {
+pub fn analyze_program(program: &Program) -> GlossaResult<AnalyzedProgram> {
     let mut scope = Scope::new();
     let mut analyzed_statements = Vec::new();
     let mut analyzer = Analyzer::new();
@@ -171,14 +171,14 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
 
 const MAX_EXPRESSION_DEPTH: usize = 200;
 
-fn check_program_depth(program: &AnalyzedProgram) -> Result<(), GlossaError> {
+fn check_program_depth(program: &AnalyzedProgram) -> GlossaResult<()> {
     for stmt in &program.statements {
         check_statement_depth(stmt, 0)?;
     }
     Ok(())
 }
 
-fn check_statement_depth(stmt: &AnalyzedStatement, depth: usize) -> Result<(), GlossaError> {
+fn check_statement_depth(stmt: &AnalyzedStatement, depth: usize) -> GlossaResult<()> {
     if depth > MAX_EXPRESSION_DEPTH {
         return Err(GlossaError::LimitExceeded {
             resource: "statement depth".into(),
@@ -253,7 +253,7 @@ fn check_statement_depth(stmt: &AnalyzedStatement, depth: usize) -> Result<(), G
     Ok(())
 }
 
-fn check_expr_depth(expr: &AnalyzedExpr, depth: usize) -> Result<(), GlossaError> {
+fn check_expr_depth(expr: &AnalyzedExpr, depth: usize) -> GlossaResult<()> {
     if depth > MAX_EXPRESSION_DEPTH {
         return Err(GlossaError::LimitExceeded {
             resource: "expression depth".into(),

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -13,7 +13,7 @@ use super::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, assemble_statement,
 };
 use crate::ast::{Clause, Expr, Statement};
-use crate::errors::GlossaError;
+use crate::errors::{GlossaError, GlossaResult};
 use crate::morphology::lexicon;
 use crate::semantic::analyzer::Analyzer;
 
@@ -23,7 +23,7 @@ pub fn analyze_control_flow(
     stmt: &Statement,
     scope: &mut Scope,
     analyzer: &mut Analyzer,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     // Note: Function definitions are handled in `mod.rs` before calling this.
 
     // Get the first word to check for control flow particles
@@ -87,7 +87,7 @@ fn parse_while_loop(
     stmt: &Statement,
     scope: &mut Scope,
     analyzer: &mut Analyzer,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
             "While loop needs at least 2 clauses: condition and body",
@@ -122,7 +122,7 @@ fn parse_for_range_loop(
     stmt: &Statement,
     scope: &mut Scope,
     analyzer: &mut Analyzer,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
             "For loop needs at least 2 clauses: range and body",
@@ -263,7 +263,7 @@ fn parse_for_iteration_loop(
     stmt: &Statement,
     scope: &mut Scope,
     analyzer: &mut Analyzer,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
             "For loop needs at least 2 clauses: collection and body",
@@ -350,7 +350,7 @@ fn parse_match_expression(
     stmt: &Statement,
     scope: &mut Scope,
     analyzer: &mut Analyzer,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if stmt.clauses().is_empty() {
         return Err(GlossaError::semantic(
             "Match expression needs at least one clause",
@@ -419,7 +419,7 @@ fn parse_match_expression(
 fn parse_return_statement(
     stmt: &Statement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     // Get the first clause
     if stmt.clauses().is_empty() {
         return Ok(Some(AnalyzedStatement::Return { value: None }));
@@ -436,7 +436,7 @@ fn parse_return_statement(
 }
 
 /// Parse return expression in a simple way
-fn parse_return_expression(clause: &Clause, scope: &Scope) -> Result<AnalyzedExpr, GlossaError> {
+fn parse_return_expression(clause: &Clause, scope: &Scope) -> GlossaResult<AnalyzedExpr> {
     // For Cycle 3, we'll do simple expression parsing
     // The expression after δός could be:
     // - A simple variable: ξ
@@ -512,7 +512,7 @@ fn parse_return_expression(clause: &Clause, scope: &Scope) -> Result<AnalyzedExp
 }
 
 /// Parse a match pattern expression
-fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, GlossaError> {
+fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> GlossaResult<AnalyzedExpr> {
     // Pattern is typically: value ᾖ
     if let Expr::Phrase(terms) = expr {
         if terms.is_empty() {
@@ -580,7 +580,7 @@ fn parse_conditional(
     scope: &mut Scope,
     analyzer: &mut Analyzer,
     depth: usize,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if depth > MAX_CONTROL_FLOW_DEPTH {
         return Err(GlossaError::LimitExceeded {
             resource: "Control flow depth".into(),
@@ -669,10 +669,7 @@ fn parse_conditional(
 }
 
 /// Skip the first word of a clause and parse the rest as an expression
-fn skip_first_word_and_parse(
-    clause: &Clause,
-    scope: &mut Scope,
-) -> Result<AnalyzedExpr, GlossaError> {
+fn skip_first_word_and_parse(clause: &Clause, scope: &mut Scope) -> GlossaResult<AnalyzedExpr> {
     // Create a modified clause without the first word
     let mut modified_clause = clause.clone();
 

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -40,7 +40,7 @@ use super::expressions::{
 };
 use super::patterns::detect_iterator_pattern;
 use crate::ast::Expr;
-use crate::errors::GlossaError;
+use crate::errors::{GlossaError, GlossaResult};
 use crate::morphology::{self};
 use crate::semantic::assembly::AssembledStatement;
 use crate::semantic::model::{AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement};
@@ -60,7 +60,7 @@ use crate::semantic::{Constituent, Literal};
 pub fn convert_assembled_to_analyzed(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<AnalyzedStatement, GlossaError> {
+) -> GlossaResult<AnalyzedStatement> {
     classify_assembled_statement(asm_stmt, scope)
 }
 
@@ -70,7 +70,7 @@ pub fn convert_assembled_to_analyzed(
 pub fn classify_assembled_statement(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<AnalyzedStatement, GlossaError> {
+) -> GlossaResult<AnalyzedStatement> {
     if let Some(res) = classify_iterator_pattern(asm_stmt, scope)? {
         return Ok(res);
     }
@@ -119,7 +119,7 @@ pub fn classify_assembled_statement(
 fn classify_iterator_pattern(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     let has_find_or_print_verb = if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
         crate::morphology::lexicon::is_print_verb(verb_lemma)
@@ -143,7 +143,7 @@ fn classify_iterator_pattern(
 fn classify_property_access_print(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
@@ -184,7 +184,7 @@ fn classify_property_access_print(
 fn classify_function_call(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
@@ -262,7 +262,7 @@ fn classify_function_call(
 fn classify_subjunctive_comparison(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
@@ -345,7 +345,7 @@ fn resolve_binding_target(
 fn classify_variable_binding(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
@@ -384,7 +384,7 @@ fn classify_variable_binding(
 fn classify_assignment(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
@@ -443,7 +443,7 @@ fn classify_assignment(
 fn classify_collection_mutation(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
@@ -464,7 +464,7 @@ fn classify_pop(
     verb_lemma: &str,
     asm_stmt: &AssembledStatement,
     scope: &Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if crate::morphology::lexicon::is_pop_verb(verb_lemma)
         && let Some(ref subject) = asm_stmt.subject
     {
@@ -494,7 +494,7 @@ fn classify_push(
     verb_lemma: &str,
     asm_stmt: &AssembledStatement,
     scope: &Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if crate::morphology::lexicon::is_push_verb(verb_lemma)
         && let Some(ref subject) = asm_stmt.subject
     {
@@ -541,7 +541,7 @@ fn classify_insert(
     verb_lemma: &str,
     asm_stmt: &AssembledStatement,
     scope: &Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if crate::morphology::lexicon::is_insert_verb(verb_lemma)
         && let Some(ref subject) = asm_stmt.subject
     {
@@ -602,7 +602,7 @@ fn classify_insert(
 fn classify_assertion(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
@@ -678,7 +678,7 @@ fn classify_assertion(
 fn classify_equality_assertion(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
@@ -789,7 +789,7 @@ fn try_print_property_access(
 fn try_print_index_access(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<Vec<AnalyzedExpr>>, GlossaError> {
+) -> GlossaResult<Option<Vec<AnalyzedExpr>>> {
     if !asm_stmt.index_accesses.is_empty() {
         let mut args = Vec::new();
         for (array_expr, index_expr) in &asm_stmt.index_accesses {
@@ -811,7 +811,7 @@ fn try_print_index_access(
 fn try_print_unwrap(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<Vec<AnalyzedExpr>>, GlossaError> {
+) -> GlossaResult<Option<Vec<AnalyzedExpr>>> {
     if !asm_stmt.unwraps.is_empty() {
         let mut args = Vec::new();
         for unwrap_expr in &asm_stmt.unwraps {
@@ -829,7 +829,7 @@ fn try_print_unwrap(
 fn try_print_default(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Vec<AnalyzedExpr>, GlossaError> {
+) -> GlossaResult<Vec<AnalyzedExpr>> {
     let mut args =
         build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 
@@ -861,7 +861,7 @@ fn try_print_default(
 fn classify_print(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
 
@@ -893,7 +893,7 @@ fn classify_print(
 fn classify_query(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if asm_stmt.is_query {
         // Containment pattern
         if asm_stmt.has_containment_preposition
@@ -968,7 +968,7 @@ fn classify_query(
 }
 
 /// Helper: Default expression
-fn classify_expression(asm_stmt: &AssembledStatement) -> Result<AnalyzedStatement, GlossaError> {
+fn classify_expression(asm_stmt: &AssembledStatement) -> GlossaResult<AnalyzedStatement> {
     // Determine if we should attempt to build expressions from literals+operators
     // or if we are in a fallback scenario (using Subject/Object with operators).
     // If literals < operators + 1, build_expressions_from_literals_and_ops will fail.
@@ -1088,7 +1088,7 @@ fn try_parse_genitive_method_call(
 fn classify_genitive_method_call(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     if let Some(ref verb) = asm_stmt.verb {
         let verb_lemma = &verb.lemma;
         if crate::morphology::lexicon::is_print_verb(verb_lemma) {

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -9,7 +9,7 @@
 
 use super::{AnalyzedMethod, AnalyzedStatement, GlossaType, Scope};
 use crate::ast::{Expr, Statement};
-use crate::errors::GlossaError;
+use crate::errors::{GlossaError, GlossaResult};
 use crate::morphology::{self};
 use crate::semantic::analyzer::Analyzer;
 use smol_str::SmolStr;
@@ -36,7 +36,7 @@ use smol_str::SmolStr;
 pub fn analyze_type_definition(
     type_def: &crate::ast::TypeDef,
     scope: &mut Scope,
-) -> Result<AnalyzedStatement, GlossaError> {
+) -> GlossaResult<AnalyzedStatement> {
     // Extract type name
     let type_name = type_def.name.normalized.clone();
 
@@ -116,7 +116,7 @@ pub fn analyze_trait_definition(
     trait_def: &crate::ast::TraitDef,
     scope: &mut Scope,
     analyzer: &mut Analyzer,
-) -> Result<AnalyzedStatement, GlossaError> {
+) -> GlossaResult<AnalyzedStatement> {
     // Extract trait name
     let trait_name = trait_def.name.normalized.clone();
 
@@ -217,7 +217,7 @@ pub fn analyze_trait_impl(
     trait_impl: &crate::ast::TraitImplDef,
     scope: &mut Scope,
     analyzer: &mut Analyzer,
-) -> Result<AnalyzedStatement, GlossaError> {
+) -> GlossaResult<AnalyzedStatement> {
     // Extract type and trait names
     let type_name = trait_impl.type_name.normalized.clone();
     let trait_name = trait_impl.trait_name.normalized.clone();
@@ -304,7 +304,7 @@ pub fn analyze_trait_impl(
 }
 
 /// Map a genitive type name to a GlossaType
-pub fn resolve_type_name(name: &str, scope: &Scope) -> Result<GlossaType, GlossaError> {
+pub fn resolve_type_name(name: &str, scope: &Scope) -> GlossaResult<GlossaType> {
     match name {
         // ἀριθμοῦ (genitive of ἀριθμός) → Number
         "αριθμου" => Ok(GlossaType::Number),
@@ -348,7 +348,7 @@ pub fn parse_function_definition(
     stmt: &Statement,
     scope: &mut Scope,
     analyzer: &mut Analyzer,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     // The middle dot (·) separates expressions within a clause
     // Structure: expr1 · expr2 where expr1 is "name ὁρίζειν [params]" and expr2 is the body
 
@@ -415,7 +415,7 @@ pub fn parse_function_definition(
 }
 
 /// Extract the function name from a function definition header expression
-fn extract_function_name_from_expr(expr: &Expr) -> Result<SmolStr, GlossaError> {
+fn extract_function_name_from_expr(expr: &Expr) -> GlossaResult<SmolStr> {
     // Collect all words and find the nominative word before ὁρίζειν
     let words = collect_words_from_expr(expr);
 
@@ -542,7 +542,7 @@ pub fn analyze_test_declaration(
     test_decl: &crate::ast::TestDecl,
     scope: &mut Scope,
     analyzer: &mut Analyzer,
-) -> Result<AnalyzedStatement, GlossaError> {
+) -> GlossaResult<AnalyzedStatement> {
     let test_name = test_decl.name.clone();
 
     // Analyze the test body statements

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -13,7 +13,7 @@
 //!    recursively to produce an [`AnalyzedExpr`]. See [`analyze_argument_expr`].
 
 use crate::ast::{Expr, Statement};
-use crate::errors::GlossaError;
+use crate::errors::{GlossaError, GlossaResult};
 use crate::morphology::{self, DisambiguationContext, analyze_article, disambiguate, resolve_best};
 use crate::semantic::assembly::Assembler;
 use crate::semantic::assembly::Literal;
@@ -49,10 +49,7 @@ use crate::semantic::types::GlossaType;
 /// let var_analyzed = analyze_argument_expr(&var_expr, &scope_with_var).unwrap();
 /// assert!(matches!(var_analyzed.expr, AnalyzedExprKind::Variable(name) if name == "x"));
 /// ```
-pub(crate) fn analyze_argument_expr(
-    expr: &Expr,
-    scope: &Scope,
-) -> Result<AnalyzedExpr, GlossaError> {
+pub(crate) fn analyze_argument_expr(expr: &Expr, scope: &Scope) -> GlossaResult<AnalyzedExpr> {
     analyze_argument_expr_recursive(expr, scope, 0)
 }
 
@@ -68,7 +65,7 @@ fn analyze_argument_expr_recursive(
     expr: &Expr,
     scope: &Scope,
     depth: usize,
-) -> Result<AnalyzedExpr, GlossaError> {
+) -> GlossaResult<AnalyzedExpr> {
     if depth > MAX_RECURSION_DEPTH {
         return Err(GlossaError::semantic(
             "Recursion limit exceeded in expression analysis",
@@ -104,7 +101,7 @@ fn analyze_argument_expr_recursive(
     }
 }
 
-fn analyze_word(w: &crate::ast::Word, scope: &Scope) -> Result<AnalyzedExpr, GlossaError> {
+fn analyze_word(w: &crate::ast::Word, scope: &Scope) -> GlossaResult<AnalyzedExpr> {
     let normalized = &w.normalized;
 
     // Check if it's a numeral
@@ -130,7 +127,7 @@ fn analyze_word(w: &crate::ast::Word, scope: &Scope) -> Result<AnalyzedExpr, Glo
     )))
 }
 
-fn analyze_literal(expr: &Expr) -> Result<AnalyzedExpr, GlossaError> {
+fn analyze_literal(expr: &Expr) -> GlossaResult<AnalyzedExpr> {
     match expr {
         Expr::NumberLiteral(n) => Ok(AnalyzedExpr {
             expr: AnalyzedExprKind::NumberLiteral(*n),
@@ -148,11 +145,7 @@ fn analyze_literal(expr: &Expr) -> Result<AnalyzedExpr, GlossaError> {
     }
 }
 
-fn analyze_array(
-    elements: &[Expr],
-    scope: &Scope,
-    depth: usize,
-) -> Result<AnalyzedExpr, GlossaError> {
+fn analyze_array(elements: &[Expr], scope: &Scope, depth: usize) -> GlossaResult<AnalyzedExpr> {
     let mut analyzed_elements = Vec::with_capacity(elements.len());
     for el in elements {
         analyzed_elements.push(analyze_argument_expr_recursive(el, scope, depth + 1)?);
@@ -174,7 +167,7 @@ fn analyze_index_access(
     index: &Expr,
     scope: &Scope,
     depth: usize,
-) -> Result<AnalyzedExpr, GlossaError> {
+) -> GlossaResult<AnalyzedExpr> {
     let array_analyzed = analyze_argument_expr_recursive(array, scope, depth + 1)?;
     let index_analyzed = analyze_argument_expr_recursive(index, scope, depth + 1)?;
 
@@ -192,7 +185,7 @@ fn analyze_property_access(
     property: &Expr,
     scope: &Scope,
     depth: usize,
-) -> Result<AnalyzedExpr, GlossaError> {
+) -> GlossaResult<AnalyzedExpr> {
     // Treat property access as variable lookup or method call preparation
     // This is simplified; usually property access is handled by the assembler context
     // But if we encounter it directly as an expression, we try to resolve it.
@@ -211,11 +204,7 @@ fn analyze_property_access(
     }
 }
 
-fn analyze_phrase(
-    terms: &[Expr],
-    scope: &Scope,
-    depth: usize,
-) -> Result<AnalyzedExpr, GlossaError> {
+fn analyze_phrase(terms: &[Expr], scope: &Scope, depth: usize) -> GlossaResult<AnalyzedExpr> {
     // A phrase could be a function call: function_name arg1 arg2 ...
     if terms.is_empty() {
         return Err(GlossaError::semantic("Empty phrase in argument"));
@@ -261,7 +250,7 @@ fn analyze_block(
     statements: &[Statement],
     scope: &Scope,
     depth: usize,
-) -> Result<AnalyzedExpr, GlossaError> {
+) -> GlossaResult<AnalyzedExpr> {
     // Blocks used as expressions must contain exactly one statement/clause/expression.
     // This prevents silent ignoring of subsequent statements (e.g., `{ stmt1. stmt2. }` evaluating to `stmt1`).
 
@@ -296,7 +285,7 @@ fn analyze_binop(
     right: &Expr,
     scope: &Scope,
     depth: usize,
-) -> Result<AnalyzedExpr, GlossaError> {
+) -> GlossaResult<AnalyzedExpr> {
     let left_analyzed = analyze_argument_expr_recursive(left, scope, depth + 1)?;
     let right_analyzed = analyze_argument_expr_recursive(right, scope, depth + 1)?;
     // Map AST op to semantic op
@@ -324,7 +313,7 @@ fn analyze_unaryop(
     operand: &Expr,
     scope: &Scope,
     depth: usize,
-) -> Result<AnalyzedExpr, GlossaError> {
+) -> GlossaResult<AnalyzedExpr> {
     match op {
         crate::ast::UnaryOperator::Unwrap => {
             let inner = analyze_argument_expr_recursive(operand, scope, depth + 1)?;
@@ -341,7 +330,7 @@ fn analyze_unaryop(
 }
 
 /// Get the first word from a statement for pattern detection
-pub fn get_first_word(stmt: &Statement) -> Result<smol_str::SmolStr, GlossaError> {
+pub fn get_first_word(stmt: &Statement) -> GlossaResult<smol_str::SmolStr> {
     if let Some(first_clause) = stmt.clauses().first()
         && let Some(first_expr) = first_clause.expressions.first()
     {
@@ -394,7 +383,7 @@ pub(crate) fn feed_expr_to_assembler_with_context(
     asm: &mut Assembler,
     expr: &Expr,
     context: &mut DisambiguationContext,
-) -> Result<(), GlossaError> {
+) -> GlossaResult<()> {
     feed_expr_recursive(asm, expr, context, 0)
 }
 
@@ -403,7 +392,7 @@ fn feed_expr_recursive(
     expr: &Expr,
     context: &mut DisambiguationContext,
     depth: usize,
-) -> Result<(), GlossaError> {
+) -> GlossaResult<()> {
     if depth > MAX_RECURSION_DEPTH {
         return Err(GlossaError::semantic(
             "Recursion limit exceeded in expression analysis",
@@ -567,7 +556,7 @@ fn feed_expr_recursive(
 }
 
 /// Recursively check expression depth to prevent stack overflow during cloning
-fn check_cloning_depth_safety(expr: &Expr, limit: usize) -> Result<(), GlossaError> {
+fn check_cloning_depth_safety(expr: &Expr, limit: usize) -> GlossaResult<()> {
     if limit == 0 {
         return Err(GlossaError::semantic(
             "Recursion limit exceeded in nested phrase analysis",
@@ -675,7 +664,7 @@ pub(crate) fn build_binary_expr(
 pub(crate) fn build_expressions_from_literals_and_ops(
     literals: &[Literal],
     operators: &[crate::morphology::lexicon::BinaryOp],
-) -> Result<Vec<AnalyzedExpr>, GlossaError> {
+) -> GlossaResult<Vec<AnalyzedExpr>> {
     // If no operators, just return literals as separate expressions
     if operators.is_empty() {
         return Ok(literals.iter().map(literal_to_analyzed_expr).collect());

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -67,10 +67,10 @@ pub use types::*;
 
 use self::expressions::feed_expr_to_assembler_with_context;
 use crate::ast::Statement;
-use crate::errors::GlossaError;
+use crate::errors::GlossaResult;
 
 /// Analyze a single statement using the slot-based assembler
-pub fn assemble_statement(stmt: &Statement) -> Result<AssembledStatement, GlossaError> {
+pub fn assemble_statement(stmt: &Statement) -> GlossaResult<AssembledStatement> {
     let mut asm = Assembler::new();
     asm.set_query(stmt.is_query());
     asm.set_propagate(stmt.is_propagate());

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -42,7 +42,7 @@ use super::{
     Scope,
 };
 use crate::ast::{Expr, Statement};
-use crate::errors::GlossaError;
+use crate::errors::{GlossaError, GlossaResult};
 use crate::text::normalize_greek;
 use smol_str::SmolStr;
 
@@ -64,7 +64,7 @@ use smol_str::SmolStr;
 pub fn try_parse_trait_method_call(
     stmt: &Statement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     // Only process Regular statements
     if let Statement::Regular { clauses, .. } = stmt {
         // Should have exactly one clause with one expression
@@ -134,7 +134,7 @@ pub fn try_parse_trait_method_call(
 pub fn try_parse_struct_instantiation(
     stmt: &Statement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedStatement>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedStatement>> {
     // Only process Regular statements
     if let Statement::Regular { clauses, .. } = stmt {
         // Should have exactly one clause
@@ -359,7 +359,7 @@ pub fn try_parse_struct_instantiation(
 pub fn detect_iterator_pattern(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
-) -> Result<Option<AnalyzedExpr>, GlossaError> {
+) -> GlossaResult<Option<AnalyzedExpr>> {
     // Need: (subject OR array) + (participles OR comparatives) + (print OR find verb)
     let verb = match &asm_stmt.verb {
         Some(v) => v,

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -38,7 +38,7 @@ use crate::ast::{
     BinOperator, Clause, Expr, Program, Statement, TestDecl, TraitDef, TraitImplDef, TypeDef,
     UnaryOperator, Word,
 };
-use crate::errors::GlossaError;
+use crate::errors::{GlossaError, GlossaResult};
 use crate::morphology::{
     Case, DisambiguationContext, PartOfSpeech, analyze_article, analyze_participle, resolve_best,
 };
@@ -52,7 +52,7 @@ use crate::parser::parse;
 /// # Errors
 ///
 /// Returns a [`GlossaError`] if the source code cannot be parsed.
-pub fn highlight(source: &str) -> Result<String, GlossaError> {
+pub fn highlight(source: &str) -> GlossaResult<String> {
     let program = parse(source)?;
     let mut highlighter = Highlighter::new();
     highlighter.highlight_program(&program)?;
@@ -72,7 +72,7 @@ impl Highlighter {
         }
     }
 
-    fn highlight_program(&mut self, program: &Program) -> Result<(), GlossaError> {
+    fn highlight_program(&mut self, program: &Program) -> GlossaResult<()> {
         for (i, stmt) in program.statements.iter().enumerate() {
             if i > 0 {
                 self.output.push('\n');
@@ -82,7 +82,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_statement(&mut self, stmt: &Statement) -> Result<(), GlossaError> {
+    fn highlight_statement(&mut self, stmt: &Statement) -> GlossaResult<()> {
         match stmt {
             Statement::Regular {
                 clauses,
@@ -112,7 +112,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_clause(&mut self, clause: &Clause) -> Result<(), GlossaError> {
+    fn highlight_clause(&mut self, clause: &Clause) -> GlossaResult<()> {
         for (i, expr) in clause.expressions.iter().enumerate() {
             if i > 0 {
                 self.output.push(' ');
@@ -122,7 +122,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_expr(&mut self, expr: &Expr) -> Result<(), GlossaError> {
+    fn highlight_expr(&mut self, expr: &Expr) -> GlossaResult<()> {
         match expr {
             Expr::StringLiteral(s) => {
                 // Sanitize string to prevent terminal injection
@@ -220,7 +220,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_word(&mut self, w: &Word) -> Result<(), GlossaError> {
+    fn highlight_word(&mut self, w: &Word) -> GlossaResult<()> {
         // 1. Check for article (sets context)
         if let Some(ctx) = analyze_article(&w.original) {
             self.context = ctx;
@@ -292,7 +292,7 @@ impl Highlighter {
 
     // --- Definitions (Simplified highlighting for now) ---
 
-    fn highlight_type_def(&mut self, def: &TypeDef) -> Result<(), GlossaError> {
+    fn highlight_type_def(&mut self, def: &TypeDef) -> GlossaResult<()> {
         write!(
             self.output,
             "{} {} {} {{ ... }}",
@@ -304,7 +304,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_trait_def(&mut self, def: &TraitDef) -> Result<(), GlossaError> {
+    fn highlight_trait_def(&mut self, def: &TraitDef) -> GlossaResult<()> {
         write!(
             self.output,
             "{} {} {} {{ ... }}",
@@ -316,7 +316,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_trait_impl(&mut self, def: &TraitImplDef) -> Result<(), GlossaError> {
+    fn highlight_trait_impl(&mut self, def: &TraitImplDef) -> GlossaResult<()> {
         write!(
             self.output,
             "{} {} {} {} {{ ... }}",
@@ -330,7 +330,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_test_decl(&mut self, decl: &TestDecl) -> Result<(), GlossaError> {
+    fn highlight_test_decl(&mut self, decl: &TestDecl) -> GlossaResult<()> {
         writeln!(
             self.output,
             "{} «{}»",

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -29,7 +29,7 @@ use miette::{IntoDiagnostic, Result};
 use std::io::{BufRead, Write};
 
 use crate::codegen::generate_statement_code;
-use crate::errors::GlossaError;
+use crate::errors::{GlossaError, GlossaResult};
 use crate::parser::parse;
 use crate::semantic::{AnalyzedStatement, GlossaType, Scope, analyze_program};
 
@@ -292,7 +292,7 @@ impl ReplContext {
         }
     }
 
-    fn execute(&mut self, input: &str) -> std::result::Result<ReplOutput, GlossaError> {
+    fn execute(&mut self, input: &str) -> GlossaResult<ReplOutput> {
         // Safety: Prevent memory exhaustion from infinite binding history
         // The REPL re-compiles the entire history on every line, so we must limit it.
         if self.bindings.len() > MAX_REPL_BINDINGS {


### PR DESCRIPTION
**Tangle:** `src/errors.rs` defined a `GlossaResult<T> = Result<T, GlossaError>` which was entirely unused. Instead, many modules (especially `semantic` and `parser`) explicitly returned `Result<T, GlossaError>` everywhere. This caused inconsistent API design and made it harder to maintain a unified error boundary.
**Blueprint:**
1. Replaced all instances of `Result<T, GlossaError>` with `GlossaResult<T>` across the codebase.
2. Updated imports in `src/semantic/*`, `src/parser/*`, and `src/tools/*` to use the unified `GlossaResult`.
**Stability:** Enforces a consistent error boundary and simplifies function signatures, acting as a single source of truth for standard operations that can fail with a `GlossaError`.

---
*PR created automatically by Jules for task [4991172084280734932](https://jules.google.com/task/4991172084280734932) started by @madmax983*