### PR TITLE
🪒 Razor: Flatten `Interpreter` scope architecture

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -107,3 +107,7 @@
 **Bloat:** The `StatementAnalyzer` trait was introduced to resolve a circular dependency between `semantic::analyzer`, `semantic::control_flow`, and `semantic::declarations`. However, since these modules all live within the same crate (`semantic`), Rust permits circular module dependencies natively via free functions, rendering the trait abstraction unnecessary. Additionally, `StatementAnalyzer` was a single-implementation trait only implemented by the empty struct `SemanticAnalyzer`.
 **Cut:** Deleted the `StatementAnalyzer` trait and the `SemanticAnalyzer` struct entirely. Replaced trait method dispatch across submodules with direct calls to `crate::semantic::analyzer::analyze_statement`.
 **Saved:** Eliminated trait boilerplate, reduced the number of files by deleting `src/semantic/traits.rs`, and removed empty struct allocations, significantly reducing cognitive overhead by flattening the semantic analysis architecture.
+## [Reduction]
+**Bloat:** `Interpreter` env used a `Vec<HashMap<String, Value>>` to represent a stack of scopes. However, only one global scope was ever instantiated or utilized within the interpreter, leading to unnecessary complexity (e.g. `.iter().rev()` for variable lookup and speculative generality).
+**Cut:** Flattened `env` to a single `HashMap<String, Value>` and simplified variable assignment, definition, and lookup logic to operate directly on the flat `HashMap`.
+**Saved:** Reduced cognitive load and unnecessary heap allocations/iteration overhead for the interpreter's variable resolution.

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -84,9 +84,8 @@ pub enum EvalError {
 /// // You could then run a program via `interp.run(&analyzed_program)`
 /// ```
 pub struct Interpreter {
-    // Stack of scopes. For now, just one global scope for simplicity.
-    // In a real implementation, this would be `Vec<HashMap<String, Value>>`.
-    env: Vec<HashMap<String, Value>>,
+    // Single global scope
+    env: HashMap<String, Value>,
 
     // Output buffer for capturing print statements (useful for testing/WASM)
     output: Vec<String>,
@@ -113,7 +112,7 @@ impl Interpreter {
     /// ```
     pub fn new() -> Self {
         Self {
-            env: vec![HashMap::new()],
+            env: HashMap::new(),
             output: Vec::new(),
         }
     }
@@ -250,28 +249,21 @@ impl Interpreter {
     }
 
     fn define_var(&mut self, name: &str, value: Value) {
-        // Define in the current (top) scope
-        if let Some(scope) = self.env.last_mut() {
-            scope.insert(name.to_string(), value);
-        }
+        // Define in the global scope
+        self.env.insert(name.to_string(), value);
     }
 
     fn assign_var(&mut self, name: &str, value: Value) -> Result<(), EvalError> {
-        // Walk up the scopes to find the variable
-        for scope in self.env.iter_mut().rev() {
-            if scope.contains_key(name) {
-                scope.insert(name.to_string(), value);
-                return Ok(());
-            }
+        if self.env.contains_key(name) {
+            self.env.insert(name.to_string(), value);
+            return Ok(());
         }
         Err(EvalError::VariableNotFound(name.to_string()))
     }
 
     fn lookup_var(&self, name: &str) -> Result<Value, EvalError> {
-        for scope in self.env.iter().rev() {
-            if let Some(val) = scope.get(name) {
-                return Ok(val.clone());
-            }
+        if let Some(val) = self.env.get(name) {
+            return Ok(val.clone());
         }
         Err(EvalError::VariableNotFound(name.to_string()))
     }
@@ -335,7 +327,7 @@ mod tests {
     #[test]
     fn test_default_impl() {
         let interp = Interpreter::default();
-        assert_eq!(interp.env.len(), 1);
+        assert_eq!(interp.env.len(), 0);
         assert!(interp.output.is_empty());
     }
 


### PR DESCRIPTION
## [Reduction]
**Bloat:** `Interpreter` env used a `Vec<HashMap<String, Value>>` to represent a stack of scopes. However, only one global scope was ever instantiated or utilized within the interpreter, leading to unnecessary complexity (e.g. `.iter().rev()` for variable lookup and speculative generality).
**Cut:** Flattened `env` to a single `HashMap<String, Value>` and simplified variable assignment, definition, and lookup logic to operate directly on the flat `HashMap`.
**Saved:** Reduced cognitive load and unnecessary heap allocations/iteration overhead for the interpreter's variable resolution.

---
*PR created automatically by Jules for task [16309233227860771767](https://jules.google.com/task/16309233227860771767) started by @madmax983*