### PR TITLE
🎨 Mosaic: UI Polish for CLI Empty States

### DIFF
--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -178,12 +178,13 @@ fn print_env<W: Write>(context: &ReplContext, w: &mut W) -> Result<()> {
         bindings.sort_by(|a, b| a.0.cmp(b.0));
 
         if bindings.is_empty() {
-            writeln!(
-                w,
-                "{}",
-                "Οὐδεμία μεταβλητή (No variables defined).".yellow()
-            )
-            .into_diagnostic()?;
+            let mut empty_table = Table::new();
+            empty_table.add_row(vec![
+                Cell::new("Οὐδεμία μεταβλητή (No variables defined).")
+                    .fg(Color::Yellow)
+                    .set_alignment(comfy_table::CellAlignment::Center),
+            ]);
+            writeln!(w, "{}", empty_table).into_diagnostic()?;
             return Ok(());
         }
 
@@ -218,12 +219,13 @@ fn print_env<W: Write>(context: &ReplContext, w: &mut W) -> Result<()> {
         }
         writeln!(w, "{table}").into_diagnostic()?;
     } else {
-        writeln!(
-            w,
-            "{}",
-            "Οὐδεμία μεταβλητή (No variables defined).".yellow()
-        )
-        .into_diagnostic()?;
+        let mut empty_table = Table::new();
+        empty_table.add_row(vec![
+            Cell::new("Οὐδεμία μεταβλητή (No variables defined).")
+                .fg(Color::Yellow)
+                .set_alignment(comfy_table::CellAlignment::Center),
+        ]);
+        writeln!(w, "{}", empty_table).into_diagnostic()?;
     }
     Ok(())
 }

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -472,11 +472,23 @@ mod tests {
 
     #[test]
     fn test_print_env_empty() {
-        let context = ReplContext::new();
+        let mut context = ReplContext::new();
         let mut buf = Vec::new();
+
+        // Context with no last_scope
         print_env(&context, &mut buf).unwrap();
-        let s = String::from_utf8(buf).unwrap();
+        let s = String::from_utf8(buf.clone()).unwrap();
         assert!(s.contains("No variables defined"));
+
+        // Execute a statement that does not create a binding
+        // so last_scope becomes Some(scope) but bindings is empty
+        buf.clear();
+        let _ = context.execute("«χαῖρε» λέγε.").unwrap();
+
+        assert!(context.last_scope.is_some());
+        print_env(&context, &mut buf).unwrap();
+        let s2 = String::from_utf8(buf).unwrap();
+        assert!(s2.contains("No variables defined"));
     }
 
     #[test]

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -254,10 +254,10 @@ pub fn run_tests(input: &Path) -> Result<()> {
 
     println!();
 
-    let mut table = Table::new();
-    table.load_preset(presets::UTF8_FULL);
-
     if !results.is_empty() {
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
+
         table.set_header(vec![
             Cell::new("Test Case")
                 .add_attribute(Attribute::Bold)
@@ -280,16 +280,17 @@ pub fn run_tests(input: &Path) -> Result<()> {
 
             table.add_row(vec![Cell::new(display_name), status_cell]);
         }
+        println!("{table}");
     } else {
-        table.add_row(vec![
+        let mut empty_table = Table::new();
+        empty_table.add_row(vec![
             Cell::new("No tests found.")
                 .fg(Color::DarkGrey)
                 .add_attribute(Attribute::Italic)
                 .set_alignment(CellAlignment::Center),
         ]);
+        println!("{empty_table}");
     }
-
-    println!("{table}");
 
     // If there were failures, try to extract and print them nicely
     if !test_output.status.success() {


### PR DESCRIPTION
🎨 Mosaic: UI Polish for CLI Empty States

🖌️ **Before:**
- In the Test Runner (`tester.rs`), when no tests were found, the "No tests found." message was inserted as a dummy value into the multi-column table layout, generating unnecessary horizontal borders and violating the clean dashboard philosophy.
- In the REPL (`repl.rs`), entering `.env` when the scope was empty outputted a raw, unformatted yellow string (`Οὐδεμία μεταβλητή (No variables defined).`), inconsistent with the table-driven visual language of the tool.

✨ **After:**
- Both empty states have been refactored to use distinct, single-cell `comfy-table` instances with `CellAlignment::Center`.
- This ensures a clean, box-bounded visual hierarchy that acts as clear feedback without mimicking a multi-column layout or falling back to raw text.

🖼️ **Visuals:**
Instead of raw strings or wide multi-column headers, the CLI now outputs centered feedback blocks like:
+-------------------------------------------+
| Οὐδεμία μεταβλητή (No variables defined). |
+-------------------------------------------+

---
*PR created automatically by Jules for task [5844757199849267431](https://jules.google.com/task/5844757199849267431) started by @madmax983*