### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -24,6 +24,27 @@ use smol_str::SmolStr;
 ///
 /// Types are checked for compatibility using [`GlossaType::is_compatible`].
 /// `GlossaType::Unknown` acts as a wildcard that matches any type (useful during inference).
+///
+/// # Examples
+///
+/// ```
+/// use glossa::semantic::GlossaType;
+///
+/// // Create simple types
+/// let num_type = GlossaType::Number;
+/// let str_type = GlossaType::String;
+///
+/// // Create complex nested types
+/// let list_of_numbers = GlossaType::List(Box::new(GlossaType::Number));
+///
+/// // Check type compatibility
+/// assert!(num_type.is_compatible(&GlossaType::Number));
+/// assert!(!num_type.is_compatible(&str_type));
+///
+/// // The Unknown type acts as a wildcard, compatible with anything
+/// assert!(GlossaType::Unknown.is_compatible(&str_type));
+/// assert!(num_type.is_compatible(&GlossaType::Unknown));
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum GlossaType {
     /// **ἀριθμός** (Number) - 64-bit signed integer (`i64`)


### PR DESCRIPTION
📖 Chapter: The `GlossaType` Enum

🔦 Insight: The `GlossaType` enum lacked a dedicated `Examples` section showing how the different variants and the compatibility check (`is_compatible`) are used in practice, specifically the wildcard nature of `Unknown`.

🧪 Example: Added an executable doctest that initializes a simple string and a complex nested list, and demonstrates checking compatibility between them and `Unknown`.

🖼️ Preview: [Docs should now display an Examples section for GlossaType]

---
*PR created automatically by Jules for task [13913994739798684777](https://jules.google.com/task/13913994739798684777) started by @madmax983*