### PR TITLE
🔒 Warden: [security fix] Fix codegen unwrap panic translation leak

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -105,3 +105,7 @@ Signed,
 **2024-05-18 - [Fix Indexing Panic in array codegen]
 **Threat:** Use of native Rust slice indexing `[u_idx]` in code generation bypassed translation layers and relied on default panics. Negative array indexes emitted panic messages lacking prefix translation markers.
 **Defense:** Replaced bracket indexing with `.get(u_idx).cloned().expect("index out of bounds: index too large")` and prefixed the negative index panic with "index out of bounds:". This guarantees safe `try_from` behavior, captures bounds failures deterministically, and integrates with the custom UI error wrapper.
+
+**YYYY-MM-DD - [codegen unwrap vulnerability]
+**Threat:** [The `Unwrap` expression kind generated an unchecked `.unwrap()` call, which maps to a raw Rust panic that bypassing the translation layer and leaking English panics to end users.]
+**Defense:** [Replaced `.unwrap()` with `.expect("attempted to unwrap an empty value")` to safely panic with an explicit message that the runtime intercepts and translates.]

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -922,7 +922,7 @@ fn generate_expr(expr: &AnalyzedExpr) -> TokenStream {
 
         AnalyzedExprKind::Unwrap(inner) => {
             let inner_tokens = generate_expr(inner);
-            quote! { #inner_tokens.unwrap() }
+            quote! { #inner_tokens.expect("attempted to unwrap an empty value") }
         }
 
         AnalyzedExprKind::IndexAccess { array, index } => generate_collection_index(array, index),
@@ -1571,7 +1571,8 @@ mod tests {
         };
 
         let code = generate_expr(&expr).to_string();
-        assert!(code.contains("unwrap"));
+        assert!(code.contains("expect"));
+        assert!(code.contains("attempted to unwrap an empty value"));
         assert!(code.contains("42"));
     }
 


### PR DESCRIPTION
🦠 **Threat**: The `AnalyzedExprKind::Unwrap` branch in the code generation module blindly emitted an `.unwrap()` call, which bypasses the English-to-Greek error translation system and risks confusing end-users with native, untranslated panics if encountered in their Glossa code output.
🛡️ **Defense**: Replaced `#inner_tokens.unwrap()` with `#inner_tokens.expect("attempted to unwrap an empty value")`. This ensures the specific English substring is intercepted at runtime and appropriately translated into an Ancient Greek error message by the system.
💥 **Severity**: Low - This primarily impacts user experience by leaking untranslated English text to the user upon an unexpected unwrap panic in the generated binary output.
🧪 **Verification**: Updated `test_generate_control_unwrap` to correctly assert on the new `.expect(...)` functionality and verified all tests, linting, and formatting successfully pass.

---
*PR created automatically by Jules for task [4562795323055620777](https://jules.google.com/task/4562795323055620777) started by @madmax983*