### PR TITLE
⚒️ Forge: Flatten Pyramids of Doom in semantic conversions

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -25,3 +25,6 @@
 **Refactoring `classify_*` in `src/semantic/conversion.rs`**
 **Learning:** Functions that parse or classify elements using heuristic priorities often become a "Pyramid of Doom" through nested `if let Some(...) = ...` blocks. This increases cognitive load and hides the critical failure path.
 **Action:** Use "Guard Clauses" (early returns) extensively in classification functions. `let Some(x) = y else { return ... };` keeps the execution path flat and adheres strictly to the 'Grandma Test'.
+**Flattened Conversion Classifications**
+**Learning:** Returning `Result<Option<T>, E>` inside a deep `if let` block causes rightward drift ('Pyramid of Doom'). Flattening with guard clauses using `else { return Ok(None); }` significantly improves readability and reduces nesting depth.
+**Action:** Always prefer guard clauses (early returns) when handling optional variables before executing the main logic.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -459,19 +459,21 @@ fn classify_collection_mutation(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if let Some(ref verb) = asm_stmt.verb {
-        let verb_lemma = &verb.lemma;
+    let Some(ref verb) = asm_stmt.verb else {
+        return Ok(None);
+    };
+    let verb_lemma = &verb.lemma;
 
-        if let Some(res) = classify_pop(verb_lemma, asm_stmt, scope)? {
-            return Ok(Some(res));
-        }
-        if let Some(res) = classify_push(verb_lemma, asm_stmt, scope)? {
-            return Ok(Some(res));
-        }
-        if let Some(res) = classify_insert(verb_lemma, asm_stmt, scope)? {
-            return Ok(Some(res));
-        }
+    if let Some(res) = classify_pop(verb_lemma, asm_stmt, scope)? {
+        return Ok(Some(res));
     }
+    if let Some(res) = classify_push(verb_lemma, asm_stmt, scope)? {
+        return Ok(Some(res));
+    }
+    if let Some(res) = classify_insert(verb_lemma, asm_stmt, scope)? {
+        return Ok(Some(res));
+    }
+
     Ok(None)
 }
 
@@ -480,29 +482,31 @@ fn classify_pop(
     asm_stmt: &AssembledStatement,
     scope: &Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if crate::morphology::lexicon::is_pop_verb(verb_lemma)
-        && let Some(ref subject) = asm_stmt.subject
-    {
-        let receiver = AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
-            glossa_type: scope
-                .lookup(&subject.lemma)
-                .cloned()
-                .unwrap_or(GlossaType::Unknown),
-        };
-
-        let method_call = AnalyzedExpr {
-            expr: AnalyzedExprKind::MethodCall {
-                receiver: Box::new(receiver),
-                method: "pop".into(),
-                args: vec![],
-            },
-            glossa_type: GlossaType::Unknown,
-        };
-
-        return Ok(Some(AnalyzedStatement::Expression(vec![method_call])));
+    if !crate::morphology::lexicon::is_pop_verb(verb_lemma) {
+        return Ok(None);
     }
-    Ok(None)
+    let Some(ref subject) = asm_stmt.subject else {
+        return Ok(None);
+    };
+
+    let receiver = AnalyzedExpr {
+        expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
+        glossa_type: scope
+            .lookup(&subject.lemma)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown),
+    };
+
+    let method_call = AnalyzedExpr {
+        expr: AnalyzedExprKind::MethodCall {
+            receiver: Box::new(receiver),
+            method: "pop".into(),
+            args: vec![],
+        },
+        glossa_type: GlossaType::Unknown,
+    };
+
+    Ok(Some(AnalyzedStatement::Expression(vec![method_call])))
 }
 
 fn classify_push(
@@ -510,46 +514,48 @@ fn classify_push(
     asm_stmt: &AssembledStatement,
     scope: &Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if crate::morphology::lexicon::is_push_verb(verb_lemma)
-        && let Some(ref subject) = asm_stmt.subject
-    {
-        let receiver = AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
+    if !crate::morphology::lexicon::is_push_verb(verb_lemma) {
+        return Ok(None);
+    }
+    let Some(ref subject) = asm_stmt.subject else {
+        return Ok(None);
+    };
+
+    let receiver = AnalyzedExpr {
+        expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
+        glossa_type: scope
+            .lookup(&subject.lemma)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown),
+    };
+
+    let arg = if let Some(lit) = asm_stmt.literals.first() {
+        literal_to_analyzed_expr(lit)
+    } else if let Some(ref obj) = asm_stmt.object {
+        AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
             glossa_type: scope
-                .lookup(&subject.lemma)
+                .lookup(&obj.lemma)
                 .cloned()
                 .unwrap_or(GlossaType::Unknown),
-        };
+        }
+    } else {
+        AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(0),
+            glossa_type: GlossaType::Number,
+        }
+    };
 
-        let arg = if let Some(lit) = asm_stmt.literals.first() {
-            literal_to_analyzed_expr(lit)
-        } else if let Some(ref obj) = asm_stmt.object {
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                glossa_type: scope
-                    .lookup(&obj.lemma)
-                    .cloned()
-                    .unwrap_or(GlossaType::Unknown),
-            }
-        } else {
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::NumberLiteral(0),
-                glossa_type: GlossaType::Number,
-            }
-        };
+    let method_call = AnalyzedExpr {
+        expr: AnalyzedExprKind::MethodCall {
+            receiver: Box::new(receiver),
+            method: "push".into(),
+            args: vec![arg],
+        },
+        glossa_type: GlossaType::Unit,
+    };
 
-        let method_call = AnalyzedExpr {
-            expr: AnalyzedExprKind::MethodCall {
-                receiver: Box::new(receiver),
-                method: "push".into(),
-                args: vec![arg],
-            },
-            glossa_type: GlossaType::Unit,
-        };
-
-        return Ok(Some(AnalyzedStatement::Expression(vec![method_call])));
-    }
-    Ok(None)
+    Ok(Some(AnalyzedStatement::Expression(vec![method_call])))
 }
 
 fn classify_insert(
@@ -557,58 +563,60 @@ fn classify_insert(
     asm_stmt: &AssembledStatement,
     scope: &Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if crate::morphology::lexicon::is_insert_verb(verb_lemma)
-        && let Some(ref subject) = asm_stmt.subject
-    {
-        let subj_name = &subject.normalized;
-        let subj_type = scope
-            .lookup(subj_name)
-            .cloned()
-            .unwrap_or(GlossaType::Unknown);
-
-        let receiver = AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(subj_name.clone()),
-            glossa_type: subj_type.clone(),
-        };
-
-        let is_map = matches!(subj_type, GlossaType::Map(_, _));
-
-        let args = if is_map && asm_stmt.literals.len() >= 2 {
-            vec![
-                literal_to_analyzed_expr(&asm_stmt.literals[0]),
-                literal_to_analyzed_expr(&asm_stmt.literals[1]),
-            ]
-        } else if let Some(lit) = asm_stmt.literals.first() {
-            vec![literal_to_analyzed_expr(lit)]
-        } else if let Some(ref obj) = asm_stmt.object {
-            vec![AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                glossa_type: scope
-                    .lookup(&obj.lemma)
-                    .cloned()
-                    .unwrap_or(GlossaType::Unknown),
-            }]
-        } else {
-            vec![]
-        };
-
-        let return_type = if is_map {
-            GlossaType::Option(Box::new(GlossaType::Unknown))
-        } else {
-            GlossaType::Boolean
-        };
-        let method_call = AnalyzedExpr {
-            expr: AnalyzedExprKind::MethodCall {
-                receiver: Box::new(receiver),
-                method: "insert".into(),
-                args,
-            },
-            glossa_type: return_type,
-        };
-
-        return Ok(Some(AnalyzedStatement::Expression(vec![method_call])));
+    if !crate::morphology::lexicon::is_insert_verb(verb_lemma) {
+        return Ok(None);
     }
-    Ok(None)
+    let Some(ref subject) = asm_stmt.subject else {
+        return Ok(None);
+    };
+
+    let subj_name = &subject.normalized;
+    let subj_type = scope
+        .lookup(subj_name)
+        .cloned()
+        .unwrap_or(GlossaType::Unknown);
+
+    let receiver = AnalyzedExpr {
+        expr: AnalyzedExprKind::Variable(subj_name.clone()),
+        glossa_type: subj_type.clone(),
+    };
+
+    let is_map = matches!(subj_type, GlossaType::Map(_, _));
+
+    let args = if is_map && asm_stmt.literals.len() >= 2 {
+        vec![
+            literal_to_analyzed_expr(&asm_stmt.literals[0]),
+            literal_to_analyzed_expr(&asm_stmt.literals[1]),
+        ]
+    } else if let Some(lit) = asm_stmt.literals.first() {
+        vec![literal_to_analyzed_expr(lit)]
+    } else if let Some(ref obj) = asm_stmt.object {
+        vec![AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+            glossa_type: scope
+                .lookup(&obj.lemma)
+                .cloned()
+                .unwrap_or(GlossaType::Unknown),
+        }]
+    } else {
+        vec![]
+    };
+
+    let return_type = if is_map {
+        GlossaType::Option(Box::new(GlossaType::Unknown))
+    } else {
+        GlossaType::Boolean
+    };
+    let method_call = AnalyzedExpr {
+        expr: AnalyzedExprKind::MethodCall {
+            receiver: Box::new(receiver),
+            method: "insert".into(),
+            args,
+        },
+        glossa_type: return_type,
+    };
+
+    Ok(Some(AnalyzedStatement::Expression(vec![method_call])))
 }
 
 /// Helper: Detect δεῖ assertion pattern
@@ -618,73 +626,78 @@ fn classify_assertion(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if let Some(ref verb) = asm_stmt.verb {
-        let verb_lemma = &verb.lemma;
+    let Some(ref verb) = asm_stmt.verb else {
+        return Ok(None);
+    };
+    let verb_lemma = &verb.lemma;
 
-        if crate::morphology::lexicon::is_assert_verb(verb_lemma) {
-            // The condition is everything except the verb
-            // Common pattern: <element> ἐν <collection> δεῖ
-
-            // Check for collection contains pattern (most common in tests)
-            if asm_stmt.has_containment_preposition
-                && let Some(ref subj) = asm_stmt.subject
-            {
-                // Pattern: element ἐν collection δεῖ
-                let subj_name = &subj.normalized;
-                let collection_type = scope
-                    .lookup(subj_name)
-                    .cloned()
-                    .unwrap_or(GlossaType::Unknown);
-
-                let element = if let Some(lit) = asm_stmt.literals.first() {
-                    literal_to_analyzed_expr(lit)
-                } else {
-                    AnalyzedExpr {
-                        expr: AnalyzedExprKind::NumberLiteral(0),
-                        glossa_type: GlossaType::Number,
-                    }
-                };
-
-                let is_map = matches!(collection_type, GlossaType::Map(_, _));
-                let method = if is_map { "contains_key" } else { "contains" };
-
-                // Handle referencing argument if not a string literal
-                let arg_expr = if matches!(element.expr, AnalyzedExprKind::StringLiteral(_)) {
-                    element
-                } else {
-                    AnalyzedExpr {
-                        expr: AnalyzedExprKind::UnaryOp {
-                            op: crate::morphology::lexicon::UnaryOp::Ref,
-                            operand: Box::new(element),
-                        },
-                        glossa_type: GlossaType::Unknown,
-                    }
-                };
-
-                let contains_expr = AnalyzedExpr {
-                    expr: AnalyzedExprKind::MethodCall {
-                        receiver: Box::new(AnalyzedExpr {
-                            expr: AnalyzedExprKind::Variable(subj_name.clone()),
-                            glossa_type: collection_type.clone(),
-                        }),
-                        method: method.into(),
-                        args: vec![arg_expr],
-                    },
-                    glossa_type: GlossaType::Boolean,
-                };
-
-                let assert_expr = AnalyzedExpr {
-                    expr: AnalyzedExprKind::Assert {
-                        condition: Box::new(contains_expr),
-                    },
-                    glossa_type: GlossaType::Unit,
-                };
-
-                return Ok(Some(AnalyzedStatement::Expression(vec![assert_expr])));
-            }
-        }
+    if !crate::morphology::lexicon::is_assert_verb(verb_lemma) {
+        return Ok(None);
     }
-    Ok(None)
+
+    // The condition is everything except the verb
+    // Common pattern: <element> ἐν <collection> δεῖ
+
+    // Check for collection contains pattern (most common in tests)
+    if !asm_stmt.has_containment_preposition {
+        return Ok(None);
+    }
+    let Some(ref subj) = asm_stmt.subject else {
+        return Ok(None);
+    };
+
+    // Pattern: element ἐν collection δεῖ
+    let subj_name = &subj.normalized;
+    let collection_type = scope
+        .lookup(subj_name)
+        .cloned()
+        .unwrap_or(GlossaType::Unknown);
+
+    let element = if let Some(lit) = asm_stmt.literals.first() {
+        literal_to_analyzed_expr(lit)
+    } else {
+        AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(0),
+            glossa_type: GlossaType::Number,
+        }
+    };
+
+    let is_map = matches!(collection_type, GlossaType::Map(_, _));
+    let method = if is_map { "contains_key" } else { "contains" };
+
+    // Handle referencing argument if not a string literal
+    let arg_expr = if matches!(element.expr, AnalyzedExprKind::StringLiteral(_)) {
+        element
+    } else {
+        AnalyzedExpr {
+            expr: AnalyzedExprKind::UnaryOp {
+                op: crate::morphology::lexicon::UnaryOp::Ref,
+                operand: Box::new(element),
+            },
+            glossa_type: GlossaType::Unknown,
+        }
+    };
+
+    let contains_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::MethodCall {
+            receiver: Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(subj_name.clone()),
+                glossa_type: collection_type.clone(),
+            }),
+            method: method.into(),
+            args: vec![arg_expr],
+        },
+        glossa_type: GlossaType::Boolean,
+    };
+
+    let assert_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::Assert {
+            condition: Box::new(contains_expr),
+        },
+        glossa_type: GlossaType::Unit,
+    };
+
+    Ok(Some(AnalyzedStatement::Expression(vec![assert_expr])))
 }
 
 /// Helper: Detect ἰσοῦται equality assertion pattern
@@ -694,42 +707,46 @@ fn classify_equality_assertion(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if let Some(ref verb) = asm_stmt.verb {
-        let verb_lemma = &verb.lemma;
+    let Some(ref verb) = asm_stmt.verb else {
+        return Ok(None);
+    };
+    let verb_lemma = &verb.lemma;
 
-        if crate::morphology::lexicon::is_equals_verb(verb_lemma) {
-            // We need two values to compare
-            let mut left_expr = None;
-            let mut right_expr = None;
-
-            // Get subject (variable)
-            if let Some(ref subj) = asm_stmt.subject
-                && let Some(var_type) = scope.lookup(&subj.lemma)
-            {
-                left_expr = Some(AnalyzedExpr {
-                    expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                    glossa_type: var_type.clone(),
-                });
-            }
-
-            // Get literal (expected value)
-            if let Some(literal) = asm_stmt.literals.first() {
-                right_expr = Some(literal_to_analyzed_expr(literal));
-            }
-
-            if let (Some(left), Some(right)) = (left_expr, right_expr) {
-                let assert_eq_expr = AnalyzedExpr {
-                    expr: AnalyzedExprKind::AssertEq {
-                        left: Box::new(left),
-                        right: Box::new(right),
-                    },
-                    glossa_type: GlossaType::Unit,
-                };
-
-                return Ok(Some(AnalyzedStatement::Expression(vec![assert_eq_expr])));
-            }
-        }
+    if !crate::morphology::lexicon::is_equals_verb(verb_lemma) {
+        return Ok(None);
     }
+
+    // We need two values to compare
+    let mut left_expr = None;
+    let mut right_expr = None;
+
+    // Get subject (variable)
+    if let Some(ref subj) = asm_stmt.subject
+        && let Some(var_type) = scope.lookup(&subj.lemma)
+    {
+        left_expr = Some(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+            glossa_type: var_type.clone(),
+        });
+    }
+
+    // Get literal (expected value)
+    if let Some(literal) = asm_stmt.literals.first() {
+        right_expr = Some(literal_to_analyzed_expr(literal));
+    }
+
+    if let (Some(left), Some(right)) = (left_expr, right_expr) {
+        let assert_eq_expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::AssertEq {
+                left: Box::new(left),
+                right: Box::new(right),
+            },
+            glossa_type: GlossaType::Unit,
+        };
+
+        return Ok(Some(AnalyzedStatement::Expression(vec![assert_eq_expr])));
+    }
+
     Ok(None)
 }
 
@@ -877,31 +894,33 @@ fn classify_print(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if let Some(ref verb) = asm_stmt.verb {
-        let verb_lemma = &verb.lemma;
+    let Some(ref verb) = asm_stmt.verb else {
+        return Ok(None);
+    };
+    let verb_lemma = &verb.lemma;
 
-        if crate::morphology::lexicon::is_print_verb(verb_lemma) {
-            if let Some(args) = try_print_binary_op(asm_stmt, scope) {
-                return Ok(Some(AnalyzedStatement::Print(args)));
-            }
-
-            if let Some(args) = try_print_property_access(asm_stmt, scope) {
-                return Ok(Some(AnalyzedStatement::Print(args)));
-            }
-
-            if let Some(args) = try_print_index_access(asm_stmt, scope)? {
-                return Ok(Some(AnalyzedStatement::Print(args)));
-            }
-
-            if let Some(args) = try_print_unwrap(asm_stmt, scope)? {
-                return Ok(Some(AnalyzedStatement::Print(args)));
-            }
-
-            let args = try_print_default(asm_stmt, scope)?;
-            return Ok(Some(AnalyzedStatement::Print(args)));
-        }
+    if !crate::morphology::lexicon::is_print_verb(verb_lemma) {
+        return Ok(None);
     }
-    Ok(None)
+
+    if let Some(args) = try_print_binary_op(asm_stmt, scope) {
+        return Ok(Some(AnalyzedStatement::Print(args)));
+    }
+
+    if let Some(args) = try_print_property_access(asm_stmt, scope) {
+        return Ok(Some(AnalyzedStatement::Print(args)));
+    }
+
+    if let Some(args) = try_print_index_access(asm_stmt, scope)? {
+        return Ok(Some(AnalyzedStatement::Print(args)));
+    }
+
+    if let Some(args) = try_print_unwrap(asm_stmt, scope)? {
+        return Ok(Some(AnalyzedStatement::Print(args)));
+    }
+
+    let args = try_print_default(asm_stmt, scope)?;
+    Ok(Some(AnalyzedStatement::Print(args)))
 }
 
 /// Helper: Detect query statement
@@ -909,77 +928,78 @@ fn classify_query(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if asm_stmt.is_query {
-        // Containment pattern
-        if asm_stmt.has_containment_preposition
-            && let Some(ref subj) = asm_stmt.subject
-        {
-            let subj_name = &subj.normalized;
-            let subj_type = scope
-                .lookup(subj_name)
-                .cloned()
-                .unwrap_or(GlossaType::Unknown);
-
-            let collection = AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj_name.clone()),
-                glossa_type: subj_type.clone(),
-            };
-
-            let element = if let Some(lit) = asm_stmt.literals.first() {
-                literal_to_analyzed_expr(lit)
-            } else {
-                AnalyzedExpr {
-                    expr: AnalyzedExprKind::NumberLiteral(0),
-                    glossa_type: GlossaType::Number,
-                }
-            };
-
-            let is_map = matches!(subj_type, GlossaType::Map(_, _));
-            let method = if is_map { "contains_key" } else { "contains" };
-
-            // Handle referencing argument if not a string literal
-            let arg_expr = if matches!(element.expr, AnalyzedExprKind::StringLiteral(_)) {
-                element
-            } else {
-                AnalyzedExpr {
-                    expr: AnalyzedExprKind::UnaryOp {
-                        op: crate::morphology::lexicon::UnaryOp::Ref,
-                        operand: Box::new(element),
-                    },
-                    glossa_type: GlossaType::Unknown,
-                }
-            };
-
-            let contains_expr = AnalyzedExpr {
-                expr: AnalyzedExprKind::MethodCall {
-                    receiver: Box::new(collection),
-                    method: method.into(),
-                    args: vec![arg_expr],
-                },
-                glossa_type: GlossaType::Boolean,
-            };
-
-            return Ok(Some(AnalyzedStatement::Query(vec![contains_expr])));
-        }
-
-        // Regular query
-        let mut exprs = Vec::new();
-        for lit in &asm_stmt.literals {
-            exprs.push(literal_to_analyzed_expr(lit));
-        }
-        if let Some(ref subj) = asm_stmt.subject {
-            let var_type = scope
-                .lookup(&subj.lemma)
-                .cloned()
-                .unwrap_or(GlossaType::Unknown);
-            exprs.push(AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: var_type,
-            });
-        }
-        return Ok(Some(AnalyzedStatement::Query(exprs)));
+    if !asm_stmt.is_query {
+        return Ok(None);
     }
-    Ok(None)
+
+    // Containment pattern
+    if asm_stmt.has_containment_preposition
+        && let Some(ref subj) = asm_stmt.subject
+    {
+        let subj_name = &subj.normalized;
+        let subj_type = scope
+            .lookup(subj_name)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown);
+
+        let collection = AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(subj_name.clone()),
+            glossa_type: subj_type.clone(),
+        };
+
+        let element = if let Some(lit) = asm_stmt.literals.first() {
+            literal_to_analyzed_expr(lit)
+        } else {
+            AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(0),
+                glossa_type: GlossaType::Number,
+            }
+        };
+
+        let is_map = matches!(subj_type, GlossaType::Map(_, _));
+        let method = if is_map { "contains_key" } else { "contains" };
+
+        // Handle referencing argument if not a string literal
+        let arg_expr = if matches!(element.expr, AnalyzedExprKind::StringLiteral(_)) {
+            element
+        } else {
+            AnalyzedExpr {
+                expr: AnalyzedExprKind::UnaryOp {
+                    op: crate::morphology::lexicon::UnaryOp::Ref,
+                    operand: Box::new(element),
+                },
+                glossa_type: GlossaType::Unknown,
+            }
+        };
+
+        let contains_expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::MethodCall {
+                receiver: Box::new(collection),
+                method: method.into(),
+                args: vec![arg_expr],
+            },
+            glossa_type: GlossaType::Boolean,
+        };
+
+        return Ok(Some(AnalyzedStatement::Query(vec![contains_expr])));
+    }
+
+    // Regular query
+    let mut exprs = Vec::new();
+    for lit in &asm_stmt.literals {
+        exprs.push(literal_to_analyzed_expr(lit));
+    }
+    if let Some(ref subj) = asm_stmt.subject {
+        let var_type = scope
+            .lookup(&subj.lemma)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown);
+        exprs.push(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+            glossa_type: var_type,
+        });
+    }
+    Ok(Some(AnalyzedStatement::Query(exprs)))
 }
 
 /// Helper: Default expression

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -1557,4 +1557,131 @@ mod tests {
             panic!("Expected AnalyzedStatement::Expression");
         }
     }
+
+    #[test]
+    fn test_classify_early_returns_coverage() {
+        let mut scope = Scope::new();
+
+        // Test missing verb
+        let no_verb_stmt = AssembledStatement {
+            verb: None,
+            ..Default::default()
+        };
+
+        // All classification functions that check for a verb should return Ok(None) early.
+        assert!(classify_pop("pop_verb", &no_verb_stmt, &scope).unwrap().is_none());
+        assert!(classify_push("push_verb", &no_verb_stmt, &scope).unwrap().is_none());
+        assert!(classify_insert("insert_verb", &no_verb_stmt, &scope).unwrap().is_none());
+        assert!(classify_assertion(&no_verb_stmt, &mut scope).unwrap().is_none());
+        assert!(classify_equality_assertion(&no_verb_stmt, &mut scope).unwrap().is_none());
+        assert!(classify_print(&no_verb_stmt, &mut scope).unwrap().is_none());
+        assert!(classify_collection_mutation(&no_verb_stmt, &mut scope).unwrap().is_none());
+
+        // Test non-matching verbs
+        let wrong_verb = Some(crate::semantic::assembly::model::VerbConstituent {
+            original: "wrong".into(),
+            normalized: "wrong".into(),
+            lemma: "wrong".into(),
+            person: None,
+            number: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        });
+
+        let wrong_verb_stmt = AssembledStatement {
+            verb: wrong_verb.clone(),
+            ..Default::default()
+        };
+
+        // classify_pop, classify_push, classify_insert
+        // Here we test passing incorrect verb_lemma directly
+        assert!(classify_pop("wrong", &wrong_verb_stmt, &scope).unwrap().is_none());
+        assert!(classify_push("wrong", &wrong_verb_stmt, &scope).unwrap().is_none());
+        assert!(classify_insert("wrong", &wrong_verb_stmt, &scope).unwrap().is_none());
+
+        // These take asm_stmt which has wrong_verb
+        assert!(classify_assertion(&wrong_verb_stmt, &mut scope).unwrap().is_none());
+        assert!(classify_equality_assertion(&wrong_verb_stmt, &mut scope).unwrap().is_none());
+        assert!(classify_print(&wrong_verb_stmt, &mut scope).unwrap().is_none());
+        assert!(classify_collection_mutation(&wrong_verb_stmt, &mut scope).unwrap().is_none());
+
+        // Test missing subject where required
+        let push_verb = crate::semantic::assembly::model::VerbConstituent {
+            original: "ὠθεῖ".into(),
+            normalized: "ὠθεῖ".into(),
+            lemma: "ὠθέω".into(),
+            person: None,
+            number: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        };
+        let pop_verb = crate::semantic::assembly::model::VerbConstituent {
+            original: "ἕλκει".into(),
+            normalized: "ἕλκει".into(),
+            lemma: "ἕλκω".into(),
+            person: None,
+            number: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        };
+        let insert_verb = crate::semantic::assembly::model::VerbConstituent {
+            original: "τίθησι".into(),
+            normalized: "τίθησι".into(),
+            lemma: "τίθημι".into(),
+            person: None,
+            number: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        };
+        let assert_verb = crate::semantic::assembly::model::VerbConstituent {
+            original: "δεῖ".into(),
+            normalized: "δεῖ".into(),
+            lemma: "δεῖ".into(),
+            person: None,
+            number: None,
+            tense: None,
+            mood: None,
+            voice: None,
+        };
+
+        // classify_push without subject
+        let mut stmt_no_subj = AssembledStatement {
+            verb: Some(push_verb.clone()),
+            subject: None,
+            ..Default::default()
+        };
+        assert!(classify_push("ὠθέω", &stmt_no_subj, &scope).unwrap().is_none());
+
+        // classify_pop without subject
+        stmt_no_subj.verb = Some(pop_verb.clone());
+        assert!(classify_pop("ἕλκω", &stmt_no_subj, &scope).unwrap().is_none());
+
+        // classify_insert without subject
+        stmt_no_subj.verb = Some(insert_verb.clone());
+        assert!(classify_insert("τίθημι", &stmt_no_subj, &scope).unwrap().is_none());
+
+        // classify_assertion without subject
+        stmt_no_subj.verb = Some(assert_verb.clone());
+        stmt_no_subj.has_containment_preposition = true; // Meet containment condition
+        assert!(classify_assertion(&stmt_no_subj, &mut scope).unwrap().is_none());
+
+        // Test classify_assertion without containment preposition
+        let stmt_no_containment = AssembledStatement {
+            verb: Some(assert_verb.clone()),
+            has_containment_preposition: false,
+            ..Default::default()
+        };
+        assert!(classify_assertion(&stmt_no_containment, &mut scope).unwrap().is_none());
+
+        // Test classify_query early return
+        let not_query_stmt = AssembledStatement {
+            is_query: false,
+            ..Default::default()
+        };
+        assert!(classify_query(&not_query_stmt, &mut scope).unwrap().is_none());
+    }
 }


### PR DESCRIPTION
### 🚮 Smell
The `classify_*` helper functions in `src/semantic/conversion.rs` contained deep "Pyramids of Doom" using nested `if let Some(...) = ...` statements to destructure the incoming `AssembledStatement`. This made the control flow hard to read and bumped code indentation far to the right.

### ✨ Solution
I introduced early return guard clauses (e.g., `let Some(ref verb) = asm_stmt.verb else { return Ok(None); }` and `if !crate::morphology::lexicon::is_... { return Ok(None); }`) across numerous functions:
- `classify_pop`
- `classify_push`
- `classify_insert`
- `classify_assertion`
- `classify_equality_assertion`
- `classify_print`
- `classify_query`
- `classify_collection_mutation`

### 🧼 Benefit
The functions are now strictly flattened. The conditions required for execution are stated up-front, and failures exit early. This dramatically reduces cognitive load, keeps the code firmly aligned left, and cleanly resolves the "Pyramid of Doom" anti-pattern.

### 🛡️ Verification
`cargo check`, `cargo test`, `cargo clippy`, and `cargo fmt` executed successfully. There are no changes to runtime behavior, only structural readability improvements.

---
*PR created automatically by Jules for task [9703332303655110411](https://jules.google.com/task/9703332303655110411) started by @madmax983*