### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/tests/sentry_assembler_coverage_tests.rs
+++ b/tests/sentry_assembler_coverage_tests.rs
@@ -1,0 +1,36 @@
+use glossa::morphology::analyze;
+use glossa::morphology::lexicon::BinaryOp;
+use glossa::semantic::Assembler;
+use glossa::semantic::assembly::Literal;
+
+#[test]
+fn test_assembler_comparison_operator() {
+    let mut asm = Assembler::new();
+    let analysis = analyze("ἴσον"); // "equal to"
+    asm.feed(&analysis, "ἴσον").unwrap();
+    let final_stmt = asm.finalize().unwrap();
+    assert_eq!(final_stmt.operators, vec![BinaryOp::Eq]);
+}
+
+#[test]
+fn test_assembler_arithmetic_operator() {
+    let mut asm = Assembler::new();
+    let analysis = analyze("ἄθροισμα"); // "sum"
+    asm.feed(&analysis, "ἄθροισμα").unwrap();
+    let final_stmt = asm.finalize().unwrap();
+    assert_eq!(final_stmt.operators, vec![BinaryOp::Add]);
+}
+
+#[test]
+fn test_assembler_numeral_value() {
+    let mut asm = Assembler::new();
+    let analysis = analyze("πέντε"); // "five"
+    asm.feed(&analysis, "πέντε").unwrap();
+    let final_stmt = asm.finalize().unwrap();
+    assert_eq!(final_stmt.literals.len(), 1);
+    if let Literal::Number(n) = final_stmt.literals[0] {
+        assert_eq!(n, 5);
+    } else {
+        panic!("Expected Number literal");
+    }
+}


### PR DESCRIPTION
🎯 Target: `Assembler::check_keywords_and_operators` and `Assembler::check_special_properties` inside `src/semantic/assembly.rs`.
💣 Risk: The arithmetic, comparison, and numeral evaluation logic was entirely untested, allowing regressions in operator matching to go undetected.
🧪 Strategy: Added specific unit tests in `tests/sentry_assembler_coverage_tests.rs` for `ἴσον` (Eq), `ἄθροισμα` (Add), and `πέντε` (Number literal) to ensure the `Assembler` properly matches and pushes them into the statement state.
🔬 Verification: Run `cargo test --test sentry_assembler_coverage_tests` and `cargo llvm-cov`.

---
*PR created automatically by Jules for task [8183757885647868906](https://jules.google.com/task/8183757885647868906) started by @madmax983*