### PR TITLE
🎻 Bard: Resolve missing documentation warnings in Tools, Morphology, and Parser

### DIFF
--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -2392,6 +2392,22 @@ pub fn is_conditional_particle(normalized_word: &str) -> bool {
     matches!(normalized_word, "ει" | "εαν" | "ην" | "αν")
 }
 
+/// The canonical sequence of words defining an 'else' block in ΓΛΩΣΣΑ logic.
+///
+/// This specific sequence of particles and negations ("εἰ", "δὲ", "μή") serves as
+/// the definitive pattern for fallback execution paths when prior conditions fail.
+///
+/// # Why these exact words?
+/// In Classical Greek conditional clauses, "εἰ δὲ μή" (literally "but if not")
+/// elegantly captures the semantics of an 'otherwise' or 'else' branch without
+/// requiring a dedicated keyword.
+///
+/// # Examples
+/// ```
+/// use glossa::morphology::lexicon::ELSE_PATTERN_WORDS;
+///
+/// assert_eq!(ELSE_PATTERN_WORDS, ["ει", "δε", "μη"]);
+/// ```
 pub const ELSE_PATTERN_WORDS: [&str; 3] = ["ει", "δε", "μη"];
 
 /// Check if a sequence is the else pattern (εἰ δὲ μή)

--- a/src/parser/grammar.rs
+++ b/src/parser/grammar.rs
@@ -73,6 +73,7 @@ use pest_derive::Parser;
 /// ```
 #[derive(Parser)]
 #[grammar = "parser/grammar.pest"]
+#[doc(hidden)]
 pub struct GlossaParser;
 
 /// Parse a ΓΛΩΣΣΑ source string into a pest parse tree (Concrete Syntax Tree)

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -33,6 +33,24 @@ pub mod mosaic;
 pub mod narrator;
 pub mod repl;
 pub mod report;
+/// The engine room for executing and building Glossa programs
+///
+/// This module orchestrates the full compilation pipeline from source file to executable binary.
+/// It bridges the gap between parsing, semantic analysis, code generation, and the final
+/// execution via `rustc`.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::runner::run_file;
+/// use std::path::Path;
+///
+/// // Execute a Glossa file directly from its path
+/// let input = Path::new("main.γλ");
+/// if let Err(e) = run_file(&input) {
+///     eprintln!("Execution failed: {}", e);
+/// }
+/// ```
 pub mod runner;
 pub mod tester;
 pub mod ui;


### PR DESCRIPTION
📖 Chapter: The "Runner" Module, "Lexicon", and "Grammar".
💡 Insight: Explained how the runner module orchestrates compilation. Detailed why `ELSE_PATTERN_WORDS` uses specific ancient Greek conditional semantics. Hid internal `pest` parsing machinery from public documentation.
🧪 Example: Added 2 executable doctests to clarify code behavior.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [11494099768126906026](https://jules.google.com/task/11494099768126906026) started by @madmax983*