### PR TITLE
⚡ Bolt: Optimize AssembledStatement cloning in resolve_binding_target

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 **Codecov Patch Gate Drops After Formatting**
 **Learning:** Running `cargo fmt` can expand untested, single-line fallback or error branches (like swapping subject/object logic) into multi-line statements. This artificially increases the number of "uncovered" lines in the diff, which can cause the strict `codecov/patch` gate (target 92.94%) to fail even if logic wasn't changed.
 **Action:** Use `cargo llvm-cov --show-missing-lines` locally to identify exactly which new lines lack coverage, and write unit tests to exercise those specific edge cases to restore the coverage percentage before pushing.
+
+**Codecov Patch Gates and Manual AST Construction**
+**Learning:** When trying to test specific logic branches (like `AssembledStatement` fallbacks in `resolve_binding_target`) to satisfy strict >92% Codecov patch gates, it is often simpler and far less brittle to manually construct the required AST/Semantic structs (`Constituent`, `AssembledStatement`, etc.) and pass them directly to the helper function in a unit test, rather than trying to reverse-engineer a raw ancient Greek string that parses and semantically evaluates perfectly into that precise edge case.
+**Action:** For edge-case branch coverage, write targeted unit tests that manually instantiate the data structures needed to trigger the specific `if` statement logic.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **Cow Optimization for Heavy AST Structs**
 **Learning:** Returning a large parsed AST struct like `AssembledStatement` (which contains multiple internal `Vec`s) by value from helper functions causes expensive clones on hot paths like variable binding.
 **Action:** Use `std::borrow::Cow<'a, AssembledStatement>` to return a borrowed reference for the happy path and only allocate `Cow::Owned` when modification (like swapping subject/object) is strictly necessary.
+
+**Codecov Patch Gate Drops After Formatting**
+**Learning:** Running `cargo fmt` can expand untested, single-line fallback or error branches (like swapping subject/object logic) into multi-line statements. This artificially increases the number of "uncovered" lines in the diff, which can cause the strict `codecov/patch` gate (target 92.94%) to fail even if logic wasn't changed.
+**Action:** Use `cargo llvm-cov --show-missing-lines` locally to identify exactly which new lines lack coverage, and write unit tests to exercise those specific edge cases to restore the coverage percentage before pushing.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 **[Slice Refactoring over Vec Collection in AST Parsing]**
 **Learning:** Avoid replacing `Vec::new()` with `Vec::with_capacity()` using arbitrary heuristics (e.g., total statement counts). `Vec::new()` is a zero-cost abstraction, whereas eager capacity allocation causes immediate heap allocations, which can lead to performance regressions if the vectors remain empty. Only use `Vec::with_capacity` when the exact required size is known in advance. When parsing or traversing ASTs (e.g., in `semantic/control_flow.rs`), avoid collecting iterator chains into intermediate vectors (e.g., `terms.iter().skip(1).collect::<Vec<_>>()`). Instead, use slice references (e.g., `&terms[1..]`) whenever possible to prevent unnecessary `O(N)` heap allocations.
 **Action:** Identify and replace unnecessary `.collect::<Vec<_>>()` calls with slices, and only use `Vec::with_capacity` with an exact calculated size.
+
+**Cow Optimization for Heavy AST Structs**
+**Learning:** Returning a large parsed AST struct like `AssembledStatement` (which contains multiple internal `Vec`s) by value from helper functions causes expensive clones on hot paths like variable binding.
+**Action:** Use `std::borrow::Cow<'a, AssembledStatement>` to return a borrowed reference for the happy path and only allocate `Cow::Owned` when modification (like swapping subject/object) is strictly necessary.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -382,10 +382,15 @@ fn classify_subjunctive_comparison(
 }
 
 /// Helper: Resolve the target variable name and the effective assembled statement for binding
-fn resolve_binding_target(
-    asm_stmt: &AssembledStatement,
+///
+/// ⚡ Bolt Optimization: Returns a `std::borrow::Cow<'_, AssembledStatement>` instead of
+/// `AssembledStatement` to avoid cloning a large struct on a hot path during semantic analysis.
+/// We only need to clone and mutate the assembled statement if we're swapping subject/object
+/// or fixing false participles. Otherwise, we just return a borrowed reference to the original statement.
+fn resolve_binding_target<'a>(
+    asm_stmt: &'a AssembledStatement,
     scope: &Scope,
-) -> Result<(String, AssembledStatement), GlossaError> {
+) -> Result<(String, std::borrow::Cow<'a, AssembledStatement>), GlossaError> {
     // Check for "false participles" (nouns misclassified as participles)
     let has_false_participle = !asm_stmt.participles.is_empty()
         && morphology::lexicon::lookup(&asm_stmt.participles[0].verb_lemma).is_none();
@@ -394,7 +399,7 @@ fn resolve_binding_target(
         let first_participle = &asm_stmt.participles[0];
         let mut fixed_asm = asm_stmt.clone();
         fixed_asm.participles = asm_stmt.participles[1..].to_vec();
-        return Ok((first_participle.normalized.to_string(), fixed_asm));
+        return Ok((first_participle.normalized.to_string(), std::borrow::Cow::Owned(fixed_asm)));
     }
 
     // Check for Subject/Object swap (if Subject is defined and Object is not, bind to Object)
@@ -406,15 +411,15 @@ fn resolve_binding_target(
             let mut swapped = asm_stmt.clone();
             swapped.subject = Some(object.clone());
             swapped.object = Some(subject.clone());
-            return Ok((object_name.to_string(), swapped));
+            return Ok((object_name.to_string(), std::borrow::Cow::Owned(swapped)));
         } else {
-            return Ok((subject_name.to_string(), asm_stmt.clone()));
+            return Ok((subject_name.to_string(), std::borrow::Cow::Borrowed(asm_stmt)));
         }
     }
 
     // Default case: Bind to Subject
     if let Some(subject) = &asm_stmt.subject {
-        return Ok((subject.normalized.to_string(), asm_stmt.clone()));
+        return Ok((subject.normalized.to_string(), std::borrow::Cow::Borrowed(asm_stmt)));
     }
 
     // Fallback: Bind to first participle (if any remain)
@@ -422,7 +427,7 @@ fn resolve_binding_target(
         let first_participle = &asm_stmt.participles[0];
         let mut fixed_asm = asm_stmt.clone();
         fixed_asm.participles = asm_stmt.participles[1..].to_vec();
-        return Ok((first_participle.normalized.to_string(), fixed_asm));
+        return Ok((first_participle.normalized.to_string(), std::borrow::Cow::Owned(fixed_asm)));
     }
 
     Err(GlossaError::semantic("Binding without subject"))
@@ -442,7 +447,7 @@ fn classify_variable_binding(
     }
 
     let (var_name, actual_asm) = resolve_binding_target(asm_stmt, scope)?;
-    let (value_expr, value_type) = extract_value(&actual_asm, scope)?;
+    let (value_expr, value_type) = extract_value(actual_asm.as_ref(), scope)?;
 
     let final_value_expr = if asm_stmt.is_propagate {
         AnalyzedExpr {
@@ -2445,7 +2450,9 @@ mod tests {
         let scope = Scope::new();
         let result = resolve_binding_target(&asm_stmt, &scope);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().0, "participle");
+        let (name, fixed_asm) = result.unwrap();
+        assert_eq!(name, "participle");
+        assert!(matches!(fixed_asm, std::borrow::Cow::Owned(_)));
     }
 
     #[test]

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -399,7 +399,10 @@ fn resolve_binding_target<'a>(
         let first_participle = &asm_stmt.participles[0];
         let mut fixed_asm = asm_stmt.clone();
         fixed_asm.participles = asm_stmt.participles[1..].to_vec();
-        return Ok((first_participle.normalized.to_string(), std::borrow::Cow::Owned(fixed_asm)));
+        return Ok((
+            first_participle.normalized.to_string(),
+            std::borrow::Cow::Owned(fixed_asm),
+        ));
     }
 
     // Check for Subject/Object swap (if Subject is defined and Object is not, bind to Object)
@@ -413,13 +416,19 @@ fn resolve_binding_target<'a>(
             swapped.object = Some(subject.clone());
             return Ok((object_name.to_string(), std::borrow::Cow::Owned(swapped)));
         } else {
-            return Ok((subject_name.to_string(), std::borrow::Cow::Borrowed(asm_stmt)));
+            return Ok((
+                subject_name.to_string(),
+                std::borrow::Cow::Borrowed(asm_stmt),
+            ));
         }
     }
 
     // Default case: Bind to Subject
     if let Some(subject) = &asm_stmt.subject {
-        return Ok((subject.normalized.to_string(), std::borrow::Cow::Borrowed(asm_stmt)));
+        return Ok((
+            subject.normalized.to_string(),
+            std::borrow::Cow::Borrowed(asm_stmt),
+        ));
     }
 
     // Fallback: Bind to first participle (if any remain)
@@ -427,7 +436,10 @@ fn resolve_binding_target<'a>(
         let first_participle = &asm_stmt.participles[0];
         let mut fixed_asm = asm_stmt.clone();
         fixed_asm.participles = asm_stmt.participles[1..].to_vec();
-        return Ok((first_participle.normalized.to_string(), std::borrow::Cow::Owned(fixed_asm)));
+        return Ok((
+            first_participle.normalized.to_string(),
+            std::borrow::Cow::Owned(fixed_asm),
+        ));
     }
 
     Err(GlossaError::semantic("Binding without subject"))

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -2444,13 +2444,57 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_binding_target_subject_object_swap() {
+        // Create a scope where 'subject_var' IS defined but 'object_var' is NOT defined.
+        // This should trigger the Subject/Object swap logic.
+        let mut scope = Scope::new();
+        scope.define("subject_var", GlossaType::Number);
+
+        let asm_stmt = AssembledStatement {
+            subject: Some(Constituent {
+                lemma: "subject_var".into(),
+                normalized: "subject_var".into(),
+                original: "subject_var".into(),
+                gender: None,
+                case: crate::morphology::Case::Nominative,
+                number: Some(crate::morphology::Number::Singular),
+                person: None,
+            }),
+            object: Some(Constituent {
+                lemma: "object_var".into(),
+                normalized: "object_var".into(),
+                original: "object_var".into(),
+                gender: None,
+                case: crate::morphology::Case::Accusative,
+                number: Some(crate::morphology::Number::Singular),
+                person: None,
+            }),
+            ..Default::default()
+        };
+
+        let result = resolve_binding_target(&asm_stmt, &scope);
+        assert!(result.is_ok());
+        let (name, fixed_asm) = result.unwrap();
+        // Since 'subject_var' was defined and 'object_var' was not, it should bind to 'object_var'
+        assert_eq!(name, "object_var");
+        assert!(matches!(fixed_asm, std::borrow::Cow::Owned(_)));
+
+        // Ensure they were actually swapped
+        assert_eq!(fixed_asm.subject.as_ref().unwrap().lemma, "object_var");
+        assert_eq!(fixed_asm.object.as_ref().unwrap().lemma, "subject_var");
+    }
+
+    #[test]
     fn test_resolve_binding_target_no_subject_has_participle() {
+        // This tests the "Fallback: Bind to first participle (if any remain)" case
+        // We use a verb_lemma that exists in the lexicon so it's NOT treated as a "false participle"
+        // Let's use "λεγω" which is definitely a verb
         let asm_stmt = AssembledStatement {
             subject: None,
             participles: vec![crate::semantic::assembly::ParticipleConstituent {
-                verb_lemma: "participle".into(),
-                normalized: "participle".into(),
-                original: "participle".into(),
+                verb_lemma: "λεγω".into(),
+                normalized: "λεγων".into(), // Actual participle
+                original: "λέγων".into(),
                 gender: crate::morphology::Gender::Masculine,
                 case: crate::morphology::Case::Nominative,
                 number: crate::morphology::Number::Singular,
@@ -2463,7 +2507,33 @@ mod tests {
         let result = resolve_binding_target(&asm_stmt, &scope);
         assert!(result.is_ok());
         let (name, fixed_asm) = result.unwrap();
-        assert_eq!(name, "participle");
+        assert_eq!(name, "λεγων");
+        assert!(matches!(fixed_asm, std::borrow::Cow::Owned(_)));
+        assert!(fixed_asm.participles.is_empty()); // Should have been consumed
+    }
+
+    #[test]
+    fn test_resolve_binding_target_false_participle() {
+        // This tests the "false participle" check at the very beginning of the function
+        let asm_stmt = AssembledStatement {
+            subject: None,
+            participles: vec![crate::semantic::assembly::ParticipleConstituent {
+                verb_lemma: "not_a_real_verb_lemma".into(), // Will fail lexicon lookup
+                normalized: "false_participle".into(),
+                original: "false_participle".into(),
+                gender: crate::morphology::Gender::Masculine,
+                case: crate::morphology::Case::Nominative,
+                number: crate::morphology::Number::Singular,
+                voice: crate::morphology::Voice::Active,
+                tense: crate::morphology::Tense::Present,
+            }],
+            ..Default::default()
+        };
+        let scope = Scope::new();
+        let result = resolve_binding_target(&asm_stmt, &scope);
+        assert!(result.is_ok());
+        let (name, fixed_asm) = result.unwrap();
+        assert_eq!(name, "false_participle");
         assert!(matches!(fixed_asm, std::borrow::Cow::Owned(_)));
     }
 

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -2485,6 +2485,42 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_binding_target_subject_object_no_swap() {
+        // Create a scope where NEITHER is defined.
+        // This should skip the swap logic and fall into the 'else' branch,
+        // binding to the subject and returning Cow::Borrowed.
+        let scope = Scope::new();
+
+        let asm_stmt = AssembledStatement {
+            subject: Some(Constituent {
+                lemma: "subject_var".into(),
+                normalized: "subject_var".into(),
+                original: "subject_var".into(),
+                gender: None,
+                case: crate::morphology::Case::Nominative,
+                number: Some(crate::morphology::Number::Singular),
+                person: None,
+            }),
+            object: Some(Constituent {
+                lemma: "object_var".into(),
+                normalized: "object_var".into(),
+                original: "object_var".into(),
+                gender: None,
+                case: crate::morphology::Case::Accusative,
+                number: Some(crate::morphology::Number::Singular),
+                person: None,
+            }),
+            ..Default::default()
+        };
+
+        let result = resolve_binding_target(&asm_stmt, &scope);
+        assert!(result.is_ok());
+        let (name, fixed_asm) = result.unwrap();
+        assert_eq!(name, "subject_var");
+        assert!(matches!(fixed_asm, std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
     fn test_resolve_binding_target_no_subject_has_participle() {
         // This tests the "Fallback: Bind to first participle (if any remain)" case
         // We use a verb_lemma that exists in the lexicon so it's NOT treated as a "false participle"


### PR DESCRIPTION
💡 **What:** Refactored `resolve_binding_target` in `src/semantic/conversion.rs` to return `std::borrow::Cow<'_, AssembledStatement>` instead of `AssembledStatement` by value.

🎯 **Why:** `AssembledStatement` is a large struct containing multiple vectors (e.g. `nominatives`, `genitives`, `adjectives`, etc.). Returning it by value forced a `.clone()` on every single variable binding parsed during semantic analysis, even in the "happy path" where no mutations (like swapping subject and object) were needed. 

📊 **Impact:** Reduces heap allocations significantly during the semantic phase by avoiding the deep clone of `AssembledStatement` on the hot path for all standard variable assignments. We now only allocate and clone if we explicitly need to swap the subject/object or fix false participles.

🔬 **Measurement:** Run `cargo test` and `cargo clippy` to verify no regressions in functionality and that the lifetime mapping is sound. Code is covered by existing semantic conversion tests.

---
*PR created automatically by Jules for task [15567619598375459956](https://jules.google.com/task/15567619598375459956) started by @madmax983*