### PR TITLE
🎻 Bard: Fix unresolved link to Symbol in docs

### DIFF
--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -8,7 +8,7 @@
 //!
 //! The resolver uses a stack-based lexical environment:
 //! * **[`Scope`]**: The entire environment, containing a stack of [`ScopeLevel`]s.
-//! * **[`ScopeLevel`]**: A single dictionary (using `FxHashMap` for speed) mapping names to [`Symbol`]s.
+//! * **[`ScopeLevel`]**: A single dictionary (using `FxHashMap` for speed) mapping names to [`Binding`]s.
 //! * **[`ScopeGuard`]**: An RAII (Resource Acquisition Is Initialization) guard returned by [`Scope::enter_scope`].
 //!   When the guard goes out of scope, it automatically drops the deepest `ScopeLevel`.
 //!

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -385,7 +385,7 @@ mod tests {
         add_cons(&mut asm.adjectives);
 
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part1".into(),
                 original: "part1".into(),
                 normalized: "part1".into(),
@@ -396,7 +396,7 @@ mod tests {
                 number: Number::Singular,
             });
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part2".into(),
                 original: "part2".into(),
                 normalized: "part2".into(),


### PR DESCRIPTION
📖 **Chapter:** The `ScopeLevel` documentation in the Semantic module.

🔦 **Insight:** The documentation for `ScopeLevel` previously referred to a `Symbol` type when describing the mapping structure (`mapping names to [`Symbol`]s`). However, the actual struct field maps names to `Binding` objects (`variables: FxHashMap<SmolStr, Binding>`). This inconsistency resulted in a `cargo doc` warning regarding an unresolved link. I updated the documentation to accurately reflect the implementation. Furthermore, a minor pathing bug was corrected in `src/tools/mosaic.rs` to fix `clippy` and compilation errors related to `ParticipleConstituent`.

🧪 **Example:** No executable doctests were required for this internal change. 

🖼️ **Preview:** `cargo doc --no-deps --document-private-items` now executes successfully without any warnings.

---
*PR created automatically by Jules for task [7848160700479564261](https://jules.google.com/task/7848160700479564261) started by @madmax983*