### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -19,3 +19,11 @@
 ## 2025-03-05 - The `cargo test --doc` Dependency Trap
 **Confusion:** Running `rustdoc --test src/codegen.rs` manually failed with unresolved import errors for internal modules like `morphology`, `semantic`, and external crates like `proc_macro2` and `smol_str`. It seemed as if the doc tests were missing imports.
 **Clarification:** Doc tests inside a crate are compiled as external black-box tests. When using `cargo test --doc`, Cargo correctly sets up the environment with `extern crate glossa` and all external dependencies available, meaning you just use `glossa::...` and external crates resolve automatically. Manual `rustdoc` runs lack this crate resolution context. Doc tests should only be verified with `cargo test --doc`.
+
+## 2025-03-11 - The Intra-Doc Link Warning Dilemma
+**Confusion:** The compiler output a warning `public documentation for Scope links to private item ScopeLevel`. Attempting to fix this by making `ScopeLevel` public violates the principle of keeping internal implementations hidden. Attempting to fix it by removing the intra-doc link (`[ScopeLevel]`) violates the Bard directive to use clickable links.
+**Clarification:** You should not expose internal private structs as public API solely to resolve `cargo doc` intra-doc link warnings. Making internal implementation details public is considered an anti-pattern. If a link points to a private item, the warning is acceptable if the alternative compromises the public API surface or explicitly contradicts persona guidelines. In this case, `ScopeLevel` remains private and the warning is tolerated.
+
+## 2025-03-11 - Cohesive Doc Block Structure
+**Confusion:** Adding new sections (like "Why it exists" and "Examples") to existing doc blocks can lead to disjointed reading experiences (e.g., an example, followed by a summary, followed by another example) if the existing block structure is not fully considered.
+**Clarification:** When updating existing rustdoc comments with new sections, reorganize the entire doc block so the top-level summary is at the very beginning, followed by explanatory sections, and ending with the code examples. Do not simply append to the end of an existing block if it breaks the logical flow.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -550,25 +550,59 @@ pub enum UnaryOperator {
     Unwrap,
 }
 
-/// A Greek word with original and normalized forms
+/// Represents a parsed word from the ΓΛΩΣΣΑ source code.
 ///
-/// This struct preserves the original polytonic Greek text (for display)
-/// while providing a normalized version for compiler analysis.
+/// A `Word` in the AST is not just a `String`. Because Ancient Greek has
+/// rich diacritics (accents, breathings) and capitalization, comparing words
+/// directly is error-prone. This struct acts as a bridge between the
+/// human-readable source and the compiler's internal matching logic,
+/// preserving the original polytonic text (for display) while providing
+/// a normalized version for compiler analysis.
 ///
-/// # Examples
+/// ## Why it exists
 ///
-/// ```
+/// In the morphological analysis phase, the compiler needs to look up words
+/// in its lexicon. If a user writes `Ἄνθρωπος` (Capital A, smooth breathing, acute accent),
+/// the compiler must recognize it as the same lemma as `ἄνθρωπος` (lowercase a, smooth, acute)
+/// or even `ανθρωπος` (stripped of all diacritics).
+///
+/// Storing both the `original` string (for exact error reporting) and the `normalized`
+/// string (for lexicon lookups and comparisons) in a single struct solves this problem
+/// at the parsing stage, preventing expensive re-allocations later.
+///
+/// ## Examples
+///
+/// You can construct a `Word` via `Word::new` for convenience, or construct it directly
+/// using [`smol_str::SmolStr`] to avoid heap allocations for small strings.
+///
+/// ```rust
 /// use glossa::ast::Word;
 ///
 /// let word = Word::new("Ἀθῆναι");
-/// assert_eq!(word.original, "Ἀθῆναι");
-/// assert_eq!(word.normalized, "αθηναι");
+/// assert_eq!(word.original.as_str(), "Ἀθῆναι");
+/// assert_eq!(word.normalized.as_str(), "αθηναι");
+/// ```
+///
+/// ```rust
+/// use glossa::ast::Word;
+/// use smol_str::SmolStr;
+///
+/// // Create a word representing the noun "ἄνθρωπος" (man) directly
+/// let man = Word {
+///     original: SmolStr::new("Ἄνθρωπος"),
+///     normalized: SmolStr::new("ανθρωπος"),
+/// };
+///
+/// assert_eq!(man.original.as_str(), "Ἄνθρωπος");
+/// assert_eq!(man.normalized.as_str(), "ανθρωπος");
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Word {
-    /// Original text with diacritics
+    /// The exact string from the source code, preserving case and diacritics.
+    /// Useful for accurate compilation error messages and source maps.
     pub original: SmolStr,
-    /// Normalized (lowercase, no diacritics)
+    /// The lowercase, diacritic-stripped version of the word.
+    /// Used for lexicon lookups, keyword matching, and semantic hashing.
     pub normalized: SmolStr,
 }
 


### PR DESCRIPTION
📖 Chapter: The AST module, specifically the `Word` struct.
🔦 Insight: Explained the critical role `Word` plays as a bridge between human-readable polytonic Ancient Greek and internal compiler lexical matching, detailing *why* both `original` and `normalized` strings are necessary.
🧪 Example: Reorganized the existing doctest and added new context, creating a cohesive, well-structured documentation block.

---
*PR created automatically by Jules for task [16081543466072187390](https://jules.google.com/task/16081543466072187390) started by @madmax983*