### PR TITLE
🔒 Warden: Safe Index Bounds check for code generator

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -102,3 +102,6 @@ Signed,
 **2025-02-12 - [TryFrom Missing Import Causing ICE]
 **Threat:** A logic bug allowed generated rust code to trigger an Internal Compiler Error (ICE) due to an out of scope `usize::try_from` usage on index accesses, leading to an inability to compile valid program trees with array indexing and rendering the previous DoS bounds checking defense ineffective.
 **Defense:** Explicitly added `#![allow(non_snake_case, unused_imports)]\nuse std::convert::TryFrom;` to `generate_rust_file` in `src/codegen.rs` to ensure the required trait is strictly imported during compilation.
+**2024-05-18 - [Fix Indexing Panic in array codegen]
+**Threat:** Use of native Rust slice indexing `[u_idx]` in code generation bypassed translation layers and relied on default panics. Negative array indexes emitted panic messages lacking prefix translation markers.
+**Defense:** Replaced bracket indexing with `.get(u_idx).cloned().expect("index out of bounds: index too large")` and prefixed the negative index panic with "index out of bounds:". This guarantees safe `try_from` behavior, captures bounds failures deterministically, and integrates with the custom UI error wrapper.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1281,10 +1281,10 @@ fn generate_collection_index(array: &AnalyzedExpr, index: &AnalyzedExpr) -> Toke
         {
             let idx = #index_tokens;
             if idx < 0 {
-                panic!("Negative index access: {}", idx);
+                panic!("index out of bounds: negative index {}", idx);
             }
-            let u_idx = usize::try_from(idx).expect("Index too large for platform memory");
-            #array_tokens[u_idx]
+            let u_idx = usize::try_from(idx).expect("index out of bounds: too large");
+            #array_tokens.get(u_idx).cloned().expect("index out of bounds: index too large")
         }
     }
 }

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -110,7 +110,7 @@ fn test_array_index_codegen() {
     // Use 'λίστη' (list) which is a known variable/type in the lexicon
     let code = compile("λίστη [1, 2] ἔστω. λίστη[0] λέγε.").unwrap();
     // The generated code should contain the panic check
-    assert!(code.contains("Negative index access"));
+    assert!(code.contains("negative index"));
     // quote! may insert spaces, so just check for "panic"
     assert!(code.contains("panic"));
 }


### PR DESCRIPTION
🦠 Threat: The compiler previously emitted raw native Rust slice indexing (`array[idx]`), bypassing error translation layers upon failure. Negative index checking also generated untranslated panics.
🛡️ Defense: Switched codegen to use `.get(idx).cloned().expect("index out of bounds: ...")` and prefixed negative index panics to explicitly trigger the runtime error translator.
💥 Severity: Low / Defense in Depth - Prevented English panic strings and raw ICEs from leaking to the Greek user interface. 
🧪 Verification: Modified unit tests in `tests/compile_tests.rs` to assert the updated "negative index" substring in output and ran `cargo test`.

---
*PR created automatically by Jules for task [5798940667897369721](https://jules.google.com/task/5798940667897369721) started by @madmax983*