### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-extract-semantic-model.md
+++ b/docs/adr/016-extract-semantic-model.md
@@ -1,0 +1,30 @@
+# 16. Extract Semantic Model
+
+Date: 2026-03-13
+Status: Accepted
+
+## Context
+
+During a structural audit by Atlas, a circular dependency was identified within the Semantic Analysis module ("Breaking The Knot: Semantic Types and Models"). Specifically, `src/semantic/types.rs` depended on `AnalyzedStatement` (located in `src/semantic/mod.rs`) for method bodies, while `mod.rs` depended on `GlossaType` (located in `types.rs`).
+
+This tangle meant the Type System relied directly on the AST it was intended to type, blurring the boundaries between Data (Model), Types (Type System), and Logic (Analysis). This tight coupling made testing and future architectural refactoring fragile.
+
+## Decision
+
+We have decided to strictly separate the structural models from the type system and the analysis logic:
+
+1. Created `src/semantic/model.rs` to serve as a pure data container for all AST nodes (`AnalyzedStatement`, `AnalyzedExpr`) and Semantic Models (`TraitDef`, `TraitImpl`).
+2. Moved `TraitDef` and associated structures from `types.rs` to `model.rs`.
+3. Moved AST nodes from `mod.rs` to `model.rs`.
+4. Refactored `mod.rs` to re-export `model` contents for backward compatibility.
+5. Removed legacy `SemanticAnalyzer` code from `mod.rs` that was duplicating logic unnecessarily.
+
+## Consequences
+
+### Positive
+- **Acyclic Graph**: The circular dependency is broken. The dependency graph is now strictly `model.rs` -> `types.rs`, with `types.rs` functioning as a leaf-level module containing no dependencies on the AST.
+- **Separation of Concerns**: Data (AST), Type System (`GlossaType`), and Analysis Logic are now strictly isolated in their respective modules.
+- **Maintainability**: Future changes to AST structure will not automatically necessitate changes to or trigger rebuilds of the core Type System utilities.
+
+### Negative
+- **Indirection**: Moving types around required updating imports and re-exports, adding slight indirection, though `mod.rs` continues to act as a convenient facade.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ C4Container
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
+        Container(alchemist, "Alchemist", "src/tools/alchemist.rs", "Transpiles Analyzed Program to Python source code")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -47,6 +48,7 @@ C4Container
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(weave, "Weave", "src/tools/weave.rs", "Generates a 'Rosetta Stone' Markdown document")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -62,6 +64,8 @@ C4Container
     Rel(semantic, mosaic, "Analyzed Program")
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")
+    Rel(semantic, alchemist, "Analyzed Program")
+    Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")
@@ -78,7 +82,7 @@ C4Component
     title Component Diagram for Semantic Analysis
 
     Container_Boundary(semantic, "Semantic Analysis") {
-        Component(orchestrator, "Orchestrator", "src/semantic/mod.rs", "Coordinates analysis pipeline")
+        Component(orchestrator, "Orchestrator", "src/semantic/analyzer.rs", "Coordinates analysis pipeline")
         Component(declarations, "Declarations", "src/semantic/declarations.rs", "Analyzes Types, Traits, Functions")
         Component(control_flow, "Control Flow", "src/semantic/control_flow.rs", "Analyzes If, While, Match")
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")


### PR DESCRIPTION
🧠 **Decision:** Recorded the move of AST nodes and semantic structures from `mod.rs` and `types.rs` into `src/semantic/model.rs` to break a circular dependency.
🗺️ **Visuals:** Updated the Semantic Analysis C4 Component diagram to show the new boundaries and `analyzer.rs` orchestrator. Updated the C4 Container diagram to include the `Alchemist` and `Weave` tools.
🔗 **Link:** See `docs/adr/016-extract-semantic-model.md`.

---
*PR created automatically by Jules for task [8681581962054182724](https://jules.google.com/task/8681581962054182724) started by @madmax983*