### PR TITLE
🪒 Razor: Remove unused AssemblyError variants

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -116,3 +116,8 @@
 **Bloat:** Unnecessary nesting of `model::` for `ParticipleConstituent` in `src/tools/mosaic.rs` test suite (`crate::semantic::assembly::model::ParticipleConstituent`), violating ADR 016 (flat modules).
 **Cut:** Removed `model::` path segment to directly access `crate::semantic::assembly::ParticipleConstituent`.
 **Saved:** 14 characters of path boilerplate and fixed `error[E0433]` compilation failure.
+
+## [Reduction]
+**Bloat:** `AssemblyError` in `src/errors/assembly.rs` contained two variants (`MissingVerb` and `GenderMismatch`) that were defined but completely unused anywhere in the codebase, leading to dead code.
+**Cut:** Deleted the `MissingVerb` and `GenderMismatch` error variants and the unused `Gender` import.
+**Saved:** Removed 13 lines of dead code and simplified the error variant surface area.

--- a/src/errors/assembly.rs
+++ b/src/errors/assembly.rs
@@ -1,4 +1,4 @@
-use crate::morphology::{Gender, Number, Person};
+use crate::morphology::{Number, Person};
 use miette::Diagnostic;
 use thiserror::Error;
 
@@ -37,16 +37,6 @@ pub enum AssemblyError {
     #[diagnostic(code(glossa::assembly::double_verb))]
     DoubleVerb,
 
-    /// No verb found in the statement
-    ///
-    /// Note: Pure expressions (like `5`) are allowed, but incomplete sentences trigger this.
-    ///
-    /// # Example
-    /// `ὁ ἄνθρωπος τὸν λόγον` (The man the word ... [missing action])
-    #[error("Ῥῆμα οὐχ εὑρέθη! Οὐδὲν ἐγένετο.")]
-    #[diagnostic(code(glossa::assembly::missing_verb))]
-    MissingVerb,
-
     /// Subject and Verb do not agree in number/person
     ///
     /// # Example
@@ -56,19 +46,6 @@ pub enum AssemblyError {
     SubjectVerbDisagreement {
         subject: (Option<Person>, Option<Number>),
         verb: (Option<Person>, Option<Number>),
-    },
-
-    /// Adjective and Noun do not agree in gender
-    ///
-    /// # Example
-    /// `ὁ καλὸς (Masc) γυνή (Fem)`
-    #[error("Ἀσυμφωνία γένους: {word1} ({gender1:?}) πρὸς {word2} ({gender2:?})")]
-    #[diagnostic(code(glossa::assembly::gender_mismatch))]
-    GenderMismatch {
-        word1: String,
-        gender1: Gender,
-        word2: String,
-        gender2: Gender,
     },
 
     /// Resource limit exceeded to prevent denial of service

--- a/tests/razor_coverage.rs
+++ b/tests/razor_coverage.rs
@@ -63,22 +63,11 @@ fn test_assembly_errors_display_impls() {
     let err = AssemblyError::DoubleVerb;
     assert!(format!("{}", err).contains("Διπλοῦν ῥῆμα"));
 
-    let err = AssemblyError::MissingVerb;
-    assert!(format!("{}", err).contains("Ῥῆμα οὐχ εὑρέθη"));
-
     let err = AssemblyError::SubjectVerbDisagreement {
         subject: (Some(Person::First), Some(Number::Singular)),
         verb: (Some(Person::Third), Some(Number::Singular)),
     };
     assert!(format!("{}", err).contains("Ἀσυμφωνία"));
-
-    let err = AssemblyError::GenderMismatch {
-        word1: "a".into(),
-        gender1: Gender::Masculine,
-        word2: "b".into(),
-        gender2: Gender::Feminine,
-    };
-    assert!(format!("{}", err).contains("Ἀσυμφωνία γένους"));
 
     let err = AssemblyError::LimitExceeded {
         resource: "x".into(),


### PR DESCRIPTION
**Bloat:** `AssemblyError` contained `MissingVerb` and `GenderMismatch` variants that were defined but never used by the compiler.
**Cut:** Deleted these unused variants and removed the unused `Gender` import. Also removed the corresponding tests in `tests/razor_coverage.rs`.
**Saved:** Reduced dead code and surface area by ~13 lines. Logged to `.jules/razor.md`.

---
*PR created automatically by Jules for task [18005739614480076176](https://jules.google.com/task/18005739614480076176) started by @madmax983*