### PR TITLE
🗣️ Echo: Helpful error messages for missing nova feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,10 @@ fn main() -> Result<()> {
         Some(Commands::Mentor) => {
             glossa::tools::mentor::run_mentor()?;
         }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mentor) => {
+            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
+        }
 
         Some(Commands::Build { input, output }) => {
             build_file(&input, output.as_deref())?;
@@ -56,20 +60,40 @@ fn main() -> Result<()> {
         Some(Commands::Mosaic { input }) => {
             glossa::tools::mosaic::run_mosaic(&input)?;
         }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mosaic { input }) => {
+            let _ = input;
+            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
+        }
 
         #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
             glossa::tools::cartographer::run_map(&input)?;
+        }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Map { input }) => {
+            let _ = input;
+            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
         }
 
         #[cfg(feature = "nova")]
         Some(Commands::Weave { input }) => {
             glossa::tools::weave::run_weave(&input)?;
         }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Weave { input }) => {
+            let _ = input;
+            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
+        }
 
         #[cfg(feature = "nova")]
         Some(Commands::Alchemist { input }) => {
             glossa::tools::alchemist::run_alchemist(&input)?;
+        }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Alchemist { input }) => {
+            let _ = input;
+            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
         }
 
         Some(Commands::Repl) | None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,9 @@ fn main() -> Result<()> {
         }
         #[cfg(not(feature = "nova"))]
         Some(Commands::Mentor) => {
-            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
+            miette::bail!(
+                "This command requires the experimental `nova` feature.\nTry running with: --features nova"
+            );
         }
 
         Some(Commands::Build { input, output }) => {
@@ -63,7 +65,9 @@ fn main() -> Result<()> {
         #[cfg(not(feature = "nova"))]
         Some(Commands::Mosaic { input }) => {
             let _ = input;
-            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
+            miette::bail!(
+                "This command requires the experimental `nova` feature.\nTry running with: --features nova"
+            );
         }
 
         #[cfg(feature = "nova")]
@@ -73,7 +77,9 @@ fn main() -> Result<()> {
         #[cfg(not(feature = "nova"))]
         Some(Commands::Map { input }) => {
             let _ = input;
-            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
+            miette::bail!(
+                "This command requires the experimental `nova` feature.\nTry running with: --features nova"
+            );
         }
 
         #[cfg(feature = "nova")]
@@ -83,7 +89,9 @@ fn main() -> Result<()> {
         #[cfg(not(feature = "nova"))]
         Some(Commands::Weave { input }) => {
             let _ = input;
-            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
+            miette::bail!(
+                "This command requires the experimental `nova` feature.\nTry running with: --features nova"
+            );
         }
 
         #[cfg(feature = "nova")]
@@ -93,7 +101,9 @@ fn main() -> Result<()> {
         #[cfg(not(feature = "nova"))]
         Some(Commands::Alchemist { input }) => {
             let _ = input;
-            miette::bail!("This command requires the experimental `nova` feature.\nTry running with: --features nova");
+            miette::bail!(
+                "This command requires the experimental `nova` feature.\nTry running with: --features nova"
+            );
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -103,7 +103,6 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -150,28 +149,24 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Map {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Generate a Markdown Rosetta Stone (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Weave {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Transpile a .γλ file to Python (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Alchemist {
         /// Input file (.γλ)
         input: PathBuf,


### PR DESCRIPTION
🤦 **The Confusion:** "Tried to run the `mentor` and `map` commands from the README. Compiler said `error: the following required arguments were not provided:` or `unexpected argument found`."
🕵️ **The Reality:** "Turns out these commands require enabling the `nova` feature, but the CLI was just hiding them completely, making it look like I typed them wrong."
💡 **The Fix:** "Expose the commands in the CLI parser unconditionally. When a user tries to run them without the feature enabled, show a helpful `miette::bail!` message telling them to add `--features nova`."

---
*PR created automatically by Jules for task [12202966750616860530](https://jules.google.com/task/12202966750616860530) started by @madmax983*