### PR TITLE
🗺️ Atlas: Centralize limit checks in Assembler

### DIFF
--- a/get_lines.py
+++ b/get_lines.py
@@ -1,0 +1,13 @@
+import sys
+
+def get_lines(filename, start_line, num_lines):
+    with open(filename, 'r') as f:
+        lines = f.readlines()
+
+    end_line = min(start_line + num_lines, len(lines))
+
+    for i in range(start_line - 1, end_line - 1):
+        print(f"{i+1}: {lines[i]}", end='')
+
+if __name__ == "__main__":
+    get_lines(sys.argv[1], int(sys.argv[2]), int(sys.argv[3]))

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -141,6 +141,18 @@ pub struct Assembler {
 }
 
 impl Assembler {
+    /// Helper to enforce resource limits within the state.
+    fn check_limit(len: usize, max: usize, resource: &str) -> Result<(), AssemblyError> {
+        if len >= max {
+            Err(AssemblyError::LimitExceeded {
+                resource: resource.to_string(),
+                max,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
     /// Create a new empty assembler
     ///
     /// # Examples
@@ -247,12 +259,7 @@ impl Assembler {
     /// asm.feed_string("χαῖρε".to_string()).unwrap();
     /// ```
     pub fn feed_string(&mut self, value: String) -> Result<(), AssemblyError> {
-        if self.state.literals.len() >= MAX_LITERALS {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Literals".to_string(),
-                max: MAX_LITERALS,
-            });
-        }
+        Self::check_limit(self.state.literals.len(), MAX_LITERALS, "Literals")?;
         self.state.literals.push(Literal::String(value));
         Ok(())
     }
@@ -268,12 +275,7 @@ impl Assembler {
     /// asm.feed_number(42).unwrap();
     /// ```
     pub fn feed_number(&mut self, value: i64) -> Result<(), AssemblyError> {
-        if self.state.literals.len() >= MAX_LITERALS {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Literals".to_string(),
-                max: MAX_LITERALS,
-            });
-        }
+        Self::check_limit(self.state.literals.len(), MAX_LITERALS, "Literals")?;
         self.state.literals.push(Literal::Number(value));
         Ok(())
     }
@@ -289,12 +291,7 @@ impl Assembler {
     /// asm.feed_boolean(true).unwrap();
     /// ```
     pub fn feed_boolean(&mut self, value: bool) -> Result<(), AssemblyError> {
-        if self.state.literals.len() >= MAX_LITERALS {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Literals".to_string(),
-                max: MAX_LITERALS,
-            });
-        }
+        Self::check_limit(self.state.literals.len(), MAX_LITERALS, "Literals")?;
         self.state.literals.push(Literal::Boolean(value));
         Ok(())
     }
@@ -312,12 +309,7 @@ impl Assembler {
     /// asm.feed_array(elements).unwrap();
     /// ```
     pub fn feed_array(&mut self, elements: Vec<Expr>) -> Result<(), AssemblyError> {
-        if self.state.arrays.len() >= MAX_ARRAYS {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Arrays".to_string(),
-                max: MAX_ARRAYS,
-            });
-        }
+        Self::check_limit(self.state.arrays.len(), MAX_ARRAYS, "Arrays")?;
         self.state.arrays.push(elements);
         Ok(())
     }
@@ -336,12 +328,7 @@ impl Assembler {
         &mut self,
         statements: Vec<crate::ast::Statement>,
     ) -> Result<(), AssemblyError> {
-        if self.state.blocks.len() >= MAX_BLOCKS {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Blocks".to_string(),
-                max: MAX_BLOCKS,
-            });
-        }
+        Self::check_limit(self.state.blocks.len(), MAX_BLOCKS, "Blocks")?;
         self.state.blocks.push(statements);
         Ok(())
     }
@@ -358,12 +345,11 @@ impl Assembler {
     /// asm.feed_nested_phrase(vec![Expr::NumberLiteral(1)]).unwrap();
     /// ```
     pub fn feed_nested_phrase(&mut self, terms: Vec<Expr>) -> Result<(), AssemblyError> {
-        if self.state.nested_phrases.len() >= MAX_NESTED_PHRASES {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Nested Phrases".to_string(),
-                max: MAX_NESTED_PHRASES,
-            });
-        }
+        Self::check_limit(
+            self.state.nested_phrases.len(),
+            MAX_NESTED_PHRASES,
+            "Nested Phrases",
+        )?;
         self.state.nested_phrases.push(terms);
         Ok(())
     }
@@ -386,12 +372,11 @@ impl Assembler {
     /// asm.feed_index_access(array, index).unwrap();
     /// ```
     pub fn feed_index_access(&mut self, array: Expr, index: Expr) -> Result<(), AssemblyError> {
-        if self.state.index_accesses.len() >= MAX_INDEX_ACCESSES {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Index Accesses".to_string(),
-                max: MAX_INDEX_ACCESSES,
-            });
-        }
+        Self::check_limit(
+            self.state.index_accesses.len(),
+            MAX_INDEX_ACCESSES,
+            "Index Accesses",
+        )?;
         self.state.index_accesses.push((array, index));
         Ok(())
     }
@@ -413,12 +398,7 @@ impl Assembler {
     /// asm.feed_unwrap(expr).unwrap();
     /// ```
     pub fn feed_unwrap(&mut self, expr: Expr) -> Result<(), AssemblyError> {
-        if self.state.unwraps.len() >= MAX_UNWRAPS {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Unwraps".to_string(),
-                max: MAX_UNWRAPS,
-            });
-        }
+        Self::check_limit(self.state.unwraps.len(), MAX_UNWRAPS, "Unwraps")?;
         self.state.unwraps.push(expr);
         Ok(())
     }
@@ -448,12 +428,7 @@ impl Assembler {
         analysis: &crate::morphology::ParticipleAnalysis,
         original: &str,
     ) -> Result<(), AssemblyError> {
-        if self.state.participles.len() >= MAX_PARTICIPLES {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Participles".to_string(),
-                max: MAX_PARTICIPLES,
-            });
-        }
+        Self::check_limit(self.state.participles.len(), MAX_PARTICIPLES, "Participles")?;
         let normalized = normalize_greek(original);
         let constituent = ParticipleConstituent {
             // OPTIMIZATION: verb_lemma() returns a normalized string
@@ -509,12 +484,7 @@ impl Assembler {
 
         if self.state.subject.is_some() {
             // Additional nominatives stored separately for function call patterns
-            if self.state.nominatives.len() >= MAX_NOMINATIVES {
-                return Err(AssemblyError::LimitExceeded {
-                    resource: "Nominatives".to_string(),
-                    max: MAX_NOMINATIVES,
-                });
-            }
+            Self::check_limit(self.state.nominatives.len(), MAX_NOMINATIVES, "Nominatives")?;
             self.state.nominatives.push(constituent);
         } else {
             self.state.subject = Some(constituent);
@@ -541,12 +511,7 @@ impl Assembler {
 
     fn handle_genitive(&mut self, constituent: Constituent) -> Result<(), AssemblyError> {
         // Genitives attach to other constituents (possession, etc.)
-        if self.state.genitives.len() >= MAX_GENITIVES {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Genitives".to_string(),
-                max: MAX_GENITIVES,
-            });
-        }
+        Self::check_limit(self.state.genitives.len(), MAX_GENITIVES, "Genitives")?;
         self.state.genitives.push(constituent);
         Ok(())
     }
@@ -621,12 +586,7 @@ impl Assembler {
             person: None, // Adjectives don't really have person
         };
 
-        if self.state.adjectives.len() >= MAX_ADJECTIVES {
-            return Err(AssemblyError::LimitExceeded {
-                resource: "Adjectives".to_string(),
-                max: MAX_ADJECTIVES,
-            });
-        }
+        Self::check_limit(self.state.adjectives.len(), MAX_ADJECTIVES, "Adjectives")?;
         self.state.adjectives.push(constituent);
         Ok(())
     }
@@ -717,12 +677,11 @@ impl Assembler {
             && matches!(self.state.literals.last(), Some(Literal::String(_)))
         {
             if let Some(ref subj) = self.state.subject {
-                if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
-                    return Err(AssemblyError::LimitExceeded {
-                        resource: "Property Accesses".to_string(),
-                        max: MAX_PROPERTY_ACCESSES,
-                    });
-                }
+                Self::check_limit(
+                    self.state.property_accesses.len(),
+                    MAX_PROPERTY_ACCESSES,
+                    "Property Accesses",
+                )?;
 
                 let delim = match self.state.literals.pop() {
                     Some(Literal::String(s)) => s,
@@ -763,22 +722,12 @@ impl Assembler {
     fn check_operators(&mut self, normalized: &str, original: &str) -> Result<bool, AssemblyError> {
         // Boolean operators
         if matches!(original, "καί" | "και") {
-            if self.state.operators.len() >= MAX_OPERATORS {
-                return Err(AssemblyError::LimitExceeded {
-                    resource: "Operators".to_string(),
-                    max: MAX_OPERATORS,
-                });
-            }
+            Self::check_limit(self.state.operators.len(), MAX_OPERATORS, "Operators")?;
             self.state.operators.push(BinaryOp::And);
             return Ok(true);
         }
         if matches!(original, "ἤ" | "ή") {
-            if self.state.operators.len() >= MAX_OPERATORS {
-                return Err(AssemblyError::LimitExceeded {
-                    resource: "Operators".to_string(),
-                    max: MAX_OPERATORS,
-                });
-            }
+            Self::check_limit(self.state.operators.len(), MAX_OPERATORS, "Operators")?;
             // ἤ with breathing+accent, but not ᾖ
             self.state.operators.push(BinaryOp::Or);
             return Ok(true);
@@ -786,24 +735,14 @@ impl Assembler {
 
         // Comparison operators
         if let Some(op) = crate::morphology::lexicon::comparison_operator(normalized) {
-            if self.state.operators.len() >= MAX_OPERATORS {
-                return Err(AssemblyError::LimitExceeded {
-                    resource: "Operators".to_string(),
-                    max: MAX_OPERATORS,
-                });
-            }
+            Self::check_limit(self.state.operators.len(), MAX_OPERATORS, "Operators")?;
             self.state.operators.push(op);
             return Ok(true);
         }
 
         // Arithmetic operators
         if let Some(op) = crate::morphology::lexicon::arithmetic_operator(normalized) {
-            if self.state.operators.len() >= MAX_OPERATORS {
-                return Err(AssemblyError::LimitExceeded {
-                    resource: "Operators".to_string(),
-                    max: MAX_OPERATORS,
-                });
-            }
+            Self::check_limit(self.state.operators.len(), MAX_OPERATORS, "Operators")?;
             self.state.operators.push(op);
             return Ok(true);
         }
@@ -823,12 +762,11 @@ impl Assembler {
         if crate::morphology::lexicon::is_length_property(normalized) {
             // If we have a subject, create a property access (use normalized original, not lemma)
             if let Some(ref subj) = self.state.subject {
-                if self.state.property_accesses.len() >= MAX_PROPERTY_ACCESSES {
-                    return Err(AssemblyError::LimitExceeded {
-                        resource: "Property Accesses".to_string(),
-                        max: MAX_PROPERTY_ACCESSES,
-                    });
-                }
+                Self::check_limit(
+                    self.state.property_accesses.len(),
+                    MAX_PROPERTY_ACCESSES,
+                    "Property Accesses",
+                )?;
                 // OPTIMIZATION: Use stored normalized form
                 self.state
                     .property_accesses
@@ -844,12 +782,11 @@ impl Assembler {
             if let Some(ref subj) = self.state.subject
                 && let Some(index) = crate::morphology::lexicon::ordinal_to_index(normalized)
             {
-                if self.state.index_accesses.len() >= MAX_INDEX_ACCESSES {
-                    return Err(AssemblyError::LimitExceeded {
-                        resource: "Index Accesses".to_string(),
-                        max: MAX_INDEX_ACCESSES,
-                    });
-                }
+                Self::check_limit(
+                    self.state.index_accesses.len(),
+                    MAX_INDEX_ACCESSES,
+                    "Index Accesses",
+                )?;
                 // Create array and index expressions (use normalized original, not lemma)
                 // OPTIMIZATION: Use stored normalized form
                 let array = Expr::Word(Word {


### PR DESCRIPTION
🕸️ Tangle: The `Assembler` struct in `src/semantic/assembly/mod.rs` repeatedly implemented identical bounds-checking logic across 19 different methods. This copy-pasted `if self.state.resource.len() >= MAX { return Err(AssemblyError::LimitExceeded ...) }` logic violated DRY principles and reduced code readability.
📐 Blueprint: Extracted the bounds-checking logic into a reusable `check_limit` helper method on the `Assembler` struct. Refactored all 19 occurrences to utilize the `?` early-return operator.
🧱 Stability: Reduced structural boilerplate. The behavior and error handling remain functionally identical.
🔬 Verification: Builds successfully, all limit-exceeded and standard test cases pass, zero Clippy warnings.

---
*PR created automatically by Jules for task [8694838155587473502](https://jules.google.com/task/8694838155587473502) started by @madmax983*