### PR TITLE
🎨 Mosaic: UI Polish for Tester Module

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -43,7 +43,7 @@ use crate::codegen::generate_rust_file;
 use crate::parser::parse;
 use crate::semantic::analyze_program;
 use crate::tools::ui::Status;
-use comfy_table::{Attribute, Cell, Color, Table, presets};
+use comfy_table::{Attribute, Cell, CellAlignment, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
 use std::fs;
@@ -254,15 +254,15 @@ pub fn run_tests(input: &Path) -> Result<()> {
 
     println!();
 
-    let mut table = Table::new();
-    table.load_preset(presets::UTF8_FULL).set_header(vec![
-        Cell::new("Test Case")
-            .add_attribute(Attribute::Bold)
-            .fg(Color::Cyan),
-        Cell::new("Status").add_attribute(Attribute::Bold),
-    ]);
-
     if !results.is_empty() {
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL).set_header(vec![
+            Cell::new("Test Case")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+            Cell::new("Status").add_attribute(Attribute::Bold),
+        ]);
+
         for result in &results {
             let status_cell = match result.status {
                 TestStatus::Ok => Cell::new("PASSED").fg(Color::Green),
@@ -278,16 +278,18 @@ pub fn run_tests(input: &Path) -> Result<()> {
 
             table.add_row(vec![Cell::new(display_name), status_cell]);
         }
+        println!("{table}");
     } else {
-        table.add_row(vec![
+        let mut empty_table = Table::new();
+        empty_table.load_preset(presets::UTF8_FULL);
+        empty_table.add_row(vec![
             Cell::new("No tests found.")
                 .fg(Color::DarkGrey)
-                .add_attribute(Attribute::Italic),
-            Cell::new("-").fg(Color::DarkGrey),
+                .add_attribute(Attribute::Italic)
+                .set_alignment(CellAlignment::Center),
         ]);
+        println!("{empty_table}");
     }
-
-    println!("{table}");
 
     // If there were failures, try to extract and print them nicely
     if !test_output.status.success() {


### PR DESCRIPTION
* 🖌️ **Before:** When running `glossa test` on a file with no tests, the tool outputted an ugly two-column table where the first cell said "No tests found." and the second cell was just a generic "-".
* ✨ **After:** The empty state is now displayed in a sleek, centralized, single-cell dashboard layout.
* 🖼️ **Visuals:** The new empty state table stands on its own without unnecessary headers or dummy columns, neatly wrapping the centered "No tests found" message.

---
*PR created automatically by Jules for task [18268812246271346957](https://jules.google.com/task/18268812246271346957) started by @madmax983*