### PR TITLE
🛡️ Sentry: Replace unwrap() calls in semantic conversion and patterns

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -1030,14 +1030,16 @@ fn classify_expression(asm_stmt: &AssembledStatement) -> Result<AnalyzedStatemen
             });
         }
     }
+    #[allow(clippy::collapsible_if)]
 
-    if asm_stmt.is_propagate && !exprs.is_empty() {
-        let last_expr = exprs.pop().unwrap();
-        let try_expr = AnalyzedExpr {
-            glossa_type: last_expr.glossa_type.clone(),
-            expr: AnalyzedExprKind::Try(Box::new(last_expr)),
-        };
-        exprs.push(try_expr);
+    if asm_stmt.is_propagate {
+        if let Some(last_expr) = exprs.pop() {
+            let try_expr = AnalyzedExpr {
+                glossa_type: last_expr.glossa_type.clone(),
+                expr: AnalyzedExprKind::Try(Box::new(last_expr)),
+            };
+            exprs.push(try_expr);
+        }
     }
 
     Ok(AnalyzedStatement::Expression(exprs))

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -172,7 +172,7 @@ pub fn try_parse_struct_instantiation(
                 return Ok(None);
             };
 
-            let last_word = if let Expr::Word(w) = terms.last().unwrap() {
+            let last_word = if let Some(Expr::Word(w)) = terms.last() {
                 w
             } else {
                 return Ok(None);

--- a/src/semantic/sentry_conversion_tests.rs
+++ b/src/semantic/sentry_conversion_tests.rs
@@ -403,3 +403,25 @@ fn test_binding_subject_object_swap() {
         panic!("Expected Binding statement");
     }
 }
+
+#[test]
+fn test_try_parse_expression_statement_empty_exprs_no_panic() -> Result<(), crate::errors::GlossaError> {
+    let mut scope = Scope::new();
+
+    // An empty statement with is_propagate = true
+    // We want to ensure this is handled cleanly without panicking.
+    let asm_stmt = AssembledStatement {
+        is_propagate: true,
+        ..Default::default()
+    };
+
+    // We expect it to gracefully return an Expression statement with 0 expressions
+    let result = crate::semantic::conversion::convert_assembled_to_analyzed(&asm_stmt, &mut scope)?;
+
+    if let AnalyzedStatement::Expression(exprs) = result {
+        assert!(exprs.is_empty(), "Should return empty expressions vector");
+    } else {
+        panic!("Expected Expression statement");
+    }
+    Ok(())
+}


### PR DESCRIPTION
This PR removes instances of `unwrap()` from the semantic phase, replacing them with standard Rust pattern-matching `if let` blocks. Even though these `unwrap` calls were guarded by length/emptiness checks, treating dynamic array extraction as fallible improves robustness against future refactoring and complies with Sentry's strict zero-panic guarantees. Includes test coverage asserting non-panic behavior on empty inputs.

---
*PR created automatically by Jules for task [16126840204568519425](https://jules.google.com/task/16126840204568519425) started by @madmax983*