### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-refactor-semantic-analyzer.md
+++ b/docs/adr/016-refactor-semantic-analyzer.md
@@ -1,0 +1,24 @@
+# 016. Refactor Semantic Analyzer into Orchestrator Structure
+
+Date: 2026-03-10
+Status: Accepted
+
+## Context
+
+The `src/semantic/mod.rs` module was orchestrating analysis but also depending on submodules like `control_flow.rs` and `declarations.rs`. These submodules in turn depended on `analyze_statement` from `mod.rs`, creating a circular dependency that made the module structure fragile and tightly coupled.
+
+## Decision
+
+We have decided to break the dependency cycle by extracting the core analysis logic into a new `src/semantic/analyzer.rs` module.
+
+Specifically:
+1.  Extracted the analysis logic into a new `src/semantic/analyzer.rs` module with a `SemanticAnalyzer` struct.
+2.  Defined a `StatementAnalyzer` trait in `src/semantic/traits.rs` to abstract the recursion.
+3.  Updated `control_flow.rs` and `declarations.rs` to accept `&mut impl StatementAnalyzer` instead of calling a concrete function.
+4.  Re-exported the public API from `mod.rs` to maintain backward compatibility.
+
+## Consequences
+
+*   **Acyclic Graph:** The circular dependency is broken. The dependency graph is now a DAG: `mod` -> `analyzer` -> `control_flow` -> `traits`. Submodules are now leaf-like with respect to the analyzer.
+*   **Clearer Boundaries:** By abstracting the recursive analysis step into a trait (`StatementAnalyzer`), the logic is strictly separated between orchestrating the parsing and analyzing specific patterns.
+*   **Backwards Compatibility:** No external API surface was changed since `mod.rs` continues to re-export the required functionality for external consumers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,9 @@ C4Component
     title Component Diagram for Semantic Analysis
 
     Container_Boundary(semantic, "Semantic Analysis") {
-        Component(orchestrator, "Orchestrator", "src/semantic/mod.rs", "Coordinates analysis pipeline")
+        Component(orchestrator, "Orchestrator", "src/semantic/mod.rs", "Facade for public API")
+        Component(analyzer, "Analyzer", "src/semantic/analyzer.rs", "Coordinates analysis pipeline")
+        Component(traits, "Traits", "src/semantic/traits.rs", "Abstracts recursive analysis")
         Component(declarations, "Declarations", "src/semantic/declarations.rs", "Analyzes Types, Traits, Functions")
         Component(control_flow, "Control Flow", "src/semantic/control_flow.rs", "Analyzes If, While, Match")
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
@@ -92,9 +94,14 @@ C4Component
 
     Container(morphology, "Morphology", "src/morphology", "Provides Case/Gender/Number analysis")
 
-    Rel(orchestrator, declarations, "Delegates to")
-    Rel(orchestrator, control_flow, "Delegates to")
-    Rel(orchestrator, conversion, "Delegates to")
+    Rel(orchestrator, analyzer, "Delegates to")
+    Rel(analyzer, declarations, "Delegates to")
+    Rel(analyzer, control_flow, "Delegates to")
+    Rel(analyzer, conversion, "Delegates to")
+
+    Rel(declarations, traits, "Calls back for nested statements")
+    Rel(control_flow, traits, "Calls back for nested statements")
+    Rel(analyzer, traits, "Implements")
 
     Rel(declarations, resolver, "Defines Symbols")
     Rel(declarations, types, "Uses")


### PR DESCRIPTION
🧠 **Decision:** Recorded the architectural refactoring to abstract semantic analysis into the `SemanticAnalyzer` and `StatementAnalyzer` trait, breaking circular dependencies between the core orchestrator and specialized submodules.
🗺️ **Visuals:** Updated the C4 Component diagram in `docs/architecture.md` to accurately represent the new boundaries, specifically adding the `analyzer` and `traits` components and documenting their relationships.
🔗 **Link:** See `docs/adr/016-refactor-semantic-analyzer.md`.

---
*PR created automatically by Jules for task [13092704226651452716](https://jules.google.com/task/13092704226651452716) started by @madmax983*