### PR TITLE
🎨 Mosaic: UI Polish for CLI Experimental Commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,14 @@ fn main() -> Result<()> {
             run_file(&input)?;
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Mentor) => {
+            #[cfg(feature = "nova")]
             glossa::tools::mentor::run_mentor()?;
+
+            #[cfg(not(feature = "nova"))]
+            miette::bail!(
+                "The 'mentor' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
         }
 
         Some(Commands::Build { input, output }) => {
@@ -52,24 +57,56 @@ fn main() -> Result<()> {
             glossa::tools::tester::run_tests(&input)?;
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Mosaic { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::mosaic::run_mosaic(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'mosaic' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::cartographer::run_map(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'map' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Weave { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::weave::run_weave(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'weave' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
-        #[cfg(feature = "nova")]
         Some(Commands::Alchemist { input }) => {
+            #[cfg(feature = "nova")]
             glossa::tools::alchemist::run_alchemist(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'alchemist' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -103,7 +103,6 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -150,28 +149,24 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Map {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Generate a Markdown Rosetta Stone (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Weave {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Transpile a .γλ file to Python (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Alchemist {
         /// Input file (.γλ)
         input: PathBuf,


### PR DESCRIPTION
🖌️ **Before:**
Experimental commands (`mentor`, `mosaic`, `map`, `weave`, `alchemist`) were completely hidden from the CLI help text if the `nova` feature was not enabled. If a user tried to run one based on documentation, `clap` would fail with an obscure "command not found" error, leaving the user guessing why a documented tool didn't work.

✨ **After:**
The commands are now unconditionally added to the `clap` `Commands` enum, meaning they always appear in the CLI help menu, providing better discoverability. If a user attempts to run an experimental command without having compiled the compiler with the `nova` feature flag, the execution gracefully catches the attempt and yields a clear, user-friendly `miette::bail!` error message explaining exactly how to enable the feature. Unused arguments in the fallback blocks are properly suppressed to avoid compilation warnings.

🖼️ **Visuals:**
When running `glossa help`, the experimental commands are now clearly listed.
When running an experimental command without the feature flag (e.g., `glossa mosaic examples/hello.γλ`), the output is:
```
  × The 'mosaic' command is experimental. Recompile glossa with '--features nova' to enable it.
```

---
*PR created automatically by Jules for task [17338164651763501695](https://jules.google.com/task/17338164651763501695) started by @madmax983*