### PR TITLE
🛡️ Sentry: Replace unwrap and add test edge cases

### DIFF
--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -127,14 +127,20 @@ impl Highlighter {
             Expr::StringLiteral(s) => {
                 // Sanitize string to prevent terminal injection
                 let sanitized: String = s.chars().flat_map(|c| c.escape_debug()).collect();
-                write!(self.output, "«{}»", sanitized.as_str().italic()).unwrap();
+                write!(self.output, "«{}»", sanitized.as_str().italic()).map_err(|e| {
+                    crate::errors::GlossaError::semantic(format!("Format error: {}", e))
+                })?;
             }
             Expr::NumberLiteral(n) => {
-                write!(self.output, "{}", n.to_string().italic()).unwrap();
+                write!(self.output, "{}", n.to_string().italic()).map_err(|e| {
+                    crate::errors::GlossaError::semantic(format!("Format error: {}", e))
+                })?;
             }
             Expr::BooleanLiteral(b) => {
                 let s = if *b { "ἀληθές" } else { "ψεῦδος" };
-                write!(self.output, "{}", s.italic()).unwrap();
+                write!(self.output, "{}", s.italic()).map_err(|e| {
+                    crate::errors::GlossaError::semantic(format!("Format error: {}", e))
+                })?;
             }
             Expr::Word(w) => self.highlight_word(w)?,
             Expr::Phrase(terms) => {
@@ -164,12 +170,14 @@ impl Highlighter {
                 self.output.push(' ');
                 self.highlight_expr(value)?;
                 self.output.push(' ');
-                write!(self.output, "{}", "ἔστω".bold()).unwrap();
+                write!(self.output, "{}", "ἔστω".bold()).map_err(|e| {
+                    crate::errors::GlossaError::semantic(format!("Format error: {}", e))
+                })?;
             }
             Expr::BinOp { left, op, right } => {
                 self.highlight_expr(left)?;
                 self.output.push(' ');
-                self.highlight_binop(op);
+                self.highlight_binop(op)?;
                 self.output.push(' ');
                 self.highlight_expr(right)?;
             }
@@ -177,15 +185,21 @@ impl Highlighter {
                 match op {
                     UnaryOperator::Unwrap => {
                         self.highlight_expr(operand)?;
-                        write!(self.output, "{}", "!".bold().red()).unwrap();
+                        write!(self.output, "{}", "!".bold().red()).map_err(|e| {
+                            crate::errors::GlossaError::semantic(format!("Format error: {}", e))
+                        })?;
                     }
                     UnaryOperator::Not => {
-                        write!(self.output, "{}", "οὐ".bold()).unwrap(); // Simplified
+                        write!(self.output, "{}", "οὐ".bold()).map_err(|e| {
+                            crate::errors::GlossaError::semantic(format!("Format error: {}", e))
+                        })?; // Simplified
                         self.output.push(' ');
                         self.highlight_expr(operand)?;
                     }
                     UnaryOperator::Neg => {
-                        write!(self.output, "-").unwrap();
+                        write!(self.output, "-").map_err(|e| {
+                            crate::errors::GlossaError::semantic(format!("Format error: {}", e))
+                        })?;
                         self.highlight_expr(operand)?;
                     }
                 }
@@ -224,7 +238,9 @@ impl Highlighter {
         // 1. Check for article (sets context)
         if let Some(ctx) = analyze_article(&w.original) {
             self.context = ctx;
-            write!(self.output, "{}", w.original).unwrap(); // Articles plain or dim? Let's leave plain
+            write!(self.output, "{}", w.original).map_err(|e| {
+                crate::errors::GlossaError::semantic(format!("Format error: {}", e))
+            })?; // Articles plain or dim? Let's leave plain
             return Ok(());
         }
 
@@ -233,7 +249,9 @@ impl Highlighter {
         let is_numeral = crate::morphology::lexicon::numeral_value(&w.normalized).is_some();
 
         if !in_lexicon && !is_numeral && analyze_participle(&w.normalized).is_some() {
-            write!(self.output, "{}", w.original.cyan()).unwrap(); // Participles as cyan (adjectival)
+            write!(self.output, "{}", w.original.cyan()).map_err(|e| {
+                crate::errors::GlossaError::semantic(format!("Format error: {}", e))
+            })?; // Participles as cyan (adjectival)
             return Ok(());
         }
 
@@ -267,11 +285,12 @@ impl Highlighter {
             _ => w.original.white(), // Default
         };
 
-        write!(self.output, "{}", styled).unwrap();
+        write!(self.output, "{}", styled)
+            .map_err(|e| crate::errors::GlossaError::semantic(format!("Format error: {}", e)))?;
         Ok(())
     }
 
-    fn highlight_binop(&mut self, op: &BinOperator) {
+    fn highlight_binop(&mut self, op: &BinOperator) -> Result<(), GlossaError> {
         let s = match op {
             BinOperator::Add => "+",
             BinOperator::Sub => "-",
@@ -287,7 +306,9 @@ impl Highlighter {
             BinOperator::And => "&&",
             BinOperator::Or => "||",
         };
-        write!(self.output, "{}", s.bold()).unwrap();
+        write!(self.output, "{}", s.bold())
+            .map_err(|e| crate::errors::GlossaError::semantic(format!("Format error: {}", e)))?;
+        Ok(())
     }
 
     // --- Definitions (Simplified highlighting for now) ---
@@ -345,7 +366,8 @@ impl Highlighter {
             self.output.push('\n');
         }
 
-        write!(self.output, "{}", "τέλος".bold()).unwrap();
+        write!(self.output, "{}", "τέλος".bold())
+            .map_err(|e| crate::errors::GlossaError::semantic(format!("Format error: {}", e)))?;
         Ok(())
     }
 }

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -55,7 +55,9 @@ use crate::parser::parse;
 pub fn highlight(source: &str) -> Result<String, GlossaError> {
     let program = parse(source)?;
     let mut highlighter = Highlighter::new();
-    highlighter.highlight_program(&program)?;
+    highlighter
+        .highlight_program(&program)
+        .map_err(|e| crate::errors::GlossaError::semantic(format!("Format error: {}", e)))?;
     Ok(highlighter.output)
 }
 
@@ -72,7 +74,7 @@ impl Highlighter {
         }
     }
 
-    fn highlight_program(&mut self, program: &Program) -> Result<(), GlossaError> {
+    fn highlight_program(&mut self, program: &Program) -> std::fmt::Result {
         for (i, stmt) in program.statements.iter().enumerate() {
             if i > 0 {
                 self.output.push('\n');
@@ -82,7 +84,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_statement(&mut self, stmt: &Statement) -> Result<(), GlossaError> {
+    fn highlight_statement(&mut self, stmt: &Statement) -> std::fmt::Result {
         match stmt {
             Statement::Regular {
                 clauses,
@@ -112,7 +114,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_clause(&mut self, clause: &Clause) -> Result<(), GlossaError> {
+    fn highlight_clause(&mut self, clause: &Clause) -> std::fmt::Result {
         for (i, expr) in clause.expressions.iter().enumerate() {
             if i > 0 {
                 self.output.push(' ');
@@ -122,25 +124,19 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_expr(&mut self, expr: &Expr) -> Result<(), GlossaError> {
+    fn highlight_expr(&mut self, expr: &Expr) -> std::fmt::Result {
         match expr {
             Expr::StringLiteral(s) => {
                 // Sanitize string to prevent terminal injection
                 let sanitized: String = s.chars().flat_map(|c| c.escape_debug()).collect();
-                write!(self.output, "«{}»", sanitized.as_str().italic()).map_err(|e| {
-                    crate::errors::GlossaError::semantic(format!("Format error: {}", e))
-                })?;
+                write!(self.output, "«{}»", sanitized.as_str().italic())?;
             }
             Expr::NumberLiteral(n) => {
-                write!(self.output, "{}", n.to_string().italic()).map_err(|e| {
-                    crate::errors::GlossaError::semantic(format!("Format error: {}", e))
-                })?;
+                write!(self.output, "{}", n.to_string().italic())?;
             }
             Expr::BooleanLiteral(b) => {
                 let s = if *b { "ἀληθές" } else { "ψεῦδος" };
-                write!(self.output, "{}", s.italic()).map_err(|e| {
-                    crate::errors::GlossaError::semantic(format!("Format error: {}", e))
-                })?;
+                write!(self.output, "{}", s.italic())?;
             }
             Expr::Word(w) => self.highlight_word(w)?,
             Expr::Phrase(terms) => {
@@ -170,9 +166,7 @@ impl Highlighter {
                 self.output.push(' ');
                 self.highlight_expr(value)?;
                 self.output.push(' ');
-                write!(self.output, "{}", "ἔστω".bold()).map_err(|e| {
-                    crate::errors::GlossaError::semantic(format!("Format error: {}", e))
-                })?;
+                write!(self.output, "{}", "ἔστω".bold())?;
             }
             Expr::BinOp { left, op, right } => {
                 self.highlight_expr(left)?;
@@ -185,21 +179,15 @@ impl Highlighter {
                 match op {
                     UnaryOperator::Unwrap => {
                         self.highlight_expr(operand)?;
-                        write!(self.output, "{}", "!".bold().red()).map_err(|e| {
-                            crate::errors::GlossaError::semantic(format!("Format error: {}", e))
-                        })?;
+                        write!(self.output, "{}", "!".bold().red())?;
                     }
                     UnaryOperator::Not => {
-                        write!(self.output, "{}", "οὐ".bold()).map_err(|e| {
-                            crate::errors::GlossaError::semantic(format!("Format error: {}", e))
-                        })?; // Simplified
+                        write!(self.output, "{}", "οὐ".bold())?; // Simplified
                         self.output.push(' ');
                         self.highlight_expr(operand)?;
                     }
                     UnaryOperator::Neg => {
-                        write!(self.output, "-").map_err(|e| {
-                            crate::errors::GlossaError::semantic(format!("Format error: {}", e))
-                        })?;
+                        write!(self.output, "-")?;
                         self.highlight_expr(operand)?;
                     }
                 }
@@ -234,13 +222,11 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_word(&mut self, w: &Word) -> Result<(), GlossaError> {
+    fn highlight_word(&mut self, w: &Word) -> std::fmt::Result {
         // 1. Check for article (sets context)
         if let Some(ctx) = analyze_article(&w.original) {
             self.context = ctx;
-            write!(self.output, "{}", w.original).map_err(|e| {
-                crate::errors::GlossaError::semantic(format!("Format error: {}", e))
-            })?; // Articles plain or dim? Let's leave plain
+            write!(self.output, "{}", w.original)?; // Articles plain or dim? Let's leave plain
             return Ok(());
         }
 
@@ -249,9 +235,7 @@ impl Highlighter {
         let is_numeral = crate::morphology::lexicon::numeral_value(&w.normalized).is_some();
 
         if !in_lexicon && !is_numeral && analyze_participle(&w.normalized).is_some() {
-            write!(self.output, "{}", w.original.cyan()).map_err(|e| {
-                crate::errors::GlossaError::semantic(format!("Format error: {}", e))
-            })?; // Participles as cyan (adjectival)
+            write!(self.output, "{}", w.original.cyan())?; // Participles as cyan (adjectival)
             return Ok(());
         }
 
@@ -285,12 +269,11 @@ impl Highlighter {
             _ => w.original.white(), // Default
         };
 
-        write!(self.output, "{}", styled)
-            .map_err(|e| crate::errors::GlossaError::semantic(format!("Format error: {}", e)))?;
+        write!(self.output, "{}", styled)?;
         Ok(())
     }
 
-    fn highlight_binop(&mut self, op: &BinOperator) -> Result<(), GlossaError> {
+    fn highlight_binop(&mut self, op: &BinOperator) -> std::fmt::Result {
         let s = match op {
             BinOperator::Add => "+",
             BinOperator::Sub => "-",
@@ -306,14 +289,13 @@ impl Highlighter {
             BinOperator::And => "&&",
             BinOperator::Or => "||",
         };
-        write!(self.output, "{}", s.bold())
-            .map_err(|e| crate::errors::GlossaError::semantic(format!("Format error: {}", e)))?;
+        write!(self.output, "{}", s.bold())?;
         Ok(())
     }
 
     // --- Definitions (Simplified highlighting for now) ---
 
-    fn highlight_type_def(&mut self, def: &TypeDef) -> Result<(), GlossaError> {
+    fn highlight_type_def(&mut self, def: &TypeDef) -> std::fmt::Result {
         write!(
             self.output,
             "{} {} {} {{ ... }}",
@@ -325,7 +307,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_trait_def(&mut self, def: &TraitDef) -> Result<(), GlossaError> {
+    fn highlight_trait_def(&mut self, def: &TraitDef) -> std::fmt::Result {
         write!(
             self.output,
             "{} {} {} {{ ... }}",
@@ -337,7 +319,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_trait_impl(&mut self, def: &TraitImplDef) -> Result<(), GlossaError> {
+    fn highlight_trait_impl(&mut self, def: &TraitImplDef) -> std::fmt::Result {
         write!(
             self.output,
             "{} {} {} {} {{ ... }}",
@@ -351,7 +333,7 @@ impl Highlighter {
         Ok(())
     }
 
-    fn highlight_test_decl(&mut self, decl: &TestDecl) -> Result<(), GlossaError> {
+    fn highlight_test_decl(&mut self, decl: &TestDecl) -> std::fmt::Result {
         writeln!(
             self.output,
             "{} «{}»",
@@ -366,8 +348,7 @@ impl Highlighter {
             self.output.push('\n');
         }
 
-        write!(self.output, "{}", "τέλος".bold())
-            .map_err(|e| crate::errors::GlossaError::semantic(format!("Format error: {}", e)))?;
+        write!(self.output, "{}", "τέλος".bold())?;
         Ok(())
     }
 }

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -432,4 +432,89 @@ failures:
         assert_eq!(failures[1].0, "test2");
         assert!(failures[1].1.contains("Error 2"));
     }
+
+    #[test]
+    fn test_extract_failures_edge_cases() {
+        struct TestCase {
+            name: &'static str,
+            input: &'static str,
+            expected_count: usize,
+        }
+
+        let test_cases = vec![
+            TestCase {
+                name: "No failures block",
+                input: "
+running 1 test
+test my_test ... FAILED
+
+test result: FAILED...
+",
+                expected_count: 0,
+            },
+            TestCase {
+                name: "Malformed stdout block",
+                input: "
+failures:
+
+---- my_test_without_end_block
+Error message here
+
+failures:
+    my_test_without_end_block
+",
+                expected_count: 0,
+            },
+        ];
+
+        for case in test_cases {
+            let failures = extract_failures(case.input);
+            assert_eq!(
+                failures.len(),
+                case.expected_count,
+                "Failed case: {}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_test_output_edge_cases() {
+        struct TestCase {
+            name: &'static str,
+            input: &'static str,
+            expected_count: usize,
+        }
+
+        let test_cases = vec![
+            TestCase {
+                name: "Empty parts (less than 4)",
+                input: "
+running 1 test
+test ... ok
+",
+                expected_count: 0,
+            },
+            TestCase {
+                name: "Missing test prefix",
+                input: "my_test ... ok",
+                expected_count: 0,
+            },
+            TestCase {
+                name: "Unknown status",
+                input: "test my_test ... WEIRD_STATUS",
+                expected_count: 0,
+            },
+        ];
+
+        for case in test_cases {
+            let results = parse_test_output(case.input);
+            assert_eq!(
+                results.len(),
+                case.expected_count,
+                "Failed case: {}",
+                case.name
+            );
+        }
+    }
 }

--- a/tests/sentry_morphology_empty_string.rs
+++ b/tests/sentry_morphology_empty_string.rs
@@ -1,0 +1,17 @@
+use glossa::morphology::conjugation::analyze_verb;
+use glossa::morphology::declension::analyze_noun;
+use glossa::morphology::participle::analyze_participle;
+
+#[test]
+fn test_morphology_empty_string_does_not_panic() {
+    assert!(analyze_noun("").is_none());
+    assert!(analyze_verb("").is_none());
+    assert!(analyze_participle("").is_none());
+}
+
+#[test]
+fn test_morphology_invalid_unicode() {
+    assert!(analyze_noun("invalid\u{FFFD}chars").is_none());
+    assert!(analyze_verb("invalid\u{FFFD}chars").is_none());
+    assert!(analyze_participle("invalid\u{FFFD}chars").is_none());
+}


### PR DESCRIPTION
This PR implements improvements identified by the Sentry persona.

1. **Remove Panic Risks in Highlighter**:
All uses of `.unwrap()` on `write!` and `writeln!` in `src/tools/highlight.rs` have been removed and replaced with standard `?` error propagation that maps `fmt::Error` to `GlossaError::semantic()`.

2. **Table-Driven Edge Case Testing**:
Added table-driven unit tests for `parse_test_output` and `extract_failures` in `src/tools/tester.rs`. These functions parse stdout output from executed tests, and they lacked test coverage for missing blocks, malformed lines, empty outputs, or missing statuses.

3. **Defensive Validation in Morphology**:
Added a test specifically to ensure that morphology handlers (`analyze_noun`, `analyze_verb`, `analyze_participle`) correctly handle empty strings and malformed unicode characters without panicking (`tests/sentry_morphology_empty_string.rs`).

---
*PR created automatically by Jules for task [2997973988641982025](https://jules.google.com/task/2997973988641982025) started by @madmax983*