### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -321,4 +321,23 @@ mod tests {
         let err = GlossaError::semantic("test");
         assert_eq!(err.category_greek(), "Σημασία");
     }
+
+    #[test]
+    fn test_parse_with_source() {
+        use miette::SourceSpan;
+        let span = SourceSpan::new(5.into(), 1_usize);
+        let err = GlossaError::parse_with_source("invalid variable name", "ἔστω x 5", span);
+        if let GlossaError::ParseError {
+            message,
+            src,
+            span: err_span,
+        } = err
+        {
+            assert_eq!(message, "invalid variable name");
+            assert_eq!(src, "ἔστω x 5");
+            assert_eq!(err_span, Some(span));
+        } else {
+            panic!("Expected ParseError");
+        }
+    }
 }

--- a/src/tools/cache.rs
+++ b/src/tools/cache.rs
@@ -199,3 +199,15 @@ impl Cache {
         exe_modified > source_modified
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_default() {
+        let cache = Cache::default();
+        // Just assert it initializes without panicking.
+        assert!(cache.base_dir.ends_with("cache"));
+    }
+}


### PR DESCRIPTION
**Target:** 
- `GlossaError::parse_with_source` constructor in `src/errors/mod.rs`
- `Default` trait implementation for `Cache` in `src/tools/cache.rs`

**Risk:** 
- Unverified error constructor behavior can lead to incorrect diagnostic span or message assignments which break user experience.
- Unverified cache default initialization logic.

**Strategy:** 
- Added a targeted unit test (`test_parse_with_source`) to assert proper struct population inside the `GlossaError::ParseError` variant.
- Added a unit test (`test_cache_default`) to ensure `Cache::default()` instantiates correctly without panicking and creates the expected directory path suffix.

**Verification:** 
- Run `cargo test` and verify that `errors::tests::test_parse_with_source` and `tools::cache::tests::test_cache_default` both pass successfully.

---
*PR created automatically by Jules for task [1458844125925289747](https://jules.google.com/task/1458844125925289747) started by @madmax983*