### PR TITLE
🪒 Razor: Fix compilation error in mosaic.rs

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -111,3 +111,8 @@
 **Bloat:** `src/semantic/assembly/` directory contained `mod.rs` and `model.rs`. `model.rs` contained DTOs tightly coupled to the assembler.
 **Cut:** Merged `model.rs` into `mod.rs` and renamed it to `src/semantic/assembly.rs`, deleting the `assembly/` folder.
 **Saved:** 1 directory, 1 file, reduced module indirection.
+
+## [Reduction]
+**Bloat:** Unnecessary nesting of `model::` for `ParticipleConstituent` in `src/tools/mosaic.rs` test suite (`crate::semantic::assembly::model::ParticipleConstituent`), violating ADR 016 (flat modules).
+**Cut:** Removed `model::` path segment to directly access `crate::semantic::assembly::ParticipleConstituent`.
+**Saved:** 14 characters of path boilerplate and fixed `error[E0433]` compilation failure.

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -385,7 +385,7 @@ mod tests {
         add_cons(&mut asm.adjectives);
 
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part1".into(),
                 original: "part1".into(),
                 normalized: "part1".into(),
@@ -396,7 +396,7 @@ mod tests {
                 number: Number::Singular,
             });
         asm.participles
-            .push(crate::semantic::assembly::model::ParticipleConstituent {
+            .push(crate::semantic::assembly::ParticipleConstituent {
                 verb_lemma: "part2".into(),
                 original: "part2".into(),
                 normalized: "part2".into(),


### PR DESCRIPTION
Update the import path for `ParticipleConstituent` in `src/tools/mosaic.rs` to fix `E0433` compilation failure. This is required because `src/semantic/assembly/model.rs` was flattened previously. Logged the finding to `.jules/razor.md` per the Razor persona guidelines.

---
*PR created automatically by Jules for task [10936191265404586467](https://jules.google.com/task/10936191265404586467) started by @madmax983*