### PR TITLE
🗣️ Echo: Fix getting started example failing to retain types

### DIFF
--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -37,22 +37,19 @@ use crate::semantic::GlossaType;
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
 
-/// A unified symbol entry in the scope
-#[derive(Debug, Clone)]
-pub enum Symbol {
-    Variable(Binding),
-    Function(FunctionSignature),
-    Type(GlossaType),
-    Trait(crate::semantic::model::TraitDef),
-}
-
 /// A scope level containing symbol bindings
 #[derive(Debug, Clone, Default)]
 struct ScopeLevel {
-    /// Symbols defined in this scope.
+    /// Variables defined in this scope.
     /// ⚡ Bolt Optimization: Uses `FxHashMap` instead of the standard `HashMap`
     /// to avoid cryptographic hashing overhead for fast, deterministic lookups of interned strings.
-    symbols: FxHashMap<SmolStr, Symbol>,
+    variables: FxHashMap<SmolStr, Binding>,
+    /// Functions defined in this scope.
+    functions: FxHashMap<SmolStr, FunctionSignature>,
+    /// Types defined in this scope.
+    types: FxHashMap<SmolStr, GlossaType>,
+    /// Traits defined in this scope.
+    traits: FxHashMap<SmolStr, crate::semantic::model::TraitDef>,
     /// Trait implementations in this scope
     trait_impls: Vec<crate::semantic::model::TraitImpl>,
 }
@@ -217,44 +214,44 @@ impl Scope {
         return_type: Option<GlossaType>,
     ) {
         let name = name.into();
-        self.current_level().symbols.insert(
+        self.current_level().functions.insert(
             name.clone(),
-            Symbol::Function(FunctionSignature {
+            FunctionSignature {
                 name,
                 param_types,
                 return_type,
-            }),
+            },
         );
     }
 
     /// Check if a name is a defined function
     pub fn is_function(&self, name: &str) -> bool {
-        self.lookup_symbol(name)
-            .map(|s| matches!(s, Symbol::Function(_)))
-            .unwrap_or(false)
+        self.lookup_function(name).is_some()
     }
 
     /// Look up a function signature
     pub fn lookup_function(&self, name: &str) -> Option<&FunctionSignature> {
-        match self.lookup_symbol(name) {
-            Some(Symbol::Function(sig)) => Some(sig),
-            _ => None,
+        for level in self.levels.iter().rev() {
+            if let Some(sig) = level.functions.get(name) {
+                return Some(sig);
+            }
         }
+        None
     }
 
     /// Define a type in this scope
     pub fn define_type(&mut self, name: impl Into<SmolStr>, glossa_type: GlossaType) {
-        self.current_level()
-            .symbols
-            .insert(name.into(), Symbol::Type(glossa_type));
+        self.current_level().types.insert(name.into(), glossa_type);
     }
 
     /// Look up a type by name
     pub fn lookup_type(&self, name: &str) -> Option<&GlossaType> {
-        match self.lookup_symbol(name) {
-            Some(Symbol::Type(ty)) => Some(ty),
-            _ => None,
+        for level in self.levels.iter().rev() {
+            if let Some(ty) = level.types.get(name) {
+                return Some(ty);
+            }
         }
+        None
     }
 
     /// Define a trait in this scope
@@ -263,17 +260,17 @@ impl Scope {
         name: impl Into<SmolStr>,
         trait_def: crate::semantic::model::TraitDef,
     ) {
-        self.current_level()
-            .symbols
-            .insert(name.into(), Symbol::Trait(trait_def));
+        self.current_level().traits.insert(name.into(), trait_def);
     }
 
     /// Look up a trait by name
     pub fn lookup_trait(&self, name: &str) -> Option<&crate::semantic::model::TraitDef> {
-        match self.lookup_symbol(name) {
-            Some(Symbol::Trait(def)) => Some(def),
-            _ => None,
+        for level in self.levels.iter().rev() {
+            if let Some(def) = level.traits.get(name) {
+                return Some(def);
+            }
         }
+        None
     }
 
     /// Register a trait implementation
@@ -319,14 +316,14 @@ impl Scope {
     /// Define a new binding in this scope
     pub fn define(&mut self, name: impl Into<SmolStr>, glossa_type: GlossaType) {
         let name = name.into();
-        self.current_level().symbols.insert(
+        self.current_level().variables.insert(
             name.clone(),
-            Symbol::Variable(Binding {
+            Binding {
                 name,
                 glossa_type,
                 mutable: false,
                 used: false,
-            }),
+            },
         );
     }
 
@@ -336,22 +333,22 @@ impl Scope {
     /// will shadow the older one until the current `ScopeLevel` is dropped.
     pub fn define_mut(&mut self, name: impl Into<SmolStr>, glossa_type: GlossaType) {
         let name = name.into();
-        self.current_level().symbols.insert(
+        self.current_level().variables.insert(
             name.clone(),
-            Symbol::Variable(Binding {
+            Binding {
                 name,
                 glossa_type,
                 mutable: true,
                 used: false,
-            }),
+            },
         );
     }
 
-    /// Helper to look up any symbol
-    fn lookup_symbol(&self, name: &str) -> Option<&Symbol> {
+    /// Helper to look up any variable
+    fn lookup_variable(&self, name: &str) -> Option<&Binding> {
         for level in self.levels.iter().rev() {
-            if let Some(symbol) = level.symbols.get(name) {
-                return Some(symbol);
+            if let Some(binding) = level.variables.get(name) {
+                return Some(binding);
             }
         }
         None
@@ -363,49 +360,39 @@ impl Scope {
     /// (global). It returns the type of the first matching variable symbol it encounters,
     /// correctly handling variable shadowing.
     pub fn lookup(&self, name: &str) -> Option<&GlossaType> {
-        match self.lookup_symbol(name) {
-            Some(Symbol::Variable(binding)) => Some(&binding.glossa_type),
-            _ => None,
-        }
+        self.lookup_variable(name).map(|b| &b.glossa_type)
     }
 
     /// Look up full binding information by name, searching parent scopes
     pub fn lookup_binding(&self, name: &str) -> Option<&Binding> {
-        match self.lookup_symbol(name) {
-            Some(Symbol::Variable(binding)) => Some(binding),
-            _ => None,
-        }
+        self.lookup_variable(name)
     }
 
-    /// Check if a name is defined in this scope (not parents)
+    /// Check if a variable name is defined in this scope (not parents)
     pub fn is_defined_locally(&self, name: &str) -> bool {
         self.levels
             .last()
-            .map(|l| l.symbols.contains_key(name))
+            .map(|l| l.variables.contains_key(name))
             .unwrap_or(false)
     }
 
-    /// Check if a name is defined anywhere in scope chain
+    /// Check if a variable name is defined anywhere in scope chain
     pub fn is_defined(&self, name: &str) -> bool {
-        // We only check for variables with this method typically,
-        // but let's check for any symbol as name collision prevents definition
-        self.lookup_symbol(name).is_some()
+        self.lookup_variable(name).is_some()
+            || self.lookup_function(name).is_some()
+            || self.lookup_type(name).is_some()
+            || self.lookup_trait(name).is_some()
     }
 
     /// Get all bindings in this scope (from all levels)
     pub fn bindings(&self) -> impl Iterator<Item = (&SmolStr, &Binding)> {
-        self.levels.iter().flat_map(|l| {
-            l.symbols.iter().filter_map(|(k, v)| match v {
-                Symbol::Variable(b) => Some((k, b)),
-                _ => None,
-            })
-        })
+        self.levels.iter().flat_map(|l| l.variables.iter())
     }
 
     /// Mark a binding as used
     pub fn mark_used(&mut self, name: &str) {
         for level in self.levels.iter_mut().rev() {
-            if let Some(Symbol::Variable(binding)) = level.symbols.get_mut(name) {
+            if let Some(binding) = level.variables.get_mut(name) {
                 binding.used = true;
                 return;
             }
@@ -416,43 +403,24 @@ impl Scope {
     pub fn unused_bindings(&self) -> Vec<&Binding> {
         self.levels
             .iter()
-            .flat_map(|l| l.symbols.values())
-            .filter_map(|s| match s {
-                Symbol::Variable(b) => Some(b),
-                _ => None,
-            })
+            .flat_map(|l| l.variables.values())
             .filter(|b| !b.used)
             .collect()
     }
 
     /// Get all functions defined in this scope
     pub fn functions(&self) -> impl Iterator<Item = &FunctionSignature> {
-        self.levels.iter().flat_map(|l| {
-            l.symbols.values().filter_map(|s| match s {
-                Symbol::Function(f) => Some(f),
-                _ => None,
-            })
-        })
+        self.levels.iter().flat_map(|l| l.functions.values())
     }
 
     /// Get all types defined in this scope
     pub fn types(&self) -> impl Iterator<Item = (&SmolStr, &GlossaType)> {
-        self.levels.iter().flat_map(|l| {
-            l.symbols.iter().filter_map(|(k, v)| match v {
-                Symbol::Type(t) => Some((k, t)),
-                _ => None,
-            })
-        })
+        self.levels.iter().flat_map(|l| l.types.iter())
     }
 
     /// Get all traits defined in this scope
     pub fn traits(&self) -> impl Iterator<Item = (&SmolStr, &crate::semantic::model::TraitDef)> {
-        self.levels.iter().flat_map(|l| {
-            l.symbols.iter().filter_map(|(k, v)| match v {
-                Symbol::Trait(t) => Some((k, t)),
-                _ => None,
-            })
-        })
+        self.levels.iter().flat_map(|l| l.traits.iter())
     }
 }
 
@@ -621,21 +589,21 @@ mod tests {
 
     #[test]
     fn test_shadowing_across_types() {
-        // This is a new test ensuring single namespace behavior
+        // This is a new test ensuring separate namespace behavior
         let mut scope = Scope::new();
         scope.define_type("Τ".to_string(), GlossaType::Number);
 
         // Should find as type
         assert!(scope.lookup_type("Τ").is_some());
 
-        // Shadow with variable
+        // Define variable with same name
         scope.define("Τ".to_string(), GlossaType::String);
 
         // Should find as variable
         assert!(scope.lookup("Τ").is_some());
 
-        // Should NOT find as type anymore (shadowed by variable)
-        assert!(scope.lookup_type("Τ").is_none());
+        // Should STILL find as type (separate namespace)
+        assert!(scope.lookup_type("Τ").is_some());
     }
 
     #[test]
@@ -701,11 +669,11 @@ mod tests {
         // Verify it is a function
         assert!(scope.is_function(name));
 
-        // Overwrite with variable (shadowing)
+        // Define variable with same name
         scope.define(name.to_string(), GlossaType::Number);
 
-        // Should now be a variable, not a function (in lookups specific to functions)
-        assert!(!scope.is_function(name));
+        // Should still be a function (separate namespace)
+        assert!(scope.is_function(name));
         assert!(scope.lookup(name).is_some());
     }
 }


### PR DESCRIPTION
🗣️ Echo: Getting Started example is broken
    
🤦 The Confusion: I tried to generate the map using `cargo run --release --features nova -- map examples/quickstart.γλ` and it printed "No architectural structures (Structs) found" even though the file contains `εἶδος Χρήστης ὁρίζειν`.

🕵️ The Reality: Because `Χρήστης` and `χρήστης` normalize to the same characters (`χρηστης`), defining the variable instance was silently wiping out the type declaration due to a shared namespace map in `ScopeLevel`.

💡 The Fix: Separated `symbols` into `variables`, `functions`, `types`, and `traits` within `ScopeLevel`. Now variables and types with structurally identical normalized names safely coexist.

---
*PR created automatically by Jules for task [4718642783290230228](https://jules.google.com/task/4718642783290230228) started by @madmax983*