### PR TITLE
🔒 Warden: Fix Stack Overflow in derived Debug on recursive AST enums

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -84,3 +84,7 @@ Signed,
 **2024-05-19 - [Interpreter Arithmetic Overflow DoS]
 **Threat:** [Integer overflow in the Simulator interpreter via uncontrolled add, sub, mul, and neg causing unexpected rustc panics.]
 **Defense:** [Replaced unsafe math operations (`+`, `-`, `*`, unary `-`) with `checked_add`, `checked_sub`, `checked_mul`, and `checked_neg` returning a new `EvalError::ArithmeticOverflow` variant instead of panicking.]
+
+**2025-03-01 - [Stack Overflow in Derived Debug on Recursive Enums]**
+**Threat:** DoS via Stack Overflow. The `Expr`, `Statement`, `Clause`, and `Program` enums in `src/ast.rs` are recursive. While `Drop`, `Clone`, and `PartialEq` used `stacker::maybe_grow`, `Debug` was auto-derived (`#[derive(Debug)]`), meaning printing a deeply nested AST (e.g. during error formatting) bypassed all checks and crashed the thread.
+**Defense:** Removed `#[derive(Debug)]` and manually implemented `std::fmt::Debug` for all recursive AST nodes using `stacker::maybe_grow` to securely handle deep nesting during formatting.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -41,14 +41,24 @@ use smol_str::SmolStr;
 /// A complete GLOSSA program
 ///
 /// The root of the Abstract Syntax Tree, containing a sequence of statements.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Program {
     /// The list of top-level statements in the program.
     pub statements: Vec<Statement>,
 }
 
+impl std::fmt::Debug for Program {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        stacker::maybe_grow(32 * 1024, 1024 * 1024, || {
+            f.debug_struct("Program")
+                .field("statements", &self.statements)
+                .finish()
+        })
+    }
+}
+
 /// A single statement, ending with . (statement), ? (query), or ; (propagate)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum Statement {
     /// A regular statement with clauses
     ///
@@ -173,10 +183,41 @@ pub struct TestDecl {
 }
 
 /// A clause within a statement (comma-separated)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Clause {
     /// Expressions in this clause (chained with middle dot)
     pub expressions: Vec<Expr>,
+}
+
+impl std::fmt::Debug for Clause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        stacker::maybe_grow(32 * 1024, 1024 * 1024, || {
+            f.debug_struct("Clause")
+                .field("expressions", &self.expressions)
+                .finish()
+        })
+    }
+}
+
+impl std::fmt::Debug for Statement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        stacker::maybe_grow(32 * 1024, 1024 * 1024, || match self {
+            Statement::Regular {
+                clauses,
+                is_query,
+                is_propagate,
+            } => f
+                .debug_struct("Regular")
+                .field("clauses", clauses)
+                .field("is_query", is_query)
+                .field("is_propagate", is_propagate)
+                .finish(),
+            Statement::TypeDefinition(td) => f.debug_tuple("TypeDefinition").field(td).finish(),
+            Statement::TraitDefinition(td) => f.debug_tuple("TraitDefinition").field(td).finish(),
+            Statement::TraitImpl(ti) => f.debug_tuple("TraitImpl").field(ti).finish(),
+            Statement::TestDeclaration(td) => f.debug_tuple("TestDeclaration").field(td).finish(),
+        })
+    }
 }
 
 impl Statement {
@@ -231,7 +272,6 @@ impl Statement {
 ///
 /// Expressions represent values that can be evaluated.
 /// They include literals, variable references, operations, and function calls.
-#[derive(Debug)]
 pub enum Expr {
     /// A string literal: «text»
     ///
@@ -323,6 +363,51 @@ pub enum Expr {
 
     /// A block of statements in braces { ... }
     Block(Vec<Statement>),
+}
+
+impl std::fmt::Debug for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        stacker::maybe_grow(32 * 1024, 1024 * 1024, || match self {
+            Expr::StringLiteral(s) => f.debug_tuple("StringLiteral").field(s).finish(),
+            Expr::NumberLiteral(n) => f.debug_tuple("NumberLiteral").field(n).finish(),
+            Expr::BooleanLiteral(b) => f.debug_tuple("BooleanLiteral").field(b).finish(),
+            Expr::ArrayLiteral(v) => f.debug_tuple("ArrayLiteral").field(v).finish(),
+            Expr::IndexAccess { array, index } => f
+                .debug_struct("IndexAccess")
+                .field("array", array)
+                .field("index", index)
+                .finish(),
+            Expr::Word(w) => f.debug_tuple("Word").field(w).finish(),
+            Expr::Phrase(v) => f.debug_tuple("Phrase").field(v).finish(),
+            Expr::PropertyAccess { owner, property } => f
+                .debug_struct("PropertyAccess")
+                .field("owner", owner)
+                .field("property", property)
+                .finish(),
+            Expr::Call { verb, arguments } => f
+                .debug_struct("Call")
+                .field("verb", verb)
+                .field("arguments", arguments)
+                .finish(),
+            Expr::Binding { name, value } => f
+                .debug_struct("Binding")
+                .field("name", name)
+                .field("value", value)
+                .finish(),
+            Expr::BinOp { left, op, right } => f
+                .debug_struct("BinOp")
+                .field("left", left)
+                .field("op", op)
+                .field("right", right)
+                .finish(),
+            Expr::UnaryOp { op, operand } => f
+                .debug_struct("UnaryOp")
+                .field("op", op)
+                .field("operand", operand)
+                .finish(),
+            Expr::Block(stmts) => f.debug_tuple("Block").field(stmts).finish(),
+        })
+    }
 }
 
 impl Clone for Expr {

--- a/tests/ast_coverage_tests.rs
+++ b/tests/ast_coverage_tests.rs
@@ -251,6 +251,101 @@ fn test_deep_expr_drop() {
     drop(expr);
 }
 #[test]
+fn test_expr_debug_formatting() {
+    let exprs = vec![
+        Expr::StringLiteral("test".to_string()),
+        Expr::NumberLiteral(42),
+        Expr::BooleanLiteral(true),
+        Expr::ArrayLiteral(vec![Expr::NumberLiteral(1)]),
+        Expr::IndexAccess {
+            array: Box::new(Expr::Word(Word::new("arr"))),
+            index: Box::new(Expr::NumberLiteral(0)),
+        },
+        Expr::Word(Word::new("word")),
+        Expr::Phrase(vec![Expr::Word(Word::new("phrase"))]),
+        Expr::PropertyAccess {
+            owner: Box::new(Expr::Word(Word::new("obj"))),
+            property: Box::new(Expr::Word(Word::new("prop"))),
+        },
+        Expr::Call {
+            verb: Word::new("call"),
+            arguments: vec![Expr::NumberLiteral(1)],
+        },
+        Expr::Binding {
+            name: Word::new("var"),
+            value: Box::new(Expr::NumberLiteral(1)),
+        },
+        Expr::BinOp {
+            left: Box::new(Expr::NumberLiteral(1)),
+            op: BinOperator::Add,
+            right: Box::new(Expr::NumberLiteral(2)),
+        },
+        Expr::UnaryOp {
+            op: UnaryOperator::Not,
+            operand: Box::new(Expr::BooleanLiteral(true)),
+        },
+        Expr::Block(vec![Statement::Regular {
+            clauses: vec![],
+            is_query: false,
+            is_propagate: false,
+        }]),
+    ];
+
+    for expr in exprs {
+        let s = format!("{:?}", expr);
+        assert!(!s.is_empty());
+    }
+}
+
+#[test]
+fn test_statement_debug_formatting() {
+    let stmts = vec![
+        Statement::Regular {
+            clauses: vec![Clause {
+                expressions: vec![Expr::NumberLiteral(1)],
+            }],
+            is_query: true,
+            is_propagate: false,
+        },
+        Statement::TypeDefinition(TypeDef {
+            name: Word::new("Type"),
+            fields: vec![],
+        }),
+        Statement::TraitDefinition(TraitDef {
+            name: Word::new("Trait"),
+            methods: vec![],
+        }),
+        Statement::TraitImpl(TraitImplDef {
+            type_name: Word::new("Type"),
+            trait_name: Word::new("Trait"),
+            methods: vec![],
+        }),
+        Statement::TestDeclaration(TestDecl {
+            name: "test".to_string(),
+            body: vec![],
+        }),
+    ];
+
+    for stmt in stmts {
+        let s = format!("{:?}", stmt);
+        assert!(!s.is_empty());
+    }
+}
+
+#[test]
+fn test_program_debug_formatting() {
+    let prog = Program {
+        statements: vec![Statement::Regular {
+            clauses: vec![],
+            is_query: false,
+            is_propagate: false,
+        }],
+    };
+    let s = format!("{:?}", prog);
+    assert!(s.contains("Program"));
+}
+
+#[test]
 fn test_statement_methods() {
     let stmt = Statement::Regular {
         clauses: vec![],

--- a/tests/havoc_debug_crash.rs
+++ b/tests/havoc_debug_crash.rs
@@ -30,13 +30,12 @@ fn havoc_crash_debug_stack_overflow() {
         println!("Formatting deep expression (depth {})...", depth);
         let _s = format!("{:?}", deep_expr);
 
-        // This line will never be reached!
-        println!("Survived? Impossible.");
+        println!("Survived and mitigated!");
         std::process::exit(0);
     }
 
     // Otherwise, we are the test runner orchestrator.
-    // Spawn a subprocess to run this exact test, and verify it CRASHES.
+    // Spawn a subprocess to run this exact test, and verify it SUCCEEDS.
     let exe = env::current_exe().expect("Failed to get current executable");
 
     let status = Command::new(exe)
@@ -46,9 +45,6 @@ fn havoc_crash_debug_stack_overflow() {
         .status()
         .expect("Failed to spawn subprocess");
 
-    // The test SUCCEEDS if the subprocess FAILED (crashed via SIGSEGV/Stack Overflow)
-    assert!(
-        !status.success(),
-        "Bug fixed? The subprocess should have crashed with a stack overflow!"
-    );
+    // The test SUCCEEDS if the subprocess SUCCEEDED (did not crash)
+    assert!(status.success(), "Subprocess should not have crashed!");
 }


### PR DESCRIPTION
**Threat:** DoS via Stack Overflow. The `Expr`, `Statement`, `Clause`, and `Program` enums in `src/ast.rs` are recursive. While `Drop`, `Clone`, and `PartialEq` used `stacker::maybe_grow`, `Debug` was auto-derived (`#[derive(Debug)]`). Printing a deeply nested AST (e.g., during error formatting) bypassed all checks and crashed the thread.
**Defense:** Removed `#[derive(Debug)]` and manually implemented `std::fmt::Debug` for all recursive AST nodes using `stacker::maybe_grow` to securely handle deep nesting during formatting.
**Severity:** High (Denial of Service).
**Verification:** Added coverage tests in `tests/ast_coverage_tests.rs` to hit every `fmt` match arm. Updated `tests/havoc_debug_crash.rs` to assert success instead of failure.

---
*PR created automatically by Jules for task [15075583880329120070](https://jules.google.com/task/15075583880329120070) started by @madmax983*