### PR TITLE
🪒 Razor: Fix Stack Overflow in derived Debug for Expr

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -231,7 +231,6 @@ impl Statement {
 ///
 /// Expressions represent values that can be evaluated.
 /// They include literals, variable references, operations, and function calls.
-#[derive(Debug)]
 pub enum Expr {
     /// A string literal: «text»
     ///
@@ -323,6 +322,51 @@ pub enum Expr {
 
     /// A block of statements in braces { ... }
     Block(Vec<Statement>),
+}
+
+impl std::fmt::Debug for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        stacker::maybe_grow(32 * 1024, 1024 * 1024, || match self {
+            Expr::StringLiteral(s) => f.debug_tuple("StringLiteral").field(s).finish(),
+            Expr::NumberLiteral(n) => f.debug_tuple("NumberLiteral").field(n).finish(),
+            Expr::BooleanLiteral(b) => f.debug_tuple("BooleanLiteral").field(b).finish(),
+            Expr::ArrayLiteral(arr) => f.debug_tuple("ArrayLiteral").field(arr).finish(),
+            Expr::IndexAccess { array, index } => f
+                .debug_struct("IndexAccess")
+                .field("array", array)
+                .field("index", index)
+                .finish(),
+            Expr::Word(w) => f.debug_tuple("Word").field(w).finish(),
+            Expr::Phrase(p) => f.debug_tuple("Phrase").field(p).finish(),
+            Expr::PropertyAccess { owner, property } => f
+                .debug_struct("PropertyAccess")
+                .field("owner", owner)
+                .field("property", property)
+                .finish(),
+            Expr::Call { verb, arguments } => f
+                .debug_struct("Call")
+                .field("verb", verb)
+                .field("arguments", arguments)
+                .finish(),
+            Expr::Binding { name, value } => f
+                .debug_struct("Binding")
+                .field("name", name)
+                .field("value", value)
+                .finish(),
+            Expr::BinOp { left, op, right } => f
+                .debug_struct("BinOp")
+                .field("left", left)
+                .field("op", op)
+                .field("right", right)
+                .finish(),
+            Expr::UnaryOp { op, operand } => f
+                .debug_struct("UnaryOp")
+                .field("op", op)
+                .field("operand", operand)
+                .finish(),
+            Expr::Block(stmts) => f.debug_tuple("Block").field(stmts).finish(),
+        })
+    }
 }
 
 impl Clone for Expr {

--- a/tests/ast_coverage_tests.rs
+++ b/tests/ast_coverage_tests.rs
@@ -50,6 +50,55 @@ fn test_expr_clone() {
 }
 
 #[test]
+fn test_expr_debug() {
+    let w = Word::new("λέγε");
+
+    let all_exprs = vec![
+        Expr::StringLiteral("test".to_string()),
+        Expr::NumberLiteral(42),
+        Expr::BooleanLiteral(true),
+        Expr::ArrayLiteral(vec![Expr::NumberLiteral(1)]),
+        Expr::IndexAccess {
+            array: Box::new(Expr::ArrayLiteral(vec![Expr::NumberLiteral(2)])),
+            index: Box::new(Expr::NumberLiteral(0)),
+        },
+        Expr::Word(w.clone()),
+        Expr::Phrase(vec![Expr::NumberLiteral(3)]),
+        Expr::PropertyAccess {
+            owner: Box::new(Expr::Word(w.clone())),
+            property: Box::new(Expr::Word(w.clone())),
+        },
+        Expr::Call {
+            verb: w.clone(),
+            arguments: vec![Expr::NumberLiteral(4)],
+        },
+        Expr::Binding {
+            name: w.clone(),
+            value: Box::new(Expr::NumberLiteral(5)),
+        },
+        Expr::BinOp {
+            left: Box::new(Expr::NumberLiteral(6)),
+            op: BinOperator::Add,
+            right: Box::new(Expr::NumberLiteral(7)),
+        },
+        Expr::UnaryOp {
+            op: UnaryOperator::Not,
+            operand: Box::new(Expr::BooleanLiteral(false)),
+        },
+        Expr::Block(vec![Statement::Regular {
+            clauses: vec![],
+            is_query: false,
+            is_propagate: false,
+        }]),
+    ];
+
+    for expr in &all_exprs {
+        let debug_str = format!("{:?}", expr);
+        assert!(!debug_str.is_empty());
+    }
+}
+
+#[test]
 fn test_expr_eq_different_types() {
     let w = Word::new("λέγε");
 

--- a/tests/havoc_debug_crash.rs
+++ b/tests/havoc_debug_crash.rs
@@ -46,9 +46,9 @@ fn havoc_crash_debug_stack_overflow() {
         .status()
         .expect("Failed to spawn subprocess");
 
-    // The test SUCCEEDS if the subprocess FAILED (crashed via SIGSEGV/Stack Overflow)
+    // The test SUCCEEDS if the subprocess SUCCEEDS (it no longer crashes!)
     assert!(
-        !status.success(),
-        "Bug fixed? The subprocess should have crashed with a stack overflow!"
+        status.success(),
+        "Bug persists! The subprocess should NOT have crashed."
     );
 }


### PR DESCRIPTION
Fixed a stack overflow bug by manually implementing `std::fmt::Debug` for the `Expr` enum using `stacker::maybe_grow`. This matches the recursion protection already used in the `Clone`, `Drop`, and `PartialEq` implementations. I also updated the `havoc_crash_debug_stack_overflow` test to assert success rather than failure.

---
*PR created automatically by Jules for task [14236340666800202182](https://jules.google.com/task/14236340666800202182) started by @madmax983*