### PR TITLE
⚡ Bolt: [performance improvement] check_else_pattern_in_expression

### DIFF
--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -2399,7 +2399,6 @@ pub fn is_else_pattern(normalized_phrase: &str) -> bool {
     normalized_phrase == "ει δε μη"
 }
 
-
 /// Check if a word is a loop particle
 pub fn is_loop_particle(normalized_word: &str) -> bool {
     matches!(normalized_word, "εως" | "δια")

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -2392,9 +2392,16 @@ pub fn is_conditional_particle(normalized_word: &str) -> bool {
     matches!(normalized_word, "ει" | "εαν" | "ην" | "αν")
 }
 
+pub const ELSE_PATTERN_WORDS: [&str; 3] = ["ει", "δε", "μη"];
+
 /// Check if a sequence is the else pattern (εἰ δὲ μή)
 pub fn is_else_pattern(normalized_phrase: &str) -> bool {
     normalized_phrase == "ει δε μη"
+}
+
+/// Check if an array of words matches the else pattern.
+pub fn is_else_pattern_words(words: &[&str]) -> bool {
+    words == ELSE_PATTERN_WORDS
 }
 
 /// Check if a word is a loop particle

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -2399,10 +2399,6 @@ pub fn is_else_pattern(normalized_phrase: &str) -> bool {
     normalized_phrase == "ει δε μη"
 }
 
-/// Check if an array of words matches the else pattern.
-pub fn is_else_pattern_words(words: &[&str]) -> bool {
-    words == ELSE_PATTERN_WORDS
-}
 
 /// Check if a word is a loop particle
 pub fn is_loop_particle(normalized_word: &str) -> bool {

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -721,26 +721,22 @@ fn skip_first_word_and_parse(
 }
 
 /// Check if a clause starts with "εἰ δὲ μή" (else pattern)
+/// ⚡ Bolt Optimization: Avoids heap allocations (`.collect::<Vec<String>>()`, `.join(" ")`)
+/// by checking the normalized strings directly from the iterator.
 fn check_else_pattern_in_expression(expr: &Expr) -> bool {
-    // Extract first 3 words from the expression
-    let words: Vec<String> = if let Expr::Phrase(terms) = expr {
-        terms
-            .iter()
-            .take(3)
-            .filter_map(|term| {
-                if let Expr::Word(w) = term {
-                    Some(w.normalized.to_string())
-                } else {
-                    None
-                }
-            })
-            .collect()
-    } else {
-        vec![]
-    };
+    if let Expr::Phrase(terms) = expr {
+        let mut words = terms.iter().filter_map(|term| {
+            if let Expr::Word(w) = term {
+                Some(w.normalized.as_str())
+            } else {
+                None
+            }
+        });
 
-    let phrase = words.join(" ");
-    lexicon::is_else_pattern(&phrase)
+        words.next() == Some("ει") && words.next() == Some("δε") && words.next() == Some("μη")
+    } else {
+        false
+    }
 }
 
 /// Check if an expression starts with a conditional particle (εἰ or ἐάν)

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -725,7 +725,7 @@ fn skip_first_word_and_parse(
 /// by checking the normalized strings directly from the iterator.
 fn check_else_pattern_in_expression(expr: &Expr) -> bool {
     if let Expr::Phrase(terms) = expr {
-        let mut words = terms.iter().filter_map(|term| {
+        let mut words = terms.iter().take(3).filter_map(|term| {
             if let Expr::Word(w) = term {
                 Some(w.normalized.as_str())
             } else {
@@ -733,7 +733,9 @@ fn check_else_pattern_in_expression(expr: &Expr) -> bool {
             }
         });
 
-        words.next() == Some("ει") && words.next() == Some("δε") && words.next() == Some("μη")
+        words.next() == Some(lexicon::ELSE_PATTERN_WORDS[0])
+            && words.next() == Some(lexicon::ELSE_PATTERN_WORDS[1])
+            && words.next() == Some(lexicon::ELSE_PATTERN_WORDS[2])
     } else {
         false
     }
@@ -862,5 +864,11 @@ mod tests {
                 .to_string()
                 .contains("Expected phrase in for iteration")
         );
+    }
+
+    #[test]
+    fn test_check_else_pattern_not_phrase() {
+        let expr = Expr::NumberLiteral(42);
+        assert!(!super::check_else_pattern_in_expression(&expr));
     }
 }


### PR DESCRIPTION
💡 **What:** Replaced the heap-allocating `check_else_pattern_in_expression` function inside `src/semantic/control_flow.rs` with a zero-cost abstraction using an iterator directly against the first three words (`ει δε μη`).

🎯 **Why:** The previous implementation collected the first 3 tokens into a `Vec<String>` and then joined them into a new `String` every single time it evaluated an expression to check if it was an `else` block (`εἰ δὲ μή`).

📊 **Impact:** Removes two unneeded heap allocations (a `Vec` and a `String`) per conditional statement parsed.

🔬 **Measurement:** `cargo test` passes. Behavior remains identical while avoiding heap overhead during semantic analysis.

---
*PR created automatically by Jules for task [10968730509622881286](https://jules.google.com/task/10968730509622881286) started by @madmax983*