### PR TITLE
🗺️ Atlas: Centralize MAX_EXPRESSION_DEPTH limit

### DIFF
--- a/src/limits.rs
+++ b/src/limits.rs
@@ -11,3 +11,7 @@ pub const MAX_PARSE_DEPTH: usize = 500;
 /// Maximum recursion depth during semantic analysis (AST processing).
 /// This prevents stack overflows when processing deeply nested phrases or expressions.
 pub const MAX_AST_DEPTH: usize = 50;
+
+/// Maximum recursion depth during semantic validation.
+/// This prevents stack overflows from evaluating deeply nested expressions in the AST.
+pub const MAX_EXPRESSION_DEPTH: usize = 200;

--- a/src/semantic/validation.rs
+++ b/src/semantic/validation.rs
@@ -6,8 +6,7 @@
 
 use super::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 use crate::errors::GlossaError;
-
-const MAX_EXPRESSION_DEPTH: usize = 200;
+use crate::limits::MAX_EXPRESSION_DEPTH;
 
 /// Validates the analyzed program to ensure it meets all semantic rules and limits.
 pub(crate) fn validate_program(program: &AnalyzedProgram) -> Result<(), GlossaError> {


### PR DESCRIPTION
**🕸️ Tangle:** The `MAX_EXPRESSION_DEPTH` constant, a magic number used for recursion protection, was hardcoded inside `src/semantic/validation.rs`. This violated the architectural pattern established in `.jules/atlas.md` to centralize all compiler-wide limits in `src/limits.rs`.

**📐 Blueprint:** 
- Moved `MAX_EXPRESSION_DEPTH` from `src/semantic/validation.rs` to `src/limits.rs`.
- Added documentation explaining its purpose (preventing stack overflows during AST semantic validation).
- Updated `src/semantic/validation.rs` to import and use the centralized limit.

**🧱 Stability:** High cohesion and separation of concerns. All limits (parsing, analysis, and validation depths) are now in a single, easily auditable source of truth.

**🔬 Verification:** `cargo check`, `cargo clippy`, `cargo test` and `cargo fmt` complete successfully with no regressions.

---
*PR created automatically by Jules for task [9238277352788485092](https://jules.google.com/task/9238277352788485092) started by @madmax983*