### PR TITLE
🗣️ Echo: Fix confusing error for nova-gated subcommands

### DIFF
--- a/hero.γλ
+++ b/hero.γλ
@@ -1,0 +1,30 @@
+// Let x be 10.
+ξ 10 ἔστω.
+
+// Let name be "Socrates".
+ὄνομα «Σωκράτης» ἔστω.
+
+// Say "Hello"
+«χαῖρε» λέγε.
+
+// Say the name (using the variable from Chapter 1)
+ὄνομα λέγε.
+
+// Define a User type
+εἶδος Χρήστης ὁρίζειν {
+    ὄνομα ὀνόματος.    // String
+    ἡλικία ἀριθμοῦ. // i64
+}.
+
+// Create an instance
+χρήστης νέον Χρήστης
+    «Πλάτων»
+    80
+ἔστω.
+
+// Let age be 80
+ἡλικία 80 ἔστω.
+
+// If age is greater than 50...
+εἰ ἡλικία 50 μεῖζον ᾖ,
+    «σοφός» λέγε.

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,14 @@ fn main() -> Result<()> {
             run_file(&input)?;
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Mentor) => {
+            #[cfg(feature = "nova")]
             glossa::tools::mentor::run_mentor()?;
+
+            #[cfg(not(feature = "nova"))]
+            miette::bail!(
+                "The 'mentor' command requires the 'nova' feature. Run with --features nova"
+            );
         }
 
         Some(Commands::Build { input, output }) => {
@@ -52,24 +57,56 @@ fn main() -> Result<()> {
             glossa::tools::tester::run_tests(&input)?;
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Mosaic { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::mosaic::run_mosaic(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'mosaic' command requires the 'nova' feature. Run with --features nova"
+                );
+            }
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::cartographer::run_map(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'map' command requires the 'nova' feature. Run with --features nova"
+                );
+            }
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Weave { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::weave::run_weave(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'weave' command requires the 'nova' feature. Run with --features nova"
+                );
+            }
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Alchemist { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::alchemist::run_alchemist(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'alchemist' command requires the 'nova' feature. Run with --features nova"
+                );
+            }
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -102,7 +102,6 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -149,28 +148,24 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Map {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Generate a Markdown Rosetta Stone (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Weave {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Transpile a .γλ file to Python (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Alchemist {
         /// Input file (.γλ)
         input: PathBuf,


### PR DESCRIPTION
🤦 **The Confusion:** Users trying to run nova-gated commands like `map` or `mentor` without the `--features nova` flag got a confusing "File not found" (Ἀρχεῖον οὐχ εὑρέθη) error because `clap` didn't recognize the command and parsed it as the positional `file` argument.
🕵️ **The Reality:** The feature is optional, but the CLI parser completely dropped the command variants when the feature wasn't enabled.
💡 **The Fix:** The commands are now always parsed by `clap`. When executed, if the `nova` feature is missing, they yield a helpful `miette::bail!` message telling the user exactly how to enable it.

---
*PR created automatically by Jules for task [17407394621909649311](https://jules.google.com/task/17407394621909649311) started by @madmax983*