### PR TITLE
🪒 Razor: Simplify code generation logic for traits and functions

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -121,3 +121,7 @@
 **Bloat:** `AssemblyError` in `src/errors/assembly.rs` contained two variants (`MissingVerb` and `GenderMismatch`) that were defined but completely unused anywhere in the codebase, leading to dead code.
 **Cut:** Deleted the `MissingVerb` and `GenderMismatch` error variants and the unused `Gender` import.
 **Saved:** Removed 13 lines of dead code and simplified the error variant surface area.
+## [Reduction]
+**Bloat:** The code generator in `src/codegen.rs` duplicated the `quote!` generation blocks for function definitions, trait definitions, and trait implementations, copying the whole block depending on the presence or absence of a return type.
+**Cut:** Consolidated the return type generation into an `Option<TokenStream>` using `.map`, and inlined `#ret_tokens` into a single, unified `quote!` block for each definition type.
+**Saved:** ~40 lines of code and significant cognitive load.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -668,18 +668,14 @@ fn generate_fn_def(
         .collect();
 
     // Generate return type
-    if let Some(ret_type) = return_type {
-        let ret_tokens = generate_type_tokens(ret_type);
-        quote! {
-            fn #fn_name(#(#param_tokens),*) -> #ret_tokens {
-                #(#body_stmts)*
-            }
-        }
-    } else {
-        quote! {
-            fn #fn_name(#(#param_tokens),*) {
-                #(#body_stmts)*
-            }
+    let ret_tokens = return_type.as_ref().map(|ty| {
+        let ty_tokens = generate_type_tokens(ty);
+        quote! { -> #ty_tokens }
+    });
+
+    quote! {
+        fn #fn_name(#(#param_tokens),*) #ret_tokens {
+            #(#body_stmts)*
         }
     }
 }
@@ -764,30 +760,18 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
             let parts = generate_trait_method_parts(method);
             let method_name = parts.name;
             let param_tokens = parts.params;
+            let ret_tokens = parts.return_type.map(|ty| quote! { -> #ty });
 
-            if let Some(ret_ty) = parts.return_type {
-                if let Some(body) = &method.body {
-                    let body_stmts = generate_statements(body);
-                    quote! {
-                        fn #method_name(#(#param_tokens),*) -> #ret_ty {
-                            #(#body_stmts)*
-                        }
-                    }
-                } else {
-                    quote! {
-                        fn #method_name(#(#param_tokens),*) -> #ret_ty;
-                    }
-                }
-            } else if let Some(body) = &method.body {
+            if let Some(body) = &method.body {
                 let body_stmts = generate_statements(body);
                 quote! {
-                    fn #method_name(#(#param_tokens),*) {
+                    fn #method_name(#(#param_tokens),*) #ret_tokens {
                         #(#body_stmts)*
                     }
                 }
             } else {
                 quote! {
-                    fn #method_name(#(#param_tokens),*);
+                    fn #method_name(#(#param_tokens),*) #ret_tokens;
                 }
             }
         })
@@ -837,18 +821,11 @@ fn generate_trait_impl(
             } else {
                 Vec::new()
             };
+            let ret_tokens = parts.return_type.map(|ty| quote! { -> #ty });
 
-            if let Some(ret_ty) = parts.return_type {
-                quote! {
-                    fn #method_name(#(#param_tokens),*) -> #ret_ty {
-                        #(#body_stmts)*
-                    }
-                }
-            } else {
-                quote! {
-                    fn #method_name(#(#param_tokens),*) {
-                        #(#body_stmts)*
-                    }
+            quote! {
+                fn #method_name(#(#param_tokens),*) #ret_tokens {
+                    #(#body_stmts)*
                 }
             }
         })


### PR DESCRIPTION
**Bloat:** The code generator in `src/codegen.rs` duplicated the `quote!` generation blocks for function definitions, trait definitions, and trait implementations, copying the whole block depending on the presence or absence of a return type.
**Cut:** Consolidated the return type generation into an `Option<TokenStream>` using `.map`, and inlined `#ret_tokens` into a single, unified `quote!` block for each definition type.
**Saved:** ~40 lines of code and significant cognitive load.

---
*PR created automatically by Jules for task [5736602911570113562](https://jules.google.com/task/5736602911570113562) started by @madmax983*