### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-add-alchemist-and-weave.md
+++ b/docs/adr/016-add-alchemist-and-weave.md
@@ -1,0 +1,29 @@
+# 16. Add Alchemist and Weave Tools
+
+Date: 2024-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+The ΓΛΩΣΣΑ compiler's "Nova" experimental feature set aims to explore different avenues for development experience and utility. Two new features have been introduced:
+1. **The Alchemist (`src/tools/alchemist.rs`)**: An experimental Python transpiler. This serves as a proof-of-concept to show that the semantic analysis phase is entirely decoupled from the Rust codegen backend, allowing for alternative output languages.
+2. **Weave (`src/tools/weave.rs`)**: A documentation generator that outputs a 'Rosetta Stone' Markdown document. It combines the original Greek source code, the intermediate Semantic Assembly (Mosaic) steps, and the final generated Rust code into a single, highly educational artifact.
+
+These components need to be formally recognized in the system architecture to maintain structural transparency.
+
+## Decision
+
+We have decided to formalize "The Alchemist" and "Weave" as official tools within the "Developer Experience (Nova)" boundary of the compiler pipeline.
+
+*   **The Alchemist** is tasked with converting the `AnalyzedProgram` from the semantic phase into Python source code.
+*   **Weave** is tasked with orchestrating the parser, semantic analyzer, Rust code generator, and the Mosaic tool to assemble a unified documentation output.
+
+## Consequences
+
+*   **Architectural Visibility:** The system context and C4 Container diagrams will be updated to reflect the presence of `alchemist` and `weave` inside the `tools` boundary, downstream from `semantic`.
+*   **Decoupling Verification:** The successful implementation of the Alchemist confirms our architectural goal that `glossa::semantic` produces a generic HIR (High-Level Intermediate Representation) suitable for multiple backends.
+*   **Educational Value:** Weave provides a concrete, automated way to generate educational materials, reinforcing ΓΛΩΣΣΑ's goal of teaching programming concepts through the lens of ancient languages.
+*   **Maintenance Burden:** We now maintain an experimental Python backend alongside the primary Rust backend. As the language grows, ensuring feature parity (or at least graceful degradation) in the Alchemist will require additional effort.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ C4Container
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
+        Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Experimental transpiler for Python scripts")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -47,6 +48,7 @@ C4Container
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(weave, "Weave", "src/tools/weave.rs", "Generates Rosetta Stone Markdown documents")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -62,6 +64,8 @@ C4Container
     Rel(semantic, mosaic, "Analyzed Program")
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")
+    Rel(semantic, alchemist, "Analyzed Program")
+    Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")


### PR DESCRIPTION
🧠 **Decision:** Recorded the addition of the experimental `alchemist` transpiler and the `weave` Rosetta Stone documentation generator.
🗺️ **Visuals:** Updated C4 Component diagram to show new tools within the 'Developer Experience (Nova)' boundary.
🔗 **Link:** See `docs/adr/016-add-alchemist-and-weave.md`.

---
*PR created automatically by Jules for task [15671801070533275045](https://jules.google.com/task/15671801070533275045) started by @madmax983*