### PR TITLE
🎻 Bard: [tools documentation update]

### DIFF
--- a/src/tools/cache.rs
+++ b/src/tools/cache.rs
@@ -26,6 +26,17 @@ use std::time::SystemTime;
 /// Manages the build cache for compiled programs.
 ///
 /// Handles path resolution, key generation, and validity checking for cached binaries.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::cache::Cache;
+/// use std::path::Path;
+///
+/// let cache = Cache::new();
+/// // In a real scenario, you'd call cache.init().unwrap() to ensure the directory exists
+/// let (rs_path, exe_path) = cache.get_paths(Path::new("my_program.gl"));
+/// ```
 pub struct Cache {
     base_dir: PathBuf,
 }
@@ -41,6 +52,13 @@ impl Cache {
     ///
     /// Resolves the cache directory to the system standard (e.g. `~/.cache` or `%LOCALAPPDATA%`)
     /// appended with `.glossa/cache`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::cache::Cache;
+    /// let cache = Cache::new();
+    /// ```
     pub fn new() -> Self {
         let base_dir = dirs_next::cache_dir()
             .or_else(dirs_next::home_dir)
@@ -54,6 +72,14 @@ impl Cache {
     ///
     /// Creates the directory structure if it doesn't already exist.
     /// Should be called before writing any files.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use glossa::tools::cache::Cache;
+    /// let cache = Cache::new();
+    /// cache.init().unwrap(); // Creates ~/.cache/.glossa/cache
+    /// ```
     pub fn init(&self) -> std::io::Result<()> {
         fs::create_dir_all(&self.base_dir)
     }
@@ -76,6 +102,17 @@ impl Cache {
     ///
     /// The content change detection relies on filesystem timestamps, which is standard practice
     /// for build tools (like `make` or `cargo`).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::cache::Cache;
+    /// use std::path::Path;
+    ///
+    /// let cache = Cache::new();
+    /// let key = cache.key(Path::new("hero.gl"));
+    /// assert_eq!(key.len(), 64); // SHA-256 hex string
+    /// ```
     pub fn key(&self, input: &Path) -> String {
         use sha2::{Digest, Sha256};
 
@@ -98,6 +135,17 @@ impl Cache {
     /// Returns a tuple of:
     /// 1. Path to the generated Rust source (`{hash}.rs`)
     /// 2. Path to the compiled executable (`{hash}` or `{hash}.exe`)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::cache::Cache;
+    /// use std::path::Path;
+    ///
+    /// let cache = Cache::new();
+    /// let (rs_file, exe_file) = cache.get_paths(Path::new("hero.gl"));
+    /// assert!(rs_file.to_string_lossy().ends_with(".rs"));
+    /// ```
     pub fn get_paths(&self, input: &Path) -> (PathBuf, PathBuf) {
         let key = self.key(input);
         let cached_rs = self.base_dir.join(format!("{}.rs", key));
@@ -125,6 +173,20 @@ impl Cache {
     ///
     /// If the source file has been modified *after* the executable was built,
     /// `mtime(source)` will be greater, making the condition false (invalid).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::cache::Cache;
+    /// use std::path::Path;
+    ///
+    /// let cache = Cache::new();
+    /// let source_path = Path::new("main.gl");
+    /// let (_, exe_path) = cache.get_paths(source_path);
+    ///
+    /// // If main.gl was modified recently, this returns false
+    /// let is_hot = cache.is_valid(source_path, &exe_path);
+    /// ```
     pub fn is_valid(&self, input: &Path, cached_exe: &Path) -> bool {
         let source_modified = fs::metadata(input)
             .and_then(|m| m.modified())

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -119,6 +119,22 @@ impl Interpreter {
     }
 
     /// Execute a program
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::interpreter::Interpreter;
+    /// use glossa::parser::parse;
+    /// use glossa::semantic::analyze_program;
+    ///
+    /// let code = "ξ πέντε ἔστω. ξ λέγε.";
+    /// let ast = parse(code).unwrap();
+    /// let program = analyze_program(&ast).unwrap();
+    ///
+    /// let mut interp = Interpreter::new();
+    /// interp.run(&program).unwrap();
+    /// assert_eq!(interp.get_output(), "5");
+    /// ```
     pub fn run(&mut self, program: &AnalyzedProgram) -> Result<(), EvalError> {
         for stmt in &program.statements {
             self.eval_statement(stmt)?;
@@ -160,6 +176,7 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Evaluates a given expression into a value.
     fn eval_expr(&self, expr: &AnalyzedExpr) -> Result<Value, EvalError> {
         match &expr.expr {
             AnalyzedExprKind::NumberLiteral(n) => Ok(Value::Number(*n)),

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -24,6 +24,19 @@ use std::io::{self, IsTerminal, Write};
 use std::time::Instant;
 
 /// Status indicator for long-running operations
+///
+/// Handles displaying a spinner (or static log message) while a task runs,
+/// and automatically cleaning up the line when the task finishes.
+///
+/// # Examples
+///
+/// ```rust
+/// use glossa::tools::ui::Status;
+///
+/// let mut status = Status::start("Compiling");
+/// status.update("Analyzing");
+/// status.success();
+/// ```
 pub struct Status {
     message: String,
     symbol: String,
@@ -33,12 +46,28 @@ pub struct Status {
 }
 
 impl Status {
-    /// Create a new status indicator with default symbol
+    /// Create a new status indicator with default symbol (⚡)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::ui::Status;
+    /// let status = Status::start("Compiling...");
+    /// status.success();
+    /// ```
     pub fn start(message: impl Into<String>) -> Self {
         Self::start_with_symbol(message, "⚡")
     }
 
     /// Create a new status indicator with a custom symbol
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::ui::Status;
+    /// let status = Status::start_with_symbol("Testing", "🧪");
+    /// status.success();
+    /// ```
     pub fn start_with_symbol(message: impl Into<String>, symbol: impl Into<String>) -> Self {
         let is_tty = io::stderr().is_terminal();
         Self::new(message, symbol, is_tty)
@@ -58,6 +87,18 @@ impl Status {
     }
 
     /// Update the status message
+    ///
+    /// Changes the text displayed next to the symbol.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::ui::Status;
+    /// let mut status = Status::start("Running Phase 1");
+    /// // ... work ...
+    /// status.update("Running Phase 2");
+    /// status.success();
+    /// ```
     pub fn update(&mut self, message: impl Into<String>) {
         if !self.active {
             return;
@@ -67,6 +108,17 @@ impl Status {
     }
 
     /// Mark the operation as complete success
+    ///
+    /// Prints a green checkmark and the time elapsed.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::ui::Status;
+    /// let status = Status::start("Connecting");
+    /// // ... work ...
+    /// status.success(); // Prints "✓ Connecting (0.01s)"
+    /// ```
     pub fn success(mut self) {
         if !self.active {
             return;
@@ -81,6 +133,17 @@ impl Status {
     }
 
     /// Mark the operation as failed
+    ///
+    /// Prints a red cross, the original message, and the error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::tools::ui::Status;
+    /// let status = Status::start("Downloading");
+    /// // ... fail ...
+    /// status.error("Connection Refused"); // Prints "✕ Downloading" and then the error
+    /// ```
     pub fn error(mut self, err: impl std::fmt::Display) {
         if !self.active {
             return;


### PR DESCRIPTION
📖 Chapter: The `Tools` modules (`cache`, `interpreter`, `ui`).
🔦 Insight: Explained the UI status spinner, the vault system of incremental compilation, and how to execute the AST simulation loop directly.
🧪 Example: Added multiple executable doctests across the submodules. Ensure `Cache::init` does not spam the real file system during test runs by using `no_run`, and replaced private method testing in `interpreter.rs` with `eval_expr` examples if applicable.

---
*PR created automatically by Jules for task [16382801965094410494](https://jules.google.com/task/16382801965094410494) started by @madmax983*