### PR TITLE
⚡ Bolt: [performance improvement] Eliminate heap allocations in GlossaType function formatting

### DIFF
--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -143,8 +143,14 @@ impl std::fmt::Display for GlossaType {
             GlossaType::Result(ok, err) => write!(f, "Ἀποτέλεσμα<{}, {}>", ok, err),
             GlossaType::Struct { name, .. } => write!(f, "Εἶδος {}", name),
             GlossaType::Function { params, returns } => {
-                let params_str: Vec<String> = params.iter().map(|p| p.to_string()).collect();
-                write!(f, "Ἔργον({}) -> {}", params_str.join(", "), returns)
+                write!(f, "Ἔργον(")?;
+                for (i, param) in params.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", param)?;
+                }
+                write!(f, ") -> {}", returns)
             }
             GlossaType::Unit => write!(f, "Οὐδέν"),
             GlossaType::Unknown => write!(f, "Ἄγνωστον"),
@@ -222,6 +228,18 @@ mod tests {
     fn test_type_to_greek() {
         assert_eq!(GlossaType::Number.to_greek(), "ἀριθμός");
         assert_eq!(GlossaType::String.to_greek(), "ὄνομα");
+    }
+
+    #[test]
+    fn test_format_function_type_multiple_params() {
+        let func = GlossaType::Function {
+            params: vec![GlossaType::Number, GlossaType::String],
+            returns: Box::new(GlossaType::Boolean),
+        };
+        assert_eq!(
+            format!("{}", func),
+            "Ἔργον(Ἀριθμός, Ὄνομα) -> Ἀληθές/Ψεῦδος"
+        );
     }
 
     #[test]


### PR DESCRIPTION
💡 **What**: Refactored the `Display` implementation for `GlossaType::Function` to replace `.collect::<Vec<_>>().join(", ")` with manual `write!` loop iterations.
🎯 **Why**: The original implementation allocated multiple short-lived `String` instances inside an intermediate heap-allocated `Vec`, and then allocated another intermediate `String` when joining. `GlossaType` formatting is a hot path during semantic type-checking errors, reporting, and debugging.
📊 **Impact**: Reduces heap allocations when printing/formatting function signatures by N+2 allocations per format call (where N = number of parameters). Replaced with a zero-cost formatting abstraction.
🔬 **Measurement**: Verify by running the newly added test `cargo test test_format_function_type_multiple_params` to ensure parameter formatting and joining semantics are correctly preserved.

---
*PR created automatically by Jules for task [6179895382851003963](https://jules.google.com/task/6179895382851003963) started by @madmax983*