### PR TITLE
🛡️ Sentry: Add test coverage for tester module

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -553,3 +553,34 @@ mod additional_sentry_tests {
         assert_eq!(results.len(), 0);
     }
 }
+
+#[cfg(test)]
+mod tests_failures {
+    use super::*;
+
+    #[test]
+    fn test_extract_failures_no_matching_start() {
+        let output = "
+failures:
+
+some random text
+no dashed lines here
+
+failures:
+    test_one
+";
+        let failures = extract_failures(output);
+        assert_eq!(failures.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_test_output_various_parts() {
+        let output = "
+test   ... ok
+test name ... ok
+test name with spaces ... ok
+";
+        let results = parse_test_output(output);
+        assert_eq!(results.len(), 2);
+    }
+}

--- a/tests/sentry_tester_tests.rs
+++ b/tests/sentry_tester_tests.rs
@@ -1,0 +1,72 @@
+use glossa::tools::tester::run_tests;
+use std::fs;
+
+#[test]
+fn test_run_tests_integration() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("test_passing.glossa");
+
+    let source = "
+δοκιμή «passing test».
+    ξ 5 ἔστω.
+    ξ 5 ἰσοῦται.
+τέλος.
+";
+    fs::write(&file_path, source).unwrap();
+
+    let result = run_tests(&file_path);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_run_tests_failing_integration() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("test_failing.glossa");
+
+    let source = "
+δοκιμή «failing test».
+    ξ 5 ἔστω.
+    ξ 4 ἰσοῦται.
+τέλος.
+";
+    fs::write(&file_path, source).unwrap();
+
+    let result = run_tests(&file_path);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_run_tests_empty_test_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("test_empty.glossa");
+
+    let source = "
+ξ 5 ἔστω.
+";
+    fs::write(&file_path, source).unwrap();
+
+    let result = run_tests(&file_path);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_run_tests_invalid_input_path() {
+    let result = run_tests(std::path::Path::new("non_existent_file.glossa"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_run_tests_compilation_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("test_compile_err.glossa");
+
+    let source = "
+δοκιμή «compile error».
+    1 2 ἴσον ἔστω.
+τέλος.
+";
+    fs::write(&file_path, source).unwrap();
+
+    let result = run_tests(&file_path);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
🎯 **Target:** `src/tools/tester.rs`
💣 **Risk:** The CLI sub-tool orchestration (`run_tests`) and text-based log scraping logic (`parse_test_output`, `extract_failures`) were largely uncovered, meaning breaking changes to `rustc`'s output format or OS/environment specifics could break test parsing silently. 
🧪 **Strategy:** Integrated tests mapping directly across end-to-end user `run_tests` behaviors (passing, failing, missing file, compilation error) via temporary mock files. Wrote direct boundary unit tests parsing malformed outputs on the log scrapers.
🔬 **Verification:** `cargo test --test 'sentry_tester_tests'` and `cargo llvm-cov`

---
*PR created automatically by Jules for task [17058551237811309373](https://jules.google.com/task/17058551237811309373) started by @madmax983*