### PR TITLE
🗣️ Echo: Fix confusing missing subcommand errors for 'nova' tools

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,11 @@ fn main() -> Result<()> {
             glossa::tools::mentor::run_mentor()?;
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mentor) => {
+            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- mentor`");
+        }
+
         Some(Commands::Build { input, output }) => {
             build_file(&input, output.as_deref())?;
         }
@@ -57,9 +62,19 @@ fn main() -> Result<()> {
             glossa::tools::mosaic::run_mosaic(&input)?;
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mosaic { .. }) => {
+            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- mosaic <FILE>`");
+        }
+
         #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
             glossa::tools::cartographer::run_map(&input)?;
+        }
+
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Map { .. }) => {
+            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- map <FILE>`");
         }
 
         #[cfg(feature = "nova")]
@@ -67,9 +82,19 @@ fn main() -> Result<()> {
             glossa::tools::weave::run_weave(&input)?;
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Weave { .. }) => {
+            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- weave <FILE>`");
+        }
+
         #[cfg(feature = "nova")]
         Some(Commands::Alchemist { input }) => {
             glossa::tools::alchemist::run_alchemist(&input)?;
+        }
+
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Alchemist { .. }) => {
+            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- alchemist <FILE>`");
         }
 
         Some(Commands::Repl) | None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,9 @@ fn main() -> Result<()> {
 
         #[cfg(not(feature = "nova"))]
         Some(Commands::Mentor) => {
-            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- mentor`");
+            miette::bail!(
+                "This tool requires the 'nova' feature. Run with `cargo run --features nova -- mentor`"
+            );
         }
 
         Some(Commands::Build { input, output }) => {
@@ -64,7 +66,9 @@ fn main() -> Result<()> {
 
         #[cfg(not(feature = "nova"))]
         Some(Commands::Mosaic { .. }) => {
-            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- mosaic <FILE>`");
+            miette::bail!(
+                "This tool requires the 'nova' feature. Run with `cargo run --features nova -- mosaic <FILE>`"
+            );
         }
 
         #[cfg(feature = "nova")]
@@ -74,7 +78,9 @@ fn main() -> Result<()> {
 
         #[cfg(not(feature = "nova"))]
         Some(Commands::Map { .. }) => {
-            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- map <FILE>`");
+            miette::bail!(
+                "This tool requires the 'nova' feature. Run with `cargo run --features nova -- map <FILE>`"
+            );
         }
 
         #[cfg(feature = "nova")]
@@ -84,7 +90,9 @@ fn main() -> Result<()> {
 
         #[cfg(not(feature = "nova"))]
         Some(Commands::Weave { .. }) => {
-            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- weave <FILE>`");
+            miette::bail!(
+                "This tool requires the 'nova' feature. Run with `cargo run --features nova -- weave <FILE>`"
+            );
         }
 
         #[cfg(feature = "nova")]
@@ -94,7 +102,9 @@ fn main() -> Result<()> {
 
         #[cfg(not(feature = "nova"))]
         Some(Commands::Alchemist { .. }) => {
-            miette::bail!("This tool requires the 'nova' feature. Run with `cargo run --features nova -- alchemist <FILE>`");
+            miette::bail!(
+                "This tool requires the 'nova' feature. Run with `cargo run --features nova -- alchemist <FILE>`"
+            );
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -102,7 +102,6 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -149,28 +148,24 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-
     Map {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Generate a Markdown Rosetta Stone (Requires "nova" feature)
-
     Weave {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Transpile a .γλ file to Python (Requires "nova" feature)
-
     Alchemist {
         /// Input file (.γλ)
         input: PathBuf,

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -102,7 +102,7 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-    #[cfg(feature = "nova")]
+
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -149,28 +149,28 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-    #[cfg(feature = "nova")]
+
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-    #[cfg(feature = "nova")]
+
     Map {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Generate a Markdown Rosetta Stone (Requires "nova" feature)
-    #[cfg(feature = "nova")]
+
     Weave {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Transpile a .γλ file to Python (Requires "nova" feature)
-    #[cfg(feature = "nova")]
+
     Alchemist {
         /// Input file (.γλ)
         input: PathBuf,


### PR DESCRIPTION
🗣️ **Echo: Getting Started example is broken**

🤦 **The Confusion:**
"Tried to run the `story_demo` / `mentor` / `mosaic`. Compiler said unrecognized subcommand."

🕵️ **The Reality:**
"Turns out I needed to enable feature `nova`, but the compiler just told me the command didn't exist."

💡 **The Fix:**
"Stop hiding the commands from the CLI parser. Expose them to `clap` unconditionally, but catch them in `main.rs` to throw a loud, helpful error saying exactly how to run the command (e.g., `cargo run --features nova -- mentor`)."

---
*PR created automatically by Jules for task [16412785678168859985](https://jules.google.com/task/16412785678168859985) started by @madmax983*