### PR TITLE
🗣️ Echo: Fix confusing errors for `nova` feature commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,12 @@ fn main() -> Result<()> {
         Some(Commands::Mentor) => {
             glossa::tools::mentor::run_mentor()?;
         }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mentor) => {
+            miette::bail!(
+                "This command requires the `nova` feature flag to be enabled.\nRun with: `cargo run --features nova -- mentor`"
+            );
+        }
 
         Some(Commands::Build { input, output }) => {
             build_file(&input, output.as_deref())?;
@@ -56,20 +62,48 @@ fn main() -> Result<()> {
         Some(Commands::Mosaic { input }) => {
             glossa::tools::mosaic::run_mosaic(&input)?;
         }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mosaic { input }) => {
+            let _ = input;
+            miette::bail!(
+                "This command requires the `nova` feature flag to be enabled.\nRun with: `cargo run --features nova -- mosaic <file>`"
+            );
+        }
 
         #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
             glossa::tools::cartographer::run_map(&input)?;
+        }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Map { input }) => {
+            let _ = input;
+            miette::bail!(
+                "This command requires the `nova` feature flag to be enabled.\nRun with: `cargo run --features nova -- map <file>`"
+            );
         }
 
         #[cfg(feature = "nova")]
         Some(Commands::Weave { input }) => {
             glossa::tools::weave::run_weave(&input)?;
         }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Weave { input }) => {
+            let _ = input;
+            miette::bail!(
+                "This command requires the `nova` feature flag to be enabled.\nRun with: `cargo run --features nova -- weave <file>`"
+            );
+        }
 
         #[cfg(feature = "nova")]
         Some(Commands::Alchemist { input }) => {
             glossa::tools::alchemist::run_alchemist(&input)?;
+        }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Alchemist { input }) => {
+            let _ = input;
+            miette::bail!(
+                "This command requires the `nova` feature flag to be enabled.\nRun with: `cargo run --features nova -- alchemist <file>`"
+            );
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -102,7 +102,6 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -149,28 +148,24 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Map {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Generate a Markdown Rosetta Stone (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Weave {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Transpile a .γλ file to Python (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Alchemist {
         /// Input file (.γλ)
         input: PathBuf,


### PR DESCRIPTION
This PR addresses a significant Developer Experience (DX) issue where experimental commands requiring the `nova` feature flag would fail with cryptic "unexpected argument" errors if the flag was not provided. By unconditionally exposing the commands in the CLI parser and providing explicit, user-friendly error messages in the execution logic, users are now clearly instructed on how to enable the required features.

---
*PR created automatically by Jules for task [6564644576335027648](https://jules.google.com/task/6564644576335027648) started by @madmax983*