### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-add-alchemist-weave-tools.md
+++ b/docs/adr/016-add-alchemist-weave-tools.md
@@ -1,0 +1,25 @@
+# 16. Add Alchemist and Weave Tools
+
+Date: 2026-03-15
+Status: Accepted
+
+## Context
+
+The ΓΛΩΣΣΑ compiler ecosystem is expanding to include new output formats beyond the primary Rust backend.
+While the primary backend targets Rust, Python is an excellent, dynamic target that aligns with the "scripting" feel of small ΓΛΩΣΣΑ programs. Additionally, there is a need for a structured way to export the codebase into a readable Markdown format, serving as a 'Rosetta Stone' to make it easy to see how Greek syntax maps to semantic meaning and compiled Rust code.
+
+## Decision
+
+We have added two new tools to the Developer Experience (Nova) boundary:
+1.  **Alchemist (`src/tools/alchemist.rs`)**: An experimental transpiler that converts ΓΛΩΣΣΑ programs into Python scripts.
+2.  **Weave (`src/tools/weave.rs`)**: An exporter that generates a 'Rosetta Stone' Markdown document combining ΓΛΩΣΣΑ source code, semantic assembly logic, and generated Rust code.
+
+## Consequences
+
+### Positive
+- **Architectural Proof**: The Alchemist transpiler proves the independence of the semantic analysis phase from the Rust code generation phase, validating the modularity of the compiler pipeline.
+- **Improved Documentation and Education**: The Weave tool provides an invaluable resource for users to understand the compilation process and the mapping between Greek syntax, semantic HIR, and the final Rust output.
+- **Alternative Export Format**: Provides a dynamic scripting target (Python) for small programs.
+
+### Negative
+- **Maintenance Overhead**: Introduces the need to maintain additional exporter logic and a new Python backend alongside the primary Rust backend.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ C4Container
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
+        Container(alchemist, "Alchemist", "src/tools/alchemist.rs", "Experimental transpiler to Python")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -47,6 +48,7 @@ C4Container
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(weave, "Weave", "src/tools/weave.rs", "Exporter for Rosetta Stone Markdown documents")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -58,11 +60,13 @@ C4Container
     Rel(semantic, report, "Analyzed Program")
     Rel(semantic, narrator, "Analyzed Program")
     Rel(semantic, cartographer, "Analyzed Program")
+    Rel(semantic, alchemist, "Analyzed Program")
     Rel(semantic, mentor, "Analyzed Program")
     Rel(semantic, mosaic, "Analyzed Program")
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
+    Rel(semantic, weave, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")
     Rel(parser, tester, "AST")


### PR DESCRIPTION
Drafted ADR 016 to document the rationale, decisions, and consequences behind adding the `alchemist` (Python transpiler) and `weave` (Markdown Rosetta Stone exporter) tools. Updated the C4 Container diagram in `docs/architecture.md` to map these tools to the system context and demonstrate their relationships with the Semantic Analyzer.

---
*PR created automatically by Jules for task [13660065872855592666](https://jules.google.com/task/13660065872855592666) started by @madmax983*