### PR TITLE
⚡ Bolt: Remove intermediate Vec allocations in extract_failures

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-**Pre-allocate semantic conversions**
-**Learning:** Pre-allocating `Vec` instances based on inner AST node sizes is extremely effective for improving AST generation speed during semantic conversion, directly removing multiple unneeded O(log N) heap allocations.
-**Action:** Implemented pre-allocation `Vec::with_capacity` optimizations in `src/semantic/declarations.rs`.
+**[Replacing .lines().collect() with .lines().peekable()]**
+**Learning:** When parsing text output streams (like from `rustc`), avoid collecting `output.lines()` into an intermediate `Vec<&str>` just to iterate using index variables. This creates an unnecessary O(N) heap allocation. Instead, use a `.peekable()` iterator and process the stream in place, manually managing `.next()` and `.peek()` calls. Be careful with mutable references when using iterator `by_ref()` and `peek()` simultaneously within the same block to avoid borrow checker errors (`cannot borrow as mutable more than once at a time`).
+**Action:** Use `output.lines().peekable()` and a `while let Some(line) = lines.next()` structure for stream processing instead of `Vec` collection.

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -97,27 +97,24 @@ fn parse_test_output(output: &str) -> Vec<TestResult> {
     results
 }
 
+/// Extracts failed tests and their output from `rustc --test` output.
+///
+/// ⚡ Bolt Optimization: Removed intermediate `.collect::<Vec<&str>>()` allocation.
+/// This parses the output stream in-place using a `Peekable` iterator, reducing memory
+/// allocations when test outputs are large.
 fn extract_failures(output: &str) -> Vec<(String, String)> {
     let mut failures = Vec::new();
-    let lines: Vec<&str> = output.lines().collect();
-    let mut i = 0;
+    let mut lines = output.lines().peekable();
 
     // Skip until "failures:"
-    while i < lines.len() {
-        if lines[i].trim() == "failures:" {
+    for line in lines.by_ref() {
+        if line.trim() == "failures:" {
             break;
         }
-        i += 1;
     }
-
-    if i >= lines.len() {
-        return failures;
-    }
-    i += 1;
 
     // Scan for "---- <name> stdout ----"
-    while i < lines.len() {
-        let line = lines[i];
+    while let Some(line) = lines.next() {
         if line.trim().starts_with("----") && line.trim().ends_with("stdout ----") {
             // Extract name: "---- test_name stdout ----"
             let trimmed = line.trim();
@@ -132,10 +129,8 @@ fn extract_failures(output: &str) -> Vec<(String, String)> {
                 .to_string();
 
             // Capture output until next "----" or empty line followed by "failures:"
-            i += 1;
             let mut message = String::new();
-            while i < lines.len() {
-                let current = lines[i];
+            while let Some(current) = lines.peek() {
                 if current.trim().starts_with("----") && current.trim().ends_with("stdout ----") {
                     // Start of next failure
                     break;
@@ -146,12 +141,10 @@ fn extract_failures(output: &str) -> Vec<(String, String)> {
                 }
                 message.push_str(current);
                 message.push('\n');
-                i += 1;
+                lines.next();
             }
             failures.push((name, message.trim().to_string()));
-            continue; // Don't increment i, loop will check current line again
         }
-        i += 1;
     }
 
     failures


### PR DESCRIPTION
💡 What: Removed `.collect::<Vec<&str>>()` chain in `extract_failures` and replaced it with a `Peekable` iterator.
🎯 Why: Collecting lines into a vector creates unnecessary heap allocations. Using an iterator processes the string in-place without memory overhead.
📊 Impact: Eliminates O(N) auxiliary space allocations when parsing large test output streams.
🔬 Measurement: Run `cargo bench` and observe reduced allocations during test execution reporting.

---
*PR created automatically by Jules for task [8982979056871416649](https://jules.google.com/task/8982979056871416649) started by @madmax983*