### PR TITLE
🔒 Warden: Prevent memory exhaustion DoS in Alchemist tool

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -77,3 +77,6 @@ Signed,
 **2024-05-15 - Unbounded File Read DoS in Weave Tool**
 **Threat:** The `run_weave` tool was using `std::fs::read_to_string`, which loads an entire file into memory without limits. An attacker could use a massive file or an infinite stream (like `/dev/zero`) to exhaust memory and crash the application.
 **Defense:** Replaced the unbounded read with the localized safe abstraction `load_source` from `crate::tools::runner::load_source`. `load_source` enforces a strict 1MB size limit by checking metadata and using `take()` on streams, preventing memory exhaustion.
+2024-05-24 - [Unbounded File Read in Alchemist]
+**Threat:** The `run_alchemist` tool used `std::fs::read_to_string`, which loads the entire file into memory without bounds checking. A malicious user could supply a massively large file, leading to memory exhaustion and a Denial of Service (DoS).
+**Defense:** Replaced the direct use of `fs::read_to_string` with `crate::tools::runner::load_source`, which enforces a strict 1MB file size limit and uses `take()` to limit read streams, preventing out-of-memory errors on large or infinite file streams (like `/dev/zero`). Verified with an automated test case (`test_run_alchemist_file_too_large`).

--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -15,7 +15,6 @@ use crate::parser::parse;
 use crate::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, analyze_program,
 };
-use std::fs;
 use std::path::Path;
 
 /// Run the Alchemist tool on a file
@@ -23,8 +22,7 @@ pub fn run_alchemist(input: &Path) -> miette::Result<()> {
     let status =
         crate::tools::ui::Status::start_with_symbol("Χημεία (Transpiling to Python)", "⚗️");
 
-    let source =
-        fs::read_to_string(input).map_err(|e| miette::miette!("Failed to read file: {}", e))?;
+    let source = crate::tools::runner::load_source(input)?;
 
     let ast = parse(&source).map_err(|e| miette::miette!("Parse error: {}", e))?;
     let program = analyze_program(&ast).map_err(|e| miette::miette!("Semantic error: {}", e))?;
@@ -386,5 +384,29 @@ mod tests {
         let py = transpile_code(code);
         assert!(py.contains("def g_προσθεσις(g_α, g_β):"));
         assert!(py.contains("    return (g_α + g_β)"));
+    }
+
+    #[test]
+    fn test_run_alchemist_file_too_large() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("too_large.γλ");
+
+        // Create a file larger than MAX_FILE_SIZE (1MB)
+        let max_size = 1024 * 1024;
+        {
+            use std::io::Write;
+            let mut f = std::fs::File::create(&input_path).unwrap();
+            let data = vec![0u8; max_size + 1];
+            f.write_all(&data).unwrap();
+        }
+
+        let result = run_alchemist(&input_path);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Ἀρχεῖον λίαν μέγα")
+        );
     }
 }


### PR DESCRIPTION
**Threat:** The `run_alchemist` tool used `std::fs::read_to_string`, which loads the entire file into memory without bounds checking. A malicious user could supply a massively large file, leading to memory exhaustion and a Denial of Service (DoS).
**Defense:** Replaced the direct use of `fs::read_to_string` with `crate::tools::runner::load_source`, which enforces a strict 1MB file size limit and uses `take()` to limit read streams, preventing out-of-memory errors on large or infinite file streams (like `/dev/zero`). Verified with an automated test case (`test_run_alchemist_file_too_large`).
**Severity:** High (DoS via memory exhaustion)
**Verification:** Added `test_run_alchemist_file_too_large` unit test that fails in Red Phase and passes in Green Phase. Checked code with `cargo clippy`, `cargo test` and `cargo fmt`. Added a journal entry to `.jules/warden.md`.

---
*PR created automatically by Jules for task [11271255866051287732](https://jules.google.com/task/11271255866051287732) started by @madmax983*