### PR TITLE
🪒 Razor: Eliminate `SemanticAnalyzer` struct and `StatementAnalyzer` trait

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -11,85 +11,9 @@ use super::declarations::{
 };
 use super::expressions::contains_function_definition_verb;
 use super::patterns::{try_parse_struct_instantiation, try_parse_trait_method_call};
-use super::{AnalyzedStatement, GlossaType, Scope, StatementAnalyzer, assemble_statement};
+use super::{AnalyzedStatement, GlossaType, Scope, assemble_statement};
 use crate::ast::{Expr, Program, Statement};
 use crate::errors::GlossaError;
-
-/// The Semantic Analyzer orchestrates the semantic analysis process.
-pub struct SemanticAnalyzer;
-
-impl SemanticAnalyzer {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for SemanticAnalyzer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl StatementAnalyzer for SemanticAnalyzer {
-    fn analyze_statement(
-        &mut self,
-        stmt: &Statement,
-        scope: &mut Scope,
-    ) -> Result<Vec<AnalyzedStatement>, GlossaError> {
-        // 1. Check for function definitions
-        if contains_function_definition_verb(stmt)
-            && let Some(func_def) = parse_function_definition(stmt, scope, self)?
-        {
-            // Register the function in the scope
-            if let AnalyzedStatement::FunctionDef {
-                name,
-                params,
-                return_type,
-                ..
-            } = &func_def
-            {
-                let param_types: Vec<GlossaType> = params
-                    .iter()
-                    .map(|(_, ty)| ty.clone().unwrap_or(GlossaType::Unknown))
-                    .collect();
-                scope.define_function(name.clone(), param_types, return_type.clone());
-            }
-            return Ok(vec![func_def]);
-        }
-
-        // 2. Check for control flow (if, while, etc.)
-        if let Some(control_flow) = analyze_control_flow(stmt, scope, self)? {
-            return Ok(vec![control_flow]);
-        }
-
-        // 3. Check for struct instantiation pattern
-        if let Some(struct_inst) = try_parse_struct_instantiation(stmt, scope)? {
-            return Ok(vec![struct_inst]);
-        }
-
-        // 4. Check for trait method call pattern
-        if let Some(method_call) = try_parse_trait_method_call(stmt, scope)? {
-            return Ok(vec![method_call]);
-        }
-
-        // 5. Check if it's a block statement (regular statement containing a single block expression)
-        if let Some(block_stmts) = extract_block_statements(stmt) {
-            let mut analyzed = Vec::new();
-            // Create a child scope for the block
-            // This ensures variables defined inside the block don't leak out
-            let mut block_scope = scope.enter_scope();
-            for s in block_stmts {
-                analyzed.extend(self.analyze_statement(s, &mut block_scope)?);
-            }
-            return Ok(analyzed);
-        }
-
-        // 6. Use the assembler-based approach for regular statements
-        let assembled = assemble_statement(stmt)?;
-        let analyzed = convert_assembled_to_analyzed(&assembled, scope)?;
-        Ok(vec![analyzed])
-    }
-}
 
 /// Analyzed program with resolved names and types
 #[derive(Debug, Clone)]
@@ -128,8 +52,58 @@ pub fn analyze_statement(
     stmt: &Statement,
     scope: &mut Scope,
 ) -> Result<Vec<AnalyzedStatement>, GlossaError> {
-    let mut analyzer = SemanticAnalyzer::new();
-    analyzer.analyze_statement(stmt, scope)
+    // 1. Check for function definitions
+    if contains_function_definition_verb(stmt)
+        && let Some(func_def) = parse_function_definition(stmt, scope)?
+    {
+        // Register the function in the scope
+        if let AnalyzedStatement::FunctionDef {
+            name,
+            params,
+            return_type,
+            ..
+        } = &func_def
+        {
+            let param_types: Vec<GlossaType> = params
+                .iter()
+                .map(|(_, ty)| ty.clone().unwrap_or(GlossaType::Unknown))
+                .collect();
+            scope.define_function(name.clone(), param_types, return_type.clone());
+        }
+        return Ok(vec![func_def]);
+    }
+
+    // 2. Check for control flow (if, while, etc.)
+    if let Some(control_flow) = analyze_control_flow(stmt, scope)? {
+        return Ok(vec![control_flow]);
+    }
+
+    // 3. Check for struct instantiation pattern
+    if let Some(struct_inst) = try_parse_struct_instantiation(stmt, scope)? {
+        return Ok(vec![struct_inst]);
+    }
+
+    // 4. Check for trait method call pattern
+    if let Some(method_call) = try_parse_trait_method_call(stmt, scope)? {
+        return Ok(vec![method_call]);
+    }
+
+    // 5. Check if it's a block statement (regular statement containing a single block expression)
+    if let Some(block_stmts) = extract_block_statements(stmt) {
+        let mut analyzed = Vec::new();
+        // Create a child scope for the block
+        // This ensures variables defined inside the block don't leak out
+        let mut block_scope = scope.enter_scope();
+        for s in block_stmts {
+            analyzed.extend(analyze_statement(s, &mut block_scope)?);
+        }
+        return Ok(analyzed);
+    }
+
+    // 6. Use the assembler-based approach for regular statements
+    let assembled = assemble_statement(stmt)?;
+    let analyzed = convert_assembled_to_analyzed(&assembled, scope)?;
+    Ok(vec![analyzed])
 }
 
 fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
@@ -151,47 +125,34 @@ pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError
     let mut scope = Scope::new();
     // ⚡ Bolt Optimization: Uses `Vec::with_capacity` based on the program statements length to prevent reallocation.
     let mut analyzed_statements = Vec::with_capacity(program.statements.len());
-    let mut analyzer = SemanticAnalyzer::new();
 
     for stmt in &program.statements {
         // Handle type definitions
         if let Statement::TypeDefinition(type_def) = stmt {
-            analyzed_statements.push(analyze_type_definition(
-                type_def,
-                &mut scope,
-                &mut analyzer,
-            )?);
+            analyzed_statements.push(analyze_type_definition(type_def, &mut scope)?);
             continue;
         }
 
         // Handle trait definitions
         if let Statement::TraitDefinition(trait_def) = stmt {
-            analyzed_statements.push(analyze_trait_definition(
-                trait_def,
-                &mut scope,
-                &mut analyzer,
-            )?);
+            analyzed_statements.push(analyze_trait_definition(trait_def, &mut scope)?);
             continue;
         }
 
         // Handle trait implementations
         if let Statement::TraitImpl(trait_impl) = stmt {
-            analyzed_statements.push(analyze_trait_impl(trait_impl, &mut scope, &mut analyzer)?);
+            analyzed_statements.push(analyze_trait_impl(trait_impl, &mut scope)?);
             continue;
         }
 
         // Handle test declarations
         if let Statement::TestDeclaration(test_decl) = stmt {
-            analyzed_statements.push(analyze_test_declaration(
-                test_decl,
-                &mut scope,
-                &mut analyzer,
-            )?);
+            analyzed_statements.push(analyze_test_declaration(test_decl, &mut scope)?);
             continue;
         }
 
         // Use the analyzer for all other statements
-        analyzed_statements.extend(analyzer.analyze_statement(stmt, &mut scope)?);
+        analyzed_statements.extend(analyze_statement(stmt, &mut scope)?);
     }
 
     let analyzed = AnalyzedProgram {

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -7,11 +7,11 @@
 //! - Return (δός)
 //! - Break/Continue (παῦε, συνέχιζε)
 
+use super::analyzer::analyze_statement;
 use super::conversion::convert_assembled_to_analyzed;
 use super::expressions::get_first_word;
 use super::{
-    AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, StatementAnalyzer,
-    assemble_statement,
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, GlossaType, Scope, assemble_statement,
 };
 use crate::ast::{Clause, Expr, Statement};
 use crate::errors::GlossaError;
@@ -23,7 +23,6 @@ use crate::morphology::lexicon;
 pub fn analyze_control_flow(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     // Note: Function definitions are handled in `mod.rs` before calling this.
 
@@ -36,22 +35,22 @@ pub fn analyze_control_flow(
 
     // Conditional: εἰ/ἐάν condition, body [, εἰ δὲ μή, else_body]
     if lexicon::is_conditional_particle(&normalized) {
-        return parse_conditional(stmt, scope, analyzer, 0);
+        return parse_conditional(stmt, scope, 0);
     }
 
     // While loop: ἕως condition, body
     if normalized == "εως" {
-        return parse_while_loop(stmt, scope, analyzer);
+        return parse_while_loop(stmt, scope);
     }
 
     // For loop with range: ἀπὸ start μέχρι/ἕως end, body
     if normalized == "απο" {
-        return parse_for_range_loop(stmt, scope, analyzer);
+        return parse_for_range_loop(stmt, scope);
     }
 
     // For loop with iteration: διὰ collection, body
     if normalized == "δια" {
-        return parse_for_iteration_loop(stmt, scope, analyzer);
+        return parse_for_iteration_loop(stmt, scope);
     }
 
     if lexicon::is_loop_particle(&normalized) {
@@ -60,7 +59,7 @@ pub fn analyze_control_flow(
     }
 
     if lexicon::is_match_particle(&normalized) {
-        return parse_match_expression(stmt, scope, analyzer);
+        return parse_match_expression(stmt, scope);
     }
 
     // Return: δός (give)
@@ -87,7 +86,6 @@ pub fn analyze_control_flow(
 fn parse_while_loop(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -109,7 +107,7 @@ fn parse_while_loop(
     };
 
     // Analyze body using unified helper
-    let body_analyzed = analyzer.analyze_statement(&body_stmt, scope)?;
+    let body_analyzed = analyze_statement(&body_stmt, scope)?;
 
     Ok(Some(AnalyzedStatement::While {
         condition: Box::new(condition_expr),
@@ -122,7 +120,6 @@ fn parse_while_loop(
 fn parse_for_range_loop(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -247,7 +244,7 @@ fn parse_for_range_loop(
         let mut loop_scope = scope.enter_scope();
         loop_scope.define(variable.clone(), GlossaType::Number);
 
-        analyzer.analyze_statement(&body_stmt, &mut loop_scope)?
+        analyze_statement(&body_stmt, &mut loop_scope)?
     };
 
     Ok(Some(AnalyzedStatement::For {
@@ -263,7 +260,6 @@ fn parse_for_range_loop(
 fn parse_for_iteration_loop(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().len() < 2 {
         return Err(GlossaError::semantic(
@@ -337,7 +333,7 @@ fn parse_for_iteration_loop(
         // TODO: Infer element type from collection type
         loop_scope.define(variable.clone(), GlossaType::String);
 
-        analyzer.analyze_statement(&body_stmt, &mut loop_scope)?
+        analyze_statement(&body_stmt, &mut loop_scope)?
     };
 
     Ok(Some(AnalyzedStatement::For {
@@ -353,7 +349,6 @@ fn parse_for_iteration_loop(
 fn parse_match_expression(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if stmt.clauses().is_empty() {
         return Err(GlossaError::semantic(
@@ -401,7 +396,7 @@ fn parse_match_expression(
                 is_query: false,
                 is_propagate: false,
             };
-            let body_analyzed = analyzer.analyze_statement(&body_stmt, scope)?;
+            let body_analyzed = analyze_statement(&body_stmt, scope)?;
 
             arms.push((pattern, body_analyzed));
         }
@@ -580,7 +575,6 @@ fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, G
 fn parse_conditional(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
     depth: usize,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     if depth > MAX_CONTROL_FLOW_DEPTH {
@@ -614,7 +608,7 @@ fn parse_conditional(
             is_query: false,
             is_propagate: false,
         };
-        analyzer.analyze_statement(&stmt, scope)?
+        analyze_statement(&stmt, scope)?
     };
 
     // Check for else/elif clause
@@ -628,7 +622,7 @@ fn parse_conditional(
                 is_query: false,
                 is_propagate: false,
             };
-            Some(analyzer.analyze_statement(&stmt, scope)?)
+            Some(analyze_statement(&stmt, scope)?)
         }
         // Check if it's "εἰ" or "ἐάν" (elif)
         else if check_conditional_start(second_expr) {
@@ -650,8 +644,7 @@ fn parse_conditional(
             };
 
             // Recursively parse as a new conditional (which becomes the else body)
-            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, analyzer, depth + 1)?
-            {
+            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, depth + 1)? {
                 Some(vec![elif_analyzed])
             } else {
                 None
@@ -777,12 +770,10 @@ fn check_conditional_start(expr: &Expr) -> bool {
 mod tests {
     use super::*;
     use crate::ast::{Clause, Expr, Statement, Word};
-    use crate::semantic::analyzer::SemanticAnalyzer;
 
     #[test]
     fn test_for_iteration_error_not_word() {
         let mut scope = Scope::new();
-        let mut analyzer = SemanticAnalyzer::new();
 
         let stmt = Statement::Regular {
             clauses: vec![
@@ -803,7 +794,7 @@ mod tests {
             is_propagate: false,
         };
 
-        let result = analyze_control_flow(&stmt, &mut scope, &mut analyzer);
+        let result = analyze_control_flow(&stmt, &mut scope);
         assert!(result.is_err());
         assert!(
             result
@@ -816,7 +807,6 @@ mod tests {
     #[test]
     fn test_for_iteration_error_missing_collection() {
         let mut scope = Scope::new();
-        let mut analyzer = SemanticAnalyzer::new();
 
         let stmt = Statement::Regular {
             clauses: vec![
@@ -834,7 +824,7 @@ mod tests {
             is_propagate: false,
         };
 
-        let result = analyze_control_flow(&stmt, &mut scope, &mut analyzer);
+        let result = analyze_control_flow(&stmt, &mut scope);
         assert!(result.is_err());
         assert!(
             result
@@ -847,7 +837,6 @@ mod tests {
     #[test]
     fn test_for_iteration_error_not_phrase() {
         let mut scope = Scope::new();
-        let mut analyzer = SemanticAnalyzer::new();
 
         // This requires testing parse_for_iteration_loop directly or bypassing analyze_control_flow
         // Since analyze_control_flow filters on get_first_word (which expects a Phrase),
@@ -868,7 +857,7 @@ mod tests {
             is_propagate: false,
         };
 
-        let result = parse_for_iteration_loop(&stmt, &mut scope, &mut analyzer);
+        let result = parse_for_iteration_loop(&stmt, &mut scope);
         assert!(result.is_err());
         assert!(
             result

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -7,7 +7,8 @@
 //! - Function definitions (ὁρίζειν for functions)
 //! - Test declarations (δοκιμή)
 
-use super::{AnalyzedMethod, AnalyzedStatement, GlossaType, Scope, StatementAnalyzer};
+use super::analyzer::analyze_statement;
+use super::{AnalyzedMethod, AnalyzedStatement, GlossaType, Scope};
 use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
 use crate::morphology::{self};
@@ -35,7 +36,6 @@ use smol_str::SmolStr;
 pub fn analyze_type_definition(
     type_def: &crate::ast::TypeDef,
     scope: &mut Scope,
-    _analyzer: &mut impl StatementAnalyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     // Extract type name
     let type_name = type_def.name.normalized.clone();
@@ -115,7 +115,6 @@ fn check_recursive_type(target_name: &str, ty: &GlossaType) -> bool {
 pub fn analyze_trait_definition(
     trait_def: &crate::ast::TraitDef,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     // Extract trait name
     let trait_name = trait_def.name.normalized.clone();
@@ -156,7 +155,7 @@ pub fn analyze_trait_definition(
                     }
                     // Properly analyze statements in the body using unified helper
                     for body_stmt in body_stmts {
-                        analyzed_body.extend(analyzer.analyze_statement(body_stmt, &mut scope)?);
+                        analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
                     }
                 }
                 Some(analyzed_body)
@@ -216,7 +215,6 @@ pub fn analyze_trait_definition(
 pub fn analyze_trait_impl(
     trait_impl: &crate::ast::TraitImplDef,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     // Extract type and trait names
     let type_name = trait_impl.type_name.normalized.clone();
@@ -262,7 +260,7 @@ pub fn analyze_trait_impl(
 
             // Analyze the method body using unified helper
             for body_stmt in &method.body {
-                analyzed_body.extend(analyzer.analyze_statement(body_stmt, &mut scope)?);
+                analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
             }
         }
 
@@ -347,7 +345,6 @@ pub fn resolve_type_name(name: &str, scope: &Scope) -> Result<GlossaType, Glossa
 pub fn parse_function_definition(
     stmt: &Statement,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
     // The middle dot (·) separates expressions within a clause
     // Structure: expr1 · expr2 where expr1 is "name ὁρίζειν [params]" and expr2 is the body
@@ -400,7 +397,7 @@ pub fn parse_function_definition(
             };
 
             // Analyze each body expression using unified helper
-            body_statements.extend(analyzer.analyze_statement(&clause_stmt, &mut function_scope)?);
+            body_statements.extend(analyze_statement(&clause_stmt, &mut function_scope)?);
         }
     }
 
@@ -542,7 +539,6 @@ pub fn infer_return_type_from_body(body: &[AnalyzedStatement]) -> Option<GlossaT
 pub fn analyze_test_declaration(
     test_decl: &crate::ast::TestDecl,
     scope: &mut Scope,
-    analyzer: &mut impl StatementAnalyzer,
 ) -> Result<AnalyzedStatement, GlossaError> {
     let test_name = test_decl.name.clone();
 
@@ -554,7 +550,7 @@ pub fn analyze_test_declaration(
         let mut test_scope = scope.enter_scope();
 
         for body_stmt in &test_decl.body {
-            analyzed_body.extend(analyzer.analyze_statement(body_stmt, &mut test_scope)?);
+            analyzed_body.extend(analyze_statement(body_stmt, &mut test_scope)?);
         }
     }
 


### PR DESCRIPTION
This PR enforces strict essentialism by simplifying the semantic analysis logic.

## Changes:
- **Removed Single-Implementation Trait:** The `StatementAnalyzer` trait was an unnecessary abstraction used exclusively by `SemanticAnalyzer`.
- **Removed Empty Struct:** `SemanticAnalyzer` contained no fields and only served as a namespace for functions.
- **Standalone Functions:** Promoted `analyze_statement` to a standalone function, matching the rest of the functional semantic analysis pipeline.
- **Signature Cleanup:** Removed the generic `analyzer` parameter from functions across `control_flow.rs` and `declarations.rs`, flattening the architecture and improving module cohesion.

All tests continue to pass with this simplified setup.

---
*PR created automatically by Jules for task [15730132579260935882](https://jules.google.com/task/15730132579260935882) started by @madmax983*