### PR TITLE
⚒️ Forge: Extract deduplicate_tail helper

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -7,6 +7,7 @@
 
 use std::borrow::Cow;
 
+use crate::morphology::deduplicate_tail;
 use crate::morphology::matcher::match_suffix;
 use crate::morphology::models::{Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice};
 use crate::text::normalize_greek;
@@ -591,29 +592,13 @@ pub fn analyze_verb_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
     });
 
     // Deduplicate identical analyses in the tail
-    let len = analyses.len();
-    if len > start_len + 1 {
-        let mut w = start_len + 1;
-        for r in start_len + 1..len {
-            let matches = {
-                let a = &analyses[w - 1];
-                let b = &analyses[r];
-                a.tense == b.tense
-                    && a.mood == b.mood
-                    && a.person == b.person
-                    && a.number == b.number
-                    && a.lemma == b.lemma
-            };
-
-            if !matches {
-                if r != w {
-                    analyses.swap(r, w);
-                }
-                w += 1;
-            }
-        }
-        analyses.truncate(w);
-    }
+    deduplicate_tail(analyses, start_len, |a, b| {
+        a.tense == b.tense
+            && a.mood == b.mood
+            && a.person == b.person
+            && a.number == b.number
+            && a.lemma == b.lemma
+    });
 }
 
 /// Conjugate a verb stem to a specific form

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -7,6 +7,7 @@
 
 use std::borrow::Cow;
 
+use crate::morphology::deduplicate_tail;
 use crate::morphology::matcher::match_suffix;
 use crate::morphology::models::{Case, Gender, MorphAnalysis, Number, PartOfSpeech};
 
@@ -248,28 +249,9 @@ pub fn analyze_noun_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
     });
 
     // Deduplicate identical analyses in the tail
-    let len = analyses.len();
-    if len > start_len + 1 {
-        let mut w = start_len + 1;
-        for r in start_len + 1..len {
-            let matches = {
-                let a = &analyses[w - 1];
-                let b = &analyses[r];
-                a.case == b.case
-                    && a.number == b.number
-                    && a.gender == b.gender
-                    && a.lemma == b.lemma
-            };
-
-            if !matches {
-                if r != w {
-                    analyses.swap(r, w);
-                }
-                w += 1;
-            }
-        }
-        analyses.truncate(w);
-    }
+    deduplicate_tail(analyses, start_len, |a, b| {
+        a.case == b.case && a.number == b.number && a.gender == b.gender && a.lemma == b.lemma
+    });
 }
 
 /// Extract stem from a word given its nominative form and declension

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -78,6 +78,26 @@ pub fn analyze_all(word: &str) -> Vec<MorphAnalysis> {
     analyze_all_from_normalized(&normalized)
 }
 
+/// Helper to deduplicate the tail of a vector from a given start index.
+pub(crate) fn deduplicate_tail<T, F>(vec: &mut Vec<T>, start_len: usize, mut is_same: F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    let len = vec.len();
+    if len > start_len + 1 {
+        let mut w = start_len + 1;
+        for r in start_len + 1..len {
+            if !is_same(&vec[w - 1], &vec[r]) {
+                if r != w {
+                    vec.swap(r, w);
+                }
+                w += 1;
+            }
+        }
+        vec.truncate(w);
+    }
+}
+
 /// Helper to analyze using an already-normalized string
 fn analyze_all_from_normalized(normalized: &str) -> Vec<MorphAnalysis> {
     // Pre-allocate capacity to avoid reallocations


### PR DESCRIPTION
🚮 **Smell:** Identical nested loop logic (spanning 15-20 lines) for array deduplication was duplicated in both `analyze_noun_all_into` (`src/morphology/declension.rs`) and `analyze_verb_all_into` (`src/morphology/conjugation.rs`). 
✨ **Solution:** Extracted the core loop into a generic `pub(crate) fn deduplicate_tail<T, F>(vec: &mut Vec<T>, start_len: usize, mut is_same: F)` helper in `src/morphology/mod.rs` and passed field-matching closures from the call sites.
🧼 **Benefit:** Eliminates duplicated logic, flattens the file structure, and honors the DRY principle, improving code readability.
🛡️ **Verification:** Tests passed via `cargo test`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt`. No logic changed.

---
*PR created automatically by Jules for task [3087842610790233207](https://jules.google.com/task/3087842610790233207) started by @madmax983*