### PR TITLE
⚒️ Forge: Refactor lookup_word into helper functions

### DIFF
--- a/src/tools/dictionary.rs
+++ b/src/tools/dictionary.rs
@@ -56,87 +56,11 @@ use crate::text::normalize_greek;
 pub fn lookup_word(word: &str) -> Result<()> {
     let normalized = normalize_greek(word);
 
-    // Header
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   L E X I C O N".bold().cyan());
-    println!("   {}", "Semantic Dictionary Lookup".italic().dim());
-    println!();
-    println!("   Analyzing: {}", word.yellow().bold());
-    if normalized != word {
-        println!("   Normalized: {}", normalized.dim());
-    }
-    println!();
+    print_header(word, &normalized);
 
     // 1. Direct Lexicon Lookup
     if let Some(entry) = lexicon::lookup(&normalized) {
-        println!(
-            "   {}",
-            "📚 Lexicon Entry (Definitive)".green().bold().underlined()
-        );
-
-        let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL).set_header(vec![
-            Cell::new("Property")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Cyan),
-            Cell::new("Value").add_attribute(Attribute::Bold),
-        ]);
-
-        table.add_row(vec![
-            Cell::new("Lemma"),
-            Cell::new(entry.lemma)
-                .fg(Color::Green)
-                .add_attribute(Attribute::Bold),
-        ]);
-
-        table.add_row(vec![
-            Cell::new("Part of Speech"),
-            Cell::new(format!("{:?}", entry.pos)),
-        ]);
-
-        table.add_row(vec![
-            Cell::new("Meaning"),
-            Cell::new(entry.meaning).fg(Color::Yellow),
-        ]);
-
-        // Clarify rust_equiv semantics: None means user-defined or no direct mapping
-        let rust_equiv_display = entry.rust_equiv.unwrap_or("(none/user-defined)");
-        table.add_row(vec![
-            Cell::new("Rust Equivalent"),
-            Cell::new(rust_equiv_display)
-                .fg(if entry.rust_equiv.is_some() {
-                    Color::Red
-                } else {
-                    Color::DarkGrey
-                })
-                .add_attribute(Attribute::Bold),
-        ]);
-
-        // Add grammatical details if present
-        if let Some(c) = entry.case {
-            table.add_row(vec![Cell::new("Case"), Cell::new(format!("{}", c))]);
-        }
-        if let Some(n) = entry.number {
-            table.add_row(vec![Cell::new("Number"), Cell::new(format!("{}", n))]);
-        }
-        if let Some(g) = entry.gender {
-            table.add_row(vec![Cell::new("Gender"), Cell::new(format!("{}", g))]);
-        }
-        if let Some(p) = entry.person {
-            table.add_row(vec![Cell::new("Person"), Cell::new(format!("{:?}", p))]);
-        }
-        if let Some(t) = entry.tense {
-            table.add_row(vec![Cell::new("Tense"), Cell::new(format!("{:?}", t))]);
-        }
-        if let Some(m) = entry.mood {
-            table.add_row(vec![Cell::new("Mood"), Cell::new(format!("{:?}", m))]);
-        }
-        if let Some(v) = entry.voice {
-            table.add_row(vec![Cell::new("Voice"), Cell::new(format!("{:?}", v))]);
-        }
-
-        println!("{table}");
-        println!();
+        print_lexicon_entry(entry);
     } else {
         println!("   {}", "✕ Not found in built-in lexicon.".yellow().bold());
         println!("   {}", "Showing morphological analysis only.".dim());
@@ -151,6 +75,95 @@ pub fn lookup_word(word: &str) -> Result<()> {
         return Ok(());
     }
 
+    print_morphological_analyses(&analyses);
+
+    Ok(())
+}
+
+fn print_header(word: &str, normalized: &str) {
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   L E X I C O N".bold().cyan());
+    println!("   {}", "Semantic Dictionary Lookup".italic().dim());
+    println!();
+    println!("   Analyzing: {}", word.yellow().bold());
+    if normalized != word {
+        println!("   Normalized: {}", normalized.dim());
+    }
+    println!();
+}
+
+fn print_lexicon_entry(entry: &crate::morphology::lexicon::LexiconEntry) {
+    println!(
+        "   {}",
+        "📚 Lexicon Entry (Definitive)".green().bold().underlined()
+    );
+
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL).set_header(vec![
+        Cell::new("Property")
+            .add_attribute(Attribute::Bold)
+            .fg(Color::Cyan),
+        Cell::new("Value").add_attribute(Attribute::Bold),
+    ]);
+
+    table.add_row(vec![
+        Cell::new("Lemma"),
+        Cell::new(entry.lemma)
+            .fg(Color::Green)
+            .add_attribute(Attribute::Bold),
+    ]);
+
+    table.add_row(vec![
+        Cell::new("Part of Speech"),
+        Cell::new(format!("{:?}", entry.pos)),
+    ]);
+
+    table.add_row(vec![
+        Cell::new("Meaning"),
+        Cell::new(entry.meaning).fg(Color::Yellow),
+    ]);
+
+    // Clarify rust_equiv semantics: None means user-defined or no direct mapping
+    let rust_equiv_display = entry.rust_equiv.unwrap_or("(none/user-defined)");
+    table.add_row(vec![
+        Cell::new("Rust Equivalent"),
+        Cell::new(rust_equiv_display)
+            .fg(if entry.rust_equiv.is_some() {
+                Color::Red
+            } else {
+                Color::DarkGrey
+            })
+            .add_attribute(Attribute::Bold),
+    ]);
+
+    // Add grammatical details if present
+    if let Some(c) = entry.case {
+        table.add_row(vec![Cell::new("Case"), Cell::new(format!("{}", c))]);
+    }
+    if let Some(n) = entry.number {
+        table.add_row(vec![Cell::new("Number"), Cell::new(format!("{}", n))]);
+    }
+    if let Some(g) = entry.gender {
+        table.add_row(vec![Cell::new("Gender"), Cell::new(format!("{}", g))]);
+    }
+    if let Some(p) = entry.person {
+        table.add_row(vec![Cell::new("Person"), Cell::new(format!("{:?}", p))]);
+    }
+    if let Some(t) = entry.tense {
+        table.add_row(vec![Cell::new("Tense"), Cell::new(format!("{:?}", t))]);
+    }
+    if let Some(m) = entry.mood {
+        table.add_row(vec![Cell::new("Mood"), Cell::new(format!("{:?}", m))]);
+    }
+    if let Some(v) = entry.voice {
+        table.add_row(vec![Cell::new("Voice"), Cell::new(format!("{:?}", v))]);
+    }
+
+    println!("{table}");
+    println!();
+}
+
+fn print_morphological_analyses(analyses: &[crate::morphology::models::MorphAnalysis]) {
     println!(
         "   {}",
         "🔬 Morphological Analysis (All Possibilities)"
@@ -208,7 +221,7 @@ pub fn lookup_word(word: &str) -> Result<()> {
         };
 
         table.add_row(vec![
-            Cell::new(analysis.lemma),
+            Cell::new(analysis.lemma.as_ref()),
             Cell::new(format!("{:?}", analysis.part_of_speech)),
             Cell::new(grammar.join(", ")),
             conf_cell,
@@ -217,8 +230,6 @@ pub fn lookup_word(word: &str) -> Result<()> {
 
     println!("{table}");
     println!();
-
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🚮 Smell: The `lookup_word` function in `src/tools/dictionary.rs` was a classic God Function (167 lines long), containing deeply nested logic for `comfy_table` UI generation, dictionary mapping, and header formatting.

✨ Solution: I extracted the three primary semantic blocks into dedicated helper functions (`print_header`, `print_lexicon_entry`, and `print_morphological_analyses`). The main `lookup_word` function now simply acts as an orchestrator for these tools.

🧼 Benefit: Drastically flattens the execution path of the dictionary tool and isolates UI generation logic into independent, testable components, adhering to high-cohesion principles without changing the existing output.

🛡️ Verification: Ran `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`. All 103 unit tests pass. Output behavior remains completely identical.

---
*PR created automatically by Jules for task [16826495183809169366](https://jules.google.com/task/16826495183809169366) started by @madmax983*