### PR TITLE
📜 Codex: ADR 015 & Architecture Diagram Update

### DIFF
--- a/docs/adr/015-flatten-interpreter.md
+++ b/docs/adr/015-flatten-interpreter.md
@@ -1,0 +1,23 @@
+# 15. Flatten Interpreter Module into Tools
+
+Date: 2026-03-04
+Status: Accepted
+
+## Context
+
+The interpreter simulator was previously located in its own directory at `src/experimental/interpreter.rs`. This structure violated the Razor persona's KISS/YAGNI principles by introducing unnecessary nesting for a single-file directory, adding bloat without structural benefit. While the interpreter is experimental, grouping it under a dedicated `experimental/` folder fragmented the tool ecosystem and deepened the module hierarchy unnecessarily.
+
+## Decision
+
+We have moved the interpreter module from `src/experimental/interpreter.rs` to `src/tools/interpreter.rs` and deleted the `src/experimental` directory.
+
+The module remains guarded behind the `#[cfg(feature = "nova")]` feature flag in `src/tools/mod.rs` to signify its experimental, non-production nature without requiring a separate directory.
+
+## Consequences
+
+### Positive
+- **Reduced Bloat**: Eliminates the single-file `src/experimental` directory, adhering to the principle of flattened hierarchies.
+- **Cohesion**: Groups the interpreter alongside other developer experience tools in the `src/tools/` module, treating it as a standard compiler tool.
+
+### Negative
+- **Visibility**: The "experimental" nature of the module is no longer visible from the file path alone; it relies entirely on the `nova` feature flag in `src/tools/mod.rs` to convey its status.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,7 @@ C4Container
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
         Container(dictionary, "The Lexicon", "src/tools/dictionary.rs", "The Source of Truth for Words (Dictionary)")
         Container(highlight, "Highlighter", "src/tools/highlight.rs", "Semantic syntax highlighting")
+        Container(interpreter, "Interpreter", "src/tools/interpreter.rs", "In-memory tree-walk simulator")
         Container(mentor, "Mentor", "src/tools/mentor.rs", "Interactive Tutorial Mode")
         Container(mosaic, "Mosaic", "src/tools/mosaic.rs", "Visualizes Semantic Assembly")
         Container(narrator, "The Bard", "src/tools/narrator.rs", "Generates English narrative ('Scroll of Logic') from AST")
@@ -60,6 +61,7 @@ C4Container
     Rel(semantic, mentor, "Analyzed Program")
     Rel(semantic, mosaic, "Analyzed Program")
     Rel(semantic, tester, "Analyzed Program")
+    Rel(semantic, interpreter, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")


### PR DESCRIPTION
🧠 **Decision:** Recorded the flattening of the module hierarchy, moving the interpreter to `src/tools/interpreter.rs` behind the `nova` feature flag to adhere to the KISS principle.
🗺️ **Visuals:** Updated the Compiler Pipeline C4 Container diagram in `docs/architecture.md` to include the Simulator component.
🔗 **Link:** See `docs/adr/015-flatten-interpreter.md`.

---
*PR created automatically by Jules for task [3831945334397078391](https://jules.google.com/task/3831945334397078391) started by @madmax983*