### PR TITLE
⚡ Bolt: Optimize Vec allocations in code generation and semantic analysis

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -549,10 +549,15 @@ fn generate_print(args: &[AnalyzedExpr]) -> TokenStream {
     if args.is_empty() {
         quote! { println!(); }
     } else {
-        // Generate format string with {} separated by spaces to avoid runtime Vec allocation
-        let format_str = std::iter::repeat_n("{}", args.len())
-            .collect::<Vec<_>>()
-            .join(" ");
+        // ⚡ Bolt Optimization: Build the format string directly to avoid the O(n) heap
+        // allocation of the intermediate Vec<_> created by .collect::<Vec<_>>().join(" ").
+        let mut format_str = String::with_capacity(args.len() * 3 - 1);
+        for i in 0..args.len() {
+            if i > 0 {
+                format_str.push(' ');
+            }
+            format_str.push_str("{}");
+        }
 
         let arg_tokens: Vec<TokenStream> = args.iter().map(generate_expr).collect();
         quote! { println!(#format_str, #(#arg_tokens),*); }

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -512,18 +512,20 @@ fn extract_parameters_from_expr(
 /// Collect all Word nodes from an expression (flattening phrases)
 fn collect_words_from_expr(expr: &Expr) -> Vec<&crate::ast::Word> {
     let mut words = Vec::new();
+    collect_words_from_expr_into(expr, &mut words);
+    words
+}
 
+fn collect_words_from_expr_into<'a>(expr: &'a Expr, words: &mut Vec<&'a crate::ast::Word>) {
     match expr {
         Expr::Word(word) => words.push(word),
         Expr::Phrase(terms) => {
             for term in terms {
-                words.extend(collect_words_from_expr(term));
+                collect_words_from_expr_into(term, words);
             }
         }
         _ => {}
     }
-
-    words
 }
 
 /// Infer the return type from the function body by examining return statements


### PR DESCRIPTION
💡 What:
- Built the `format_str` in `generate_print` manually using a pre-allocated `String` rather than `iter::repeat().collect::<Vec<_>>().join()`.
- Added `collect_words_from_expr_into` helper in `src/semantic/declarations.rs` to collect AST words into a single shared `Vec` reference.

🎯 Why: 
- `Vec` allocations are relatively expensive, especially in tight recursive loops like AST traversal or within code generation functions that are called frequently.
- `collect::<Vec<_>>().join(" ")` creates an intermediate heap-allocated array strictly to be consumed by `join`, throwing it away immediately.

📊 Impact: 
- Eliminates one `Vec` allocation per `println!` statement translated.
- Eliminates `O(N)` `Vec` allocations (where N is the depth of the AST phrase) during parameter extraction.
- Compile times and runtime memory profiles will be subtly tighter and more robust.

🔬 Measurement:
- Codebase still compiles safely and unit tests run 100% cleanly without logical changes.

---
*PR created automatically by Jules for task [3323326157859924049](https://jules.google.com/task/3323326157859924049) started by @madmax983*