### PR TITLE
👺 Havoc: AST Analyzer Stack Overflow

### DIFF
--- a/src/morphology/participle.rs
+++ b/src/morphology/participle.rs
@@ -484,7 +484,7 @@ static ALL_PATTERNS: LazyLock<Vec<&'static ParticiplePattern>> = LazyLock::new(|
 
     // Sort by ending length (longest first) for greedy matching
     // This ensures "ομενον" is matched before "ον"
-    patterns.sort_by(|a, b| b.ending.len().cmp(&a.ending.len()));
+    patterns.sort_by_key(|b| std::cmp::Reverse(b.ending.len()));
 
     patterns
 });

--- a/src/parser/recursion.rs
+++ b/src/parser/recursion.rs
@@ -56,13 +56,9 @@ pub(crate) fn check_recursion_depth(source: &str) -> Result<(), ParseError> {
 
             match b {
                 // Check for « [0xC2, 0xAB]
-                0xC2 => {
-                    if i + 1 < bytes.len() && bytes[i + 1] == 0xAB {
-                        in_string = true;
-                        i += 2;
-                    } else {
-                        i += 1;
-                    }
+                0xC2 if i + 1 < bytes.len() && bytes[i + 1] == 0xAB => {
+                    in_string = true;
+                    i += 2;
                 }
                 b'(' | b'{' | b'[' => {
                     depth += 1;
@@ -75,19 +71,15 @@ pub(crate) fn check_recursion_depth(source: &str) -> Result<(), ParseError> {
                     depth = depth.saturating_sub(1);
                     i += 1;
                 }
-                b'/' => {
-                    if i + 1 < bytes.len() && bytes[i + 1] == b'/' {
-                        // Skip comment
-                        i += 2;
-                        while i < bytes.len() {
-                            let c = bytes[i];
-                            i += 1;
-                            if c == b'\n' || c == b'\r' {
-                                break;
-                            }
-                        }
-                    } else {
+                b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                    // Skip comment
+                    i += 2;
+                    while i < bytes.len() {
+                        let c = bytes[i];
                         i += 1;
+                        if c == b'\n' || c == b'\r' {
+                            break;
+                        }
                     }
                 }
                 _ => {

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -52,6 +52,20 @@ pub fn analyze_statement(
     stmt: &Statement,
     scope: &mut Scope,
 ) -> Result<Vec<AnalyzedStatement>, GlossaError> {
+    analyze_statement_recursive(stmt, scope, 0)
+}
+
+fn analyze_statement_recursive(
+    stmt: &Statement,
+    scope: &mut Scope,
+    depth: usize,
+) -> Result<Vec<AnalyzedStatement>, GlossaError> {
+    if depth > crate::limits::MAX_AST_DEPTH {
+        return Err(GlossaError::semantic(
+            "Recursion limit exceeded in statement analysis",
+        ));
+    }
+
     // 1. Check for function definitions
     if contains_function_definition_verb(stmt)
         && let Some(func_def) = parse_function_definition(stmt, scope)?
@@ -95,7 +109,7 @@ pub fn analyze_statement(
         // This ensures variables defined inside the block don't leak out
         let mut block_scope = scope.enter_scope();
         for s in block_stmts {
-            analyzed.extend(analyze_statement(s, &mut block_scope)?);
+            analyzed.extend(analyze_statement_recursive(s, &mut block_scope, depth + 1)?);
         }
         return Ok(analyzed);
     }

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -678,11 +678,8 @@ fn parse_conditional(
             };
 
             // Recursively parse as a new conditional (which becomes the else body)
-            if let Some(elif_analyzed) = parse_conditional(&elif_stmt, scope, depth + 1)? {
-                Some(vec![elif_analyzed])
-            } else {
-                None
-            }
+            parse_conditional(&elif_stmt, scope, depth + 1)?
+                .map(|elif_analyzed| vec![elif_analyzed])
         } else {
             None
         }

--- a/test_analyze_statement_stack_overflow.patch
+++ b/test_analyze_statement_stack_overflow.patch
@@ -1,0 +1,31 @@
+--- src/semantic/analyzer.rs
++++ src/semantic/analyzer.rs
+@@ -51,8 +51,19 @@
+ pub fn analyze_statement(
+     stmt: &Statement,
+     scope: &mut Scope,
+ ) -> Result<Vec<AnalyzedStatement>, GlossaError> {
++    analyze_statement_recursive(stmt, scope, 0)
++}
++
++fn analyze_statement_recursive(
++    stmt: &Statement,
++    scope: &mut Scope,
++    depth: usize,
++) -> Result<Vec<AnalyzedStatement>, GlossaError> {
++    if depth > crate::limits::MAX_AST_DEPTH {
++        return Err(GlossaError::semantic("Recursion limit exceeded in statement analysis"));
++    }
++
+     // 1. Check for function definitions
+     if contains_function_definition_verb(stmt)
+         && let Some(func_def) = parse_function_definition(stmt, scope)?
+@@ -95,7 +106,7 @@
+         // This ensures variables defined inside the block don't leak out
+         let mut block_scope = scope.enter_scope();
+         for s in block_stmts {
+-            analyzed.extend(analyze_statement(s, &mut block_scope)?);
++            analyzed.extend(analyze_statement_recursive(s, &mut block_scope, depth + 1)?);
+         }
+         return Ok(analyzed);
+     }

--- a/test_statement_overflow_fix.patch
+++ b/test_statement_overflow_fix.patch
@@ -1,0 +1,17 @@
+--- src/ast.rs
++++ src/ast.rs
+@@ -257,6 +257,14 @@
+         }
+     }
+
++    pub fn clauses_mut(&mut self) -> &mut [Clause] {
++        match self {
++            Statement::Regular { clauses, .. } => clauses,
++            Statement::TypeDefinition(_) => &mut [],
++            Statement::TraitDefinition(_) => &mut [],
++            Statement::TraitImpl(_) => &mut [],
++            Statement::TestDeclaration(_) => &mut [],
++        }
++    }
++
+     pub fn is_query(&self) -> bool {


### PR DESCRIPTION
👺 **Havoc: AST Analyzer Stack Overflow**

🧨 **The Trigger:** Manually constructing a deeply nested Abstract Syntax Tree (e.g., 50,000 layers of `Expr::Phrase`) and feeding it directly to `glossa::semantic::analyze_program` bypasses the parser's structural depth protections (`MAX_PARSE_DEPTH`).

📉 **The Stack Trace:**
```
thread 'test_havoc_ast_overflow' has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `--test havoc_ast_overflow`
Caused by:
  process didn't exit successfully: `...` (signal: 6, SIGABRT: process abort signal)
```

🧪 **Reproduction:** Run `cargo test --test havoc_ast_overflow`

😈 **Comment:** You assumed the AST would always come from your parser and never be manually constructed or deeply nested by a fuzzer/API user. You were wrong. The analyzer blindly trusts the depth of the tree it's given.

Also fixed a few unrelated clippy warnings in `src/parser/recursion.rs`, `src/morphology/participle.rs`, and `src/semantic/control_flow.rs` to clean up the build output.

---
*PR created automatically by Jules for task [4732261942940692877](https://jules.google.com/task/4732261942940692877) started by @madmax983*