### PR TITLE
🎨 Mosaic: UI Polish for Experimental CLI Commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,9 @@
 use clap::Parser;
 use miette::Result;
 
+#[cfg(not(feature = "nova"))]
+use crossterm::style::Stylize;
+
 use glossa::tools::cli::{Cli, Commands};
 use glossa::tools::dictionary::lookup_word;
 use glossa::tools::repl::run_repl;
@@ -23,9 +26,11 @@ fn main() -> Result<()> {
             run_file(&input)?;
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Mentor) => {
+            #[cfg(feature = "nova")]
             glossa::tools::mentor::run_mentor()?;
+            #[cfg(not(feature = "nova"))]
+            print_nova_required("Μέντωρ (Mentor)", "mentor");
         }
 
         Some(Commands::Build { input, output }) => {
@@ -52,24 +57,36 @@ fn main() -> Result<()> {
             glossa::tools::tester::run_tests(&input)?;
         }
 
-        #[cfg(feature = "nova")]
+        #[allow(unused_variables)]
         Some(Commands::Mosaic { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::mosaic::run_mosaic(&input)?;
+            #[cfg(not(feature = "nova"))]
+            print_nova_required("Ψηφιδωτόν (Mosaic)", "mosaic");
         }
 
-        #[cfg(feature = "nova")]
+        #[allow(unused_variables)]
         Some(Commands::Map { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::cartographer::run_map(&input)?;
+            #[cfg(not(feature = "nova"))]
+            print_nova_required("Χαρτογράφησις (Map)", "map");
         }
 
-        #[cfg(feature = "nova")]
+        #[allow(unused_variables)]
         Some(Commands::Weave { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::weave::run_weave(&input)?;
+            #[cfg(not(feature = "nova"))]
+            print_nova_required("Ὕφανσις (Weave)", "weave");
         }
 
-        #[cfg(feature = "nova")]
+        #[allow(unused_variables)]
         Some(Commands::Alchemist { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::alchemist::run_alchemist(&input)?;
+            #[cfg(not(feature = "nova"))]
+            print_nova_required("Χημεία (Alchemist)", "alchemist");
         }
 
         Some(Commands::Repl) | None => {
@@ -78,4 +95,27 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(not(feature = "nova"))]
+fn print_nova_required(tool_name: &str, cli_command: &str) {
+    println!();
+    println!(
+        "   {}",
+        format!("Γ Λ Ω Σ Σ Α   {}", tool_name).bold().cyan()
+    );
+    println!("   {}", "Experimental Tool Disabled".italic().dim());
+    println!();
+    println!("   {}", "✕ Feature Not Enabled".red().bold());
+    println!(
+        "   The `{}` tool is experimental and requires the `nova` feature.",
+        cli_command
+    );
+    println!();
+    println!("   {}", "To use it, recompile glossa with:".dim());
+    println!(
+        "   {}",
+        format!("cargo run --features nova -- {} [args...]", cli_command).yellow()
+    );
+    println!();
 }

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -102,7 +102,6 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -149,28 +148,24 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Map {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Generate a Markdown Rosetta Stone (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Weave {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Transpile a .γλ file to Python (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Alchemist {
         /// Input file (.γλ)
         input: PathBuf,


### PR DESCRIPTION
🖌️ **Before:**
If a user tried to run an experimental command (like `map`, `mosaic`, `weave`, etc.) without compiling the compiler with `--features nova`, `clap` would simply throw a generic error: 
`error: unexpected argument 'map' found`
This created a poor Developer Experience (DX) because the user had no idea why the command documented in the help output was failing.

✨ **After:**
The experimental commands are now parsed by `clap` universally. If the `nova` feature is missing, `main.rs` catches the request and outputs a beautifully formatted, clear error message explaining exactly why the command is disabled and provides instructions to the user on how to enable it.

🖼️ **Visuals:**
The new error message is formatted as a dashboard alert using `crossterm::style::Stylize`. It displays:
- A Cyan bold header: `Γ Λ Ω Σ Σ Α   [Tool Name]`
- A dimmed subtitle: `Experimental Tool Disabled`
- A red warning: `✕ Feature Not Enabled`
- An explanation: `The '[command]' tool is experimental and requires the 'nova' feature.`
- A yellow copy-paste instruction: `cargo run --features nova -- [command] [args...]`

---
*PR created automatically by Jules for task [9118888867354965606](https://jules.google.com/task/9118888867354965606) started by @madmax983*