### PR TITLE
🗺️ Atlas: Remove leaked AssemblyError from semantic public API

### DIFF
--- a/src/semantic/assembler_tests.rs
+++ b/src/semantic/assembler_tests.rs
@@ -1,6 +1,6 @@
 use crate::ast::{Expr, Word};
 use crate::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech, Person, analyze};
-use crate::semantic::AssemblyError;
+use crate::errors::AssemblyError;
 use crate::semantic::assembly::{
     Assembler, MAX_ADJECTIVES, MAX_ARRAYS, MAX_BLOCKS, MAX_GENITIVES, MAX_INDEX_ACCESSES,
     MAX_LITERALS, MAX_NESTED_PHRASES, MAX_NOMINATIVES, MAX_OPERATORS, MAX_PARTICIPLES,

--- a/src/semantic/assembler_tests.rs
+++ b/src/semantic/assembler_tests.rs
@@ -1,6 +1,6 @@
 use crate::ast::{Expr, Word};
-use crate::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech, Person, analyze};
 use crate::errors::AssemblyError;
+use crate::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech, Person, analyze};
 use crate::semantic::assembly::{
     Assembler, MAX_ADJECTIVES, MAX_ARRAYS, MAX_BLOCKS, MAX_GENITIVES, MAX_INDEX_ACCESSES,
     MAX_LITERALS, MAX_NESTED_PHRASES, MAX_NOMINATIVES, MAX_OPERATORS, MAX_PARTICIPLES,

--- a/src/semantic/assembly.rs
+++ b/src/semantic/assembly.rs
@@ -105,7 +105,7 @@
 //! ```
 
 use crate::ast::{Expr, Word};
-pub use crate::errors::AssemblyError;
+use crate::errors::AssemblyError;
 pub(crate) use crate::limits::{
     MAX_ADJECTIVES, MAX_ARRAYS, MAX_BLOCKS, MAX_GENITIVES, MAX_INDEX_ACCESSES, MAX_LITERALS,
     MAX_NESTED_PHRASES, MAX_NOMINATIVES, MAX_OPERATORS, MAX_PARTICIPLES, MAX_PROPERTY_ACCESSES,

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -60,7 +60,7 @@ pub use crate::morphology::{DisambiguationContext, analyze_article, disambiguate
 pub use analyzer::{AnalyzedProgram, analyze_program};
 pub use assembly::Assembler;
 pub use assembly::{
-    AssembledStatement, AssemblyError, Constituent, Literal, ParticipleConstituent, VerbConstituent,
+    AssembledStatement, Constituent, Literal, ParticipleConstituent, VerbConstituent,
 };
 pub use model::*;
 pub use resolver::*;

--- a/tests/havoc_operator_stress.rs
+++ b/tests/havoc_operator_stress.rs
@@ -32,7 +32,7 @@ fn test_stack_overflow_in_drop() {
             println!("Analysis FAILED (expected): {:?}", e);
             match e {
                 glossa::errors::GlossaError::AssemblyError(
-                    glossa::semantic::AssemblyError::LimitExceeded { resource, max },
+                    glossa::errors::AssemblyError::LimitExceeded { resource, max },
                 ) => {
                     assert_eq!(resource, "Operators");
                     assert_eq!(*max, 256);

--- a/tests/havoc_overflow.rs
+++ b/tests/havoc_overflow.rs
@@ -35,7 +35,7 @@ fn test_stack_overflow_mitigation() {
             println!("Caught expected error: {:?}", e);
             match e {
                 GlossaError::LimitExceeded { .. } => {}
-                GlossaError::AssemblyError(glossa::semantic::AssemblyError::LimitExceeded {
+                GlossaError::AssemblyError(glossa::errors::AssemblyError::LimitExceeded {
                     ..
                 }) => {}
                 _ => panic!(


### PR DESCRIPTION
🕸️ Tangle: The `AssemblyError` type belongs to the `errors` module but was being publicly re-exported through the `semantic` and `semantic::assembly` modules, creating a leaky abstraction and an unnecessarily tangled public API boundary.

📐 Blueprint: Removed `pub use crate::errors::AssemblyError` from `src/semantic/assembly.rs` and the corresponding re-export from `src/semantic/mod.rs`. Updated tests in `src/semantic/assembler_tests.rs`, `tests/havoc_operator_stress.rs`, and `tests/havoc_overflow.rs` to import the type directly from `glossa::errors::AssemblyError`.

🧱 Stability: Enforces a single source of truth for `AssemblyError` within the `errors` module, reducing coupling and enforcing strict, clean module boundaries across the codebase.

🔬 Verification: The codebase successfully compiles, and all unit tests and integration tests pass smoothly using `cargo check`, `cargo test`, and `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [16986340600219171214](https://jules.google.com/task/16986340600219171214) started by @madmax983*