### PR TITLE
🔒 Warden: Prevent memory exhaustion DoS in Weave tool

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -74,3 +74,6 @@ Signed,
 **2023-10-27 - Remove Unsafe Drop in AST**
 **Threat:** Use of `unsafe` code with `std::ptr::read` in `src/ast.rs`'s `Drop` implementation to prevent recursion, which could have led to bugs or memory leaks on panics and was highly dependent on exact memory layouts and variant checks.
 **Defense:** Rewrote the `Drop` implementation using 100% safe Rust via `std::mem::replace` and `std::mem::take` to explicitly dismantle nested enum variants by replacing their children with trivial non-allocating dummy values, allowing safe teardown without risking stack overflows.
+**2024-05-15 - Unbounded File Read DoS in Weave Tool**
+**Threat:** The `run_weave` tool was using `std::fs::read_to_string`, which loads an entire file into memory without limits. An attacker could use a massive file or an infinite stream (like `/dev/zero`) to exhaust memory and crash the application.
+**Defense:** Replaced the unbounded read with the localized safe abstraction `load_source` from `crate::tools::runner::load_source`. `load_source` enforces a strict 1MB size limit by checking metadata and using `take()` on streams, preventing memory exhaustion.

--- a/src/tools/weave.rs
+++ b/src/tools/weave.rs
@@ -14,6 +14,7 @@ use crate::codegen::generate_rust_file;
 use crate::parser::parse;
 use crate::semantic::analyze_program;
 use crate::tools::mosaic::run_mosaic_inner;
+use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
@@ -30,7 +31,7 @@ pub fn run_weave(input: &Path) -> Result<()> {
 
     let status = Status::start_with_symbol("Ὕφανσις (Weaving)", "🕸️");
 
-    let source = fs::read_to_string(input).into_diagnostic()?;
+    let source = load_source(input)?;
 
     // 1. Parse & Analyze
     let ast = parse(&source).map_err(|e| miette::miette!("{}", e))?;
@@ -130,5 +131,28 @@ mod tests {
         let result = run_weave(path);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("οὐχ εὑρέθη"));
+    }
+
+    #[test]
+    fn test_run_weave_file_too_large() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("too_large.γλ");
+
+        // Create a file larger than MAX_FILE_SIZE (1MB)
+        let max_size = 1024 * 1024;
+        {
+            let mut f = std::fs::File::create(&input_path).unwrap();
+            let data = vec![0u8; max_size + 1];
+            f.write_all(&data).unwrap();
+        }
+
+        let result = run_weave(&input_path);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Ἀρχεῖον λίαν μέγα")
+        );
     }
 }


### PR DESCRIPTION
**Threat:** The `run_weave` tool was using `std::fs::read_to_string`, which loads an entire file into memory without limits. An attacker could use a massive file or an infinite stream (like `/dev/zero`) to exhaust memory and crash the application.
**Defense:** Replaced the unbounded read with the localized safe abstraction `load_source` from `crate::tools::runner::load_source`. `load_source` enforces a strict 1MB size limit by checking metadata and using `take()` on streams, preventing memory exhaustion. Added a specific test case for validation.

---
*PR created automatically by Jules for task [17942380988598739209](https://jules.google.com/task/17942380988598739209) started by @madmax983*