### PR TITLE
🪒 Razor: Implement manual Debug for Expr to fix stack overflow

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -107,3 +107,8 @@
 **Bloat:** The `StatementAnalyzer` trait was introduced to resolve a circular dependency between `semantic::analyzer`, `semantic::control_flow`, and `semantic::declarations`. However, since these modules all live within the same crate (`semantic`), Rust permits circular module dependencies natively via free functions, rendering the trait abstraction unnecessary. Additionally, `StatementAnalyzer` was a single-implementation trait only implemented by the empty struct `SemanticAnalyzer`.
 **Cut:** Deleted the `StatementAnalyzer` trait and the `SemanticAnalyzer` struct entirely. Replaced trait method dispatch across submodules with direct calls to `crate::semantic::analyzer::analyze_statement`.
 **Saved:** Eliminated trait boilerplate, reduced the number of files by deleting `src/semantic/traits.rs`, and removed empty struct allocations, significantly reducing cognitive overhead by flattening the semantic analysis architecture.
+
+## [Reduction]
+**Bloat:** Derived `Debug` on deeply recursive `Expr` enum triggered stack overflows.
+**Cut:** Replaced derived `Debug` with a manual implementation wrapped in `stacker::maybe_grow`.
+**Saved:** Prevented application crashes; eliminated silent DoS vulnerability during error reporting.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -231,7 +231,6 @@ impl Statement {
 ///
 /// Expressions represent values that can be evaluated.
 /// They include literals, variable references, operations, and function calls.
-#[derive(Debug)]
 pub enum Expr {
     /// A string literal: «text»
     ///
@@ -323,6 +322,52 @@ pub enum Expr {
 
     /// A block of statements in braces { ... }
     Block(Vec<Statement>),
+}
+
+impl std::fmt::Debug for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Prevent stack overflow on deep formatting
+        stacker::maybe_grow(32 * 1024, 1024 * 1024, || match self {
+            Expr::StringLiteral(s) => f.debug_tuple("StringLiteral").field(s).finish(),
+            Expr::NumberLiteral(n) => f.debug_tuple("NumberLiteral").field(n).finish(),
+            Expr::BooleanLiteral(b) => f.debug_tuple("BooleanLiteral").field(b).finish(),
+            Expr::ArrayLiteral(v) => f.debug_tuple("ArrayLiteral").field(v).finish(),
+            Expr::IndexAccess { array, index } => f
+                .debug_struct("IndexAccess")
+                .field("array", array)
+                .field("index", index)
+                .finish(),
+            Expr::Word(w) => f.debug_tuple("Word").field(w).finish(),
+            Expr::Phrase(v) => f.debug_tuple("Phrase").field(v).finish(),
+            Expr::PropertyAccess { owner, property } => f
+                .debug_struct("PropertyAccess")
+                .field("owner", owner)
+                .field("property", property)
+                .finish(),
+            Expr::Call { verb, arguments } => f
+                .debug_struct("Call")
+                .field("verb", verb)
+                .field("arguments", arguments)
+                .finish(),
+            Expr::Binding { name, value } => f
+                .debug_struct("Binding")
+                .field("name", name)
+                .field("value", value)
+                .finish(),
+            Expr::BinOp { left, op, right } => f
+                .debug_struct("BinOp")
+                .field("left", left)
+                .field("op", op)
+                .field("right", right)
+                .finish(),
+            Expr::UnaryOp { op, operand } => f
+                .debug_struct("UnaryOp")
+                .field("op", op)
+                .field("operand", operand)
+                .finish(),
+            Expr::Block(stmts) => f.debug_tuple("Block").field(stmts).finish(),
+        })
+    }
 }
 
 impl Clone for Expr {

--- a/tests/ast_coverage_tests.rs
+++ b/tests/ast_coverage_tests.rs
@@ -239,6 +239,55 @@ fn test_expr_drop() {
 }
 
 #[test]
+fn test_expr_debug_format() {
+    let w = Word::new("λέγε");
+
+    let all_exprs = vec![
+        Expr::StringLiteral("test".to_string()),
+        Expr::NumberLiteral(42),
+        Expr::BooleanLiteral(true),
+        Expr::ArrayLiteral(vec![Expr::NumberLiteral(1)]),
+        Expr::IndexAccess {
+            array: Box::new(Expr::ArrayLiteral(vec![Expr::NumberLiteral(2)])),
+            index: Box::new(Expr::NumberLiteral(0)),
+        },
+        Expr::Word(w.clone()),
+        Expr::Phrase(vec![Expr::NumberLiteral(3)]),
+        Expr::PropertyAccess {
+            owner: Box::new(Expr::Word(w.clone())),
+            property: Box::new(Expr::Word(w.clone())),
+        },
+        Expr::Call {
+            verb: w.clone(),
+            arguments: vec![Expr::NumberLiteral(4)],
+        },
+        Expr::Binding {
+            name: w.clone(),
+            value: Box::new(Expr::NumberLiteral(5)),
+        },
+        Expr::BinOp {
+            left: Box::new(Expr::NumberLiteral(6)),
+            op: BinOperator::Add,
+            right: Box::new(Expr::NumberLiteral(7)),
+        },
+        Expr::UnaryOp {
+            op: UnaryOperator::Not,
+            operand: Box::new(Expr::BooleanLiteral(false)),
+        },
+        Expr::Block(vec![Statement::Regular {
+            clauses: vec![],
+            is_query: false,
+            is_propagate: false,
+        }]),
+    ];
+
+    for expr in all_exprs {
+        let debug_str = format!("{:?}", expr);
+        assert!(!debug_str.is_empty());
+    }
+}
+
+#[test]
 fn test_deep_expr_drop() {
     let mut expr = Expr::BooleanLiteral(true);
     for _ in 0..1000 {

--- a/tests/havoc_debug_crash.rs
+++ b/tests/havoc_debug_crash.rs
@@ -30,13 +30,13 @@ fn havoc_crash_debug_stack_overflow() {
         println!("Formatting deep expression (depth {})...", depth);
         let _s = format!("{:?}", deep_expr);
 
-        // This line will never be reached!
-        println!("Survived? Impossible.");
+        // If the bug is fixed, we will reach this line and exit with success (0)
+        println!("Survived! The bug is fixed.");
         std::process::exit(0);
     }
 
     // Otherwise, we are the test runner orchestrator.
-    // Spawn a subprocess to run this exact test, and verify it CRASHES.
+    // Spawn a subprocess to run this exact test, and verify it SUCCEEDS.
     let exe = env::current_exe().expect("Failed to get current executable");
 
     let status = Command::new(exe)
@@ -46,9 +46,9 @@ fn havoc_crash_debug_stack_overflow() {
         .status()
         .expect("Failed to spawn subprocess");
 
-    // The test SUCCEEDS if the subprocess FAILED (crashed via SIGSEGV/Stack Overflow)
+    // The test SUCCEEDS if the subprocess SUCCEEDS (does NOT crash with Stack Overflow)
     assert!(
-        !status.success(),
-        "Bug fixed? The subprocess should have crashed with a stack overflow!"
+        status.success(),
+        "Bug is still present! The subprocess crashed with a stack overflow!"
     );
 }


### PR DESCRIPTION
# 🪒 Razor: Implement manual Debug for Expr to fix stack overflow

Replaced the derived `Debug` on the deeply recursive `Expr` enum with a manual implementation wrapped in `stacker::maybe_grow`. This prevents process crashes (Stack Overflow) when printing deeply nested syntax trees during error reporting. 

Updated the regression test in `tests/havoc_debug_crash.rs` to assert success and added a reduction entry to the Razor journal.

---
*PR created automatically by Jules for task [14171094982064398076](https://jules.google.com/task/14171094982064398076) started by @madmax983*