### PR TITLE
🪒 Razor: De-abstract Layer Lasagna Formatting Wrappers

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -111,3 +111,7 @@
 **Bloat:** `src/semantic/assembly/` directory contained `mod.rs` and `model.rs`. `model.rs` contained DTOs tightly coupled to the assembler.
 **Cut:** Merged `model.rs` into `mod.rs` and renamed it to `src/semantic/assembly.rs`, deleting the `assembly/` folder.
 **Saved:** 1 directory, 1 file, reduced module indirection.
+## [Reduction]
+**Bloat:** `GlossaReport` and `CompilationReport` in `src/tools/report.rs` were purely formatting wrappers around data, implementing `Display` just to be printed once ("Layer Lasagna").
+**Cut:** Replaced the structs and trait implementations with straightforward, standalone formatting functions (`format_glossa_report` and `format_compilation_report`).
+**Saved:** Removed 2 structs and 2 trait implementations (~20 lines of boilerplate), simplified call sites in `runner.rs`.

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -385,7 +385,7 @@ mod tests {
         add_cons(&mut asm.adjectives);
 
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part1".into(),
                 original: "part1".into(),
                 normalized: "part1".into(),
@@ -396,7 +396,7 @@ mod tests {
                 number: Number::Singular,
             });
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part2".into(),
                 original: "part2".into(),
                 normalized: "part2".into(),

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -12,12 +12,10 @@
 //! * How deep is the nesting? (`max_depth`)
 //! * How "functional" vs "imperative" is the style? (Expression vs Statement count)
 //!
-//! The [`GlossaReport`] provides a dashboard-style summary of these metrics.
+//! The `format_glossa_report` function provides a dashboard-style summary of these metrics.
 
 use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
-use std::fmt::Display;
-use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
@@ -227,150 +225,144 @@ impl ProgramStats {
     }
 }
 
-/// A human-readable report for an analyzed program
-pub struct GlossaReport<'a> {
-    program: &'a AnalyzedProgram,
-    stats: ProgramStats,
-    filename: String,
-}
-
-impl<'a> GlossaReport<'a> {
-    /// Creates a new GlossaReport.
-    ///
-    /// ## Examples
-    ///
-    /// ```rust
-    /// use glossa::parser::parse;
-    /// use glossa::semantic::analyze_program;
-    /// use glossa::tools::report::GlossaReport;
-    ///
-    /// let source = "ξ πέντε ἔστω.";
-    /// let ast = parse(source).unwrap();
-    /// let program = analyze_program(&ast).unwrap();
-    /// let report = GlossaReport::new(&program, "main.γλ".to_string());
-    ///
-    /// let output = format!("{}", report);
-    /// assert!(output.contains("main.γλ"));
-    /// assert!(output.contains("1")); // Statement count
-    /// ```
-    pub fn new(program: &'a AnalyzedProgram, filename: String) -> Self {
-        let stats = ProgramStats::new(program);
-        Self {
-            program,
-            stats,
-            filename,
-        }
-    }
-}
-
-impl Display for GlossaReport<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL).set_header(vec![
-            Cell::new("Μετρική (Metric)")
-                .add_attribute(comfy_table::Attribute::Bold)
-                .fg(Color::Cyan),
-            Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
-        ]);
-
-        table.add_row(vec![
-            Cell::new("Ἀρχεῖον (File)"),
-            Cell::new(&self.filename).fg(Color::Green),
-        ]);
-        table.add_row(vec![
-            Cell::new("Προτάσεις (Statements)"),
-            Cell::new(self.stats.statement_count),
-        ]);
-        table.add_row(vec![
-            Cell::new("Εκφράσεις (Expressions)"),
-            Cell::new(self.stats.expression_count),
-        ]);
-        table.add_row(vec![
-            Cell::new("Μεταβλητές (Bindings)"),
-            Cell::new(self.stats.binding_count),
-        ]);
-
-        if self.stats.function_count > 0 {
-            table.add_row(vec![
-                Cell::new("Συναρτήσεις (Functions)"),
-                Cell::new(self.stats.function_count),
-            ]);
-        }
-
-        if self.stats.type_count > 0 {
-            table.add_row(vec![
-                Cell::new("Τύποι (Types)"),
-                Cell::new(self.stats.type_count),
-            ]);
-        }
-
-        if self.stats.loop_count > 0 {
-            table.add_row(vec![
-                Cell::new("Βρόχοι (Loops)"),
-                Cell::new(self.stats.loop_count),
-            ]);
-        }
-
-        if self.stats.max_depth > 0 {
-            table.add_row(vec![
-                Cell::new("Βάθος (Max Depth)"),
-                Cell::new(self.stats.max_depth),
-            ]);
-        }
-
-        writeln!(f)?;
-        writeln!(f, "   {}", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan())?;
-        writeln!(f, "   {}", "Language Metrics Dashboard".italic().dim())?;
-        writeln!(f)?;
-        writeln!(f, "{}", table)?;
-
-        // If there are top-level functions, list them
-        let functions: Vec<_> = self.program.scope.functions().collect();
-        if !functions.is_empty() {
-            writeln!(f, "\n{}", "ΣΥΝΑΡΤΗΣΕΙΣ (FUNCTIONS)".bold())?;
-            let mut func_table = Table::new();
-            func_table.load_preset(presets::UTF8_FULL).set_header(vec![
-                "Ὄνομα (Name)",
-                "Παράμετροι (Params)",
-                "Επιστροφή (Returns)",
-            ]);
-
-            for func in functions {
-                let params = func
-                    .param_types
-                    .iter()
-                    .map(|t| t.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                let ret = func
-                    .return_type
-                    .as_ref()
-                    .map(|t| t.to_string())
-                    .unwrap_or_else(|| "Οὐδέν".to_string());
-
-                func_table.add_row(vec![
-                    Cell::new(&func.name).fg(Color::Cyan),
-                    Cell::new(if params.is_empty() { "-" } else { &params }),
-                    Cell::new(ret).fg(Color::Yellow),
-                ]);
-            }
-            writeln!(f, "{}", func_table)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// A comprehensive report for the compilation process
+/// Formats a human-readable report for an analyzed program.
 ///
 /// ## Examples
 ///
 /// ```rust
 /// use glossa::parser::parse;
 /// use glossa::semantic::analyze_program;
-/// use glossa::tools::report::{CompilationReport, ProgramStats};
-/// use std::path::PathBuf;
+/// use glossa::tools::report::format_glossa_report;
+///
+/// let source = "ξ πέντε ἔστω.";
+/// let ast = parse(source).unwrap();
+/// let program = analyze_program(&ast).unwrap();
+/// let output = format_glossa_report(&program, "main.γλ");
+///
+/// assert!(output.contains("main.γλ"));
+/// assert!(output.contains("1")); // Statement count
+/// ```
+pub fn format_glossa_report(program: &AnalyzedProgram, filename: &str) -> String {
+    use std::fmt::Write;
+
+    let stats = ProgramStats::new(program);
+    let mut output = String::new();
+
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL).set_header(vec![
+        Cell::new("Μετρική (Metric)")
+            .add_attribute(comfy_table::Attribute::Bold)
+            .fg(Color::Cyan),
+        Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
+    ]);
+
+    table.add_row(vec![
+        Cell::new("Ἀρχεῖον (File)"),
+        Cell::new(filename).fg(Color::Green),
+    ]);
+    table.add_row(vec![
+        Cell::new("Προτάσεις (Statements)"),
+        Cell::new(stats.statement_count),
+    ]);
+    table.add_row(vec![
+        Cell::new("Εκφράσεις (Expressions)"),
+        Cell::new(stats.expression_count),
+    ]);
+    table.add_row(vec![
+        Cell::new("Μεταβλητές (Bindings)"),
+        Cell::new(stats.binding_count),
+    ]);
+
+    if stats.function_count > 0 {
+        table.add_row(vec![
+            Cell::new("Συναρτήσεις (Functions)"),
+            Cell::new(stats.function_count),
+        ]);
+    }
+
+    if stats.type_count > 0 {
+        table.add_row(vec![
+            Cell::new("Τύποι (Types)"),
+            Cell::new(stats.type_count),
+        ]);
+    }
+
+    if stats.loop_count > 0 {
+        table.add_row(vec![
+            Cell::new("Βρόχοι (Loops)"),
+            Cell::new(stats.loop_count),
+        ]);
+    }
+
+    if stats.max_depth > 0 {
+        table.add_row(vec![
+            Cell::new("Βάθος (Max Depth)"),
+            Cell::new(stats.max_depth),
+        ]);
+    }
+
+    writeln!(&mut output).unwrap();
+    writeln!(
+        &mut output,
+        "   {}",
+        "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan()
+    )
+    .unwrap();
+    writeln!(
+        &mut output,
+        "   {}",
+        "Language Metrics Dashboard".italic().dim()
+    )
+    .unwrap();
+    writeln!(&mut output).unwrap();
+    writeln!(&mut output, "{}", table).unwrap();
+
+    // If there are top-level functions, list them
+    let functions: Vec<_> = program.scope.functions().collect();
+    if !functions.is_empty() {
+        writeln!(&mut output, "\n{}", "ΣΥΝΑΡΤΗΣΕΙΣ (FUNCTIONS)".bold()).unwrap();
+        let mut func_table = Table::new();
+        func_table.load_preset(presets::UTF8_FULL).set_header(vec![
+            "Ὄνομα (Name)",
+            "Παράμετροι (Params)",
+            "Επιστροφή (Returns)",
+        ]);
+
+        for func in functions {
+            let params = func
+                .param_types
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            let ret = func
+                .return_type
+                .as_ref()
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "Οὐδέν".to_string());
+
+            func_table.add_row(vec![
+                Cell::new(&func.name).fg(Color::Cyan),
+                Cell::new(if params.is_empty() { "-" } else { &params }),
+                Cell::new(ret).fg(Color::Yellow),
+            ]);
+        }
+        writeln!(&mut output, "{}", func_table).unwrap();
+    }
+
+    output
+}
+
+/// Formats a comprehensive report for the compilation process
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::parser::parse;
+/// use glossa::semantic::analyze_program;
+/// use glossa::tools::report::{format_compilation_report, ProgramStats};
+/// use std::path::Path;
 /// use std::time::Duration;
 ///
 /// let source = "ξ πέντε ἔστω.";
@@ -378,84 +370,92 @@ impl Display for GlossaReport<'_> {
 /// let program = analyze_program(&ast).unwrap();
 /// let stats = ProgramStats::new(&program);
 ///
-/// let report = CompilationReport {
-///     input_path: PathBuf::from("main.γλ"),
-///     output_path: PathBuf::from("main.rs"),
-///     input_size: 15,
-///     output_size: 150,
-///     duration: Duration::from_millis(10),
-///     stats,
-/// };
+/// let output = format_compilation_report(
+///     Path::new("main.γλ"),
+///     Path::new("main.rs"),
+///     15,
+///     150,
+///     Duration::from_millis(10),
+///     &stats,
+/// );
 ///
-/// let output = format!("{}", report);
 /// assert!(output.contains("main.γλ"));
 /// assert!(output.contains("15 bytes"));
 /// ```
-pub struct CompilationReport {
-    pub input_path: PathBuf,
-    pub output_path: PathBuf,
-    pub input_size: u64,
-    pub output_size: u64,
-    pub duration: Duration,
-    pub stats: ProgramStats,
-}
+pub fn format_compilation_report(
+    input_path: &std::path::Path,
+    output_path: &std::path::Path,
+    input_size: u64,
+    output_size: u64,
+    duration: Duration,
+    stats: &ProgramStats,
+) -> String {
+    use std::fmt::Write;
+    let mut output = String::new();
 
-impl Display for CompilationReport {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL).set_header(vec![
-            Cell::new("Μετρική (Metric)")
-                .add_attribute(comfy_table::Attribute::Bold)
-                .fg(Color::Cyan),
-            Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
-        ]);
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL).set_header(vec![
+        Cell::new("Μετρική (Metric)")
+            .add_attribute(comfy_table::Attribute::Bold)
+            .fg(Color::Cyan),
+        Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
+    ]);
 
-        // Input File
-        table.add_row(vec![
-            Cell::new("Εἴσοδος (Input)"),
-            Cell::new(self.input_path.display().to_string()).fg(Color::Yellow),
-        ]);
+    // Input File
+    table.add_row(vec![
+        Cell::new("Εἴσοδος (Input)"),
+        Cell::new(input_path.display().to_string()).fg(Color::Yellow),
+    ]);
 
-        // Output File
-        table.add_row(vec![
-            Cell::new("Ἔξοδος (Output)"),
-            Cell::new(self.output_path.display().to_string()).fg(Color::Green),
-        ]);
+    // Output File
+    table.add_row(vec![
+        Cell::new("Ἔξοδος (Output)"),
+        Cell::new(output_path.display().to_string()).fg(Color::Green),
+    ]);
 
-        // Time
-        table.add_row(vec![
-            Cell::new("Χρόνος (Time)"),
-            Cell::new(format!("{:.2?}", self.duration)),
-        ]);
+    // Time
+    table.add_row(vec![
+        Cell::new("Χρόνος (Time)"),
+        Cell::new(format!("{:.2?}", duration)),
+    ]);
 
-        // Sizes
-        table.add_row(vec![
-            Cell::new("Μέγεθος Εἰσόδου (Input Size)"),
-            Cell::new(format!("{} bytes", self.input_size)),
-        ]);
-        table.add_row(vec![
-            Cell::new("Μέγεθος Ἐξόδου (Output Size)"),
-            Cell::new(format!("{} bytes", self.output_size)),
-        ]);
+    // Sizes
+    table.add_row(vec![
+        Cell::new("Μέγεθος Εἰσόδου (Input Size)"),
+        Cell::new(format!("{} bytes", input_size)),
+    ]);
+    table.add_row(vec![
+        Cell::new("Μέγεθος Ἐξόδου (Output Size)"),
+        Cell::new(format!("{} bytes", output_size)),
+    ]);
 
-        // Stats summary
-        table.add_row(vec![
-            Cell::new("Προτάσεις (Statements)"),
-            Cell::new(self.stats.statement_count),
-        ]);
-        table.add_row(vec![
-            Cell::new("Συναρτήσεις (Functions)"),
-            Cell::new(self.stats.function_count),
-        ]);
+    // Stats summary
+    table.add_row(vec![
+        Cell::new("Προτάσεις (Statements)"),
+        Cell::new(stats.statement_count),
+    ]);
+    table.add_row(vec![
+        Cell::new("Συναρτήσεις (Functions)"),
+        Cell::new(stats.function_count),
+    ]);
 
-        writeln!(f)?;
-        writeln!(f, "   {}", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan())?;
-        writeln!(f, "   {}", "Compilation Metrics Dashboard".italic().dim())?;
-        writeln!(f)?;
-        writeln!(f, "{}", table)?;
+    writeln!(&mut output).unwrap();
+    writeln!(
+        &mut output,
+        "   {}",
+        "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan()
+    )
+    .unwrap();
+    writeln!(
+        &mut output,
+        "   {}",
+        "Compilation Metrics Dashboard".italic().dim()
+    )
+    .unwrap();
+    writeln!(&mut output).unwrap();
+    writeln!(&mut output, "{}", table).unwrap();
 
-        Ok(())
-    }
+    output
 }
 
 #[cfg(test)]
@@ -516,8 +516,7 @@ mod tests {
     #[test]
     fn test_report_generation_coverage() {
         let program = create_dummy_program();
-        let report = GlossaReport::new(&program, "test.gl".to_string());
-        let output = format!("{}", report);
+        let output = format_glossa_report(&program, "test.gl");
 
         assert!(output.contains("R E P O R T"));
         assert!(output.contains("test.gl"));
@@ -529,16 +528,14 @@ mod tests {
     fn test_compilation_report_coverage() {
         let program = create_dummy_program();
         let stats = ProgramStats::new(&program);
-        let report = CompilationReport {
-            input_path: PathBuf::from("input.gl"),
-            output_path: PathBuf::from("output.rs"),
-            input_size: 100,
-            output_size: 200,
-            duration: Duration::from_millis(123),
-            stats,
-        };
-
-        let output = format!("{}", report);
+        let output = format_compilation_report(
+            std::path::Path::new("input.gl"),
+            std::path::Path::new("output.rs"),
+            100,
+            200,
+            Duration::from_millis(123),
+            &stats,
+        );
 
         assert!(output.contains("R E P O R T"));
         assert!(output.contains("input.gl"));

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -4,7 +4,7 @@ use crate::semantic::{AnalyzedProgram, analyze_program};
 use crate::tools::cache::Cache;
 use crate::tools::highlight::highlight;
 use crate::tools::narrator::tell_tale;
-use crate::tools::report::{CompilationReport, GlossaReport, ProgramStats};
+use crate::tools::report::{ProgramStats, format_compilation_report, format_glossa_report};
 use crate::tools::ui::Status;
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
@@ -147,14 +147,14 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 
     status.success();
 
-    let report = CompilationReport {
-        input_path: input.to_path_buf(),
-        output_path,
+    let report = format_compilation_report(
+        input,
+        &output_path,
         input_size,
         output_size,
         duration,
-        stats,
-    };
+        &stats,
+    );
 
     println!("{}", report);
 
@@ -338,7 +338,7 @@ pub fn check_file(input: &Path) -> Result<()> {
         .unwrap_or(input.as_os_str())
         .to_string_lossy()
         .to_string();
-    let report = GlossaReport::new(&analyzed, filename);
+    let report = format_glossa_report(&analyzed, &filename);
 
     status.success();
     println!("{}", report);


### PR DESCRIPTION
Removed `GlossaReport` and `CompilationReport` structs from `src/tools/report.rs` and replaced them with straightforward `format_glossa_report` and `format_compilation_report` functions. These structs were pure formatting wrappers carrying no useful logic and existing solely to implement the `Display` trait ("Layer Lasagna"). Simplifies the API and refactors call sites in `runner.rs` to consume data directly. Also fixed a stale path in `mosaic.rs` test that surfaced during validation.

Refactored tests to use functional APIs and updated `.jules/razor.md` to document the reduction.

---
*PR created automatically by Jules for task [11630598224904114099](https://jules.google.com/task/11630598224904114099) started by @madmax983*