### PR TITLE
⚒️ Forge: Refactor generate_statement in src/codegen.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -17,3 +17,7 @@
 **Refactoring `generate_expr` in `src/codegen/mod.rs`**
 **Learning:** Grouping helper functions by category (Simple, Complex, Control Flow) makes the main dispatch function (`generate_expr`) trivial to read and significantly reduces cognitive load when navigating the file.
 **Action:** When extracting logic from large match statements, group the extracted helpers into logical sections within the file to maintain navigability.
+
+**Refactoring generate_statement in src/codegen.rs**
+**Learning:** Extracting large match blocks that do not strictly require mutable state or complex logic into small, focused helper functions (like `generate_statement_binding`, `generate_statement_assignment`, etc.) significantly flattens the code structure and improves readability, adhering to the 'Grandma Test' and avoiding the 'Pyramid of Doom'.
+**Action:** Regularly review large `match` blocks, especially those used for dispatch, and extract inline logic into well-named private functions.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -465,77 +465,72 @@ fn generate_statement(stmt: &AnalyzedStatement) -> TokenStream {
             name,
             value,
             mutable,
-        } => {
-            // Check if it's an array to force mutable
-            let is_array = matches!(value.expr, AnalyzedExprKind::ArrayLiteral(_));
-            generate_let(name, value, *mutable || is_array)
-        }
-
-        AnalyzedStatement::Assignment { name, value } => {
-            let name_ident = sanitize_ident(name);
-            let value_tokens = generate_expr(value);
-            quote! { #name_ident = #value_tokens; }
-        }
-
+        } => generate_statement_binding(name, value, *mutable),
+        AnalyzedStatement::Assignment { name, value } => generate_statement_assignment(name, value),
         AnalyzedStatement::Print(exprs) | AnalyzedStatement::Query(exprs) => generate_print(exprs),
-
-        AnalyzedStatement::Expression(exprs) => {
-            let expr_tokens: Vec<TokenStream> = exprs
-                .iter()
-                .map(|e| {
-                    let tokens = generate_expr(e);
-                    quote! { #tokens; }
-                })
-                .collect();
-            quote! { #(#expr_tokens)* }
-        }
-
+        AnalyzedStatement::Expression(exprs) => generate_statement_expression(exprs),
         AnalyzedStatement::If {
             condition,
             then_body,
             else_body,
         } => generate_if(condition, then_body, else_body),
-
         AnalyzedStatement::While { condition, body } => generate_while(condition, body),
-
         AnalyzedStatement::For {
             variable,
             iterator,
             body,
         } => generate_for(variable, iterator, body),
-
         AnalyzedStatement::Match { scrutinee, arms } => generate_match(scrutinee, arms),
-
         AnalyzedStatement::Break => quote! { break; },
-
         AnalyzedStatement::Continue => quote! { continue; },
-
-        AnalyzedStatement::Return { value } => match value {
-            Some(e) => {
-                let value_tokens = generate_expr(e);
-                quote! { return #value_tokens; }
-            }
-            None => quote! { return; },
-        },
-
+        AnalyzedStatement::Return { value } => generate_statement_return(value),
         AnalyzedStatement::FunctionDef {
             name,
             params,
             body,
             return_type,
         } => generate_fn_def(name, params, body, return_type),
-
         AnalyzedStatement::TypeDefinition { name, fields } => generate_struct_def(name, fields),
-
         AnalyzedStatement::TraitDefinition { name, methods } => generate_trait_def(name, methods),
-
         AnalyzedStatement::TraitImplementation {
             trait_name,
             type_name,
             methods,
         } => generate_trait_impl(trait_name, type_name, methods),
-
         AnalyzedStatement::TestDeclaration { name, body } => generate_test(name, body),
+    }
+}
+
+fn generate_statement_binding(name: &str, value: &AnalyzedExpr, mutable: bool) -> TokenStream {
+    // Check if it's an array to force mutable
+    let is_array = matches!(value.expr, AnalyzedExprKind::ArrayLiteral(_));
+    generate_let(name, value, mutable || is_array)
+}
+
+fn generate_statement_assignment(name: &str, value: &AnalyzedExpr) -> TokenStream {
+    let name_ident = sanitize_ident(name);
+    let value_tokens = generate_expr(value);
+    quote! { #name_ident = #value_tokens; }
+}
+
+fn generate_statement_expression(exprs: &[AnalyzedExpr]) -> TokenStream {
+    let expr_tokens: Vec<TokenStream> = exprs
+        .iter()
+        .map(|e| {
+            let tokens = generate_expr(e);
+            quote! { #tokens; }
+        })
+        .collect();
+    quote! { #(#expr_tokens)* }
+}
+
+fn generate_statement_return(value: &Option<Box<AnalyzedExpr>>) -> TokenStream {
+    match value {
+        Some(e) => {
+            let value_tokens = generate_expr(e);
+            quote! { return #value_tokens; }
+        }
+        None => quote! { return; },
     }
 }
 


### PR DESCRIPTION
⚒️ Forge: Refactor generate_statement match branches

🚮 Smell: The `generate_statement` function in `src/codegen.rs` had a large `match` block with inline logic for simple statements like Binding, Assignment, Expression, and Return.
✨ Solution: Extracted the logic for these branches into small, focused private helper functions (`generate_statement_binding`, `generate_statement_assignment`, `generate_statement_expression`, and `generate_statement_return`).
🧼 Benefit: Reduces cognitive load, flattens the match statement, and adheres to the 'Grandma Test' for readability.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [12744600841239730957](https://jules.google.com/task/12744600841239730957) started by @madmax983*