### PR TITLE
🎨 Mosaic: UI Polish for Alchemist

### DIFF
--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -15,6 +15,8 @@ use crate::parser::parse;
 use crate::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, analyze_program,
 };
+use comfy_table::{Attribute, Cell, Color, Table, presets};
+use crossterm::style::Stylize;
 use std::path::Path;
 
 /// Run the Alchemist tool on a file
@@ -31,7 +33,25 @@ pub fn run_alchemist(input: &Path) -> miette::Result<()> {
 
     status.success();
 
-    println!("--- Python (The Alchemist) ---\n{}", python_code);
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   A L C H E M I S T".bold().cyan());
+    println!("   {}", "Python Transpilation Result".italic().dim());
+    println!();
+
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL);
+
+    table.set_header(vec![
+        Cell::new("Python Source Code")
+            .add_attribute(Attribute::Bold)
+            .fg(Color::Cyan),
+    ]);
+
+    let formatted_code = format!("```python\n{}\n```", python_code.trim());
+    table.add_row(vec![Cell::new(formatted_code)]);
+
+    println!("{table}");
+    println!();
 
     Ok(())
 }

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -385,7 +385,7 @@ mod tests {
         add_cons(&mut asm.adjectives);
 
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part1".into(),
                 original: "part1".into(),
                 normalized: "part1".into(),
@@ -396,7 +396,7 @@ mod tests {
                 number: Number::Singular,
             });
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part2".into(),
                 original: "part2".into(),
                 normalized: "part2".into(),


### PR DESCRIPTION
🖌️ **Before:** `run_alchemist` in `src/tools/alchemist.rs` printed the generated Python code as a raw string under a plain text header `--- Python (The Alchemist) ---`. It felt like reading a log file rather than a polished tool output.
✨ **After:** The transpiler now outputs a structured, framed dashboard using `comfy-table` with syntax block formatting (`python`), matching the visual hierarchy established by the Cartographer tool. 
🖼️ **Visuals:** The header uses bold cyan and italic dim styling (`Γ Λ Ω Σ Σ Α   A L C H E M I S T`). The Python code is wrapped inside a full UTF-8 border table with a cyan, bold column header `Python Source Code`.

---
*PR created automatically by Jules for task [15793359496172696240](https://jules.google.com/task/15793359496172696240) started by @madmax983*