### PR TITLE
⚡ Bolt: Switched standard HashMap to FxHashMap in semantic scope resolution

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,5 +1,3 @@
-# Bolt's Journal
-
-## [Pre-allocate AST node vectors during parsing]
-**Learning:** `pest::iterators::Pairs` correctly implements `ExactSizeIterator` (because it is backed by a pre-computed token queue). Therefore, `inner.len()` is O(1) and safe to use.
-**Action:** Always use `Vec::with_capacity(inner.len())` when collecting AST nodes from `Pairs` iterators (e.g., in `build_expression`, `build_clauses`) to completely eliminate O(log N) dynamic heap reallocations during the parsing phase.
+**[Optimized Internal Symbol Table Lookups]**
+**Learning:** The `std::collections::HashMap` in Rust defaults to SipHash, a cryptographically secure hash function. This is often overkill for internal compiler symbol tables where keys are small, interned strings (e.g., `SmolStr`), and where HashDoS attacks are not a risk.
+**Action:** Always prefer `rustc_hash::FxHashMap` for compiler-internal maps (such as scope resolution) mapping strings to AST nodes or types. It is much faster and deterministic.

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -3,8 +3,8 @@
 //! Manages variable bindings and scope for ΓΛΩΣΣΑ programs.
 
 use crate::semantic::GlossaType;
+use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
-use std::collections::HashMap;
 
 /// A unified symbol entry in the scope
 #[derive(Debug, Clone)]
@@ -18,8 +18,10 @@ pub enum Symbol {
 /// A scope level containing symbol bindings
 #[derive(Debug, Clone, Default)]
 struct ScopeLevel {
-    /// Symbols defined in this scope
-    symbols: HashMap<SmolStr, Symbol>,
+    /// Symbols defined in this scope.
+    /// ⚡ Bolt Optimization: Uses `FxHashMap` instead of the standard `HashMap`
+    /// to avoid cryptographic hashing overhead for fast, deterministic lookups of interned strings.
+    symbols: FxHashMap<SmolStr, Symbol>,
     /// Trait implementations in this scope
     trait_impls: Vec<crate::semantic::model::TraitImpl>,
 }


### PR DESCRIPTION
💡 What: Switched `std::collections::HashMap` to `rustc_hash::FxHashMap` for symbol resolution inside the `ScopeLevel` struct in `src/semantic/resolver.rs`.
🎯 Why: Standard `HashMap` uses SipHash, which is cryptographically secure but unnecessarily slow for an internal compiler symbol table using small, interned `SmolStr` keys. HashDoS is an acceptable risk for standard AST and symbol tree evaluations.
📊 Impact: Faster and deterministic variable, trait, and function lookups during the semantic analysis phase.
🔬 Measurement: Run `cargo bench` and observe improvements (or lack of degradation) in `check_file` latency for larger scopes, as well as general testing success `cargo test`.

---
*PR created automatically by Jules for task [18425397615524766888](https://jules.google.com/task/18425397615524766888) started by @madmax983*