### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-break-semantic-dependency-cycle.md
+++ b/docs/adr/016-break-semantic-dependency-cycle.md
@@ -1,0 +1,21 @@
+# 16. Break Semantic Module Dependency Cycle
+
+Date: 2026-03-07
+Status: Proposed
+
+## Context
+
+The `semantic` module contained a circular dependency between the main orchestrator (`analyzer.rs`) and specialized submodules (`control_flow.rs`, `declarations.rs`). These submodules directly depended on the concrete `Analyzer` implementation in order to recursively parse statements within loops, conditionals, and functions. This tight coupling complicated testing and violated dependency graph rules (creating an acyclic graph violation).
+
+## Decision
+
+We introduced a `StatementAnalyzer` trait in a new `traits.rs` module to abstract the statement analysis recursion logic. The semantic logic was extracted into a `SemanticAnalyzer` struct that implements this trait. The specialized submodules (`control_flow.rs` and `declarations.rs`) now rely on the `StatementAnalyzer` trait instead of the concrete orchestrator implementation.
+
+## Consequences
+
+### Positive
+- **Acyclic Dependency Graph**: Breaking the circular dependency enforces a clean, one-way dependency flow, satisfying the Atlas persona's architectural requirements.
+- **Decoupling**: The submodules are decoupled from the main orchestrator, making the codebase easier to reason about and mock in testing.
+
+### Negative
+- **Abstraction Overhead**: Introduces a single-use trait interface (`StatementAnalyzer`), which adds minor indirection when tracing code execution.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,7 @@ C4Component
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")
         Component(types, "Type System", "src/semantic/types.rs", "GlossaType definitions and utilities")
+        Component(traits, "Traits", "src/semantic/traits.rs", "Defines StatementAnalyzer trait for abstraction")
     }
 
     Container(morphology, "Morphology", "src/morphology", "Provides Case/Gender/Number analysis")
@@ -95,13 +96,16 @@ C4Component
     Rel(orchestrator, declarations, "Delegates to")
     Rel(orchestrator, control_flow, "Delegates to")
     Rel(orchestrator, conversion, "Delegates to")
+    Rel(orchestrator, traits, "Implements")
 
     Rel(declarations, resolver, "Defines Symbols")
     Rel(declarations, types, "Uses")
     Rel(declarations, model, "Produces")
+    Rel(declarations, traits, "Uses for recursion")
 
     Rel(control_flow, expressions, "Analyzes conditions")
     Rel(control_flow, model, "Produces")
+    Rel(control_flow, traits, "Uses for recursion")
 
     Rel(conversion, assembly, "Uses Assembler")
     Rel(assembly, morphology, "Uses")


### PR DESCRIPTION
Drafts ADR 016 to formally document the architectural decision to break circular dependencies in the semantic module using a `StatementAnalyzer` trait. It also updates the Mermaid C4 Component diagram to enforce architectural transparency and map accuracy in accordance with the Codex persona.

---
*PR created automatically by Jules for task [3891136244474668668](https://jules.google.com/task/3891136244474668668) started by @madmax983*