### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-introduce-weave.md
+++ b/docs/adr/016-introduce-weave.md
@@ -1,0 +1,25 @@
+# 16. Introduce Weave Rosetta Stone Exporter
+
+Date: 2026-03-09
+Status: Proposed
+
+## Context
+
+As the ΓΛΩΣΣΑ compiler ecosystem expands, there is a growing need to demystify the semantic assembly process and the relationship between Ancient Greek source code, the compiler's semantic interpretation, and the generated Rust code. Previously, users and contributors had to piece together these phases using discrete tools like `mosaic` (for assembly) and inspecting the compiled `.rs` output. This fragmented developer experience makes learning the language and debugging the compiler more difficult.
+
+## Decision
+
+We have introduced the `Weave` tool (`src/tools/weave.rs`), guarded by the `nova` feature flag, to act as an exporter. "Weave" generates a consolidated 'Rosetta Stone' Markdown document that combines:
+1. The original ΓΛΩΣΣΑ source code.
+2. The semantic assembly logic (visualized via `mosaic`).
+3. The generated Rust code.
+
+## Consequences
+
+### Positive
+- **Educational Value:** The generated Rosetta Stone document provides an immediate, side-by-side comparison of the full pipeline, greatly improving the onboarding experience for new users and contributors.
+- **Debugging:** It serves as a unified artifact for examining compilation edge cases and assembly mappings.
+- **Architectural Alignment:** The tool neatly integrates into the existing "Developer Experience (Nova)" tool ecosystem, reusing the existing `run_mosaic_inner` and `generate_rust_file` interfaces.
+
+### Negative
+- **Maintenance Surface:** Adds another developer tool to maintain and test, specifically requiring coverage for Markdown generation and structural rendering logic.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,7 @@ C4Container
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(weave, "Weave", "src/tools/weave.rs", "Exports a Rosetta Stone Markdown document")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -62,6 +63,7 @@ C4Container
     Rel(semantic, mosaic, "Analyzed Program")
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")
+    Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")


### PR DESCRIPTION
🧠 **Decision:** Recorded the introduction of the Weave tool as an exporter to generate Rosetta Stone Markdown.
🗺️ **Visuals:** Updated C4 Container diagram in `docs/architecture.md` to show the new Weave tool and its boundary under Developer Experience.
🔗 **Link:** See `docs/adr/016-introduce-weave.md`.

---
*PR created automatically by Jules for task [5595939899968971468](https://jules.google.com/task/5595939899968971468) started by @madmax983*