### PR TITLE
🔒 Warden: [security fix] Fix arithmetic overflow panic in Interpreter

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -80,3 +80,7 @@ Signed,
 2024-05-24 - [Unbounded File Read in Alchemist]
 **Threat:** The `run_alchemist` tool used `std::fs::read_to_string`, which loads the entire file into memory without bounds checking. A malicious user could supply a massively large file, leading to memory exhaustion and a Denial of Service (DoS).
 **Defense:** Replaced the direct use of `fs::read_to_string` with `crate::tools::runner::load_source`, which enforces a strict 1MB file size limit and uses `take()` to limit read streams, preventing out-of-memory errors on large or infinite file streams (like `/dev/zero`). Verified with an automated test case (`test_run_alchemist_file_too_large`).
+
+**2024-05-19 - [Interpreter Arithmetic Overflow DoS]
+**Threat:** [Integer overflow in the Simulator interpreter via uncontrolled add, sub, mul, and neg causing unexpected rustc panics.]
+**Defense:** [Replaced unsafe math operations (`+`, `-`, `*`, unary `-`) with `checked_add`, `checked_sub`, `checked_mul`, and `checked_neg` returning a new `EvalError::ArithmeticOverflow` variant instead of panicking.]

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -59,6 +59,9 @@ pub enum EvalError {
     #[error("διαίρεσις διὰ μηδενός (Division by zero)")]
     DivisionByZero,
 
+    #[error("ἀριθμητικὴ ὑπερχείλισις (Arithmetic overflow)")]
+    ArithmeticOverflow,
+
     #[error("μὴ ὑλοποιημένον (Not implemented): {0}")]
     NotImplemented(String),
 }
@@ -179,14 +182,25 @@ impl Interpreter {
     fn eval_bin_op(&self, op: &BinaryOp, left: Value, right: Value) -> Result<Value, EvalError> {
         match (op, &left, &right) {
             // Arithmetic
-            (BinaryOp::Add, Value::Number(l), Value::Number(r)) => Ok(Value::Number(l + r)),
-            (BinaryOp::Sub, Value::Number(l), Value::Number(r)) => Ok(Value::Number(l - r)),
-            (BinaryOp::Mul, Value::Number(l), Value::Number(r)) => Ok(Value::Number(l * r)),
+            (BinaryOp::Add, Value::Number(l), Value::Number(r)) => l
+                .checked_add(*r)
+                .map(Value::Number)
+                .ok_or(EvalError::ArithmeticOverflow),
+            (BinaryOp::Sub, Value::Number(l), Value::Number(r)) => l
+                .checked_sub(*r)
+                .map(Value::Number)
+                .ok_or(EvalError::ArithmeticOverflow),
+            (BinaryOp::Mul, Value::Number(l), Value::Number(r)) => l
+                .checked_mul(*r)
+                .map(Value::Number)
+                .ok_or(EvalError::ArithmeticOverflow),
             (BinaryOp::Div, Value::Number(l), Value::Number(r)) => {
                 if *r == 0 {
                     return Err(EvalError::DivisionByZero);
                 }
-                Ok(Value::Number(l / r))
+                l.checked_div(*r)
+                    .map(Value::Number)
+                    .ok_or(EvalError::ArithmeticOverflow)
             }
 
             // Comparison
@@ -210,7 +224,10 @@ impl Interpreter {
     fn eval_unary_op(&self, op: &UnaryOp, operand: Value) -> Result<Value, EvalError> {
         match (op, operand) {
             (UnaryOp::Not, Value::Boolean(b)) => Ok(Value::Boolean(!b)),
-            (UnaryOp::Neg, Value::Number(n)) => Ok(Value::Number(-n)),
+            (UnaryOp::Neg, Value::Number(n)) => n
+                .checked_neg()
+                .map(Value::Number)
+                .ok_or(EvalError::ArithmeticOverflow),
             _ => Err(EvalError::NotImplemented(format!("Unary op {:?}", op))),
         }
     }

--- a/tests/warden_overflow_sim.rs
+++ b/tests/warden_overflow_sim.rs
@@ -1,0 +1,92 @@
+#![cfg(feature = "nova")]
+use glossa::morphology::lexicon::{BinaryOp, UnaryOp};
+use glossa::semantic::{
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
+};
+use glossa::tools::interpreter::Interpreter;
+
+#[test]
+fn test_warden_overflow_sim_defense() {
+    let mut interpreter = Interpreter::new();
+
+    let cases = vec![
+        // Add max + 1
+        (BinaryOp::Add, i64::MAX, 1),
+        // Sub min - 1
+        (BinaryOp::Sub, i64::MIN, 1),
+        // Mul max * 2
+        (BinaryOp::Mul, i64::MAX, 2),
+        // Div min / -1
+        (BinaryOp::Div, i64::MIN, -1),
+    ];
+
+    for (op, l, r) in cases {
+        let number_expr_l = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(l),
+            glossa_type: GlossaType::Number,
+        };
+        let number_expr_r = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(r),
+            glossa_type: GlossaType::Number,
+        };
+        let bin_expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::BinOp {
+                left: Box::new(number_expr_l),
+                op,
+                right: Box::new(number_expr_r),
+            },
+            glossa_type: GlossaType::Number,
+        };
+
+        let stmt = AnalyzedStatement::Expression(vec![bin_expr]);
+
+        let program = AnalyzedProgram {
+            statements: vec![stmt],
+            scope: Scope::new(),
+        };
+
+        let result = interpreter.run(&program);
+        assert!(
+            result.is_err(),
+            "Interpreter should return an error on overflow instead of panicking"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("overflow") || err.to_string().contains("ὑπερχείλισις"),
+            "Expected overflow error, got: {}",
+            err
+        );
+    }
+
+    // Test Negate i64::MIN
+    let number_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(i64::MIN),
+        glossa_type: GlossaType::Number,
+    };
+    let neg_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::UnaryOp {
+            op: UnaryOp::Neg,
+            operand: Box::new(number_expr),
+        },
+        glossa_type: GlossaType::Number,
+    };
+
+    let stmt2 = AnalyzedStatement::Expression(vec![neg_expr]);
+
+    let program2 = AnalyzedProgram {
+        statements: vec![stmt2],
+        scope: Scope::new(),
+    };
+
+    let result2 = interpreter.run(&program2);
+    assert!(
+        result2.is_err(),
+        "Interpreter should return an error on overflow instead of panicking for unary neg"
+    );
+    let err = result2.unwrap_err();
+    assert!(
+        err.to_string().contains("overflow") || err.to_string().contains("ὑπερχείλισις"),
+        "Expected overflow error, got: {}",
+        err
+    );
+}


### PR DESCRIPTION
🔒 Warden: [security fix] Fix arithmetic overflow panic in Interpreter

**Threat:** Unchecked math operations (+, -, *, /) and unary negation in the `Interpreter` (`glossa sim`) can cause integer overflow panics (e.g., negating `i64::MIN`, `i64::MAX + 1`). Because the `Interpreter` runs these values in memory as the AST is walked, a crafted file can DoS the compiler/interpreter process.
**Defense:** Replaced raw `l + r`, `l - r`, `l * r`, `l / r`, and `-n` operations with `.checked_add()`, `.checked_sub()`, `.checked_mul()`, `.checked_div()`, and `.checked_neg()`. Introduced a new `EvalError::ArithmeticOverflow` variant to gracefully bubble up the error instead of panicking.
**Severity:** High - Can panic the process parsing/evaluating untrusted input.
**Verification:** Added tests simulating overflow bounds for binary and unary operations in `tests/warden_overflow_sim.rs`. All tests pass successfully.

---
*PR created automatically by Jules for task [8277382038390883263](https://jules.google.com/task/8277382038390883263) started by @madmax983*