### PR TITLE
⚒️ Forge: Refactor classify_query for better readability

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -40,3 +40,7 @@
 **Refactoring God Functions in CLI Display Utilities**
 **Learning:** Functions that generate complex UI tables (like `add_row` in `src/tools/mosaic.rs`) often become God Functions (~150+ lines) as they aggregate many different data types and conditions into a single string. This creates a "Pyramid of Doom" of data preparation right before UI construction.
 **Action:** Extract the complex column data preparation logic into distinct formatting helper functions (e.g., `format_subject`, `format_other_column`), keeping the main row addition function focused solely on inserting the mapped columns into the table UI.
+
+**Refactoring `classify_query`**
+**Learning:** Functions evaluating containment and standard statements side-by-side often accumulate to 50+ lines due to nested query logic. Using guard clauses to immediately exit if the condition isn't met (`if !asm_stmt.is_query { return Ok(None); }`) removes one level of indentation. Furthermore, extracting dense logical blocks (like the containment condition) into dedicated helpers (`classify_containment_query`) flattens the execution path.
+**Action:** When acting as Forge and encountering Pyramids of Doom, deeply nested logic, or long chained `if let` sequential returns, refactor by inverting the initial `if` statements into early returns (guard clauses) and extract large interior code blocks into highly readable, dedicated helper functions to flatten execution paths.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -1015,77 +1015,91 @@ fn classify_query(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {
-    if asm_stmt.is_query {
-        // Containment pattern
-        if asm_stmt.has_containment_preposition
-            && let Some(ref subj) = asm_stmt.subject
-        {
-            let subj_name = &subj.normalized;
-            let subj_type = scope
-                .lookup(subj_name)
-                .cloned()
-                .unwrap_or(GlossaType::Unknown);
-
-            let collection = AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj_name.clone()),
-                glossa_type: subj_type.clone(),
-            };
-
-            let element = if let Some(lit) = asm_stmt.literals.first() {
-                literal_to_analyzed_expr(lit)
-            } else {
-                AnalyzedExpr {
-                    expr: AnalyzedExprKind::NumberLiteral(0),
-                    glossa_type: GlossaType::Number,
-                }
-            };
-
-            let is_map = matches!(subj_type, GlossaType::Map(_, _));
-            let method = if is_map { "contains_key" } else { "contains" };
-
-            // Handle referencing argument if not a string literal
-            let arg_expr = if matches!(element.expr, AnalyzedExprKind::StringLiteral(_)) {
-                element
-            } else {
-                AnalyzedExpr {
-                    expr: AnalyzedExprKind::UnaryOp {
-                        op: crate::morphology::lexicon::UnaryOp::Ref,
-                        operand: Box::new(element),
-                    },
-                    glossa_type: GlossaType::Unknown,
-                }
-            };
-
-            let contains_expr = AnalyzedExpr {
-                expr: AnalyzedExprKind::MethodCall {
-                    receiver: Box::new(collection),
-                    method: method.into(),
-                    args: vec![arg_expr],
-                },
-                glossa_type: GlossaType::Boolean,
-            };
-
-            return Ok(Some(AnalyzedStatement::Query(vec![contains_expr])));
-        }
-
-        // Regular query
-        let mut exprs = Vec::with_capacity(asm_stmt.literals.len() + 1);
-        for lit in &asm_stmt.literals {
-            exprs.push(literal_to_analyzed_expr(lit));
-        }
-        if let Some(ref subj) = asm_stmt.subject {
-            let var_type = scope
-                .lookup(&subj.lemma)
-                .cloned()
-                .unwrap_or(GlossaType::Unknown);
-            exprs.push(AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: var_type,
-            });
-        }
-        return Ok(Some(AnalyzedStatement::Query(exprs)));
+    if !asm_stmt.is_query {
+        return Ok(None);
     }
-    Ok(None)
+
+    if let Some(analyzed) = classify_containment_query(asm_stmt, scope)? {
+        return Ok(Some(analyzed));
+    }
+
+    // Regular query
+    let mut exprs = Vec::with_capacity(asm_stmt.literals.len() + 1);
+    for lit in &asm_stmt.literals {
+        exprs.push(literal_to_analyzed_expr(lit));
+    }
+    if let Some(ref subj) = asm_stmt.subject {
+        let var_type = scope
+            .lookup(&subj.lemma)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown);
+        exprs.push(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+            glossa_type: var_type,
+        });
+    }
+    Ok(Some(AnalyzedStatement::Query(exprs)))
+}
+
+/// Helper: Detect containment queries
+fn classify_containment_query(
+    asm_stmt: &AssembledStatement,
+    scope: &mut Scope,
+) -> Result<Option<AnalyzedStatement>, GlossaError> {
+    if !asm_stmt.has_containment_preposition {
+        return Ok(None);
+    }
+
+    let Some(ref subj) = asm_stmt.subject else {
+        return Ok(None);
+    };
+
+    let subj_name = &subj.normalized;
+    let subj_type = scope
+        .lookup(subj_name)
+        .cloned()
+        .unwrap_or(GlossaType::Unknown);
+
+    let collection = AnalyzedExpr {
+        expr: AnalyzedExprKind::Variable(subj_name.clone()),
+        glossa_type: subj_type.clone(),
+    };
+
+    let element = if let Some(lit) = asm_stmt.literals.first() {
+        literal_to_analyzed_expr(lit)
+    } else {
+        AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(0),
+            glossa_type: GlossaType::Number,
+        }
+    };
+
+    let is_map = matches!(subj_type, GlossaType::Map(_, _));
+    let method = if is_map { "contains_key" } else { "contains" };
+
+    // Handle referencing argument if not a string literal
+    let arg_expr = if matches!(element.expr, AnalyzedExprKind::StringLiteral(_)) {
+        element
+    } else {
+        AnalyzedExpr {
+            expr: AnalyzedExprKind::UnaryOp {
+                op: crate::morphology::lexicon::UnaryOp::Ref,
+                operand: Box::new(element),
+            },
+            glossa_type: GlossaType::Unknown,
+        }
+    };
+
+    let contains_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::MethodCall {
+            receiver: Box::new(collection),
+            method: method.into(),
+            args: vec![arg_expr],
+        },
+        glossa_type: GlossaType::Boolean,
+    };
+
+    Ok(Some(AnalyzedStatement::Query(vec![contains_expr])))
 }
 
 /// Helper: Default expression


### PR DESCRIPTION
🚮 Smell: `classify_query` in `src/semantic/conversion.rs` was a 75-line function with nested `if` statements for checking the containment pattern versus a regular query, leading to high cognitive load.
✨ Solution: Refactored `classify_query` to use early returns (guard clauses) by inverting the initial `is_query` check. Extracted the 50-line containment logic into a dedicated, highly readable helper function `classify_containment_query`.
🧼 Benefit: Flattens the execution path, significantly improves readability, and directly reduces technical debt by following idiomatic Rust patterns.
🛡️ Verification: `cargo clippy` passed with no warnings. `cargo test` passed successfully. No logic was altered.

---
*PR created automatically by Jules for task [15292244871183283501](https://jules.google.com/task/15292244871183283501) started by @madmax983*