### PR TITLE
👺 Havoc: AST Debug format stack overflow panic

### DIFF
--- a/tests/havoc_debug_panic.rs
+++ b/tests/havoc_debug_panic.rs
@@ -1,0 +1,10 @@
+use glossa::ast::Expr;
+
+#[test]
+fn test_debug_stack_overflow() {
+    let mut expr = Expr::NumberLiteral(1);
+    for _ in 0..20000 {
+        expr = Expr::Phrase(vec![expr]);
+    }
+    let _debug_str = format!("{:?}", expr);
+}


### PR DESCRIPTION
🧨 **The Trigger:** Deeply nested `Expr::Phrase` node passed to `format!("{:?}", expr)` causing a recursion stack overflow because `#[derive(Debug)]` generates un-protected recursive code.

📉 **The Stack Trace:** 
thread 'test_debug_stack_overflow' has overflowed its stack
fatal runtime error: stack overflow, aborting
(SIGABRT: process abort signal)

🧪 **Reproduction:** Run `cargo test --test havoc_debug_panic`. This test programmatically constructs a deeply recursive tree (`Expr::Phrase(Expr::Phrase(Expr::Phrase(...)))`) up to 20,000 elements, then calls `format!("{:?}", expr)`.

😈 **Comment:** "You thought your custom Drop and Clone implementations protected you against deep syntax trees. But you forgot that developers like to log their syntax trees! The system panics trying to log its own failure."

---
*PR created automatically by Jules for task [17374163176998826727](https://jules.google.com/task/17374163176998826727) started by @madmax983*