### PR TITLE
🪒 Razor: Delete unnecessary QuantifierFlags struct wrapper

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -97,3 +97,8 @@
 **Bloat:** `Analyzer` struct in `src/semantic/analyzer.rs` was completely empty with no fields, used purely as a namespace for the `analyze` method that was passed around to other modules.
 **Cut:** Deleted the `Analyzer` struct and converted `Analyzer::analyze` into a standalone `analyze_statement` function. Updated calling signatures across `control_flow.rs` and `declarations.rs` to remove the unnecessary `analyzer: &mut Analyzer` parameter.
 **Saved:** Removed empty struct instantiation, cleaned up ~20 function signatures, improved modular cohesion and flattened architectural layers.
+
+## [Reduction]
+**Bloat:** `QuantifierFlags` struct in `src/semantic/patterns.rs` was a classic 'Enterprise FizzBuzz' wrapper for two booleans.
+**Cut:** Removed the struct entirely and extracted its logic into a simple helper function `determine_quantifiers` that returns a `(bool, bool)` tuple.
+**Saved:** 1 struct definition, 1 impl block, simplified method signatures.

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -382,7 +382,7 @@ pub fn detect_iterator_pattern(
     };
 
     // Determine flags for any/all quantification
-    let flags = QuantifierFlags::from(asm_stmt);
+    let (is_any, is_all) = determine_quantifiers(asm_stmt);
 
     // Start with .iter()
     // chain: collection.iter()
@@ -399,7 +399,7 @@ pub fn detect_iterator_pattern(
     let mut has_ops = false;
 
     // Process adjectives (filter, any, all)
-    if process_adjectives(asm_stmt, scope, &flags, &mut current_expr) {
+    if process_adjectives(asm_stmt, scope, is_any, is_all, &mut current_expr) {
         has_ops = true;
     }
 
@@ -410,7 +410,8 @@ pub fn detect_iterator_pattern(
     }
 
     // Handle any/all operations with explicit operators (comparatives stored as operators)
-    let is_any_all = process_explicit_quantifiers(asm_stmt, scope, &flags, &mut current_expr);
+    let is_any_all =
+        process_explicit_quantifiers(asm_stmt, scope, is_any, is_all, &mut current_expr);
     if is_any_all {
         return Ok(Some(current_expr));
     }
@@ -492,36 +493,30 @@ fn extract_collection(asm_stmt: &AssembledStatement) -> Option<AnalyzedExpr> {
     }
 }
 
-/// Flags to track quantifier presence (any/all)
-struct QuantifierFlags {
-    is_any: bool,
-    is_all: bool,
-}
+/// Helper: Determine if 'any' or 'all' quantifiers are present.
+/// Returns (is_any, is_all).
+fn determine_quantifiers(asm_stmt: &AssembledStatement) -> (bool, bool) {
+    let mut is_any = false;
+    let mut is_all = false;
 
-impl QuantifierFlags {
-    fn from(asm_stmt: &AssembledStatement) -> Self {
-        let mut is_any = false;
-        let mut is_all = false;
-
-        if let Some(ref subj) = asm_stmt.subject {
-            let subj_lemma = normalize_greek(&subj.lemma);
-            is_any = crate::morphology::lexicon::is_any_quantifier(&subj_lemma);
-            is_all = crate::morphology::lexicon::is_all_quantifier(&subj_lemma);
-        }
-
-        // Also check nominatives for quantifiers
-        for nom in &asm_stmt.nominatives {
-            let nom_lemma = normalize_greek(&nom.lemma);
-            if crate::morphology::lexicon::is_any_quantifier(&nom_lemma) {
-                is_any = true;
-            }
-            if crate::morphology::lexicon::is_all_quantifier(&nom_lemma) {
-                is_all = true;
-            }
-        }
-
-        Self { is_any, is_all }
+    if let Some(ref subj) = asm_stmt.subject {
+        let subj_lemma = normalize_greek(&subj.lemma);
+        is_any = crate::morphology::lexicon::is_any_quantifier(&subj_lemma);
+        is_all = crate::morphology::lexicon::is_all_quantifier(&subj_lemma);
     }
+
+    // Also check nominatives for quantifiers
+    for nom in &asm_stmt.nominatives {
+        let nom_lemma = normalize_greek(&nom.lemma);
+        if crate::morphology::lexicon::is_any_quantifier(&nom_lemma) {
+            is_any = true;
+        }
+        if crate::morphology::lexicon::is_all_quantifier(&nom_lemma) {
+            is_all = true;
+        }
+    }
+
+    (is_any, is_all)
 }
 
 /// Helper: Process adjectives for filter/any/all patterns
@@ -529,7 +524,8 @@ impl QuantifierFlags {
 fn process_adjectives(
     asm_stmt: &AssembledStatement,
     scope: &Scope,
-    flags: &QuantifierFlags,
+    is_any: bool,
+    is_all: bool,
     current_expr: &mut AnalyzedExpr,
 ) -> bool {
     // Check for comparative adjective filter/any/all pattern
@@ -562,9 +558,9 @@ fn process_adjectives(
             let filter_closure = create_comparison_predicate(bin_op, comparison_expr);
 
             // Determine which method to call based on quantifier
-            let method = if flags.is_any {
+            let method = if is_any {
                 "any"
-            } else if flags.is_all {
+            } else if is_all {
                 "all"
             } else {
                 "filter"
@@ -577,7 +573,7 @@ fn process_adjectives(
                     method: method.into(),
                     args: vec![filter_closure],
                 },
-                glossa_type: if flags.is_any || flags.is_all {
+                glossa_type: if is_any || is_all {
                     GlossaType::Boolean
                 } else {
                     GlossaType::Unknown
@@ -751,10 +747,11 @@ fn process_participles(
 fn process_explicit_quantifiers(
     asm_stmt: &AssembledStatement,
     scope: &Scope,
-    flags: &QuantifierFlags,
+    is_any: bool,
+    is_all: bool,
     current_expr: &mut AnalyzedExpr,
 ) -> bool {
-    if (!flags.is_any && !flags.is_all) || asm_stmt.operators.is_empty() {
+    if (!is_any && !is_all) || asm_stmt.operators.is_empty() {
         return false;
     }
 
@@ -767,7 +764,7 @@ fn process_explicit_quantifiers(
             let comparison_expr = extract_comparison_value(asm_stmt, scope);
             let any_all_closure = create_comparison_predicate(bin_op, comparison_expr);
 
-            let method = if flags.is_any { "any" } else { "all" };
+            let method = if is_any { "any" } else { "all" };
 
             let new_expr = AnalyzedExpr {
                 expr: AnalyzedExprKind::MethodCall {


### PR DESCRIPTION
🪒 Razor: Delete unnecessary QuantifierFlags struct wrapper

Replaced the `QuantifierFlags` struct in `src/semantic/patterns.rs` (which merely held two booleans) with a simple tuple `(bool, bool)` returned by a helper function. This eliminates unnecessary object instantiation and simplifies the function signatures that were passing it around.

**Bloat:** The `QuantifierFlags` struct and its `impl` block were classic "Enterprise FizzBuzz" over-engineering for passing around simple boolean state.
**Cut:** Deleted the struct and refactored the logic into a standalone helper function.
**Saved:** ~10 lines of boilerplate code and cognitive load.

---
*PR created automatically by Jules for task [1041617130436481541](https://jules.google.com/task/1041617130436481541) started by @madmax983*