### PR TITLE
📜 Codex: ADRs for Alchemist & Weave and Architecture Diagram Update

### DIFF
--- a/docs/adr/016-add-alchemist-tool.md
+++ b/docs/adr/016-add-alchemist-tool.md
@@ -1,0 +1,21 @@
+# 16. Add Alchemist Tool
+
+Date: 2026-03-14
+Status: Proposed
+
+## Context
+
+The compiler's primary backend targets Rust. However, there is a need to prove the independence of the semantic phase from the Rust codegen phase, as well as a desire to have a dynamic target that aligns well with the "scripting" feel of small ΓΛΩΣΣΑ programs.
+
+## Decision
+
+We have introduced an experimental transpiler called "Alchemist" (`src/tools/alchemist.rs`) that converts ΓΛΩΣΣΑ programs into Python scripts.
+
+## Consequences
+
+### Positive
+- **Backend Independence**: Proves that the semantic phase is truly independent of the Rust codegen phase.
+- **Dynamic Target**: Offers a secondary, dynamic code generation target (Python) that can be useful for scripting and rapid prototyping.
+
+### Negative
+- **Maintenance Burden**: Introduces an additional backend that must be maintained and kept in sync with the primary semantic analysis phase and language features.

--- a/docs/adr/017-add-weave-tool.md
+++ b/docs/adr/017-add-weave-tool.md
@@ -1,0 +1,21 @@
+# 17. Add Weave Tool
+
+Date: 2026-03-14
+Status: Proposed
+
+## Context
+
+As the project scales, users and learners need a way to export their codebase into a structured, readable Markdown format for documentation and educational purposes, making it easier to see how Greek syntax maps to semantic meaning and compiled Rust code.
+
+## Decision
+
+We have implemented the "Weave" functionality (`src/tools/weave.rs`), an exporter that generates a 'Rosetta Stone' Markdown document combining Glossa source code, semantic assembly logic, and generated Rust code.
+
+## Consequences
+
+### Positive
+- **Educational Value**: Greatly enhances the educational aspect by creating a direct, visual mapping between the source, its assembly, and its final code.
+- **Documentation Aid**: Allows users to quickly generate documentation demonstrating how the language compiles.
+
+### Negative
+- **Dependency on Mosaic and Codegen**: Tightly couples this tool to the internal structure of both the Mosaic assembly visualization tool and the Rust codegen system.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ C4Container
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
+        Container(alchemist, "Alchemist", "src/tools/alchemist.rs", "Experimental Python transpiler")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -47,6 +48,7 @@ C4Container
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(weave, "Weave", "src/tools/weave.rs", "Generates Rosetta Stone Markdown document")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -55,6 +57,7 @@ C4Container
     Rel(parser, morphology, "AST (Unresolved)")
     Rel(parser, highlight, "AST (Unresolved)")
     Rel(morphology, semantic, "AST (Resolved Morphology)")
+    Rel(semantic, alchemist, "Analyzed Program")
     Rel(semantic, report, "Analyzed Program")
     Rel(semantic, narrator, "Analyzed Program")
     Rel(semantic, cartographer, "Analyzed Program")
@@ -62,6 +65,7 @@ C4Container
     Rel(semantic, mosaic, "Analyzed Program")
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")
+    Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")


### PR DESCRIPTION
**🧠 Decision:** Recorded the creation of `alchemist` (Python transpiler) and `weave` (Rosetta Stone Markdown exporter) tools in `docs/adr/`.
**🗺️ Visuals:** Updated C4 Container Diagram in `docs/architecture.md` to map the new tools to the Developer Experience boundary.
**🔗 Link:** See `docs/adr/016-add-alchemist-tool.md` and `docs/adr/017-add-weave-tool.md`.

---
*PR created automatically by Jules for task [5335920572374432009](https://jules.google.com/task/5335920572374432009) started by @madmax983*