### PR TITLE
🗺️ Atlas: Restrict internal module visibility to pub(crate)

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -625,7 +625,7 @@ pub fn analyze_verb_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
 /// # Examples
 ///
 /// ```rust
-/// use glossa::morphology::{conjugation::conjugate, Tense, Mood, Voice, Person, Number};
+/// use glossa::morphology::{conjugate, Tense, Mood, Voice, Person, Number};
 ///
 /// // Conjugate "λεγ" (to say) in Present Active Indicative, 1st Person Singular
 /// let result = conjugate("λεγ", Tense::Present, Mood::Indicative, Voice::Active, Person::First, Number::Singular);
@@ -668,7 +668,7 @@ pub fn conjugate(
 /// # Examples
 ///
 /// ```rust
-/// use glossa::morphology::{conjugation::infinitive, Tense, Voice};
+/// use glossa::morphology::{infinitive, Tense, Voice};
 ///
 /// // Present Active Infinitive of "λεγ" (to say)
 /// let result = infinitive("λεγ", Tense::Present, Voice::Active);

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -158,7 +158,7 @@ const DECLENSION_PATTERNS: &[DeclensionPattern] = &[
 ///
 /// # Examples
 /// ```
-/// use glossa::morphology::declension::analyze_noun;
+/// use glossa::morphology::analyze_noun;
 /// use glossa::morphology::{Case, Number, Gender};
 ///
 /// let analysis = analyze_noun("λογον").unwrap();
@@ -288,7 +288,7 @@ pub fn analyze_noun_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
 ///
 /// # Examples
 /// ```
-/// use glossa::morphology::declension::{get_stem, Declension};
+/// use glossa::morphology::{get_stem, Declension};
 ///
 /// assert_eq!(get_stem("λογος", Declension::Second), "λογ");
 /// assert_eq!(get_stem("τιμη", Declension::First), "τιμ");
@@ -331,7 +331,7 @@ pub fn get_stem(nominative: &str, declension: Declension) -> String {
 ///
 /// # Examples
 /// ```
-/// use glossa::morphology::declension::{decline, Declension};
+/// use glossa::morphology::{decline, Declension};
 /// use glossa::morphology::{Case, Gender, Number};
 ///
 /// // Decline "λογ" (word) to Accusative Plural

--- a/src/morphology/models.rs
+++ b/src/morphology/models.rs
@@ -197,7 +197,7 @@ impl std::fmt::Display for Gender {
 /// # Examples
 ///
 /// ```
-/// use glossa::morphology::models::{analyses_compatible, MorphAnalysis, PartOfSpeech, Case};
+/// use glossa::morphology::{analyses_compatible, MorphAnalysis, PartOfSpeech, Case};
 ///
 /// let mut a = MorphAnalysis::new("λογος".to_string(), PartOfSpeech::Noun);
 /// a.case = Some(Case::Nominative);

--- a/src/morphology/participle.rs
+++ b/src/morphology/participle.rs
@@ -16,7 +16,7 @@
 //! ## Examples
 //!
 //! ```
-//! use glossa::morphology::participle::analyze_participle;
+//! use glossa::morphology::analyze_participle;
 //! use glossa::morphology::Tense;
 //!
 //! let p = analyze_participle("γραφων").unwrap();
@@ -53,7 +53,7 @@ impl ParticipleAnalysis {
     /// # Examples
     ///
     /// ```
-    /// use glossa::morphology::participle::analyze_participle;
+    /// use glossa::morphology::analyze_participle;
     ///
     /// let p = analyze_participle("γραφων").unwrap();
     /// assert_eq!(p.verb_lemma(), "γραφω");
@@ -498,7 +498,7 @@ static ALL_PATTERNS: LazyLock<Vec<&'static ParticiplePattern>> = LazyLock::new(|
 /// # Examples
 ///
 /// ```
-/// use glossa::morphology::participle::analyze_participle;
+/// use glossa::morphology::analyze_participle;
 /// use glossa::morphology::Tense;
 ///
 /// let p = analyze_participle("γραφων").unwrap();

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -52,7 +52,7 @@ impl ProgramStats {
     ///
     /// ## Examples
     ///
-    /// ```rust
+    /// ```ignore
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
     /// use glossa::tools::report::ProgramStats;
@@ -239,7 +239,7 @@ impl<'a> GlossaReport<'a> {
     ///
     /// ## Examples
     ///
-    /// ```rust
+    /// ```ignore
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
     /// use glossa::tools::report::GlossaReport;
@@ -366,7 +366,7 @@ impl Display for GlossaReport<'_> {
 ///
 /// ## Examples
 ///
-/// ```rust
+/// ```ignore
 /// use glossa::parser::parse;
 /// use glossa::semantic::analyze_program;
 /// use glossa::tools::report::{CompilationReport, ProgramStats};

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -30,7 +30,7 @@ use std::time::Instant;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```ignore
 /// use glossa::tools::ui::Status;
 ///
 /// let mut status = Status::start("Compiling");
@@ -50,7 +50,7 @@ impl Status {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```ignore
     /// use glossa::tools::ui::Status;
     /// let status = Status::start("Compiling...");
     /// status.success();
@@ -63,7 +63,7 @@ impl Status {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```ignore
     /// use glossa::tools::ui::Status;
     /// let status = Status::start_with_symbol("Testing", "🧪");
     /// status.success();
@@ -92,7 +92,7 @@ impl Status {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```ignore
     /// use glossa::tools::ui::Status;
     /// let mut status = Status::start("Running Phase 1");
     /// // ... work ...
@@ -113,7 +113,7 @@ impl Status {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```ignore
     /// use glossa::tools::ui::Status;
     /// let status = Status::start("Connecting");
     /// // ... work ...
@@ -138,7 +138,7 @@ impl Status {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```ignore
     /// use glossa::tools::ui::Status;
     /// let status = Status::start("Downloading");
     /// // ... fail ...


### PR DESCRIPTION
🗺️ Atlas: Restrict internal module visibility

🕸️ Tangle: Internal submodules in `morphology`, `tools`, and `parser` were needlessly exposed via `pub mod`, breaking encapsulation and exposing implementation details to external consumers and tests.

📐 Blueprint:
- Changed `pub mod` to `pub(crate) mod` for most internal submodules.
- Maintained `pub mod` only for heavily integrated submodules (`lexicon`, `cli`, `highlight`, `interpreter`, `cache`, `narrator`, `numerals`, `grammar`).
- Added explicit `pub use` re-exports in module facades (like `src/morphology/mod.rs`) for functions required by tests and external consumers.
- Updated tests and doctests to use the new public facades instead of direct internal paths. Disabled doctests for `pub(crate)` tool internals.

🧱 Stability: Enforced high cohesion and low coupling by securing the module boundaries.
🔬 Verification: Builds successfully, all tests pass (`cargo check`, `cargo test --all-targets --all-features`, `cargo test --doc`), strict separation enforced.

---
*PR created automatically by Jules for task [8955893139073840969](https://jules.google.com/task/8955893139073840969) started by @madmax983*