### PR TITLE
🪒 Razor: Remove empty Analyzer struct and flatten architecture

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -92,3 +92,8 @@
 **Bloat:** `src/experimental/` directory containing only an `interpreter.rs` tool.
 **Cut:** Moved `interpreter.rs` to `src/tools/` and deleted the `experimental` module entirely.
 **Saved:** 1 directory, reduced module depth, strictly enforced production quality for all files in `src/`.
+
+## [Reduction]
+**Bloat:** `Analyzer` struct in `src/semantic/analyzer.rs` was completely empty with no fields, used purely as a namespace for the `analyze` method that was passed around to other modules.
+**Cut:** Deleted the `Analyzer` struct and converted `Analyzer::analyze` into a standalone `analyze_statement` function. Updated calling signatures across `control_flow.rs` and `declarations.rs` to remove the unnecessary `analyzer: &mut Analyzer` parameter.
+**Saved:** Removed empty struct instantiation, cleaned up ~20 function signatures, improved modular cohesion and flattened architectural layers.

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -22,81 +22,62 @@ pub struct AnalyzedProgram {
     pub scope: Scope,
 }
 
-/// The main semantic analyzer struct
-pub struct Analyzer;
-
-impl Analyzer {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for Analyzer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Analyzer {
-    pub fn analyze(
-        &mut self,
-        stmt: &Statement,
-        scope: &mut Scope,
-    ) -> Result<Vec<AnalyzedStatement>, GlossaError> {
-        // 1. Check for function definitions
-        if contains_function_definition_verb(stmt)
-            && let Some(func_def) = parse_function_definition(stmt, scope, self)?
+pub fn analyze_statement(
+    stmt: &Statement,
+    scope: &mut Scope,
+) -> Result<Vec<AnalyzedStatement>, GlossaError> {
+    // 1. Check for function definitions
+    if contains_function_definition_verb(stmt)
+        && let Some(func_def) = parse_function_definition(stmt, scope)?
+    {
+        // Register the function in the scope
+        if let AnalyzedStatement::FunctionDef {
+            name,
+            params,
+            return_type,
+            ..
+        } = &func_def
         {
-            // Register the function in the scope
-            if let AnalyzedStatement::FunctionDef {
-                name,
-                params,
-                return_type,
-                ..
-            } = &func_def
-            {
-                let param_types: Vec<GlossaType> = params
-                    .iter()
-                    .map(|(_, ty)| ty.clone().unwrap_or(GlossaType::Unknown))
-                    .collect();
-                scope.define_function(name.clone(), param_types, return_type.clone());
-            }
-            return Ok(vec![func_def]);
+            let param_types: Vec<GlossaType> = params
+                .iter()
+                .map(|(_, ty)| ty.clone().unwrap_or(GlossaType::Unknown))
+                .collect();
+            scope.define_function(name.clone(), param_types, return_type.clone());
         }
-
-        // 2. Check for control flow (if, while, etc.)
-        // Pass self as the analyzer
-        if let Some(control_flow) = analyze_control_flow(stmt, scope, self)? {
-            return Ok(vec![control_flow]);
-        }
-
-        // 3. Check for struct instantiation pattern
-        if let Some(struct_inst) = try_parse_struct_instantiation(stmt, scope)? {
-            return Ok(vec![struct_inst]);
-        }
-
-        // 4. Check for trait method call pattern
-        if let Some(method_call) = try_parse_trait_method_call(stmt, scope)? {
-            return Ok(vec![method_call]);
-        }
-
-        // 5. Check if it's a block statement (regular statement containing a single block expression)
-        if let Some(block_stmts) = extract_block_statements(stmt) {
-            let mut analyzed = Vec::new();
-            // Create a child scope for the block
-            // This ensures variables defined inside the block don't leak out
-            let mut block_scope = scope.enter_scope();
-            for s in block_stmts {
-                analyzed.extend(self.analyze(s, &mut block_scope)?);
-            }
-            return Ok(analyzed);
-        }
-
-        // 6. Use the assembler-based approach for regular statements
-        let assembled = assemble_statement(stmt)?;
-        let analyzed = convert_assembled_to_analyzed(&assembled, scope)?;
-        Ok(vec![analyzed])
+        return Ok(vec![func_def]);
     }
+
+    // 2. Check for control flow (if, while, etc.)
+    if let Some(control_flow) = analyze_control_flow(stmt, scope)? {
+        return Ok(vec![control_flow]);
+    }
+
+    // 3. Check for struct instantiation pattern
+    if let Some(struct_inst) = try_parse_struct_instantiation(stmt, scope)? {
+        return Ok(vec![struct_inst]);
+    }
+
+    // 4. Check for trait method call pattern
+    if let Some(method_call) = try_parse_trait_method_call(stmt, scope)? {
+        return Ok(vec![method_call]);
+    }
+
+    // 5. Check if it's a block statement (regular statement containing a single block expression)
+    if let Some(block_stmts) = extract_block_statements(stmt) {
+        let mut analyzed = Vec::new();
+        // Create a child scope for the block
+        // This ensures variables defined inside the block don't leak out
+        let mut block_scope = scope.enter_scope();
+        for s in block_stmts {
+            analyzed.extend(analyze_statement(s, &mut block_scope)?);
+        }
+        return Ok(analyzed);
+    }
+
+    // 6. Use the assembler-based approach for regular statements
+    let assembled = assemble_statement(stmt)?;
+    let analyzed = convert_assembled_to_analyzed(&assembled, scope)?;
+    Ok(vec![analyzed])
 }
 
 fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
@@ -113,11 +94,10 @@ fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
 
 /// Perform semantic analysis on a program
 ///
-/// This is the entry point that instantiates the Analyzer.
+/// This is the entry point for semantic analysis.
 pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError> {
     let mut scope = Scope::new();
     let mut analyzed_statements = Vec::new();
-    let mut analyzer = Analyzer::new();
 
     for stmt in &program.statements {
         // Handle type definitions
@@ -128,32 +108,24 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
 
         // Handle trait definitions
         if let Statement::TraitDefinition(trait_def) = stmt {
-            analyzed_statements.push(analyze_trait_definition(
-                trait_def,
-                &mut scope,
-                &mut analyzer,
-            )?);
+            analyzed_statements.push(analyze_trait_definition(trait_def, &mut scope)?);
             continue;
         }
 
         // Handle trait implementations
         if let Statement::TraitImpl(trait_impl) = stmt {
-            analyzed_statements.push(analyze_trait_impl(trait_impl, &mut scope, &mut analyzer)?);
+            analyzed_statements.push(analyze_trait_impl(trait_impl, &mut scope)?);
             continue;
         }
 
         // Handle test declarations
         if let Statement::TestDeclaration(test_decl) = stmt {
-            analyzed_statements.push(analyze_test_declaration(
-                test_decl,
-                &mut scope,
-                &mut analyzer,
-            )?);
+            analyzed_statements.push(analyze_test_declaration(test_decl, &mut scope)?);
             continue;
         }
 
         // Use the analyzer for all other statements
-        analyzed_statements.extend(analyzer.analyze(stmt, &mut scope)?);
+        analyzed_statements.extend(analyze_statement(stmt, &mut scope)?);
     }
 
     let analyzed = AnalyzedProgram {

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -15,14 +15,13 @@ use super::{
 use crate::ast::{Clause, Expr, Statement};
 use crate::errors::GlossaError;
 use crate::morphology::lexicon;
-use crate::semantic::analyzer::Analyzer;
+use crate::semantic::analyzer::analyze_statement;
 
 /// Check if a statement is a control flow construct and analyze it
 /// Returns Some(AnalyzedStatement) if it's control flow, None otherwise
 pub fn analyze_control_flow(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     // Note: Function definitions are handled in `mod.rs` before calling this.
 
@@ -35,22 +34,22 @@ pub fn analyze_control_flow(
 
     // Conditional: εἰ/ἐάν condition, body [, εἰ δὲ μή, else_body]
     if lexicon::is_conditional_particle(&normalized) {
-        return parse_conditional(stmt, scope, analyzer, 0);
+        return parse_conditional(stmt, scope, 0);
     }
 
     // While loop: ἕως condition, body
     if normalized == "εως" {
-        return parse_while_loop(stmt, scope, analyzer);
+        return parse_while_loop(stmt, scope);
     }
 
     // For loop with range: ἀπὸ start μέχρι/ἕως end, body
     if normalized == "απο" {
-        return parse_for_range_loop(stmt, scope, analyzer);
+        return parse_for_range_loop(stmt, scope);
     }
 
     // For loop with iteration: διὰ collection, body
     if normalized == "δια" {
-        return parse_for_iteration_loop(stmt, scope, analyzer);
+        return parse_for_iteration_loop(stmt, scope);
     }
 
     if lexicon::is_loop_particle(&normalized) {
@@ -59,7 +58,7 @@ pub fn analyze_control_flow(
     }
 
     if lexicon::is_match_particle(&normalized) {
-        return parse_match_expression(stmt, scope, analyzer);
+        return parse_match_expression(stmt, scope);
     }
 
     // Return: δός (give)
@@ -86,7 +85,6 @@ pub fn analyze_control_flow(
 fn parse_while_loop(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -108,7 +106,7 @@ fn parse_while_loop(
     };
 
     // Analyze body using unified helper
-    let body_analyzed = analyzer.analyze(&body_stmt, scope)?;
+    let body_analyzed = analyze_statement(&body_stmt, scope)?;
 
     Ok(Some(AnalyzedStatement::While {
         condition: Box::new(condition_expr),
@@ -121,7 +119,6 @@ fn parse_while_loop(
 fn parse_for_range_loop(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -246,7 +243,7 @@ fn parse_for_range_loop(
         let mut loop_scope = scope.enter_scope();
         loop_scope.define(variable.clone(), GlossaType::Number);
 
-        analyzer.analyze(&body_stmt, &mut loop_scope)?
+        analyze_statement(&body_stmt, &mut loop_scope)?
     };
 
     Ok(Some(AnalyzedStatement::For {
@@ -262,7 +259,6 @@ fn parse_for_range_loop(
 fn parse_for_iteration_loop(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -333,7 +329,7 @@ fn parse_for_iteration_loop(
         // TODO: Infer element type from collection type
         loop_scope.define(variable.clone(), GlossaType::String);
 
-        analyzer.analyze(&body_stmt, &mut loop_scope)?
+        analyze_statement(&body_stmt, &mut loop_scope)?
     };
 
     Ok(Some(AnalyzedStatement::For {
@@ -349,7 +345,6 @@ fn parse_for_iteration_loop(
 fn parse_match_expression(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().is_empty() {
         return Err(GlossaError::semantic(
@@ -397,7 +392,7 @@ fn parse_match_expression(
                 is_query: false,
                 is_propagate: false,
             };
-            let body_analyzed = analyzer.analyze(&body_stmt, scope)?;
+            let body_analyzed = analyze_statement(&body_stmt, scope)?;
 
             arms.push((pattern, body_analyzed));
         }
@@ -578,7 +573,7 @@ const MAX_CONTROL_FLOW_DEPTH: usize = 100;
 fn parse_conditional(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
+
     depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if depth > MAX_CONTROL_FLOW_DEPTH {
@@ -612,7 +607,7 @@ fn parse_conditional(
             is_query: false,
             is_propagate: false,
         };
-        analyzer.analyze(&stmt, scope)?
+        analyze_statement(&stmt, scope)?
     };
 
     // Check for else/elif clause
@@ -626,7 +621,7 @@ fn parse_conditional(
                 is_query: false,
                 is_propagate: false,
             };
-            Some(analyzer.analyze(&stmt, scope)?)
+            Some(analyze_statement(&stmt, scope)?)
         }
         // Check if it's "εἰ" or "ἐάν" (elif)
         else if check_conditional_start(second_expr) {
@@ -648,8 +643,7 @@ fn parse_conditional(
             };
 
             // Recursively parse as a new conditional (which becomes the else body)
-            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, analyzer, depth + 1)?
-            {
+            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, depth + 1)? {
                 Some(vec![elif_analyzed])
             } else {
                 None

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -11,7 +11,7 @@ use super::{AnalyzedMethod, AnalyzedStatement, GlossaType, Scope};
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
 use crate::morphology::{self};
-use crate::semantic::analyzer::Analyzer;
+use crate::semantic::analyzer::analyze_statement;
 use smol_str::SmolStr;
 
 /// Analyze a type definition statement
@@ -115,7 +115,6 @@ fn check_recursive_type(target_name: &str, ty: &GlossaType) -> bool {
 pub fn analyze_trait_definition(
     trait_def: &crate::ast::TraitDef,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     // Extract trait name
     let trait_name = trait_def.name.normalized.clone();
@@ -156,7 +155,7 @@ pub fn analyze_trait_definition(
                     }
                     // Properly analyze statements in the body using unified helper
                     for body_stmt in body_stmts {
-                        analyzed_body.extend(analyzer.analyze(body_stmt, &mut scope)?);
+                        analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
                     }
                 }
                 Some(analyzed_body)
@@ -216,7 +215,6 @@ pub fn analyze_trait_definition(
 pub fn analyze_trait_impl(
     trait_impl: &crate::ast::TraitImplDef,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     // Extract type and trait names
     let type_name = trait_impl.type_name.normalized.clone();
@@ -262,7 +260,7 @@ pub fn analyze_trait_impl(
 
             // Analyze the method body using unified helper
             for body_stmt in &method.body {
-                analyzed_body.extend(analyzer.analyze(body_stmt, &mut scope)?);
+                analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
             }
         }
 
@@ -347,7 +345,6 @@ pub fn resolve_type_name(name: &str, scope: &Scope) -> Result<GlossaType, Glossa
 pub fn parse_function_definition(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     // The middle dot (·) separates expressions within a clause
     // Structure: expr1 · expr2 where expr1 is "name ὁρίζειν [params]" and expr2 is the body
@@ -399,7 +396,7 @@ pub fn parse_function_definition(
             };
 
             // Analyze each body expression using unified helper
-            body_statements.extend(analyzer.analyze(&clause_stmt, &mut function_scope)?);
+            body_statements.extend(analyze_statement(&clause_stmt, &mut function_scope)?);
         }
     }
 
@@ -541,7 +538,6 @@ pub fn infer_return_type_from_body(body: &[AnalyzedStatement]) -> Option<GlossaT
 pub fn analyze_test_declaration(
     test_decl: &crate::ast::TestDecl,
     scope: &mut Scope,
-    analyzer: &mut Analyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     let test_name = test_decl.name.clone();
 
@@ -553,7 +549,7 @@ pub fn analyze_test_declaration(
         let mut test_scope = scope.enter_scope();
 
         for body_stmt in &test_decl.body {
-            analyzed_body.extend(analyzer.analyze(body_stmt, &mut test_scope)?);
+            analyzed_body.extend(analyze_statement(body_stmt, &mut test_scope)?);
         }
     }
 


### PR DESCRIPTION
Removed the `Analyzer` struct from `src/semantic/analyzer.rs` as it was completely empty with no fields, used purely as a namespace for the `analyze` method. Converted `Analyzer::analyze` into a standalone `analyze_statement` function and updated calling signatures across `control_flow.rs` and `declarations.rs` to remove the unnecessary `analyzer: &mut Analyzer` parameter.

This reduces boilerplate, cleans up ~20 function signatures, improves modular cohesion, and flattens the architectural layers in accordance with the Razor KISS principle.

Recorded learning in `.jules/razor.md`.

---
*PR created automatically by Jules for task [10511978480720027261](https://jules.google.com/task/10511978480720027261) started by @madmax983*