### PR TITLE
🪒 Razor: Delete unused Statement::expressions method

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -107,3 +107,8 @@
 **Bloat:** The `StatementAnalyzer` trait was introduced to resolve a circular dependency between `semantic::analyzer`, `semantic::control_flow`, and `semantic::declarations`. However, since these modules all live within the same crate (`semantic`), Rust permits circular module dependencies natively via free functions, rendering the trait abstraction unnecessary. Additionally, `StatementAnalyzer` was a single-implementation trait only implemented by the empty struct `SemanticAnalyzer`.
 **Cut:** Deleted the `StatementAnalyzer` trait and the `SemanticAnalyzer` struct entirely. Replaced trait method dispatch across submodules with direct calls to `crate::semantic::analyzer::analyze_statement`.
 **Saved:** Eliminated trait boilerplate, reduced the number of files by deleting `src/semantic/traits.rs`, and removed empty struct allocations, significantly reducing cognitive overhead by flattening the semantic analysis architecture.
+
+## [Reduction]
+**Bloat:** `Statement::expressions()` method in `src/ast.rs` was never used in the codebase.
+**Cut:** Deleted the dead code and its associated tests in `tests/ast_coverage_tests.rs`.
+**Saved:** Removed unused method and simplified the `Statement` AST node implementation.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -180,19 +180,6 @@ pub struct Clause {
 }
 
 impl Statement {
-    /// Get all expressions flattened (for backwards compatibility)
-    pub fn expressions(&self) -> Box<dyn Iterator<Item = &Expr> + '_> {
-        match self {
-            Statement::Regular { clauses, .. } => {
-                Box::new(clauses.iter().flat_map(|c| c.expressions.iter()))
-            }
-            Statement::TypeDefinition(_) => Box::new(std::iter::empty()),
-            Statement::TraitDefinition(_) => Box::new(std::iter::empty()),
-            Statement::TraitImpl(_) => Box::new(std::iter::empty()),
-            Statement::TestDeclaration(_) => Box::new(std::iter::empty()),
-        }
-    }
-
     /// Check if this is a query statement
     pub fn is_query(&self) -> bool {
         match self {

--- a/tests/ast_coverage_tests.rs
+++ b/tests/ast_coverage_tests.rs
@@ -275,7 +275,6 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 
     let stmt = Statement::TypeDefinition(TypeDef {
         name: Word::new("t"),
@@ -284,7 +283,6 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 
     let stmt = Statement::TraitDefinition(TraitDef {
         name: Word::new("t"),
@@ -293,7 +291,6 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 
     let stmt = Statement::TraitImpl(TraitImplDef {
         type_name: Word::new("t"),
@@ -303,5 +300,4 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 }


### PR DESCRIPTION
## 🪒 Razor: Delete unused Statement::expressions method

The `Statement::expressions()` method in `src/ast.rs` was returning a `Box<dyn Iterator<Item = &Expr> + '_>` and was completely unused anywhere else in the compiler logic.

As per the YAGNI principle, I have deleted this dead code, as well as the test calls covering it in `tests/ast_coverage_tests.rs`. This flattens unnecessary abstractions and simplifies the codebase. I have also recorded this reduction in `.jules/razor.md`.

---
*PR created automatically by Jules for task [2231179932657766931](https://jules.google.com/task/2231179932657766931) started by @madmax983*