### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-formalize-alchemist-and-weave.md
+++ b/docs/adr/016-formalize-alchemist-and-weave.md
@@ -1,0 +1,27 @@
+# 16. Formalize Alchemist and Weave Tools
+
+Date: 2025-02-25
+Status: Proposed
+
+## Context
+
+The `src/tools/` directory contains two new modules, `alchemist.rs` and `weave.rs`, which lack formal documentation and architectural recognition.
+
+`alchemist.rs` (The Alchemist) transpiles ΓΛΩΣΣΑ programs to Python scripts. This demonstrates the independence of the semantic analysis phase from the Rust code generation phase, offering a dynamic script target for small programs.
+
+`weave.rs` (The Weave) generates a "Rosetta Stone" Markdown document. This exporter combines ΓΛΩΣΣΑ source code, the semantic assembly visualization (Mosaic), and the generated Rust code into a single, highly readable format, enhancing documentation and educational capabilities.
+
+## Decision
+
+We formally recognize these two modules as part of the "Nova" Developer Experience toolset.
+
+- `alchemist.rs` is responsible for Python transpilation.
+- `weave.rs` is responsible for generating educational Markdown artifacts.
+
+Both components receive the "Analyzed Program" from the semantic analysis pipeline, mapping Greek syntax to output code.
+
+## Consequences
+
+- **Documentation**: Our architectural diagrams and documentation will accurately represent all tools in the ecosystem.
+- **Educational Value**: `weave.rs` greatly simplifies teaching the mapping of morphology to code.
+- **Maintenance Trade-off**: Supporting multiple exporters (Rust and Python) adds maintenance overhead. Changes to the core language semantics must now be implemented in two separate code generators.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ C4Container
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
+        Container(alchemist, "Alchemist", "src/tools/alchemist.rs", "Transpiles ΓΛΩΣΣΑ to Python scripts")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -47,6 +48,7 @@ C4Container
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(weave, "Weave", "src/tools/weave.rs", "Generates Rosetta Stone Markdown document")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -62,6 +64,8 @@ C4Container
     Rel(semantic, mosaic, "Analyzed Program")
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")
+    Rel(semantic, alchemist, "Analyzed Program")
+    Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")


### PR DESCRIPTION
🧠 **Decision:** Recorded the formal inclusion of `alchemist.rs` (Python Transpiler) and `weave.rs` ("Rosetta Stone" Generator) into the Nova toolset.
🗺️ **Visuals:** Updated the C4 Container diagram in `architecture.md` to map the `alchemist` and `weave` containers and their relationships within the Semantic Analysis boundary.
🔗 **Link:** See `docs/adr/016-formalize-alchemist-and-weave.md`.

---
*PR created automatically by Jules for task [4902493178516305416](https://jules.google.com/task/4902493178516305416) started by @madmax983*