### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-root-api-facade.md
+++ b/docs/adr/016-root-api-facade.md
@@ -1,0 +1,18 @@
+# 16. Implement Root API Facade
+
+Date: 2026-03-20
+Status: Accepted
+
+## Context
+The codebase lacked clear module boundaries at the root level, indiscriminately exposing internal implementation details via `pub mod` to downstream consumers. This violated encapsulation and increased the public surface area unnecessarily.
+
+## Decision
+Applied the Facade pattern by restricting the visibility of internal modules (`pub(crate) mod` where possible, or keeping them `pub` where tests required) while explicitly lifting the primary public APIs to the top level via targeted `pub use` statements.
+
+## Consequences
+### Positive
+- Reduced public surface area, ensuring external users only depend on intentionally exported structures like `Program`, `generate_rust`, `parse`, `AnalyzedProgram`, and `analyze_program`.
+- Improved encapsulation and clearer boundaries between internal modules and the public API.
+
+### Negative
+- Requires maintaining explicit `pub use` statements in `src/lib.rs` for any new public APIs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,3 +116,33 @@ C4Component
 
     Rel(model, types, "Uses")
 ```
+
+## Root API (Facade Pattern)
+
+The root level of the library uses the Facade pattern to restrict access to internal modules and explicitly export the primary public APIs.
+
+```mermaid
+classDiagram
+    class glossa_lib {
+        +tools::highlight
+        +ast::Program
+        +codegen::generate_rust
+        +parser::parse
+        +semantic::AnalyzedProgram
+        +semantic::analyze_program
+    }
+
+    class InternalModules {
+        +ast
+        +codegen
+        +errors
+        +limits
+        +morphology
+        +parser
+        +semantic
+        +text
+        +tools
+    }
+
+    glossa_lib ..> InternalModules : Uses (pub use)
+```


### PR DESCRIPTION
🧠 **Decision:** Documented the architectural shift to the Facade pattern for the root level of the library in `docs/adr/016-root-api-facade.md`. This restricts internal modules and explicitly exports public structures like `Program`, `parse`, and `analyze_program`.
🗺️ **Visuals:** Updated the Component Architecture diagram in `docs/architecture.md` with a new Mermaid Class Diagram to clearly show the boundaries and dependencies of the new Public API Facade.
🔗 **Link:** See `docs/adr/016-root-api-facade.md`.

---
*PR created automatically by Jules for task [11732460970674229175](https://jules.google.com/task/11732460970674229175) started by @madmax983*