### PR TITLE
🗣️ Echo: Fix misleading 'File not found' error for experimental CLI tools

### DIFF
--- a/.jules/echo.md
+++ b/.jules/echo.md
@@ -14,3 +14,9 @@
 1. Change the test run command in the README to point to a file that actually exists, like `cargo run --release -- test examples/working_tests.γλ`.
 2. Fix the variable scoping check in the compiler so it actually throws `Οὐκ οἶδα τὸ ὄνομα`.
 3. Catch missing verbs during parsing/semantic analysis so they return `Ῥῆμα οὐχ εὑρέθη` instead of triggering an internal Rust compiler panic.
+
+# 🗣️ Echo: Getting Started example is broken
+
+* 🤦 **The Confusion:** "Tried to run `mentor` tool from the README. Compiler said `File not found: mentor`."
+* 🕵️ **The Reality:** "Turns out I needed to enable feature `nova`. Because the feature was off, the `mentor` command wasn't compiled in the CLI, so `clap` thought I was trying to run a `.γλ` file named `mentor`."
+* 💡 **The Fix:** "Change the CLI commands to always exist, but hide them when `nova` is not enabled, and return a helpful error message instructing the user to run with `--features nova` instead of falling back to running a file."

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,17 @@ fn main() -> Result<()> {
             run_file(&input)?;
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Mentor) => {
-            glossa::tools::mentor::run_mentor()?;
+            #[cfg(feature = "nova")]
+            {
+                glossa::tools::mentor::run_mentor()?;
+            }
+            #[cfg(not(feature = "nova"))]
+            {
+                miette::bail!(
+                    "The 'mentor' command requires the experimental 'nova' feature.\nPlease run again with: cargo run --features nova -- mentor"
+                );
+            }
         }
 
         Some(Commands::Build { input, output }) => {
@@ -52,19 +60,46 @@ fn main() -> Result<()> {
             glossa::tools::tester::run_tests(&input)?;
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Mosaic { input }) => {
-            glossa::tools::mosaic::run_mosaic(&input)?;
+            #[cfg(feature = "nova")]
+            {
+                glossa::tools::mosaic::run_mosaic(&input)?;
+            }
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input; // Ignore unused variable warning
+                miette::bail!(
+                    "The 'mosaic' command requires the experimental 'nova' feature.\nPlease run again with: cargo run --features nova -- mosaic <file>"
+                );
+            }
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
-            glossa::tools::cartographer::run_map(&input)?;
+            #[cfg(feature = "nova")]
+            {
+                glossa::tools::cartographer::run_map(&input)?;
+            }
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'map' command requires the experimental 'nova' feature.\nPlease run again with: cargo run --features nova -- map <file>"
+                );
+            }
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Weave { input }) => {
-            glossa::tools::weave::run_weave(&input)?;
+            #[cfg(feature = "nova")]
+            {
+                glossa::tools::weave::run_weave(&input)?;
+            }
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'weave' command requires the experimental 'nova' feature.\nPlease run again with: cargo run --features nova -- weave <file>"
+                );
+            }
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -65,15 +65,11 @@ pub fn run_map(input: &Path) -> Result<()> {
     table.load_preset(presets::UTF8_FULL);
 
     if map.trim() == "classDiagram" {
-        table.set_header(vec![
-            Cell::new("Status")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Yellow),
-        ]);
         table.add_row(vec![
             Cell::new("No architectural structures (Structs) found.")
                 .fg(Color::DarkGrey)
-                .add_attribute(Attribute::Italic),
+                .add_attribute(Attribute::Italic)
+                .set_alignment(comfy_table::CellAlignment::Center),
         ]);
         println!("{table}");
         println!();

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -68,7 +68,7 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-    #[cfg(feature = "nova")]
+    #[cfg_attr(not(feature = "nova"), command(hide = true))]
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -115,21 +115,21 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-    #[cfg(feature = "nova")]
+    #[cfg_attr(not(feature = "nova"), command(hide = true))]
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-    #[cfg(feature = "nova")]
+    #[cfg_attr(not(feature = "nova"), command(hide = true))]
     Map {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Generate a Markdown Rosetta Stone (Requires "nova" feature)
-    #[cfg(feature = "nova")]
+    #[cfg_attr(not(feature = "nova"), command(hide = true))]
     Weave {
         /// Input file (.γλ)
         input: PathBuf,

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -279,12 +279,17 @@ pub fn run_tests(input: &Path) -> Result<()> {
             table.add_row(vec![Cell::new(display_name), status_cell]);
         }
     } else {
-        table.add_row(vec![
+        let mut empty_table = Table::new();
+        empty_table.load_preset(comfy_table::presets::UTF8_FULL);
+        empty_table.add_row(vec![
             Cell::new("No tests found.")
                 .fg(Color::DarkGrey)
-                .add_attribute(Attribute::Italic),
-            Cell::new("-").fg(Color::DarkGrey),
+                .add_attribute(Attribute::Italic)
+                .set_alignment(comfy_table::CellAlignment::Center),
         ]);
+        println!();
+        println!("{empty_table}");
+        return Ok(());
     }
 
     println!("{table}");


### PR DESCRIPTION
This PR addresses a DX issue highlighted by the "Echo" persona: running experimental tools like `glossa mentor` without the `--features nova` flag resulted in a confusing "File not found" error, because `clap` fell back to treating the unrecognized command as the default `run <file>` positional argument.

The fix introduces the experimental variants conditionally hiding them (`#[cfg_attr(not(feature = "nova"), command(hide = true))]`) from `cli.rs` so they are still parsed, but intercepts the execution in `main.rs` to print a highly actionable error instructing the user to enable the feature flag.

It also includes UI polish requested by the "Mosaic" persona memory: centering empty state text strings in one-column tables instead of injecting dummy cells in `comfy-table` configurations.

---
*PR created automatically by Jules for task [3063710717505427586](https://jules.google.com/task/3063710717505427586) started by @madmax983*