### PR TITLE
⚡ Bolt: Optimize Vec allocations in semantic analysis

### DIFF
--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -370,7 +370,7 @@ fn parse_match_expression(
     let scrutinee = skip_first_word_and_parse(&synthetic_clause, scope)?;
 
     // Build arms: pattern from clause[i], expr 1 → body from clause[i+1], expr 0
-    let mut arms = Vec::new();
+    let mut arms = Vec::with_capacity(stmt.clauses().len() / 2);
 
     for i in 0..stmt.clauses().len() {
         let clause = &stmt.clauses()[i];
@@ -633,7 +633,7 @@ fn parse_conditional(
         // Check if it's "εἰ" or "ἐάν" (elif)
         else if check_conditional_start(second_expr) {
             // Build a new statement for the elif chain
-            let mut elif_clauses = Vec::new();
+            let mut elif_clauses = Vec::with_capacity(stmt.clauses().len() - 1);
 
             // New clause 0: just the elif condition (from clause 1, expr 1)
             elif_clauses.push(Clause {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -763,7 +763,7 @@ fn try_print_property_access(
     scope: &mut Scope,
 ) -> Option<Vec<AnalyzedExpr>> {
     if !asm_stmt.property_accesses.is_empty() {
-        let mut args = Vec::new();
+        let mut args = Vec::with_capacity(asm_stmt.property_accesses.len());
         for (owner, method) in &asm_stmt.property_accesses {
             let receiver = AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(owner.clone().into()),
@@ -806,7 +806,7 @@ fn try_print_index_access(
     scope: &mut Scope,
 ) -> Result<Option<Vec<AnalyzedExpr>>, GlossaError> {
     if !asm_stmt.index_accesses.is_empty() {
-        let mut args = Vec::new();
+        let mut args = Vec::with_capacity(asm_stmt.index_accesses.len());
         for (array_expr, index_expr) in &asm_stmt.index_accesses {
             let array_analyzed = analyze_argument_expr(array_expr, scope)?;
             let index_analyzed = analyze_argument_expr(index_expr, scope)?;
@@ -828,7 +828,7 @@ fn try_print_unwrap(
     scope: &mut Scope,
 ) -> Result<Option<Vec<AnalyzedExpr>>, GlossaError> {
     if !asm_stmt.unwraps.is_empty() {
-        let mut args = Vec::new();
+        let mut args = Vec::with_capacity(asm_stmt.unwraps.len());
         for unwrap_expr in &asm_stmt.unwraps {
             let inner_analyzed = analyze_argument_expr(unwrap_expr, scope)?;
             args.push(AnalyzedExpr {
@@ -963,7 +963,7 @@ fn classify_query(
         }
 
         // Regular query
-        let mut exprs = Vec::new();
+        let mut exprs = Vec::with_capacity(asm_stmt.literals.len() + 1);
         for lit in &asm_stmt.literals {
             exprs.push(literal_to_analyzed_expr(lit));
         }
@@ -1078,7 +1078,7 @@ fn try_parse_genitive_method_call(
                         glossa_type: owner_type.clone(),
                     };
 
-                    let mut args = Vec::new();
+                    let mut args = Vec::with_capacity(asm_stmt.literals.len());
                     for lit in &asm_stmt.literals {
                         args.push(literal_to_analyzed_expr(lit));
                     }


### PR DESCRIPTION
💡 What: Replaced multiple `Vec::new()` calls with `Vec::with_capacity(n)` in `src/semantic/conversion.rs` and `src/semantic/control_flow.rs` based on the known lengths of the collections being mapped over.
🎯 Why: Constructing vectors with `Vec::new()` requires multiple dynamic heap reallocations as elements are pushed. Since the capacities can be derived from the AST / AssembledStatement fields in these paths, pre-allocation guarantees a single allocation.
📊 Impact: Eliminates multiple intermediate heap allocations per statement when parsing complex statements, function arguments, or match expressions.
🔬 Measurement: Verify tests still pass safely by running `cargo test` and `cargo clippy`.

---
*PR created automatically by Jules for task [3113924926448704279](https://jules.google.com/task/3113924926448704279) started by @madmax983*