### PR TITLE
🪒 Razor: Centralize limit constants

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -97,3 +97,8 @@
 **Bloat:** `Analyzer` struct in `src/semantic/analyzer.rs` was completely empty with no fields, used purely as a namespace for the `analyze` method that was passed around to other modules.
 **Cut:** Deleted the `Analyzer` struct and converted `Analyzer::analyze` into a standalone `analyze_statement` function. Updated calling signatures across `control_flow.rs` and `declarations.rs` to remove the unnecessary `analyzer: &mut Analyzer` parameter.
 **Saved:** Removed empty struct instantiation, cleaned up ~20 function signatures, improved modular cohesion and flattened architectural layers.
+
+## [Reduction]
+**Bloat:** `MAX_*` depth/limit constants scattered across `src/semantic/assembly/model.rs` and `src/semantic/control_flow.rs`, creating architectural duplication and inconsistent definition points.
+**Cut:** Centralized all compiler depth limit constants into `src/limits.rs`.
+**Saved:** Centralized logic (Single Source of Truth) and improved transparency for architectural constraints.

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -15,3 +15,33 @@ pub const MAX_AST_DEPTH: usize = 50;
 /// Maximum recursion depth during semantic validation.
 /// This prevents stack overflows from evaluating deeply nested expressions in the AST.
 pub const MAX_EXPRESSION_DEPTH: usize = 200;
+
+// Semantic limit constants (from assembly/model.rs)
+/// Maximum number of adjectives allowed per statement
+pub const MAX_ADJECTIVES: usize = 1024;
+/// Maximum number of literals (strings/numbers) allowed per statement
+pub const MAX_LITERALS: usize = 1024;
+/// Maximum number of nominatives (subjects/function names) allowed per statement
+pub const MAX_NOMINATIVES: usize = 256;
+/// Maximum number of genitives (possessors) allowed per statement
+pub const MAX_GENITIVES: usize = 256;
+/// Maximum number of array literals allowed per statement
+pub const MAX_ARRAYS: usize = 256;
+/// Maximum number of index accesses allowed per statement
+pub const MAX_INDEX_ACCESSES: usize = 256;
+/// Maximum number of property accesses allowed per statement
+pub const MAX_PROPERTY_ACCESSES: usize = 256;
+/// Maximum number of nested phrases (parenthesized calls) allowed per statement
+pub const MAX_NESTED_PHRASES: usize = 256;
+/// Maximum number of participles (lambdas) allowed per statement
+pub const MAX_PARTICIPLES: usize = 256;
+/// Maximum number of unwrap operations allowed per statement
+pub const MAX_UNWRAPS: usize = 256;
+/// Maximum number of binary operators allowed per statement
+pub const MAX_OPERATORS: usize = 256;
+/// Maximum number of block expressions allowed per statement
+pub const MAX_BLOCKS: usize = 256;
+
+// Semantic limit constants (from control_flow.rs)
+/// Maximum depth of nested control flow structures
+pub const MAX_CONTROL_FLOW_DEPTH: usize = 100;

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -109,6 +109,11 @@ pub use model::*;
 
 use crate::ast::{Expr, Word};
 pub use crate::errors::AssemblyError;
+pub(crate) use crate::limits::{
+    MAX_ADJECTIVES, MAX_ARRAYS, MAX_BLOCKS, MAX_GENITIVES, MAX_INDEX_ACCESSES, MAX_LITERALS,
+    MAX_NESTED_PHRASES, MAX_NOMINATIVES, MAX_OPERATORS, MAX_PARTICIPLES, MAX_PROPERTY_ACCESSES,
+    MAX_UNWRAPS,
+};
 use crate::morphology::lexicon::BinaryOp;
 use crate::morphology::{Case, Gender, Mood, MorphAnalysis, Number, PartOfSpeech, Person};
 use crate::text::normalize_greek;

--- a/src/semantic/assembly/model.rs
+++ b/src/semantic/assembly/model.rs
@@ -9,34 +9,6 @@ use crate::morphology::lexicon::BinaryOp;
 use crate::morphology::{Case, Gender, Mood, Number, Person, Tense, Voice};
 use smol_str::SmolStr;
 
-// Constants for resource limits to prevent DoS
-// These limits are enforced to prevent malicious code from exhausting memory or stack space
-// by creating excessively long lists of adjectives, literals, or nested structures.
-/// Maximum number of adjectives allowed per statement
-pub(crate) const MAX_ADJECTIVES: usize = 1024;
-/// Maximum number of literals (strings/numbers) allowed per statement
-pub(crate) const MAX_LITERALS: usize = 1024;
-/// Maximum number of nominatives (subjects/function names) allowed per statement
-pub(crate) const MAX_NOMINATIVES: usize = 256;
-/// Maximum number of genitives (possessors) allowed per statement
-pub(crate) const MAX_GENITIVES: usize = 256;
-/// Maximum number of array literals allowed per statement
-pub(crate) const MAX_ARRAYS: usize = 256;
-/// Maximum number of index accesses allowed per statement
-pub(crate) const MAX_INDEX_ACCESSES: usize = 256;
-/// Maximum number of property accesses allowed per statement
-pub(crate) const MAX_PROPERTY_ACCESSES: usize = 256;
-/// Maximum number of nested phrases (parenthesized calls) allowed per statement
-pub(crate) const MAX_NESTED_PHRASES: usize = 256;
-/// Maximum number of participles (lambdas) allowed per statement
-pub(crate) const MAX_PARTICIPLES: usize = 256;
-/// Maximum number of unwrap operations allowed per statement
-pub(crate) const MAX_UNWRAPS: usize = 256;
-/// Maximum number of binary operators allowed per statement
-pub(crate) const MAX_OPERATORS: usize = 256;
-/// Maximum number of block expressions allowed per statement
-pub(crate) const MAX_BLOCKS: usize = 256;
-
 /// A fully assembled statement with all grammatical roles filled
 ///
 /// This struct represents the "final state" of a sentence after parsing.

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use crate::ast::{Clause, Expr, Statement};
 use crate::errors::GlossaError;
+use crate::limits::MAX_CONTROL_FLOW_DEPTH;
 use crate::morphology::lexicon;
 use crate::semantic::analyzer::analyze_statement;
 
@@ -566,8 +567,6 @@ fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, G
 
     Err(GlossaError::semantic("Invalid match pattern"))
 }
-
-const MAX_CONTROL_FLOW_DEPTH: usize = 100;
 
 /// Parse a conditional statement (εἰ/ἐάν)
 fn parse_conditional(


### PR DESCRIPTION
🪒 Razor: Centralize limit constants

This PR follows the essentialist "Razor" philosophy to eliminate architectural duplication and enforce a Single Source of Truth for compiler limits.

**What was done:**
- Moved all `MAX_*` depth/limit constants from `src/semantic/assembly/model.rs` and `src/semantic/control_flow.rs` to `src/limits.rs`.
- Updated `src/semantic/assembly/mod.rs` to use `pub(crate) use crate::limits::...` to expose the constants to its submodules without redefining them.
- Updated `src/semantic/control_flow.rs` to import its depth limit from `crate::limits`.
- Appended a journal entry to `.jules/razor.md` documenting the reduction.
- Ran `cargo test`, `cargo clippy`, and `cargo fmt`.

---
*PR created automatically by Jules for task [4808440829378170939](https://jules.google.com/task/4808440829378170939) started by @madmax983*