### PR TITLE
👺 Havoc: Fatal stack overflow (SIGABRT) in semantic analyzer via deeply nested AST

### DIFF
--- a/tests/havoc_deep_ast.rs
+++ b/tests/havoc_deep_ast.rs
@@ -1,0 +1,30 @@
+use glossa::ast::{Clause, Expr, Program, Statement};
+
+#[test]
+#[ignore = "Demonstrates a SIGABRT stack overflow when directly analyzing deeply nested ASTs bypassing parser limits"]
+fn test_deep_ast_overflow_analyzer() {
+    let depth = 50000;
+
+    // We construct a deeply nested AST manually.
+    // This simulates an API consumer constructing their own AST, bypassing the parser's
+    // string length or `check_recursion_depth` constraints, or an unbounded macro expansion.
+    let mut expr = Expr::NumberLiteral(1);
+    for _ in 0..depth {
+        expr = Expr::Phrase(vec![expr]);
+    }
+
+    let stmt = Statement::Regular {
+        clauses: vec![Clause {
+            expressions: vec![expr],
+        }],
+        is_query: false,
+        is_propagate: false,
+    };
+
+    let prog = Program {
+        statements: vec![stmt],
+    };
+
+    // 💥 DETONATE: This will cause a fatal stack overflow (SIGABRT)
+    let _res = glossa::semantic::analyzer::analyze_program(&prog);
+}


### PR DESCRIPTION
🧨 **The Trigger:** 
A programmatically constructed, deeply nested Abstract Syntax Tree (specifically `Expr::Phrase` nested ~50,000 levels deep) passed directly to `glossa::semantic::analyzer::analyze_program(&ast)`. This bypasses the parser's linear `check_recursion_depth` limit completely, allowing an API consumer or macro expansion to send unbounded data into the semantic phase.

📉 **The Stack Trace:**
```
thread 'test_deep_ast_overflow_analyzer' (23289) has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `--test havoc_deep_ast`

Caused by:
  process didn't exit successfully: `/app/target/debug/deps/havoc_deep_ast-443ec71537875137` (signal: 6, SIGABRT: process abort signal)
```

🧪 **Reproduction:**
Run `cargo test --test havoc_deep_ast -- --ignored`.

😈 **Comment:** 
You locked the front door (`check_recursion_depth` in the parser), but left the back window wide open. The public `analyze_program` API trusts the structure blindly. An attacker constructing AST nodes programmatically, or an unbounded recursive macro, will shatter the stack instantly. I didn't fix it. Have fun picking up the pieces.

---
*PR created automatically by Jules for task [8097301769208575085](https://jules.google.com/task/8097301769208575085) started by @madmax983*