### PR TITLE
🪒 Razor: Flatten report display abstractions

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -116,3 +116,8 @@
 **Bloat:** Unnecessary nesting of `model::` for `ParticipleConstituent` in `src/tools/mosaic.rs` test suite (`crate::semantic::assembly::model::ParticipleConstituent`), violating ADR 016 (flat modules).
 **Cut:** Removed `model::` path segment to directly access `crate::semantic::assembly::ParticipleConstituent`.
 **Saved:** 14 characters of path boilerplate and fixed `error[E0433]` compilation failure.
+
+## [Reduction]
+**Bloat:** `src/tools/report.rs` contained "Layer Lasagna" abstractions: `GlossaReport` and `CompilationReport` structs that existed solely to implement the `Display` trait.
+**Cut:** Deleted the structs and their `Display` implementations, replacing them with straightforward standalone formatting functions (`format_glossa_report` and `format_compilation_report`).
+**Saved:** Reduced struct instantiation boilerplate and unnecessary indirection, flattening the reporting architecture.

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -17,9 +17,6 @@
 use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 
-
-
-
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 
 /// Statistics for an analyzed program
@@ -303,8 +300,14 @@ pub fn format_glossa_report(program: &AnalyzedProgram, filename: &str) -> String
 
     let mut output = String::new();
     output.push('\n');
-    output.push_str(&format!("   {}\n", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan()));
-    output.push_str(&format!("   {}\n", "Language Metrics Dashboard".italic().dim()));
+    output.push_str(&format!(
+        "   {}\n",
+        "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan()
+    ));
+    output.push_str(&format!(
+        "   {}\n",
+        "Language Metrics Dashboard".italic().dim()
+    ));
     output.push('\n');
     output.push_str(&format!("{}\n", table));
 
@@ -429,8 +432,14 @@ pub fn format_compilation_report(
 
     let mut output = String::new();
     output.push('\n');
-    output.push_str(&format!("   {}\n", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan()));
-    output.push_str(&format!("   {}\n", "Compilation Metrics Dashboard".italic().dim()));
+    output.push_str(&format!(
+        "   {}\n",
+        "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan()
+    ));
+    output.push_str(&format!(
+        "   {}\n",
+        "Compilation Metrics Dashboard".italic().dim()
+    ));
     output.push('\n');
     output.push_str(&format!("{}\n", table));
 
@@ -497,7 +506,6 @@ mod tests {
         let program = create_dummy_program();
         let output = format_glossa_report(&program, "test.gl");
 
-
         assert!(output.contains("R E P O R T"));
         assert!(output.contains("test.gl"));
         assert!(output.contains("test_func")); // Function list
@@ -516,8 +524,6 @@ mod tests {
             std::time::Duration::from_millis(123),
             &stats,
         );
-
-
 
         assert!(output.contains("R E P O R T"));
         assert!(output.contains("input.gl"));

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -16,9 +16,9 @@
 
 use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
-use std::fmt::Display;
-use std::path::PathBuf;
-use std::time::Duration;
+
+
+
 
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 
@@ -229,149 +229,131 @@ impl ProgramStats {
 }
 
 /// A human-readable report for an analyzed program
-pub struct GlossaReport<'a> {
-    program: &'a AnalyzedProgram,
-    stats: ProgramStats,
-    filename: String,
-}
-
-impl<'a> GlossaReport<'a> {
-    /// Creates a new GlossaReport.
-    ///
-    /// ## Examples
-    ///
-    /// ```rust
-    /// use glossa::parser::parse;
-    /// use glossa::semantic::analyze_program;
-    /// use glossa::tools::report::GlossaReport;
-    ///
-    /// let source = "ξ πέντε ἔστω.";
-    /// let ast = parse(source).unwrap();
-    /// let program = analyze_program(&ast).unwrap();
-    /// let report = GlossaReport::new(&program, "main.γλ".to_string());
-    ///
-    /// let output = format!("{}", report);
-    /// assert!(output.contains("main.γλ"));
-    /// assert!(output.contains("1")); // Statement count
-    /// ```
-    pub fn new(program: &'a AnalyzedProgram, filename: String) -> Self {
-        let stats = ProgramStats::new(program);
-        Self {
-            program,
-            stats,
-            filename,
-        }
-    }
-}
-
-impl Display for GlossaReport<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL).set_header(vec![
-            Cell::new("Μετρική (Metric)")
-                .add_attribute(comfy_table::Attribute::Bold)
-                .fg(Color::Cyan),
-            Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
-        ]);
-
-        table.add_row(vec![
-            Cell::new("Ἀρχεῖον (File)"),
-            Cell::new(&self.filename).fg(Color::Green),
-        ]);
-        table.add_row(vec![
-            Cell::new("Προτάσεις (Statements)"),
-            Cell::new(self.stats.statement_count),
-        ]);
-        table.add_row(vec![
-            Cell::new("Εκφράσεις (Expressions)"),
-            Cell::new(self.stats.expression_count),
-        ]);
-        table.add_row(vec![
-            Cell::new("Μεταβλητές (Bindings)"),
-            Cell::new(self.stats.binding_count),
-        ]);
-
-        if self.stats.function_count > 0 {
-            table.add_row(vec![
-                Cell::new("Συναρτήσεις (Functions)"),
-                Cell::new(self.stats.function_count),
-            ]);
-        }
-
-        if self.stats.type_count > 0 {
-            table.add_row(vec![
-                Cell::new("Τύποι (Types)"),
-                Cell::new(self.stats.type_count),
-            ]);
-        }
-
-        if self.stats.loop_count > 0 {
-            table.add_row(vec![
-                Cell::new("Βρόχοι (Loops)"),
-                Cell::new(self.stats.loop_count),
-            ]);
-        }
-
-        if self.stats.max_depth > 0 {
-            table.add_row(vec![
-                Cell::new("Βάθος (Max Depth)"),
-                Cell::new(self.stats.max_depth),
-            ]);
-        }
-
-        writeln!(f)?;
-        writeln!(f, "   {}", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan())?;
-        writeln!(f, "   {}", "Language Metrics Dashboard".italic().dim())?;
-        writeln!(f)?;
-        writeln!(f, "{}", table)?;
-
-        // If there are top-level functions, list them
-        let functions: Vec<_> = self.program.scope.functions().collect();
-        if !functions.is_empty() {
-            writeln!(f, "\n{}", "ΣΥΝΑΡΤΗΣΕΙΣ (FUNCTIONS)".bold())?;
-            let mut func_table = Table::new();
-            func_table.load_preset(presets::UTF8_FULL).set_header(vec![
-                "Ὄνομα (Name)",
-                "Παράμετροι (Params)",
-                "Επιστροφή (Returns)",
-            ]);
-
-            for func in functions {
-                let params = func
-                    .param_types
-                    .iter()
-                    .map(|t| t.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                let ret = func
-                    .return_type
-                    .as_ref()
-                    .map(|t| t.to_string())
-                    .unwrap_or_else(|| "Οὐδέν".to_string());
-
-                func_table.add_row(vec![
-                    Cell::new(&func.name).fg(Color::Cyan),
-                    Cell::new(if params.is_empty() { "-" } else { &params }),
-                    Cell::new(ret).fg(Color::Yellow),
-                ]);
-            }
-            writeln!(f, "{}", func_table)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// A comprehensive report for the compilation process
+/// Formats a human-readable report for an analyzed program
 ///
 /// ## Examples
 ///
 /// ```rust
 /// use glossa::parser::parse;
 /// use glossa::semantic::analyze_program;
-/// use glossa::tools::report::{CompilationReport, ProgramStats};
-/// use std::path::PathBuf;
+/// use glossa::tools::report::format_glossa_report;
+///
+/// let source = "ξ πέντε ἔστω.";
+/// let ast = parse(source).unwrap();
+/// let program = analyze_program(&ast).unwrap();
+/// let output = format_glossa_report(&program, "main.γλ");
+///
+/// assert!(output.contains("main.γλ"));
+/// assert!(output.contains("1")); // Statement count
+/// ```
+pub fn format_glossa_report(program: &AnalyzedProgram, filename: &str) -> String {
+    let stats = ProgramStats::new(program);
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL).set_header(vec![
+        Cell::new("Μετρική (Metric)")
+            .add_attribute(comfy_table::Attribute::Bold)
+            .fg(Color::Cyan),
+        Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
+    ]);
+
+    table.add_row(vec![
+        Cell::new("Ἀρχεῖον (File)"),
+        Cell::new(filename).fg(Color::Green),
+    ]);
+    table.add_row(vec![
+        Cell::new("Προτάσεις (Statements)"),
+        Cell::new(stats.statement_count),
+    ]);
+    table.add_row(vec![
+        Cell::new("Εκφράσεις (Expressions)"),
+        Cell::new(stats.expression_count),
+    ]);
+    table.add_row(vec![
+        Cell::new("Μεταβλητές (Bindings)"),
+        Cell::new(stats.binding_count),
+    ]);
+
+    if stats.function_count > 0 {
+        table.add_row(vec![
+            Cell::new("Συναρτήσεις (Functions)"),
+            Cell::new(stats.function_count),
+        ]);
+    }
+
+    if stats.type_count > 0 {
+        table.add_row(vec![
+            Cell::new("Τύποι (Types)"),
+            Cell::new(stats.type_count),
+        ]);
+    }
+
+    if stats.loop_count > 0 {
+        table.add_row(vec![
+            Cell::new("Βρόχοι (Loops)"),
+            Cell::new(stats.loop_count),
+        ]);
+    }
+
+    if stats.max_depth > 0 {
+        table.add_row(vec![
+            Cell::new("Βάθος (Max Depth)"),
+            Cell::new(stats.max_depth),
+        ]);
+    }
+
+    let mut output = String::new();
+    output.push('\n');
+    output.push_str(&format!("   {}\n", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan()));
+    output.push_str(&format!("   {}\n", "Language Metrics Dashboard".italic().dim()));
+    output.push('\n');
+    output.push_str(&format!("{}\n", table));
+
+    // If there are top-level functions, list them
+    let functions: Vec<_> = program.scope.functions().collect();
+    if !functions.is_empty() {
+        output.push_str(&format!("\n{}\n", "ΣΥΝΑΡΤΗΣΕΙΣ (FUNCTIONS)".bold()));
+        let mut func_table = Table::new();
+        func_table.load_preset(presets::UTF8_FULL).set_header(vec![
+            "Ὄνομα (Name)",
+            "Παράμετροι (Params)",
+            "Επιστροφή (Returns)",
+        ]);
+
+        for func in functions {
+            let params = func
+                .param_types
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            let ret = func
+                .return_type
+                .as_ref()
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "Οὐδέν".to_string());
+
+            func_table.add_row(vec![
+                Cell::new(&func.name).fg(Color::Cyan),
+                Cell::new(if params.is_empty() { "-" } else { &params }),
+                Cell::new(ret).fg(Color::Yellow),
+            ]);
+        }
+        output.push_str(&format!("{}\n", func_table));
+    }
+
+    output
+}
+
+/// Formats a comprehensive report for the compilation process
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::parser::parse;
+/// use glossa::semantic::analyze_program;
+/// use glossa::tools::report::{format_compilation_report, ProgramStats};
+/// use std::path::Path;
 /// use std::time::Duration;
 ///
 /// let source = "ξ πέντε ἔστω.";
@@ -379,84 +361,80 @@ impl Display for GlossaReport<'_> {
 /// let program = analyze_program(&ast).unwrap();
 /// let stats = ProgramStats::new(&program);
 ///
-/// let report = CompilationReport {
-///     input_path: PathBuf::from("main.γλ"),
-///     output_path: PathBuf::from("main.rs"),
-///     input_size: 15,
-///     output_size: 150,
-///     duration: Duration::from_millis(10),
-///     stats,
-/// };
+/// let output = format_compilation_report(
+///     Path::new("main.γλ"),
+///     Path::new("main.rs"),
+///     15,
+///     150,
+///     Duration::from_millis(10),
+///     &stats,
+/// );
 ///
-/// let output = format!("{}", report);
 /// assert!(output.contains("main.γλ"));
 /// assert!(output.contains("15 bytes"));
 /// ```
-pub struct CompilationReport {
-    pub input_path: PathBuf,
-    pub output_path: PathBuf,
-    pub input_size: u64,
-    pub output_size: u64,
-    pub duration: Duration,
-    pub stats: ProgramStats,
-}
+pub fn format_compilation_report(
+    input_path: &std::path::Path,
+    output_path: &std::path::Path,
+    input_size: u64,
+    output_size: u64,
+    duration: std::time::Duration,
+    stats: &ProgramStats,
+) -> String {
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL).set_header(vec![
+        Cell::new("Μετρική (Metric)")
+            .add_attribute(comfy_table::Attribute::Bold)
+            .fg(Color::Cyan),
+        Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
+    ]);
 
-impl Display for CompilationReport {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL).set_header(vec![
-            Cell::new("Μετρική (Metric)")
-                .add_attribute(comfy_table::Attribute::Bold)
-                .fg(Color::Cyan),
-            Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
-        ]);
+    // Input File
+    table.add_row(vec![
+        Cell::new("Εἴσοδος (Input)"),
+        Cell::new(input_path.display().to_string()).fg(Color::Yellow),
+    ]);
 
-        // Input File
-        table.add_row(vec![
-            Cell::new("Εἴσοδος (Input)"),
-            Cell::new(self.input_path.display().to_string()).fg(Color::Yellow),
-        ]);
+    // Output File
+    table.add_row(vec![
+        Cell::new("Ἔξοδος (Output)"),
+        Cell::new(output_path.display().to_string()).fg(Color::Green),
+    ]);
 
-        // Output File
-        table.add_row(vec![
-            Cell::new("Ἔξοδος (Output)"),
-            Cell::new(self.output_path.display().to_string()).fg(Color::Green),
-        ]);
+    // Time
+    table.add_row(vec![
+        Cell::new("Χρόνος (Time)"),
+        Cell::new(format!("{:.2?}", duration)),
+    ]);
 
-        // Time
-        table.add_row(vec![
-            Cell::new("Χρόνος (Time)"),
-            Cell::new(format!("{:.2?}", self.duration)),
-        ]);
+    // Sizes
+    table.add_row(vec![
+        Cell::new("Μέγεθος Εἰσόδου (Input Size)"),
+        Cell::new(format!("{} bytes", input_size)),
+    ]);
+    table.add_row(vec![
+        Cell::new("Μέγεθος Ἐξόδου (Output Size)"),
+        Cell::new(format!("{} bytes", output_size)),
+    ]);
 
-        // Sizes
-        table.add_row(vec![
-            Cell::new("Μέγεθος Εἰσόδου (Input Size)"),
-            Cell::new(format!("{} bytes", self.input_size)),
-        ]);
-        table.add_row(vec![
-            Cell::new("Μέγεθος Ἐξόδου (Output Size)"),
-            Cell::new(format!("{} bytes", self.output_size)),
-        ]);
+    // Stats summary
+    table.add_row(vec![
+        Cell::new("Προτάσεις (Statements)"),
+        Cell::new(stats.statement_count),
+    ]);
+    table.add_row(vec![
+        Cell::new("Συναρτήσεις (Functions)"),
+        Cell::new(stats.function_count),
+    ]);
 
-        // Stats summary
-        table.add_row(vec![
-            Cell::new("Προτάσεις (Statements)"),
-            Cell::new(self.stats.statement_count),
-        ]);
-        table.add_row(vec![
-            Cell::new("Συναρτήσεις (Functions)"),
-            Cell::new(self.stats.function_count),
-        ]);
+    let mut output = String::new();
+    output.push('\n');
+    output.push_str(&format!("   {}\n", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan()));
+    output.push_str(&format!("   {}\n", "Compilation Metrics Dashboard".italic().dim()));
+    output.push('\n');
+    output.push_str(&format!("{}\n", table));
 
-        writeln!(f)?;
-        writeln!(f, "   {}", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan())?;
-        writeln!(f, "   {}", "Compilation Metrics Dashboard".italic().dim())?;
-        writeln!(f)?;
-        writeln!(f, "{}", table)?;
-
-        Ok(())
-    }
+    output
 }
 
 #[cfg(test)]
@@ -517,8 +495,8 @@ mod tests {
     #[test]
     fn test_report_generation_coverage() {
         let program = create_dummy_program();
-        let report = GlossaReport::new(&program, "test.gl".to_string());
-        let output = format!("{}", report);
+        let output = format_glossa_report(&program, "test.gl");
+
 
         assert!(output.contains("R E P O R T"));
         assert!(output.contains("test.gl"));
@@ -530,16 +508,16 @@ mod tests {
     fn test_compilation_report_coverage() {
         let program = create_dummy_program();
         let stats = ProgramStats::new(&program);
-        let report = CompilationReport {
-            input_path: PathBuf::from("input.gl"),
-            output_path: PathBuf::from("output.rs"),
-            input_size: 100,
-            output_size: 200,
-            duration: Duration::from_millis(123),
-            stats,
-        };
+        let output = format_compilation_report(
+            std::path::Path::new("input.gl"),
+            std::path::Path::new("output.rs"),
+            100,
+            200,
+            std::time::Duration::from_millis(123),
+            &stats,
+        );
 
-        let output = format!("{}", report);
+
 
         assert!(output.contains("R E P O R T"));
         assert!(output.contains("input.gl"));

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -4,7 +4,7 @@ use crate::semantic::{AnalyzedProgram, analyze_program};
 use crate::tools::cache::Cache;
 use crate::tools::highlight::highlight;
 use crate::tools::narrator::tell_tale;
-use crate::tools::report::{format_compilation_report, format_glossa_report, ProgramStats};
+use crate::tools::report::{ProgramStats, format_compilation_report, format_glossa_report};
 use crate::tools::ui::Status;
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -4,7 +4,7 @@ use crate::semantic::{AnalyzedProgram, analyze_program};
 use crate::tools::cache::Cache;
 use crate::tools::highlight::highlight;
 use crate::tools::narrator::tell_tale;
-use crate::tools::report::{CompilationReport, GlossaReport, ProgramStats};
+use crate::tools::report::{format_compilation_report, format_glossa_report, ProgramStats};
 use crate::tools::ui::Status;
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
@@ -147,16 +147,16 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 
     status.success();
 
-    let report = CompilationReport {
-        input_path: input.to_path_buf(),
-        output_path,
+    let report_output = format_compilation_report(
+        input,
+        &output_path,
         input_size,
         output_size,
         duration,
-        stats,
-    };
+        &stats,
+    );
 
-    println!("{}", report);
+    println!("{}", report_output);
 
     Ok(())
 }
@@ -338,10 +338,10 @@ pub fn check_file(input: &Path) -> Result<()> {
         .unwrap_or(input.as_os_str())
         .to_string_lossy()
         .to_string();
-    let report = GlossaReport::new(&analyzed, filename);
+    let report_output = format_glossa_report(&analyzed, &filename);
 
     status.success();
-    println!("{}", report);
+    println!("{}", report_output);
 
     Ok(())
 }


### PR DESCRIPTION
**Bloat:** `src/tools/report.rs` contained "Layer Lasagna" abstractions: `GlossaReport` and `CompilationReport` structs that existed solely to implement the `Display` trait.

**Cut:** Deleted the structs and their `Display` implementations, replacing them with straightforward standalone formatting functions (`format_glossa_report` and `format_compilation_report`).

**Saved:** Reduced struct instantiation boilerplate and unnecessary indirection, flattening the reporting architecture.

---
*PR created automatically by Jules for task [10611230630837552860](https://jules.google.com/task/10611230630837552860) started by @madmax983*