### PR TITLE
🗺️ Atlas: [Cleaning The Sprawl: Unused Help Module]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -124,3 +124,7 @@
 **Tangle:** Internal modules were needlessly exposed via `pub mod` across various modules (`errors/mod.rs`, `morphology/mod.rs`, `parser/mod.rs`, `semantic/mod.rs`, `tools/mod.rs`). This broke clear module boundaries and leaked implementation details.
 **Blueprint:** Upgraded `pub mod` to `pub(crate) mod` for all internal modules while keeping `pub mod` only where necessary for public APIs (e.g. `highlight` in `tools/mod.rs` and `lexicon` in `morphology/mod.rs`). Fixed tests to import via the newly defined explicit public interfaces and selectively retained `pub mod` when refactoring deeply nested integration test imports was excessively invasive without providing architectural value.
 **Stability:** Enforced high cohesion and low coupling by ensuring strict encapsulation and clean public interfaces.
+
+## [Cleaning The Sprawl: Unused Help Module]
+**Tangle:** `src/errors/mod.rs` exported a `pub mod help` containing constants that were never used, polluting the public API.
+**Blueprint:** Removed the `help` module entirely to eliminate dead code and enforce a cleaner public interface.

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -281,23 +281,7 @@ pub type GlossaResult<T> = Result<T, GlossaError>;
 pub(crate) mod assembly;
 pub use assembly::AssemblyError;
 
-/// Help messages in Greek
-pub mod help {
-    /// Help for the binding construct
-    pub const BINDING: &str = "Χρῆσις: ὄνομα τιμή ἔστω.
-Παράδειγμα: ξ πέντε ἔστω.";
 
-    /// Help for the print construct
-    pub const PRINT: &str = "Χρῆσις: τιμή λέγε.
-Παράδειγμα: «χαῖρε κόσμε» λέγε.";
-
-    /// Help for cases
-    pub const CASES: &str = "Πτώσεις καὶ σημασίαι:
-• Ὀνομαστική - τὸ ὑποκείμενον
-• Γενική - κτῆσις, δάνεισμα (&)
-• Δοτική - δάνεισμα μεταβλητόν (&mut)
-• Αἰτιατική - τὸ ἀντικείμενον, κίνησις";
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -281,8 +281,6 @@ pub type GlossaResult<T> = Result<T, GlossaError>;
 pub(crate) mod assembly;
 pub use assembly::AssemblyError;
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/razor_coverage.rs
+++ b/tests/razor_coverage.rs
@@ -87,13 +87,6 @@ fn test_assembly_errors_display_impls() {
     assert!(format!("{}", err).contains("Ὑπέρβασις ὁρίου"));
 }
 
-#[test]
-fn test_errors_help_module() {
-    assert!(glossa::errors::help::BINDING.contains("Χρῆσις"));
-    assert!(glossa::errors::help::PRINT.contains("Χρῆσις"));
-    assert!(glossa::errors::help::CASES.contains("Πτώσεις"));
-}
-
 // --- Assembler Structs Coverage ---
 
 #[test]


### PR DESCRIPTION
🕸️ Tangle: The `src/errors/mod.rs` exported an unused `help` module (`pub mod help`) containing unused constants (`BINDING`, `PRINT`, `CASES`), which polluted the public API and caused Clippy dead-code warnings.
📐 Blueprint: Removed the `help` module entirely, adhering to YAGNI and enforcing a cleaner public interface. Removed references to this dead code in unit tests.
🧱 Stability: Reduced codebase sprawl, removed dead code, strictly enforced `-D warnings`.
🔬 Verification: Builds successfully, all tests pass, and Clippy warnings are eliminated.

---
*PR created automatically by Jules for task [17338398511082993881](https://jules.google.com/task/17338398511082993881) started by @madmax983*