### PR TITLE
⚡ Bolt: Optimize `analyze_program` vector allocation

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -149,7 +149,8 @@ fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
 /// This is the entry point for semantic analysis.
 pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError> {
     let mut scope = Scope::new();
-    let mut analyzed_statements = Vec::new();
+    // ⚡ Bolt Optimization: Uses `Vec::with_capacity` based on the program statements length to prevent reallocation.
+    let mut analyzed_statements = Vec::with_capacity(program.statements.len());
     let mut analyzer = SemanticAnalyzer::new();
 
     for stmt in &program.statements {


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(program.statements.len())` in `analyze_program`.
🎯 Why: To prevent unnecessary O(log N) intermediate heap reallocations when pushing elements during semantic analysis, since the maximum number of statements is known in advance.
📊 Impact: Eliminates multiple heap reallocations per compiled program.
🔬 Measurement: Run `cargo bench` or `cargo test` to verify correctness and potential minor speedups in compilation times.

---
*PR created automatically by Jules for task [9643904057223051213](https://jules.google.com/task/9643904057223051213) started by @madmax983*