### PR TITLE
🛡️ Sentry: [test coverage improvement] Semantic Extraction and Codegen edge cases

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1554,6 +1554,32 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_checked_op() {
+        let left = quote! { a };
+        let right = quote! { b };
+        let code =
+            generate_checked_op(left, right, "checked_add", "arithmetic overflow").to_string();
+        assert!(code.contains("checked_add"));
+        assert!(code.contains("expect"));
+        assert!(code.contains("arithmetic overflow"));
+    }
+
+    #[test]
+    fn test_generate_control_unwrap() {
+        let expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::Unwrap(Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(42),
+                glossa_type: GlossaType::Number,
+            })),
+            glossa_type: GlossaType::Number,
+        };
+
+        let code = generate_expr(&expr).to_string();
+        assert!(code.contains("unwrap"));
+        assert!(code.contains("42"));
+    }
+
+    #[test]
     fn test_generate_unreachable_operators() {
         // Manually trigger fallback operators like Le/Ge that aren't parsed yet
         let left = AnalyzedExpr {

--- a/src/semantic/sentry_conversion_tests.rs
+++ b/src/semantic/sentry_conversion_tests.rs
@@ -403,3 +403,42 @@ fn test_binding_subject_object_swap() {
         panic!("Expected Binding statement");
     }
 }
+
+#[test]
+fn test_try_parse_genitive_method_call_extraction() {
+    let mut scope = Scope::new();
+    scope.define(
+        "owner",
+        GlossaType::Struct {
+            name: "OwnerType".into(),
+            gender: crate::morphology::Gender::Masculine,
+            fields: vec![],
+        },
+    );
+
+    let asm_stmt = AssembledStatement {
+        subject: Some(make_constituent("method_name", "method_name")),
+        genitives: vec![make_constituent("owner", "owner")],
+        ..Default::default()
+    };
+
+    let (analyzed, _) =
+        extract_value(&asm_stmt, &scope).expect("Should extract genitive method call");
+
+    if let AnalyzedExprKind::MethodCall {
+        receiver,
+        method,
+        args,
+    } = analyzed.expr
+    {
+        assert_eq!(method, "method_name");
+        assert!(args.is_empty());
+        if let AnalyzedExprKind::Variable(owner_name) = receiver.expr {
+            assert_eq!(owner_name, "owner");
+        } else {
+            panic!("Expected receiver to be a Variable");
+        }
+    } else {
+        panic!("Expected MethodCall, got {:?}", analyzed.expr);
+    }
+}


### PR DESCRIPTION
🎯 Target: `extract_value` in `src/semantic/conversion.rs` and codegen macro functions `generate_control_unwrap` and `generate_checked_op` in `src/codegen.rs`.
💣 Risk: Missing test coverage for parsing complex combinations (like properties extracted using genitives or unwrap syntax logic) might result in silent regression. Lack of unit testing for specific AST macro code generators can cause rustc compilation failures in outputs.
🧪 Strategy: Added specific table-driven edge case tests (`test_try_parse_genitive_method_call_extraction`) to safely build AST definitions. Added codegen macro unit tests for `test_generate_checked_op` and `test_generate_control_unwrap` to cover all lines in macro generators using quote!.
🔬 Verification: `cargo test -p glossa codegen` and `cargo test -p glossa sentry_conversion_tests`

---
*PR created automatically by Jules for task [10082262063888394409](https://jules.google.com/task/10082262063888394409) started by @madmax983*