### PR TITLE
⚒️ Forge: Extract add_row logic in mosaic.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -33,3 +33,7 @@
 **Refactoring God Functions in the Alchemist**
 **Learning:** `transpile_statement` in `src/tools/alchemist.rs` was a classic God Function (over 200 lines) with a deeply nested match statement containing complex string building logic for each AST node. When using `replace_with_git_merge_diff` or python scripting to extract match arms into helper functions (`transpile_if`, `transpile_while`, etc.), it's critical to capture or destructure the enum variables correctly in the helper functions to prevent `unused_variables` warnings from clippy. In this case, I used `AnalyzedStatement::If { .. } => transpile_if(stmt, indent)` in the top-level match and handled destructuring inside `transpile_if` to resolve warnings.
 **Action:** Always verify `cargo clippy --all-targets --all-features -- -D warnings` after extracting match arms. If variables bound in the match arm are no longer used locally because the whole object is passed, use `..` to ignore them.
+
+**Refactoring God Functions in CLI Display Utilities**
+**Learning:** Functions that generate complex UI tables (like `add_row` in `src/tools/mosaic.rs`) often become God Functions (~150+ lines) as they aggregate many different data types and conditions into a single string. This creates a "Pyramid of Doom" of data preparation right before UI construction.
+**Action:** Extract the complex column data preparation logic into distinct formatting helper functions (e.g., `format_subject`, `format_other_column`), keeping the main row addition function focused solely on inserting the mapped columns into the table UI.

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -132,7 +132,7 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
     Ok(())
 }
 
-fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
+fn format_subject(asm: &AssembledStatement) -> String {
     let subject = asm
         .subject
         .as_ref()
@@ -149,7 +149,8 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
         }
         extra_noms.push_str(&fmt_constituent(nom));
     }
-    let full_subject = if !extra_noms.is_empty() {
+
+    if !extra_noms.is_empty() {
         if !subject.is_empty() {
             format!("{} (+ {})", subject, extra_noms)
         } else {
@@ -157,21 +158,10 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
         }
     } else {
         subject
-    };
+    }
+}
 
-    let verb = asm
-        .verb
-        .as_ref()
-        .map(|v| v.original.to_string())
-        .unwrap_or_default();
-    let object = asm.object.as_ref().map(fmt_constituent).unwrap_or_default();
-    let indirect = asm
-        .indirect
-        .as_ref()
-        .map(fmt_constituent)
-        .unwrap_or_default();
-
-    // Collect other interesting things
+fn format_other_column(asm: &AssembledStatement) -> String {
     let mut other = Vec::new();
 
     // Literals
@@ -284,13 +274,33 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
         other.push(format!("Flags: [{}]", flags.join(", ")));
     }
 
+    other.join("\n")
+}
+
+fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
+    let full_subject = format_subject(asm);
+
+    let verb = asm
+        .verb
+        .as_ref()
+        .map(|v| v.original.to_string())
+        .unwrap_or_default();
+    let object = asm.object.as_ref().map(fmt_constituent).unwrap_or_default();
+    let indirect = asm
+        .indirect
+        .as_ref()
+        .map(fmt_constituent)
+        .unwrap_or_default();
+
+    let other_column = format_other_column(asm);
+
     table.add_row(vec![
         Cell::new(format!("{}", line)),
         Cell::new(full_subject),
         Cell::new(verb),
         Cell::new(object),
         Cell::new(indirect),
-        Cell::new(other.join("\n")).fg(Color::DarkGrey),
+        Cell::new(other_column).fg(Color::DarkGrey),
     ]);
 }
 
@@ -385,7 +395,7 @@ mod tests {
         add_cons(&mut asm.adjectives);
 
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part1".into(),
                 original: "part1".into(),
                 normalized: "part1".into(),
@@ -396,7 +406,7 @@ mod tests {
                 number: Number::Singular,
             });
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part2".into(),
                 original: "part2".into(),
                 normalized: "part2".into(),


### PR DESCRIPTION
🚮 **Smell:** The `add_row` function in `src/tools/mosaic.rs` was a "God Function" (~150 lines) that handled highly complex string building for a UI table, creating a "Pyramid of Doom" of data preparation right before UI construction.
✨ **Solution:** Extracted the column data preparation logic into two distinct, well-named helper functions (`format_subject` and `format_other_column`), keeping the main row addition function focused solely on inserting the mapped columns into the table. Also fixed a minor import path in `src/tools/mosaic.rs` tests (`crate::semantic::assembly::model::ParticipleConstituent` to `crate::semantic::assembly::ParticipleConstituent`).
🧼 **Benefit:** Reduces cognitive load, keeps the code flat, and isolates UI formatting logic from data aggregation.
🛡️ **Verification:** Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all`, and `cargo test`. All passed successfully. No logic changed.

---
*PR created automatically by Jules for task [14136325354776452992](https://jules.google.com/task/14136325354776452992) started by @madmax983*