### PR TITLE
🎨 Mosaic: UI Polish for Empty States

### DIFF
--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -36,7 +36,7 @@
 use crate::parser::parse;
 use crate::semantic::{AnalyzedProgram, AnalyzedStatement, GlossaType, analyze_program};
 use crate::tools::ui::Status;
-use comfy_table::{Attribute, Cell, Color, Table, presets};
+use comfy_table::{Attribute, Cell, CellAlignment, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 use std::collections::HashSet;
@@ -65,15 +65,11 @@ pub fn run_map(input: &Path) -> Result<()> {
     table.load_preset(presets::UTF8_FULL);
 
     if map.trim() == "classDiagram" {
-        table.set_header(vec![
-            Cell::new("Status")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Yellow),
-        ]);
         table.add_row(vec![
             Cell::new("No architectural structures (Structs) found.")
                 .fg(Color::DarkGrey)
-                .add_attribute(Attribute::Italic),
+                .add_attribute(Attribute::Italic)
+                .set_alignment(CellAlignment::Center),
         ]);
         println!("{table}");
         println!();

--- a/src/tools/dictionary.rs
+++ b/src/tools/dictionary.rs
@@ -231,6 +231,11 @@ mod tests {
     }
 
     #[test]
+    fn test_lookup_unknown_no_analyses() {
+        lookup_word("asdfasdfasdf").unwrap();
+    }
+
+    #[test]
     fn test_lookup_verb() {
         lookup_word("λέγε").unwrap();
     }

--- a/src/tools/dictionary.rs
+++ b/src/tools/dictionary.rs
@@ -45,7 +45,7 @@
 //!    λόγος  Noun  Accusative, Singular, Masculine  1.00
 //! ```
 
-use comfy_table::{Attribute, Cell, Color, Table, presets};
+use comfy_table::{Attribute, Cell, CellAlignment, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 
@@ -142,7 +142,13 @@ pub fn lookup_word(word: &str) -> Result<()> {
     let analyses = analyze_all(word);
 
     if analyses.is_empty() {
-        println!("   {}", "× No morphological analysis found.".red());
+        let mut empty_table = Table::new();
+        empty_table.add_row(vec![
+            Cell::new("× No morphological analysis found.")
+                .fg(Color::Red)
+                .set_alignment(CellAlignment::Center),
+        ]);
+        println!("{empty_table}");
         return Ok(());
     }
 


### PR DESCRIPTION
🖌️ **Before:**
- `cartographer` map outputs a two-row table (header + row) for the empty states ("No architectural structures (Structs) found."), lacking centered alignment.
- `dictionary` morphological analysis empty state prints a raw string to the console ("× No morphological analysis found.").

✨ **After:**
- Empty states across `cartographer` and `dictionary` now use a standard, single-cell table with `CellAlignment::Center`.

🖼️ **Visuals:**
Instead of raw strings or clunky multi-row structures, the CLI maintains a clean dashboard appearance using `comfy-table` with consistent centering and color coding for empty states.

---
*PR created automatically by Jules for task [12825521851623743599](https://jules.google.com/task/12825521851623743599) started by @madmax983*