### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-enforce-facade-pattern.md
+++ b/docs/adr/016-enforce-facade-pattern.md
@@ -1,0 +1,28 @@
+# 16. Enforce Facade Pattern in glossa crate
+
+Date: 2026-03-24
+Status: Accepted
+
+## Context
+
+The `glossa` crate previously exposed all its internal modules (`ast`, `codegen`, `limits`, `morphology`, `parser`, `semantic`, `text`) as fully public (`pub mod`). This structure leaked internal implementation details to downstream users, creating a sprawling and confusing public API. It violated the principle of encapsulation, making it difficult for users to determine which functions and structures were intended for public consumption and which were strictly internal to the compiler's pipeline.
+
+## Decision
+
+We have enforced the Facade pattern in `src/lib.rs`.
+
+* Internal modules have been downgraded to `pub(crate) mod` (or kept `pub mod` only where explicitly required by the `glossa` binary or integration tests).
+* We have added explicit `pub use` statements in `src/lib.rs` to clearly define and export the true public API.
+
+The explicitly exported public API now consists of:
+* `tools::highlight`
+* `ast::Program`
+* `codegen::generate_rust`
+* `parser::parse`
+* `semantic::{AnalyzedProgram, analyze_program}`
+
+## Consequences
+
+* **Encapsulation**: Internal compiler logic and intermediate structures are hidden from the crate's external interface.
+* **Clarity**: Downstream users now have a clean, focused API that exposes only the necessary types and functions for parsing, analyzing, and generating code.
+* **Maintainability**: Changing internal module structures is less likely to break the public API, provided the explicit exports in `src/lib.rs` are maintained.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,15 @@ The compiler is organized as a pipeline of modules, transforming source text int
 C4Container
     title Container Diagram for ΓΛΩΣΣΑ Compiler
 
+    Container_Boundary(api, "Public API (Facade)") {
+        Container(api_ast, "ast::Program", "src/ast.rs", "Abstract Syntax Tree")
+        Container(api_parse, "parser::parse", "src/parser/mod.rs", "Parses source to AST")
+        Container(api_analyzed, "semantic::AnalyzedProgram", "src/semantic/model.rs", "Analyzed Program structure")
+        Container(api_analyze, "semantic::analyze_program", "src/semantic/mod.rs", "Analyzes AST")
+        Container(api_codegen, "codegen::generate_rust", "src/codegen.rs", "Generates Rust source")
+        Container(api_highlight, "tools::highlight", "src/tools/highlight.rs", "Syntax highlighting utility")
+    }
+
     Container(lexer, "Lexer", "src/parser/grammar.rs", "Tokenizes source, handling Unicode normalization")
     Container(parser, "Parser", "src/parser", "Constructs AST, enforcing recursion limits (max depth 500)")
     Container(morphology, "Declension Resolver", "src/morphology", "Analyzes case, gender, number, and resolves agreement")
@@ -67,6 +76,10 @@ C4Container
     Rel(morphology, dictionary, "Lexicon Data")
     Rel(parser, tester, "AST")
     Rel(codegen, tester, "Rust Source")
+
+    Rel(api_parse, parser, "Delegates to")
+    Rel(api_analyze, semantic, "Delegates to")
+    Rel(api_codegen, codegen, "Delegates to")
 ```
 
 ## Semantic Analysis (C4 Component Level)


### PR DESCRIPTION
🧠 **Decision:** Recorded the enforcement of the Facade Pattern in the `glossa` crate, where internal modules were changed to `pub(crate) mod` and specific items were explicitly re-exported in `src/lib.rs` using `pub use`.

🗺️ **Visuals:** Updated the Container Diagram (C4 Component Model) in `docs/architecture.md` to reflect the newly established `Public API (Facade)` boundary and its distinct components (`api_ast`, `api_parse`, `api_analyzed`, `api_analyze`, `api_codegen`, `api_highlight`).

🔗 **Link:** See `docs/adr/016-enforce-facade-pattern.md`.

---
*PR created automatically by Jules for task [4742829697227068874](https://jules.google.com/task/4742829697227068874) started by @madmax983*