### PR TITLE
⚡ Bolt: Optimize AST generation vectors with `Vec::with_capacity`

### DIFF
--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -4,11 +4,14 @@ use crate::parser::common::ParseError;
 use crate::parser::grammar::Rule;
 use pest::iterators::Pair;
 
+/// ⚡ Bolt Optimization: Uses `Vec::with_capacity` based on the inner pairs length.
+/// This prevents intermediate heap reallocations when building type definition fields.
 pub(crate) fn build_type_definition(pair: Pair<'_, Rule>) -> Result<TypeDef, ParseError> {
     let mut type_name = None;
-    let mut fields = Vec::new();
+    let inner_pairs = pair.into_inner();
+    let mut fields = Vec::with_capacity(inner_pairs.len());
 
-    for inner in pair.into_inner() {
+    for inner in inner_pairs {
         match inner.as_rule() {
             Rule::greek_word => {
                 // This is the type name (between εἶδος and ὁρίζειν)
@@ -37,10 +40,13 @@ pub(crate) fn build_type_definition(pair: Pair<'_, Rule>) -> Result<TypeDef, Par
     Ok(TypeDef { name, fields })
 }
 
+/// ⚡ Bolt Optimization: Uses `Vec::with_capacity` based on the inner pairs length.
+/// This prevents intermediate heap reallocations when collecting field declaration words.
 fn build_field_declaration(pair: Pair<'_, Rule>) -> Result<FieldDecl, ParseError> {
-    let mut words = Vec::new();
+    let inner_pairs = pair.into_inner();
+    let mut words = Vec::with_capacity(inner_pairs.len());
 
-    for inner in pair.into_inner() {
+    for inner in inner_pairs {
         if inner.as_rule() == Rule::greek_word {
             words.push(Word {
                 original: inner.as_str().into(),
@@ -214,11 +220,14 @@ pub(crate) fn build_trait_impl(pair: Pair<'_, Rule>) -> Result<TraitImplDef, Par
     })
 }
 
+/// ⚡ Bolt Optimization: Uses `Vec::with_capacity` based on the inner pairs length.
+/// This minimizes heap allocations for test declaration bodies.
 pub(crate) fn build_test_declaration(pair: Pair<'_, Rule>) -> Result<TestDecl, ParseError> {
     let mut test_name = None;
-    let mut body = Vec::new();
+    let inner_pairs = pair.into_inner();
+    let mut body = Vec::with_capacity(inner_pairs.len());
 
-    for inner in pair.into_inner() {
+    for inner in inner_pairs {
         match inner.as_rule() {
             Rule::string_literal => {
                 // Extract the content from «name»

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -66,22 +66,22 @@ fn build_block_expr(inner: Pair<'_, Rule>) -> Result<Expr, ParseError> {
 
 /// Builds an array literal expression.
 ///
-/// ⚡ Bolt Optimization: Uses `elements.reserve()` when the number of elements is known.
+/// ⚡ Bolt Optimization: Uses `Vec::with_capacity` when the number of elements is known.
 /// This prevents intermediate array reallocations for large array literals.
 fn build_array_literal_expr(inner: Pair<'_, Rule>) -> Result<Expr, ParseError> {
-    let mut elements = Vec::new();
     for child in inner.into_inner() {
         if child.as_rule() == Rule::array_elements {
             let elem_pairs = child.into_inner();
-            elements.reserve(elem_pairs.len());
+            let mut elements = Vec::with_capacity(elem_pairs.len());
             for elem in elem_pairs {
                 if elem.as_rule() == Rule::array_element {
                     elements.push(build_array_element(elem)?);
                 }
             }
+            return Ok(Expr::ArrayLiteral(elements));
         }
     }
-    Ok(Expr::ArrayLiteral(elements))
+    Ok(Expr::ArrayLiteral(Vec::new())) // Empty array literal
 }
 
 fn build_indexed_word_expr(inner: Pair<'_, Rule>) -> Result<Expr, ParseError> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -71,7 +71,11 @@ fn parse_source(source: &str) -> Result<Program, ParseError> {
 
     for pair in pairs {
         if pair.as_rule() == Rule::program {
-            for inner in pair.into_inner() {
+            let inner_pairs = pair.into_inner();
+            // ⚡ Bolt Optimization: Uses `statements.reserve` based on the program pairs length.
+            // This prevents intermediate heap reallocations when assembling the AST.
+            statements.reserve(inner_pairs.len());
+            for inner in inner_pairs {
                 if inner.as_rule() == Rule::statement {
                     statements.push(build_statement(inner)?);
                 }


### PR DESCRIPTION
💡 **What:** Replaced parameter-less `Vec::new()` instantiations during the AST builder phase (specifically within `build_type_definition`, `build_field_declaration`, `build_test_declaration`, `build_array_literal_expr`, and `parse_source`) with `Vec::with_capacity(capacity)` using `pest::Pairs::len()`.
🎯 **Why:** To prevent O(log N) dynamic heap reallocations when building collections like arrays, AST blocks, and statement lists.
📊 **Impact:** Reduces parser-phase memory allocations, improving compilation speed and reducing fragmentation.
🔬 **Measurement:** Execute `cargo test` and verify that the AST is safely built without any panics, and `cargo clippy` detects no redundant allocations.

---
*PR created automatically by Jules for task [6699123946761617021](https://jules.google.com/task/6699123946761617021) started by @madmax983*