### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-centralize-expression-depth-limit.md
+++ b/docs/adr/016-centralize-expression-depth-limit.md
@@ -1,0 +1,18 @@
+# 16. Centralize MAX_EXPRESSION_DEPTH limit
+
+Date: 2026-03-06
+Status: Proposed
+
+## Context
+
+The ΓΛΩΣΣΑ compiler is susceptible to denial-of-service (DoS) attacks via stack overflows when parsing deeply nested expressions. While a recursion depth limit for the parser (`MAX_PARSE_DEPTH`) was already implemented and centralized, the limit during the semantic analysis phase (`MAX_EXPRESSION_DEPTH`) remained scattered and hardcoded within modules like `src/semantic/expressions.rs`. This lack of centralization made the system's structural limits difficult to audit and maintain, violating the Atlas persona's architectural directives for high cohesion and single sources of truth.
+
+## Decision
+
+We have decided to centralize the semantic depth limit (`MAX_EXPRESSION_DEPTH`, currently set to 200) into the `src/limits.rs` module, alongside the existing parser limits. Furthermore, the AST depth validation logic has been extracted into a dedicated `src/semantic/validation.rs` module to separate tree limit checks from semantic orchestration.
+
+## Consequences
+
+*   **Maintainability**: All compiler-wide architectural limits (recursion depths, etc.) are now located in a single, auditable file (`src/limits.rs`).
+*   **Security**: Centralized limits ensure that protective bounds against stack overflows and DoS attacks are consistently applied and easier to tune.
+*   **Structural Clarity**: Extracting the validation logic into `src/semantic/validation.rs` improves the cohesion of the `semantic` module, removing limit-checking boilerplate from the core expression analysis paths.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ C4Container
     Container(lexer, "Lexer", "src/parser/grammar.rs", "Tokenizes source, handling Unicode normalization")
     Container(parser, "Parser", "src/parser", "Constructs AST, enforcing recursion limits (max depth 500)")
     Container(morphology, "Declension Resolver", "src/morphology", "Analyzes case, gender, number, and resolves agreement")
-    Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
+    Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, ownership, and enforces semantic recursion limits (max depth 200)")
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
@@ -88,11 +88,13 @@ C4Component
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")
         Component(types, "Type System", "src/semantic/types.rs", "GlossaType definitions and utilities")
+        Component(validation, "Validation", "src/semantic/validation.rs", "Enforces AST depth recursion limits (MAX_EXPRESSION_DEPTH)")
     }
 
     Container(morphology, "Morphology", "src/morphology", "Provides Case/Gender/Number analysis")
 
     Rel(orchestrator, declarations, "Delegates to")
+    Rel(orchestrator, validation, "Delegates to")
     Rel(orchestrator, control_flow, "Delegates to")
     Rel(orchestrator, conversion, "Delegates to")
 


### PR DESCRIPTION
🧠 **Decision:** Recorded the centralization of the semantic depth limit `MAX_EXPRESSION_DEPTH` in `src/limits.rs` and extraction of validation logic to `semantic/validation.rs`.
🗺️ **Visuals:** Updated the C4 Container and Component models in `docs/architecture.md` to reflect the new `Validation` boundaries and limits logic.
🔗 **Link:** See `docs/adr/016-centralize-expression-depth-limit.md`.

---
*PR created automatically by Jules for task [5810393071820844490](https://jules.google.com/task/5810393071820844490) started by @madmax983*