### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-flatten-assembly.md
+++ b/docs/adr/016-flatten-assembly.md
@@ -1,0 +1,22 @@
+# 16. Flatten Assembly Module
+
+Date: 2026-03-16
+Status: Accepted
+
+## Context
+
+The `semantic` module previously contained an `assembly` directory with `mod.rs` and `model.rs` files. These files were tightly coupled via DTOs (`AssembledStatement`, `Constituent`, etc.). This directory nesting added architectural layers, cognitive overhead, and bloat without providing structural benefit, which violated the Razor persona's essentialism philosophy (KISS, YAGNI, DRY).
+
+## Decision
+
+We have merged `src/semantic/assembly/mod.rs` and `src/semantic/assembly/model.rs` into a single `src/semantic/assembly.rs` file.
+
+## Consequences
+
+### Positive
+- **Reduced Bloat**: Eliminates unnecessary directory nesting and extra files, adhering to the principle of flattened hierarchies.
+- **Improved Cohesion**: Tightly coupled Data Transfer Objects (DTOs) and the logic that uses them are now unified in a single file, reducing cognitive overhead and simplifying the module structure.
+- **Consistency**: Aligns with similar flattening decisions made in the codebase, such as the `interpreter` module.
+
+### Negative
+- **File Size**: The combined `assembly.rs` file is larger than the individual `mod.rs` and `model.rs` files, which may slightly increase the time required to scroll through or conceptually navigate the single file.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,7 @@ C4Component
         Component(control_flow, "Control Flow", "src/semantic/control_flow.rs", "Analyzes If, While, Match")
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
-        Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
+        Component(assembly, "Assembly", "src/semantic/assembly.rs", "Routes words to grammatical slots")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -385,7 +385,7 @@ mod tests {
         add_cons(&mut asm.adjectives);
 
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part1".into(),
                 original: "part1".into(),
                 normalized: "part1".into(),
@@ -396,7 +396,7 @@ mod tests {
                 number: Number::Singular,
             });
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part2".into(),
                 original: "part2".into(),
                 normalized: "part2".into(),


### PR DESCRIPTION
🧠 **Decision:** Recorded the flattening of the `assembly` module into `docs/adr/016-flatten-assembly.md` to reflect the reduction in cognitive overhead and architectural bloat.

🗺️ **Visuals:** Updated the path for the Assembly component in the C4 Component Diagram within `docs/architecture.md`.

🔗 **Link:** See `docs/adr/016-flatten-assembly.md`.

---
*PR created automatically by Jules for task [11091220799555583873](https://jules.google.com/task/11091220799555583873) started by @madmax983*