### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-flatten-semantic-assembly.md
+++ b/docs/adr/016-flatten-semantic-assembly.md
@@ -1,0 +1,21 @@
+# 16. Flatten Semantic Assembly Module
+
+Date: 2026-03-17
+Status: Accepted
+
+## Context
+
+The `src/semantic/assembly/mod.rs` and `src/semantic/assembly/model.rs` files were tightly coupled via DTOs (`AssembledStatement`, `Constituent`, etc.) and introduced unnecessary directory nesting within the `semantic` module. This structure violated the Razor persona's essentialism philosophy (KISS, YAGNI, DRY) by adding architectural layers and cognitive overhead without providing clear structural benefits.
+
+## Decision
+
+We eliminated the unnecessary directory nesting by flattening the semantic assembly module. The separate files `src/semantic/assembly/mod.rs` and `src/semantic/assembly/model.rs` have been merged into a single `src/semantic/assembly.rs` file. Types previously nested in `model::` must now be accessed directly via `crate::semantic::assembly::` to prevent path resolution errors in dependent tools.
+
+## Consequences
+
+### Positive
+- **Reduced Bloat**: Eliminates the `src/semantic/assembly` directory, adhering to the principle of flattened hierarchies.
+- **Cognitive Load**: Reduces architectural layers and cognitive overhead without altering compiler behavior.
+
+### Negative
+- **File Size**: The combined `src/semantic/assembly.rs` file is larger, which might marginally increase navigation time within that specific file.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,7 @@ C4Component
         Component(control_flow, "Control Flow", "src/semantic/control_flow.rs", "Analyzes If, While, Match")
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
-        Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
+        Component(assembly, "Assembly", "src/semantic/assembly.rs", "Routes words to grammatical slots")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -385,7 +385,7 @@ mod tests {
         add_cons(&mut asm.adjectives);
 
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part1".into(),
                 original: "part1".into(),
                 normalized: "part1".into(),
@@ -396,7 +396,7 @@ mod tests {
                 number: Number::Singular,
             });
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part2".into(),
                 original: "part2".into(),
                 normalized: "part2".into(),


### PR DESCRIPTION
🧠 **Decision:** Recorded the flattening of the `semantic/assembly` module into a single file, adhering to the Razor persona's KISS and YAGNI principles to reduce architectural layers and cognitive overhead without altering compiler behavior.
🗺️ **Visuals:** Updated the Component Diagram for Semantic Analysis in `docs/architecture.md` to point `Assembly` to `src/semantic/assembly.rs` instead of `src/semantic/assembly/mod.rs`.
🔗 **Link:** See `docs/adr/016-flatten-semantic-assembly.md`.

---
*PR created automatically by Jules for task [10223594468702536777](https://jules.google.com/task/10223594468702536777) started by @madmax983*