### PR TITLE
🪒 Razor: Flatten TraitMethodCall into MethodCall

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -97,3 +97,7 @@
 **Bloat:** `Analyzer` struct in `src/semantic/analyzer.rs` was completely empty with no fields, used purely as a namespace for the `analyze` method that was passed around to other modules.
 **Cut:** Deleted the `Analyzer` struct and converted `Analyzer::analyze` into a standalone `analyze_statement` function. Updated calling signatures across `control_flow.rs` and `declarations.rs` to remove the unnecessary `analyzer: &mut Analyzer` parameter.
 **Saved:** Removed empty struct instantiation, cleaned up ~20 function signatures, improved modular cohesion and flattened architectural layers.
+## [Reduction]
+**Bloat:** `AnalyzedExprKind::TraitMethodCall` variant duplicated `MethodCall` logic throughout the compiler, but traits resolve functionally identical to regular method calls.
+**Cut:** Deleted `TraitMethodCall` completely and migrated all AST processing layers (codegen, validation, report, narrator) to solely rely on `MethodCall` logic.
+**Saved:** Removed an unnecessary abstraction, simplified match blocks across 4 tools, and eliminated `generate_trait_method_call` (saving ~50 lines of boilerplate).

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -919,13 +919,6 @@ fn generate_expr(expr: &AnalyzedExpr) -> TokenStream {
             args,
         } => generate_method_call(receiver, method, args),
 
-        AnalyzedExprKind::TraitMethodCall {
-            receiver,
-            method_name,
-            args,
-            ..
-        } => generate_trait_method_call(receiver, method_name, args),
-
         AnalyzedExprKind::VerbCall { verb, args }
         | AnalyzedExprKind::FunctionCall { func: verb, args } => generate_function_call(verb, args),
 
@@ -1285,18 +1278,6 @@ fn generate_method_call(
         sanitize_ident(method)
     };
 
-    let arg_tokens: Vec<TokenStream> = args.iter().map(generate_expr).collect();
-    quote! { #recv.#method_ident(#(#arg_tokens),*) }
-}
-
-fn generate_trait_method_call(
-    receiver: &AnalyzedExpr,
-    method_name: &str,
-    args: &[AnalyzedExpr],
-) -> TokenStream {
-    // Treat as regular method call
-    let recv = generate_expr(receiver);
-    let method_ident = sanitize_ident(method_name);
     let arg_tokens: Vec<TokenStream> = args.iter().map(generate_expr).collect();
     quote! { #recv.#method_ident(#(#arg_tokens),*) }
 }

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -345,17 +345,6 @@ pub enum AnalyzedExprKind {
         args: Vec<AnalyzedExpr>,
     },
 
-    /// Trait method call `receiver.<TraitName>::method(args)` (from trait impl)
-    ///
-    /// # Example
-    /// `user.Show::print()`
-    TraitMethodCall {
-        receiver: Box<AnalyzedExpr>,
-        trait_name: SmolStr,
-        method_name: SmolStr,
-        args: Vec<AnalyzedExpr>,
-    },
-
     /// Struct instantiation: `variable νέον type_name args... ἔστω`
     ///
     /// # Example

--- a/src/semantic/validation.rs
+++ b/src/semantic/validation.rs
@@ -129,8 +129,7 @@ fn check_expr_depth(expr: &AnalyzedExpr, depth: usize) -> Result<(), GlossaError
             check_expr_depth(array, depth + 1)?;
             check_expr_depth(index, depth + 1)?;
         }
-        AnalyzedExprKind::MethodCall { receiver, args, .. }
-        | AnalyzedExprKind::TraitMethodCall { receiver, args, .. } => {
+        AnalyzedExprKind::MethodCall { receiver, args, .. } => {
             check_expr_depth(receiver, depth + 1)?;
             for arg in args {
                 check_expr_depth(arg, depth + 1)?;

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -351,21 +351,6 @@ fn tell_expr(expr: &AnalyzedExpr) -> String {
                 args_str.join(", ")
             )
         }
-        AnalyzedExprKind::TraitMethodCall {
-            receiver,
-            trait_name,
-            method_name,
-            args,
-        } => {
-            let args_str: Vec<String> = args.iter().map(tell_expr).collect();
-            format!(
-                "{} as {}::{}({})",
-                tell_expr(receiver),
-                trait_name,
-                method_name,
-                args_str.join(", ")
-            )
-        }
         AnalyzedExprKind::StructInstantiation {
             type_name,
             fields,

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -207,8 +207,7 @@ impl ProgramStats {
                     self.visit_expr(arg);
                 }
             }
-            AnalyzedExprKind::MethodCall { receiver, args, .. }
-            | AnalyzedExprKind::TraitMethodCall { receiver, args, .. } => {
+            AnalyzedExprKind::MethodCall { receiver, args, .. } => {
                 self.visit_expr(receiver);
                 for arg in args {
                     self.visit_expr(arg);
@@ -725,13 +724,12 @@ mod tests {
                     glossa_type: GlossaType::Number,
                 },
                 AnalyzedExpr {
-                    expr: AnalyzedExprKind::TraitMethodCall {
+                    expr: AnalyzedExprKind::MethodCall {
                         receiver: Box::new(AnalyzedExpr {
                             expr: AnalyzedExprKind::NumberLiteral(1),
                             glossa_type: GlossaType::Number,
                         }),
-                        trait_name: "Num".into(),
-                        method_name: "abs".into(),
+                        method: "abs".into(),
                         args: vec![],
                     },
                     glossa_type: GlossaType::Number,

--- a/tests/narrator_coverage.rs
+++ b/tests/narrator_coverage.rs
@@ -375,16 +375,15 @@ fn test_bard_exprs() {
     );
 
     test_expr_tale(
-        AnalyzedExprKind::TraitMethodCall {
+        AnalyzedExprKind::MethodCall {
             receiver: Box::new(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable("obj".into()),
                 glossa_type: GlossaType::Unknown,
             }),
-            trait_name: "T".into(),
-            method_name: "m".into(),
+            method: "m".into(),
             args: vec![],
         },
-        "`obj` as T::m()",
+        "`obj`.m()",
     );
 
     test_expr_tale(


### PR DESCRIPTION
**Bloat:** `AnalyzedExprKind::TraitMethodCall` variant duplicated `MethodCall` logic throughout the compiler, but traits resolve functionally identical to regular method calls. The trait analysis step already parsed them cleanly to `MethodCall`.

**Cut:** Deleted `TraitMethodCall` entirely and migrated all AST processing layers (codegen, validation, report, narrator) to solely rely on `MethodCall` logic.

**Saved:** Removed an unnecessary abstraction, simplified `match` blocks across 4 tools (codegen, reporting), and eliminated `generate_trait_method_call` (saving ~50 lines of boilerplate). All unit tests now construct standard `MethodCall` objects successfully instead of redundant `TraitMethodCall` variants.

---
*PR created automatically by Jules for task [16155785941629055140](https://jules.google.com/task/16155785941629055140) started by @madmax983*