### PR TITLE
🎸 Bard: Fix intra-doc link to limits in assembly mod

### DIFF
--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -60,7 +60,7 @@
 //! * **Literals**: Max 1024
 //! * **Nested Structures**: Max 256 (Arrays, Blocks, Phrases)
 //!
-//! See [`model`] for the full list of limits.
+//! See [`crate::limits`] for the full list of limits.
 //!
 //! ## The Hero's Journey: A Sentence's Path
 //!


### PR DESCRIPTION
🎸 **Bard: Assembly limits documentation fix**

**📖 Chapter:** `semantic::assembly` module documentation

**🔦 Insight:** The module-level documentation for `src/semantic/assembly/mod.rs` was linking to a private `model` module for the list of limits. This caused a `cargo doc` warning: `public documentation for assembly links to private item model`. Since the compiler-wide limits are properly centralized in `src/limits.rs`, the documentation should point there instead.

**🧪 Example:** Changed `[`model`]` to `[`crate::limits`]`.

**🖼️ Preview:** `cargo doc --no-deps` now runs cleanly without warnings.

---
*PR created automatically by Jules for task [10235273218231897506](https://jules.google.com/task/10235273218231897506) started by @madmax983*