### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,9 @@ fn main() -> Result<()> {
 
         #[cfg(not(feature = "nova"))]
         Some(Commands::Mentor) => {
-            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
+            miette::bail!(
+                "This command requires the 'nova' feature. Run again with `--features nova`."
+            );
         }
 
         Some(Commands::Build { input, output }) => {
@@ -65,7 +67,9 @@ fn main() -> Result<()> {
         #[cfg(not(feature = "nova"))]
         Some(Commands::Mosaic { input }) => {
             let _ = input;
-            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
+            miette::bail!(
+                "This command requires the 'nova' feature. Run again with `--features nova`."
+            );
         }
 
         #[cfg(feature = "nova")]
@@ -76,7 +80,9 @@ fn main() -> Result<()> {
         #[cfg(not(feature = "nova"))]
         Some(Commands::Map { input }) => {
             let _ = input;
-            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
+            miette::bail!(
+                "This command requires the 'nova' feature. Run again with `--features nova`."
+            );
         }
 
         #[cfg(feature = "nova")]
@@ -87,7 +93,9 @@ fn main() -> Result<()> {
         #[cfg(not(feature = "nova"))]
         Some(Commands::Weave { input }) => {
             let _ = input;
-            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
+            miette::bail!(
+                "This command requires the 'nova' feature. Run again with `--features nova`."
+            );
         }
 
         #[cfg(feature = "nova")]
@@ -98,7 +106,9 @@ fn main() -> Result<()> {
         #[cfg(not(feature = "nova"))]
         Some(Commands::Alchemist { input }) => {
             let _ = input;
-            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
+            miette::bail!(
+                "This command requires the 'nova' feature. Run again with `--features nova`."
+            );
         }
 
         Some(Commands::Repl) | None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,11 @@ fn main() -> Result<()> {
             glossa::tools::mentor::run_mentor()?;
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mentor) => {
+            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
+        }
+
         Some(Commands::Build { input, output }) => {
             build_file(&input, output.as_deref())?;
         }
@@ -57,9 +62,21 @@ fn main() -> Result<()> {
             glossa::tools::mosaic::run_mosaic(&input)?;
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mosaic { input }) => {
+            let _ = input;
+            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
+        }
+
         #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
             glossa::tools::cartographer::run_map(&input)?;
+        }
+
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Map { input }) => {
+            let _ = input;
+            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
         }
 
         #[cfg(feature = "nova")]
@@ -67,9 +84,21 @@ fn main() -> Result<()> {
             glossa::tools::weave::run_weave(&input)?;
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Weave { input }) => {
+            let _ = input;
+            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
+        }
+
         #[cfg(feature = "nova")]
         Some(Commands::Alchemist { input }) => {
             glossa::tools::alchemist::run_alchemist(&input)?;
+        }
+
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Alchemist { input }) => {
+            let _ = input;
+            miette::bail!("This command requires the 'nova' feature. Run again with `--features nova`.");
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -103,7 +103,6 @@ pub enum Commands {
     },
 
     /// Start the interactive tutorial (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mentor,
 
     /// Compile a .γλ file to Rust source
@@ -150,28 +149,24 @@ pub enum Commands {
     },
 
     /// Visualize the assembled sentence structure (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Mosaic {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Visualize the program architecture as a map (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Map {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Generate a Markdown Rosetta Stone (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Weave {
         /// Input file (.γλ)
         input: PathBuf,
     },
 
     /// Transpile a .γλ file to Python (Requires "nova" feature)
-    #[cfg(feature = "nova")]
     Alchemist {
         /// Input file (.γλ)
         input: PathBuf,


### PR DESCRIPTION
🤦 **The Confusion:**
"Tried to run the `nova` experimental tools based on the README. Compiler threw a confusing 'unrecognized subcommand' error from `clap` because I didn't include the feature flag."

🕵️ **The Reality:**
"Turns out the CLI commands are entirely gated behind `#[cfg(feature = "nova")]`, meaning if the feature isn't active, the CLI acts like the commands don't even exist."

💡 **The Fix:**
"Removed the feature gates from the CLI enum in `cli.rs` so they are always visible. Added fallback match arms in `main.rs` that execute `miette::bail!` with a clear, explicit instruction to run the command again with `--features nova`."

---
*PR created automatically by Jules for task [9446578175682719829](https://jules.google.com/task/9446578175682719829) started by @madmax983*