### PR TITLE
🪒 Razor: Delete `TraitImpl` DTO and dead `lookup_trait_impl` code

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -113,6 +113,7 @@
 **Saved:** 1 directory, 1 file, reduced module indirection.
 
 ## [Reduction]
-**Bloat:** Unnecessary nesting of `model::` for `ParticipleConstituent` in `src/tools/mosaic.rs` test suite (`crate::semantic::assembly::model::ParticipleConstituent`), violating ADR 016 (flat modules).
-**Cut:** Removed `model::` path segment to directly access `crate::semantic::assembly::ParticipleConstituent`.
-**Saved:** 14 characters of path boilerplate and fixed `error[E0433]` compilation failure.
+## [Reduction]
+**Bloat:** `src/semantic/model.rs` defined a `TraitImpl` DTO that was only ever used to transport two strings into a `ScopeLevel` vector. Additionally, `src/semantic/resolver.rs` contained a `lookup_trait_impl` method that was dead code (never called).
+**Cut:** Deleted the `TraitImpl` struct entirely, replaced the `ScopeLevel` vector with `Vec<(SmolStr, SmolStr)>`, and deleted the unused `lookup_trait_impl` method.
+**Saved:** Reduced DTO boilerplate, eliminated dead code, and simplified internal state tracking for trait implementations.

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -284,14 +284,8 @@ pub fn analyze_trait_impl(
         }
     }
 
-    // Create the trait implementation
-    let trait_impl_semantic = crate::semantic::model::TraitImpl {
-        trait_name: trait_name.clone(),
-        type_name: type_name.clone(),
-    };
-
     // Register the trait impl in scope
-    scope.register_trait_impl(trait_impl_semantic);
+    scope.register_trait_impl(type_name.clone(), trait_name.clone());
 
     Ok(AnalyzedStatement::TraitImplementation {
         trait_name,

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -460,10 +460,3 @@ pub struct TraitDef {
     pub name: SmolStr,
     pub methods: Vec<AnalyzedMethod>,
 }
-
-/// Trait implementation for a type
-#[derive(Debug, Clone)]
-pub struct TraitImpl {
-    pub trait_name: SmolStr,
-    pub type_name: SmolStr,
-}

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -50,8 +50,8 @@ struct ScopeLevel {
     types: FxHashMap<SmolStr, GlossaType>,
     /// Traits defined in this scope.
     traits: FxHashMap<SmolStr, crate::semantic::model::TraitDef>,
-    /// Trait implementations in this scope
-    trait_impls: Vec<crate::semantic::model::TraitImpl>,
+    /// Trait implementations in this scope: (type_name, trait_name)
+    trait_impls: Vec<(SmolStr, SmolStr)>,
 }
 
 impl ScopeLevel {
@@ -274,35 +274,21 @@ impl Scope {
     }
 
     /// Register a trait implementation
-    pub fn register_trait_impl(&mut self, impl_def: crate::semantic::model::TraitImpl) {
-        self.current_level().trait_impls.push(impl_def);
-    }
-
-    /// Look up a trait implementation for a given type and trait
-    pub fn lookup_trait_impl(
-        &self,
-        type_name: &str,
-        trait_name: &str,
-    ) -> Option<&crate::semantic::model::TraitImpl> {
-        for level in self.levels.iter().rev() {
-            for impl_def in &level.trait_impls {
-                if impl_def.type_name == type_name && impl_def.trait_name == trait_name {
-                    return Some(impl_def);
-                }
-            }
-        }
-        None
+    pub fn register_trait_impl(&mut self, type_name: SmolStr, trait_name: SmolStr) {
+        self.current_level()
+            .trait_impls
+            .push((type_name, trait_name));
     }
 
     /// Check if a type has a trait method with the given name
     pub fn has_trait_method(&self, type_name: &str, method_name: &str) -> bool {
         for level in self.levels.iter().rev() {
-            for trait_impl in &level.trait_impls {
-                if trait_impl.type_name != type_name {
+            for (impl_type_name, impl_trait_name) in &level.trait_impls {
+                if impl_type_name != type_name {
                     continue;
                 }
                 // Check if the trait has this method
-                if let Some(trait_def) = self.lookup_trait(&trait_impl.trait_name) {
+                if let Some(trait_def) = self.lookup_trait(impl_trait_name) {
                     let has_method = trait_def.methods.iter().any(|m| m.name == method_name);
                     if has_method {
                         return true;


### PR DESCRIPTION
## [Reduction]
**Bloat:** `src/semantic/model.rs` defined a `TraitImpl` DTO that was only ever used to transport two strings into a `ScopeLevel` vector. Additionally, `src/semantic/resolver.rs` contained a `lookup_trait_impl` method that was dead code (never called).
**Cut:** Deleted the `TraitImpl` struct entirely, replaced the `ScopeLevel` vector with `Vec<(SmolStr, SmolStr)>`, and deleted the unused `lookup_trait_impl` method.
**Saved:** Reduced DTO boilerplate, eliminated dead code, and simplified internal state tracking for trait implementations.

---
*PR created automatically by Jules for task [8110395351531778781](https://jules.google.com/task/8110395351531778781) started by @madmax983*