### PR TITLE
🎻 Bard: [documentation update] Fix rustdoc warnings

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -84,7 +84,7 @@ const AORIST_ACTIVE_SUBJ: &[(&str, Person, Number)] = &[
 
 /// Present Active Optative endings
 /// Pattern: γράφοιμι "I might write"
-/// The optative mood expresses possibility, wish, or potential - natural for Option<T>
+/// The optative mood expresses possibility, wish, or potential - natural for `Option<T>`
 /// NOTE: Must be sorted by length descending!
 const PRESENT_ACTIVE_OPT: &[(&str, Person, Number)] = &[
     ("οιμεν", Person::First, Number::Plural),
@@ -97,7 +97,7 @@ const PRESENT_ACTIVE_OPT: &[(&str, Person, Number)] = &[
 
 /// Aorist Passive Optative endings
 /// Pattern: εὑρεθείη "might be found"
-/// Used for values that "might exist" (Option<T> semantics)
+/// Used for values that "might exist" (`Option<T>` semantics)
 /// NOTE: Must be sorted by length descending!
 const AORIST_PASSIVE_OPT: &[(&str, Person, Number)] = &[
     ("θειημεν", Person::First, Number::Plural),

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -611,7 +611,7 @@ fn classify_insert(
 }
 
 /// Helper: Detect δεῖ assertion pattern
-/// Pattern: <condition> δεῖ (any word order)
+/// Pattern: `<condition>` δεῖ (any word order)
 /// Examples: "2 ἐν χ δεῖ", "δεῖ 2 ἐν χ"
 fn classify_assertion(
     asm_stmt: &AssembledStatement,
@@ -687,7 +687,7 @@ fn classify_assertion(
 }
 
 /// Helper: Detect ἰσοῦται equality assertion pattern
-/// Pattern: <value1> <value2> ἰσοῦται (any word order)
+/// Pattern: `<value1>` `<value2>` ἰσοῦται (any word order)
 /// Examples: "κ 5 ἰσοῦται", "ἰσοῦται κ 5", "5 κ ἰσοῦται"
 fn classify_equality_assertion(
     asm_stmt: &AssembledStatement,

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -328,7 +328,7 @@ pub fn resolve_type_name(name: &str, scope: &Scope) -> Result<GlossaType, Glossa
     }
 }
 
-/// Parse a function definition: name ὁρίζειν [params]· body
+/// Parse a function definition: name ὁρίζειν \[params\]· body
 ///
 /// This handles the `ὁρίζειν` verb when used to define standalone functions.
 ///


### PR DESCRIPTION
📖 Chapter: The Core Semantic and Morphology modules
🔦 Insight: Rustdoc attempts to interpret generic brackets (`<T>`) as HTML tags and square brackets (`[params]`) as intra-doc links, which causes build warnings if they are meant as literal text or placeholders.
🧪 Example: Cleaned up 6 separate warnings generated during `cargo doc` runs across `src/semantic/declarations.rs`, `src/morphology/conjugation.rs`, and `src/semantic/conversion.rs`.
🖼️ Preview: `cargo doc` now executes with 0 warnings.

---
*PR created automatically by Jules for task [3661157154685537307](https://jules.google.com/task/3661157154685537307) started by @madmax983*