### PR TITLE
⚡ Bolt: Optimize intermediate Vec allocations during string joining

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 **[Slice Refactoring over Vec Collection in AST Parsing]**
 **Learning:** Avoid replacing `Vec::new()` with `Vec::with_capacity()` using arbitrary heuristics (e.g., total statement counts). `Vec::new()` is a zero-cost abstraction, whereas eager capacity allocation causes immediate heap allocations, which can lead to performance regressions if the vectors remain empty. Only use `Vec::with_capacity` when the exact required size is known in advance. When parsing or traversing ASTs (e.g., in `semantic/control_flow.rs`), avoid collecting iterator chains into intermediate vectors (e.g., `terms.iter().skip(1).collect::<Vec<_>>()`). Instead, use slice references (e.g., `&terms[1..]`) whenever possible to prevent unnecessary `O(N)` heap allocations.
 **Action:** Identify and replace unnecessary `.collect::<Vec<_>>()` calls with slices, and only use `Vec::with_capacity` with an exact calculated size.
+
+**[String Joining Allocations]**
+**Learning:** Multiple replacements of the `.collect::<Vec<String>>().join(", ")` pattern in large files using regex or sed scripts can easily create malformed blocks and duplicate helper functions if the text isn't uniquely matched.
+**Action:** When appending helper functions or new code into Rust files using automated text replacement scripts, always insert them *before* the `#[cfg(test)] mod tests` block to avoid triggering Clippy's `items_after_test_module` warning, and use surgical replacements (`replace_with_git_merge_diff`) when possible to prevent malformed code syntax.

--- a/fix_mosaic.sh
+++ b/fix_mosaic.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+cat << 'INNER_EOF' > /tmp/mosaic_patch.diff
+--- a/src/tools/mosaic.rs
++++ b/src/tools/mosaic.rs
+@@ -140,12 +140,13 @@
+         .unwrap_or_default();
+
+     // Combine nominatives if subject is present or if there are multiple
+-    let extra_noms = asm
+-        .nominatives
+-        .iter()
+-        .map(fmt_constituent)
+-        .collect::<Vec<_>>()
+-        .join(", ");
++    let mut extra_noms = String::with_capacity(asm.nominatives.len() * 16);
++    for (i, nom) in asm.nominatives.iter().enumerate() {
++        if i > 0 {
++            extra_noms.push_str(", ");
++        }
++        extra_noms.push_str(&fmt_constituent(nom));
++    }
+     let full_subject = if !extra_noms.is_empty() {
+         if !subject.is_empty() {
+             format!("{} (+ {})", subject, extra_noms)
+@@ -183,34 +184,37 @@
+
+     // Genitives
+     if !asm.genitives.is_empty() {
+-        let gens = asm
+-            .genitives
+-            .iter()
+-            .map(fmt_constituent)
+-            .collect::<Vec<_>>()
+-            .join(", ");
++        let mut gens = String::with_capacity(asm.genitives.len() * 16);
++        for (i, g) in asm.genitives.iter().enumerate() {
++            if i > 0 {
++                gens.push_str(", ");
++            }
++            gens.push_str(&fmt_constituent(g));
++        }
+         other.push(format!("Gen: [{}]", gens));
+     }
+
+     // Adjectives
+     if !asm.adjectives.is_empty() {
+-        let adjs = asm
+-            .adjectives
+-            .iter()
+-            .map(fmt_constituent)
+-            .collect::<Vec<_>>()
+-            .join(", ");
++        let mut adjs = String::with_capacity(asm.adjectives.len() * 16);
++        for (i, a) in asm.adjectives.iter().enumerate() {
++            if i > 0 {
++                adjs.push_str(", ");
++            }
++            adjs.push_str(&fmt_constituent(a));
++        }
+         other.push(format!("Adj: [{}]", adjs));
+     }
+
+     // Participles
+     if !asm.participles.is_empty() {
+-        let parts = asm
+-            .participles
+-            .iter()
+-            .map(|p| p.original.to_string())
+-            .collect::<Vec<_>>()
+-            .join(", ");
++        let mut parts = String::with_capacity(asm.participles.len() * 16);
++        for (i, p) in asm.participles.iter().enumerate() {
++            if i > 0 {
++                parts.push_str(", ");
++            }
++            parts.push_str(&p.original);
++        }
+         other.push(format!("Participles: [{}]", parts));
+     }
+
+@@ -222,12 +226,13 @@
+         other.push(format!("Index Accesses: {}", asm.index_accesses.len()));
+     }
+     if !asm.property_accesses.is_empty() {
+-        let props = asm
+-            .property_accesses
+-            .iter()
+-            .map(|(o, p)| format!("{}.{}", o, p))
+-            .collect::<Vec<_>>()
+-            .join(", ");
++        let mut props = String::with_capacity(asm.property_accesses.len() * 16);
++        for (i, (o, p)) in asm.property_accesses.iter().enumerate() {
++            if i > 0 {
++                props.push_str(", ");
++            }
++            props.push_str(&format!("{}.{}", o, p));
++        }
+         other.push(format!("Properties: [{}]", props));
+     }
+     if !asm.blocks.is_empty() {
+INNER_EOF
+patch -p1 < /tmp/mosaic_patch.diff

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -140,12 +140,13 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
         .unwrap_or_default();
 
     // Combine nominatives if subject is present or if there are multiple
-    let extra_noms = asm
-        .nominatives
-        .iter()
-        .map(fmt_constituent)
-        .collect::<Vec<_>>()
-        .join(", ");
+    let mut extra_noms = String::with_capacity(asm.nominatives.len() * 16);
+    for (i, nom) in asm.nominatives.iter().enumerate() {
+        if i > 0 {
+            extra_noms.push_str(", ");
+        }
+        extra_noms.push_str(&fmt_constituent(nom));
+    }
     let full_subject = if !extra_noms.is_empty() {
         if !subject.is_empty() {
             format!("{} (+ {})", subject, extra_noms)
@@ -183,34 +184,37 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
 
     // Genitives
     if !asm.genitives.is_empty() {
-        let gens = asm
-            .genitives
-            .iter()
-            .map(fmt_constituent)
-            .collect::<Vec<_>>()
-            .join(", ");
+        let mut gens = String::with_capacity(asm.genitives.len() * 16);
+        for (i, g) in asm.genitives.iter().enumerate() {
+            if i > 0 {
+                gens.push_str(", ");
+            }
+            gens.push_str(&fmt_constituent(g));
+        }
         other.push(format!("Gen: [{}]", gens));
     }
 
     // Adjectives
     if !asm.adjectives.is_empty() {
-        let adjs = asm
-            .adjectives
-            .iter()
-            .map(fmt_constituent)
-            .collect::<Vec<_>>()
-            .join(", ");
+        let mut adjs = String::with_capacity(asm.adjectives.len() * 16);
+        for (i, a) in asm.adjectives.iter().enumerate() {
+            if i > 0 {
+                adjs.push_str(", ");
+            }
+            adjs.push_str(&fmt_constituent(a));
+        }
         other.push(format!("Adj: [{}]", adjs));
     }
 
     // Participles
     if !asm.participles.is_empty() {
-        let parts = asm
-            .participles
-            .iter()
-            .map(|p| p.original.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
+        let mut parts = String::with_capacity(asm.participles.len() * 16);
+        for (i, p) in asm.participles.iter().enumerate() {
+            if i > 0 {
+                parts.push_str(", ");
+            }
+            parts.push_str(&p.original);
+        }
         other.push(format!("Participles: [{}]", parts));
     }
 
@@ -222,12 +226,13 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
         other.push(format!("Index Accesses: {}", asm.index_accesses.len()));
     }
     if !asm.property_accesses.is_empty() {
-        let props = asm
-            .property_accesses
-            .iter()
-            .map(|(o, p)| format!("{}.{}", o, p))
-            .collect::<Vec<_>>()
-            .join(", ");
+        let mut props = String::with_capacity(asm.property_accesses.len() * 16);
+        for (i, (o, p)) in asm.property_accesses.iter().enumerate() {
+            if i > 0 {
+                props.push_str(", ");
+            }
+            props.push_str(&format!("{}.{}", o, p));
+        }
         other.push(format!("Properties: [{}]", props));
     }
     if !asm.blocks.is_empty() {

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -46,6 +46,30 @@ use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table};
 /// assert!(narrative.contains("BIND"));
 /// assert!(narrative.contains("Let `ξ` be 5"));
 /// ```
+/// ⚡ Bolt Optimization: Avoids intermediate `Vec<String>` allocation.
+fn join_exprs(exprs: &[AnalyzedExpr]) -> String {
+    let mut buf = String::with_capacity(exprs.len() * 16);
+    for (i, expr) in exprs.iter().enumerate() {
+        if i > 0 {
+            buf.push_str(", ");
+        }
+        buf.push_str(&tell_expr(expr));
+    }
+    buf
+}
+
+/// ⚡ Bolt Optimization: Avoids intermediate `Vec<String>` allocation.
+fn join_types(types: &[GlossaType]) -> String {
+    let mut buf = String::with_capacity(types.len() * 8);
+    for (i, ty) in types.iter().enumerate() {
+        if i > 0 {
+            buf.push_str(", ");
+        }
+        buf.push_str(&tell_type(ty));
+    }
+    buf
+}
+
 pub fn tell_tale(program: &AnalyzedProgram) -> String {
     let mut table = Table::new();
     table
@@ -183,8 +207,8 @@ fn add_assignment(table: &mut Table, prefix: &str, name: &str, value: &AnalyzedE
 }
 
 fn add_print(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
-    let expr_strs: Vec<String> = exprs.iter().map(tell_expr).collect();
-    let script = format!("Proclaim: {}", expr_strs.join(", "));
+    let expr_strs = join_exprs(exprs);
+    let script = format!("Proclaim: {}", expr_strs);
     table.add_row(vec![
         Cell::new("PRINT").fg(Color::Green),
         Cell::new(format!("{}{}", prefix, script)),
@@ -193,8 +217,8 @@ fn add_print(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
 }
 
 fn add_expression(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
-    let expr_strs: Vec<String> = exprs.iter().map(tell_expr).collect();
-    let script = format!("Do: {}", expr_strs.join(", "));
+    let expr_strs = join_exprs(exprs);
+    let script = format!("Do: {}", expr_strs);
     table.add_row(vec![
         Cell::new("EXPR").fg(Color::DarkGrey),
         Cell::new(format!("{}{}", prefix, script)),
@@ -203,8 +227,8 @@ fn add_expression(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
 }
 
 fn add_query(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
-    let expr_strs: Vec<String> = exprs.iter().map(tell_expr).collect();
-    let script = format!("Query oracle: {}", expr_strs.join(", "));
+    let expr_strs = join_exprs(exprs);
+    let script = format!("Query oracle: {}", expr_strs);
     table.add_row(vec![
         Cell::new("QUERY").fg(Color::Magenta),
         Cell::new(format!("{}{}", prefix, script)),
@@ -501,28 +525,23 @@ fn tell_expr(expr: &AnalyzedExpr) -> String {
 }
 
 fn tell_verb_call(verb: &str, args: &[AnalyzedExpr]) -> String {
-    let args_str: Vec<String> = args.iter().map(tell_expr).collect();
-    format!("{}({})", verb, args_str.join(", "))
+    let args_str = join_exprs(args);
+    format!("{}({})", verb, args_str)
 }
 
 fn tell_array_literal(exprs: &[AnalyzedExpr]) -> String {
-    let expr_strs: Vec<String> = exprs.iter().map(tell_expr).collect();
-    format!("[{}]", expr_strs.join(", "))
+    let expr_strs = join_exprs(exprs);
+    format!("[{}]", expr_strs)
 }
 
 fn tell_function_call(func: &str, args: &[AnalyzedExpr]) -> String {
-    let args_str: Vec<String> = args.iter().map(tell_expr).collect();
-    format!("{}({})", func, args_str.join(", "))
+    let args_str = join_exprs(args);
+    format!("{}({})", func, args_str)
 }
 
 fn tell_method_call(receiver: &AnalyzedExpr, method: &str, args: &[AnalyzedExpr]) -> String {
-    let args_str: Vec<String> = args.iter().map(tell_expr).collect();
-    format!(
-        "{}.{}({})",
-        tell_expr(receiver),
-        method,
-        args_str.join(", ")
-    )
+    let args_str = join_exprs(args);
+    format!("{}.{}({})", tell_expr(receiver), method, args_str)
 }
 
 fn tell_trait_method_call(
@@ -531,13 +550,13 @@ fn tell_trait_method_call(
     method_name: &str,
     args: &[AnalyzedExpr],
 ) -> String {
-    let args_str: Vec<String> = args.iter().map(tell_expr).collect();
+    let args_str = join_exprs(args);
     format!(
         "{} as {}::{}({})",
         tell_expr(receiver),
         trait_name,
         method_name,
-        args_str.join(", ")
+        args_str
     )
 }
 
@@ -546,14 +565,14 @@ fn tell_struct_instantiation(
     fields: &[smol_str::SmolStr],
     args: &[AnalyzedExpr],
 ) -> String {
-    let args_str: Vec<String> = args.iter().map(tell_expr).collect();
-    // Zip fields and args for better display
-    let fields_args: Vec<String> = fields
-        .iter()
-        .zip(args_str.iter())
-        .map(|(f, a)| format!("{}: {}", f, a))
-        .collect();
-    format!("{} {{ {} }}", type_name, fields_args.join(", "))
+    let mut fields_args = String::with_capacity(fields.len() * 16);
+    for (i, (f, a)) in fields.iter().zip(args.iter()).enumerate() {
+        if i > 0 {
+            fields_args.push_str(", ");
+        }
+        fields_args.push_str(&format!("{}: {}", f, tell_expr(a)));
+    }
+    format!("{} {{ {} }}", type_name, fields_args)
 }
 
 fn tell_lambda(
@@ -587,8 +606,8 @@ fn tell_type(ty: &GlossaType) -> String {
         GlossaType::Result(ok, err) => format!("Result<{}, {}>", tell_type(ok), tell_type(err)),
         GlossaType::Struct { name, .. } => name.to_string(),
         GlossaType::Function { params, returns } => {
-            let params_str: Vec<String> = params.iter().map(tell_type).collect();
-            format!("Fn({}) -> {}", params_str.join(", "), tell_type(returns))
+            let params_str = join_types(params);
+            format!("Fn({}) -> {}", params_str, tell_type(returns))
         }
         GlossaType::Unit => "()".to_string(),
         GlossaType::Unknown => "?".to_string(),


### PR DESCRIPTION
💡 **What:** Replaced intermediate `.collect::<Vec<_>>().join(", ")` heap allocations across the CLI dashboard tools (`Narrator` and `Mosaic`) with `String::with_capacity` memory-aware loops.
🎯 **Why:** To adhere to the zero-cost abstractions philosophy and reduce memory footprint on hot rendering paths (especially for large AST translations during narrative storytelling and UI assembly).
📊 **Impact:** Removes several intermediate `Vec<String>` and `Vec<&str>` allocations per output row/narrative step, resulting in fewer memory re-allocations and GC churn during CLI execution.
🔬 **Measurement:** Verified via `cargo test` and `cargo clippy`. No regressions found in semantic storytelling or table generation logic.

---
*PR created automatically by Jules for task [11060589921224384671](https://jules.google.com/task/11060589921224384671) started by @madmax983*