### PR TITLE
🗺️ Atlas: [Breaking The Cycle: Semantic Mod vs Submodules]

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -155,13 +155,21 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
     for stmt in &program.statements {
         // Handle type definitions
         if let Statement::TypeDefinition(type_def) = stmt {
-            analyzed_statements.push(analyze_type_definition(type_def, &mut scope, &mut analyzer)?);
+            analyzed_statements.push(analyze_type_definition(
+                type_def,
+                &mut scope,
+                &mut analyzer,
+            )?);
             continue;
         }
 
         // Handle trait definitions
         if let Statement::TraitDefinition(trait_def) = stmt {
-            analyzed_statements.push(analyze_trait_definition(trait_def, &mut scope, &mut analyzer)?);
+            analyzed_statements.push(analyze_trait_definition(
+                trait_def,
+                &mut scope,
+                &mut analyzer,
+            )?);
             continue;
         }
 
@@ -173,7 +181,11 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
 
         // Handle test declarations
         if let Statement::TestDeclaration(test_decl) = stmt {
-            analyzed_statements.push(analyze_test_declaration(test_decl, &mut scope, &mut analyzer)?);
+            analyzed_statements.push(analyze_test_declaration(
+                test_decl,
+                &mut scope,
+                &mut analyzer,
+            )?);
             continue;
         }
 

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -11,9 +11,85 @@ use super::declarations::{
 };
 use super::expressions::contains_function_definition_verb;
 use super::patterns::{try_parse_struct_instantiation, try_parse_trait_method_call};
-use super::{AnalyzedStatement, GlossaType, Scope, assemble_statement};
+use super::{AnalyzedStatement, GlossaType, Scope, StatementAnalyzer, assemble_statement};
 use crate::ast::{Expr, Program, Statement};
 use crate::errors::GlossaError;
+
+/// The Semantic Analyzer orchestrates the semantic analysis process.
+pub struct SemanticAnalyzer;
+
+impl SemanticAnalyzer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SemanticAnalyzer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StatementAnalyzer for SemanticAnalyzer {
+    fn analyze_statement(
+        &mut self,
+        stmt: &Statement,
+        scope: &mut Scope,
+    ) -> Result<Vec<AnalyzedStatement>, GlossaError> {
+        // 1. Check for function definitions
+        if contains_function_definition_verb(stmt)
+            && let Some(func_def) = parse_function_definition(stmt, scope, self)?
+        {
+            // Register the function in the scope
+            if let AnalyzedStatement::FunctionDef {
+                name,
+                params,
+                return_type,
+                ..
+            } = &func_def
+            {
+                let param_types: Vec<GlossaType> = params
+                    .iter()
+                    .map(|(_, ty)| ty.clone().unwrap_or(GlossaType::Unknown))
+                    .collect();
+                scope.define_function(name.clone(), param_types, return_type.clone());
+            }
+            return Ok(vec![func_def]);
+        }
+
+        // 2. Check for control flow (if, while, etc.)
+        if let Some(control_flow) = analyze_control_flow(stmt, scope, self)? {
+            return Ok(vec![control_flow]);
+        }
+
+        // 3. Check for struct instantiation pattern
+        if let Some(struct_inst) = try_parse_struct_instantiation(stmt, scope)? {
+            return Ok(vec![struct_inst]);
+        }
+
+        // 4. Check for trait method call pattern
+        if let Some(method_call) = try_parse_trait_method_call(stmt, scope)? {
+            return Ok(vec![method_call]);
+        }
+
+        // 5. Check if it's a block statement (regular statement containing a single block expression)
+        if let Some(block_stmts) = extract_block_statements(stmt) {
+            let mut analyzed = Vec::new();
+            // Create a child scope for the block
+            // This ensures variables defined inside the block don't leak out
+            let mut block_scope = scope.enter_scope();
+            for s in block_stmts {
+                analyzed.extend(self.analyze_statement(s, &mut block_scope)?);
+            }
+            return Ok(analyzed);
+        }
+
+        // 6. Use the assembler-based approach for regular statements
+        let assembled = assemble_statement(stmt)?;
+        let analyzed = convert_assembled_to_analyzed(&assembled, scope)?;
+        Ok(vec![analyzed])
+    }
+}
 
 /// Analyzed program with resolved names and types
 #[derive(Debug, Clone)]
@@ -52,58 +128,8 @@ pub fn analyze_statement(
     stmt: &Statement,
     scope: &mut Scope,
 ) -> Result<Vec<AnalyzedStatement>, GlossaError> {
-    // 1. Check for function definitions
-    if contains_function_definition_verb(stmt)
-        && let Some(func_def) = parse_function_definition(stmt, scope)?
-    {
-        // Register the function in the scope
-        if let AnalyzedStatement::FunctionDef {
-            name,
-            params,
-            return_type,
-            ..
-        } = &func_def
-        {
-            let param_types: Vec<GlossaType> = params
-                .iter()
-                .map(|(_, ty)| ty.clone().unwrap_or(GlossaType::Unknown))
-                .collect();
-            scope.define_function(name.clone(), param_types, return_type.clone());
-        }
-        return Ok(vec![func_def]);
-    }
-
-    // 2. Check for control flow (if, while, etc.)
-    if let Some(control_flow) = analyze_control_flow(stmt, scope)? {
-        return Ok(vec![control_flow]);
-    }
-
-    // 3. Check for struct instantiation pattern
-    if let Some(struct_inst) = try_parse_struct_instantiation(stmt, scope)? {
-        return Ok(vec![struct_inst]);
-    }
-
-    // 4. Check for trait method call pattern
-    if let Some(method_call) = try_parse_trait_method_call(stmt, scope)? {
-        return Ok(vec![method_call]);
-    }
-
-    // 5. Check if it's a block statement (regular statement containing a single block expression)
-    if let Some(block_stmts) = extract_block_statements(stmt) {
-        let mut analyzed = Vec::new();
-        // Create a child scope for the block
-        // This ensures variables defined inside the block don't leak out
-        let mut block_scope = scope.enter_scope();
-        for s in block_stmts {
-            analyzed.extend(analyze_statement(s, &mut block_scope)?);
-        }
-        return Ok(analyzed);
-    }
-
-    // 6. Use the assembler-based approach for regular statements
-    let assembled = assemble_statement(stmt)?;
-    let analyzed = convert_assembled_to_analyzed(&assembled, scope)?;
-    Ok(vec![analyzed])
+    let mut analyzer = SemanticAnalyzer::new();
+    analyzer.analyze_statement(stmt, scope)
 }
 
 fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
@@ -124,34 +150,35 @@ fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
 pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError> {
     let mut scope = Scope::new();
     let mut analyzed_statements = Vec::new();
+    let mut analyzer = SemanticAnalyzer::new();
 
     for stmt in &program.statements {
         // Handle type definitions
         if let Statement::TypeDefinition(type_def) = stmt {
-            analyzed_statements.push(analyze_type_definition(type_def, &mut scope)?);
+            analyzed_statements.push(analyze_type_definition(type_def, &mut scope, &mut analyzer)?);
             continue;
         }
 
         // Handle trait definitions
         if let Statement::TraitDefinition(trait_def) = stmt {
-            analyzed_statements.push(analyze_trait_definition(trait_def, &mut scope)?);
+            analyzed_statements.push(analyze_trait_definition(trait_def, &mut scope, &mut analyzer)?);
             continue;
         }
 
         // Handle trait implementations
         if let Statement::TraitImpl(trait_impl) = stmt {
-            analyzed_statements.push(analyze_trait_impl(trait_impl, &mut scope)?);
+            analyzed_statements.push(analyze_trait_impl(trait_impl, &mut scope, &mut analyzer)?);
             continue;
         }
 
         // Handle test declarations
         if let Statement::TestDeclaration(test_decl) = stmt {
-            analyzed_statements.push(analyze_test_declaration(test_decl, &mut scope)?);
+            analyzed_statements.push(analyze_test_declaration(test_decl, &mut scope, &mut analyzer)?);
             continue;
         }
 
         // Use the analyzer for all other statements
-        analyzed_statements.extend(analyze_statement(stmt, &mut scope)?);
+        analyzed_statements.extend(analyzer.analyze_statement(stmt, &mut scope)?);
     }
 
     let analyzed = AnalyzedProgram {

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -10,18 +10,18 @@
 use super::conversion::convert_assembled_to_analyzed;
 use super::expressions::get_first_word;
 use super::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, assemble_statement,
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, StatementAnalyzer, assemble_statement,
 };
 use crate::ast::{Clause, Expr, Statement};
 use crate::errors::GlossaError;
 use crate::morphology::lexicon;
-use crate::semantic::analyzer::analyze_statement;
 
 /// Check if a statement is a control flow construct and analyze it
 /// Returns Some(AnalyzedStatement) if it's control flow, None otherwise
 pub fn analyze_control_flow(
     stmt: &Statement,
     scope: &mut Scope,
+    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     // Note: Function definitions are handled in `mod.rs` before calling this.
 
@@ -34,22 +34,22 @@ pub fn analyze_control_flow(
 
     // Conditional: εἰ/ἐάν condition, body [, εἰ δὲ μή, else_body]
     if lexicon::is_conditional_particle(&normalized) {
-        return parse_conditional(stmt, scope, 0);
+        return parse_conditional(stmt, scope, analyzer, 0);
     }
 
     // While loop: ἕως condition, body
     if normalized == "εως" {
-        return parse_while_loop(stmt, scope);
+        return parse_while_loop(stmt, scope, analyzer);
     }
 
     // For loop with range: ἀπὸ start μέχρι/ἕως end, body
     if normalized == "απο" {
-        return parse_for_range_loop(stmt, scope);
+        return parse_for_range_loop(stmt, scope, analyzer);
     }
 
     // For loop with iteration: διὰ collection, body
     if normalized == "δια" {
-        return parse_for_iteration_loop(stmt, scope);
+        return parse_for_iteration_loop(stmt, scope, analyzer);
     }
 
     if lexicon::is_loop_particle(&normalized) {
@@ -58,7 +58,7 @@ pub fn analyze_control_flow(
     }
 
     if lexicon::is_match_particle(&normalized) {
-        return parse_match_expression(stmt, scope);
+        return parse_match_expression(stmt, scope, analyzer);
     }
 
     // Return: δός (give)
@@ -85,6 +85,7 @@ pub fn analyze_control_flow(
 fn parse_while_loop(
     stmt: &Statement,
     scope: &mut Scope,
+    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -106,7 +107,7 @@ fn parse_while_loop(
     };
 
     // Analyze body using unified helper
-    let body_analyzed = analyze_statement(&body_stmt, scope)?;
+    let body_analyzed = analyzer.analyze_statement(&body_stmt, scope)?;
 
     Ok(Some(AnalyzedStatement::While {
         condition: Box::new(condition_expr),
@@ -119,6 +120,7 @@ fn parse_while_loop(
 fn parse_for_range_loop(
     stmt: &Statement,
     scope: &mut Scope,
+    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -243,7 +245,7 @@ fn parse_for_range_loop(
         let mut loop_scope = scope.enter_scope();
         loop_scope.define(variable.clone(), GlossaType::Number);
 
-        analyze_statement(&body_stmt, &mut loop_scope)?
+        analyzer.analyze_statement(&body_stmt, &mut loop_scope)?
     };
 
     Ok(Some(AnalyzedStatement::For {
@@ -259,6 +261,7 @@ fn parse_for_range_loop(
 fn parse_for_iteration_loop(
     stmt: &Statement,
     scope: &mut Scope,
+    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -329,7 +332,7 @@ fn parse_for_iteration_loop(
         // TODO: Infer element type from collection type
         loop_scope.define(variable.clone(), GlossaType::String);
 
-        analyze_statement(&body_stmt, &mut loop_scope)?
+        analyzer.analyze_statement(&body_stmt, &mut loop_scope)?
     };
 
     Ok(Some(AnalyzedStatement::For {
@@ -345,6 +348,7 @@ fn parse_for_iteration_loop(
 fn parse_match_expression(
     stmt: &Statement,
     scope: &mut Scope,
+    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().is_empty() {
         return Err(GlossaError::semantic(
@@ -392,7 +396,7 @@ fn parse_match_expression(
                 is_query: false,
                 is_propagate: false,
             };
-            let body_analyzed = analyze_statement(&body_stmt, scope)?;
+            let body_analyzed = analyzer.analyze_statement(&body_stmt, scope)?;
 
             arms.push((pattern, body_analyzed));
         }
@@ -573,7 +577,7 @@ const MAX_CONTROL_FLOW_DEPTH: usize = 100;
 fn parse_conditional(
     stmt: &Statement,
     scope: &mut Scope,
-
+    analyzer: &mut impl StatementAnalyzer,
     depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if depth > MAX_CONTROL_FLOW_DEPTH {
@@ -607,7 +611,7 @@ fn parse_conditional(
             is_query: false,
             is_propagate: false,
         };
-        analyze_statement(&stmt, scope)?
+        analyzer.analyze_statement(&stmt, scope)?
     };
 
     // Check for else/elif clause
@@ -621,7 +625,7 @@ fn parse_conditional(
                 is_query: false,
                 is_propagate: false,
             };
-            Some(analyze_statement(&stmt, scope)?)
+            Some(analyzer.analyze_statement(&stmt, scope)?)
         }
         // Check if it's "εἰ" or "ἐάν" (elif)
         else if check_conditional_start(second_expr) {
@@ -643,7 +647,7 @@ fn parse_conditional(
             };
 
             // Recursively parse as a new conditional (which becomes the else body)
-            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, depth + 1)? {
+            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, analyzer, depth + 1)? {
                 Some(vec![elif_analyzed])
             } else {
                 None

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -10,7 +10,8 @@
 use super::conversion::convert_assembled_to_analyzed;
 use super::expressions::get_first_word;
 use super::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, StatementAnalyzer, assemble_statement,
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, StatementAnalyzer,
+    assemble_statement,
 };
 use crate::ast::{Clause, Expr, Statement};
 use crate::errors::GlossaError;
@@ -647,7 +648,8 @@ fn parse_conditional(
             };
 
             // Recursively parse as a new conditional (which becomes the else body)
-            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, analyzer, depth + 1)? {
+            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, analyzer, depth + 1)?
+            {
                 Some(vec![elif_analyzed])
             } else {
                 None

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -7,11 +7,10 @@
 //! - Function definitions (ὁρίζειν for functions)
 //! - Test declarations (δοκιμή)
 
-use super::{AnalyzedMethod, AnalyzedStatement, GlossaType, Scope};
+use super::{AnalyzedMethod, AnalyzedStatement, GlossaType, Scope, StatementAnalyzer};
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
 use crate::morphology::{self};
-use crate::semantic::analyzer::analyze_statement;
 use smol_str::SmolStr;
 
 /// Analyze a type definition statement
@@ -36,6 +35,7 @@ use smol_str::SmolStr;
 pub fn analyze_type_definition(
     type_def: &crate::ast::TypeDef,
     scope: &mut Scope,
+    _analyzer: &mut impl StatementAnalyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     // Extract type name
     let type_name = type_def.name.normalized.clone();
@@ -115,6 +115,7 @@ fn check_recursive_type(target_name: &str, ty: &GlossaType) -> bool {
 pub fn analyze_trait_definition(
     trait_def: &crate::ast::TraitDef,
     scope: &mut Scope,
+    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     // Extract trait name
     let trait_name = trait_def.name.normalized.clone();
@@ -155,7 +156,7 @@ pub fn analyze_trait_definition(
                     }
                     // Properly analyze statements in the body using unified helper
                     for body_stmt in body_stmts {
-                        analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
+                        analyzed_body.extend(analyzer.analyze_statement(body_stmt, &mut scope)?);
                     }
                 }
                 Some(analyzed_body)
@@ -215,6 +216,7 @@ pub fn analyze_trait_definition(
 pub fn analyze_trait_impl(
     trait_impl: &crate::ast::TraitImplDef,
     scope: &mut Scope,
+    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     // Extract type and trait names
     let type_name = trait_impl.type_name.normalized.clone();
@@ -260,7 +262,7 @@ pub fn analyze_trait_impl(
 
             // Analyze the method body using unified helper
             for body_stmt in &method.body {
-                analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
+                analyzed_body.extend(analyzer.analyze_statement(body_stmt, &mut scope)?);
             }
         }
 
@@ -345,6 +347,7 @@ pub fn resolve_type_name(name: &str, scope: &Scope) -> Result<GlossaType, Glossa
 pub fn parse_function_definition(
     stmt: &Statement,
     scope: &mut Scope,
+    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     // The middle dot (·) separates expressions within a clause
     // Structure: expr1 · expr2 where expr1 is "name ὁρίζειν [params]" and expr2 is the body
@@ -397,7 +400,7 @@ pub fn parse_function_definition(
             };
 
             // Analyze each body expression using unified helper
-            body_statements.extend(analyze_statement(&clause_stmt, &mut function_scope)?);
+            body_statements.extend(analyzer.analyze_statement(&clause_stmt, &mut function_scope)?);
         }
     }
 
@@ -539,6 +542,7 @@ pub fn infer_return_type_from_body(body: &[AnalyzedStatement]) -> Option<GlossaT
 pub fn analyze_test_declaration(
     test_decl: &crate::ast::TestDecl,
     scope: &mut Scope,
+    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     let test_name = test_decl.name.clone();
 
@@ -550,7 +554,7 @@ pub fn analyze_test_declaration(
         let mut test_scope = scope.enter_scope();
 
         for body_stmt in &test_decl.body {
-            analyzed_body.extend(analyze_statement(body_stmt, &mut test_scope)?);
+            analyzed_body.extend(analyzer.analyze_statement(body_stmt, &mut test_scope)?);
         }
     }
 

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -53,11 +53,13 @@ mod resolver;
 #[cfg(test)]
 mod sentry_conversion_tests;
 
+pub(crate) mod traits;
 mod types;
 pub(crate) mod validation;
 
 pub use crate::morphology::{DisambiguationContext, analyze_article, disambiguate, resolve_best};
 pub use analyzer::{AnalyzedProgram, analyze_program};
+pub use traits::StatementAnalyzer;
 pub use assembly::Assembler;
 pub use assembly::{
     AssembledStatement, AssemblyError, Constituent, Literal, ParticipleConstituent, VerbConstituent,

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -59,13 +59,13 @@ pub(crate) mod validation;
 
 pub use crate::morphology::{DisambiguationContext, analyze_article, disambiguate, resolve_best};
 pub use analyzer::{AnalyzedProgram, analyze_program};
-pub use traits::StatementAnalyzer;
 pub use assembly::Assembler;
 pub use assembly::{
     AssembledStatement, AssemblyError, Constituent, Literal, ParticipleConstituent, VerbConstituent,
 };
 pub use model::*;
 pub use resolver::*;
+pub use traits::StatementAnalyzer;
 pub use types::*;
 
 use self::expressions::feed_expr_to_assembler_with_context;

--- a/src/semantic/traits.rs
+++ b/src/semantic/traits.rs
@@ -1,0 +1,17 @@
+//! Trait definitions for semantic analysis
+
+use crate::ast::Statement;
+use crate::errors::GlossaError;
+use crate::semantic::{AnalyzedStatement, Scope};
+
+/// Abstract trait for analyzing statements.
+/// This breaks the circular dependency between the orchestrator (`mod.rs`/`analyzer.rs`)
+/// and the submodules (`control_flow.rs`, `declarations.rs`).
+pub trait StatementAnalyzer {
+    /// Semantically analyze a single statement and update the scope environment.
+    fn analyze_statement(
+        &mut self,
+        stmt: &Statement,
+        scope: &mut Scope,
+    ) -> Result<Vec<AnalyzedStatement>, GlossaError>;
+}


### PR DESCRIPTION
**Tangle:** The `src/semantic/mod.rs` module was orchestrating analysis but also depending on submodules like `control_flow.rs` and `declarations.rs`. These submodules in turn depended on `analyze_statement` from `mod.rs` (or `analyzer.rs`), creating a circular dependency that made the module structure fragile and coupled.

**Blueprint:**
1. Extracted the analysis logic into a new `SemanticAnalyzer` struct in `src/semantic/analyzer.rs`.
2. Defined a `StatementAnalyzer` trait in `src/semantic/traits.rs` to abstract the recursion.
3. Updated `control_flow.rs` and `declarations.rs` to accept `&mut impl StatementAnalyzer` instead of calling a concrete function.
4. Re-exported the public API from `mod.rs` to maintain backward compatibility.

**Stability:** Broken the dependency cycle. The dependency graph is now a DAG: `mod` -> `analyzer` -> `control_flow` -> `traits`. Submodules are now leaf-like with respect to the analyzer.

**Verification:** Ran `cargo check` and `cargo test`, ensuring the codebase compiles and test coverage is maintained.

---
*PR created automatically by Jules for task [11948367608511462177](https://jules.google.com/task/11948367608511462177) started by @madmax983*