### PR TITLE
🗺️ Atlas: Enforce module boundaries with pub(crate)

### DIFF
--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -19,13 +19,13 @@
 //! Disambiguation uses syntactic context (article agreement, verb agreement) in the
 //! semantic analysis phase.
 
-pub mod conjugation;
-pub mod declension;
-pub mod disambiguation;
-pub mod lexicon;
+pub(crate) mod conjugation;
+pub(crate) mod declension;
+pub(crate) mod disambiguation;
+pub(crate) mod lexicon;
 pub(crate) mod matcher;
-pub mod models;
-pub mod participle;
+pub(crate) mod models;
+pub(crate) mod participle;
 
 pub use conjugation::*;
 pub use declension::*;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -25,7 +25,7 @@
 pub(crate) mod common;
 pub(crate) mod declarations;
 pub(crate) mod expressions;
-pub mod grammar;
+pub(crate) mod grammar;
 pub mod numerals;
 pub(crate) mod recursion;
 pub(crate) mod statements;

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -26,7 +26,7 @@ use crate::errors::GlossaError;
 ///
 /// ```rust
 /// use glossa::ast::Program;
-/// use glossa::semantic::analyzer::analyze_program;
+/// use glossa::semantic::analyze_program;
 ///
 /// // Create an empty program structure
 /// let empty_ast = Program { statements: vec![] };

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -31,10 +31,10 @@
 //! This allows for authentic Greek syntax where emphasis is conveyed through word order
 //! without changing the semantic meaning.
 
-pub mod analyzer;
+pub(crate) mod analyzer;
 #[cfg(test)]
 mod assembler_tests;
-pub mod assembly;
+pub(crate) mod assembly;
 #[cfg(test)]
 mod classification_tests;
 pub(crate) mod control_flow;
@@ -57,7 +57,7 @@ mod types;
 pub(crate) mod validation;
 
 pub use crate::morphology::{DisambiguationContext, analyze_article, disambiguate, resolve_best};
-pub use analyzer::{AnalyzedProgram, analyze_program};
+pub use analyzer::{AnalyzedProgram, analyze_program, analyze_statement};
 pub use assembly::Assembler;
 pub use assembly::{
     AssembledStatement, AssemblyError, Constituent, Literal, ParticipleConstituent, VerbConstituent,

--- a/tests/alchemist_coverage.rs
+++ b/tests/alchemist_coverage.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "nova")]
 
-use glossa::morphology::lexicon::{BinaryOp, UnaryOp};
+use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };

--- a/tests/control_flow_tests.rs
+++ b/tests/control_flow_tests.rs
@@ -200,18 +200,9 @@ fn test_lexicon_conditional_particles() {
     use glossa::morphology::*;
 
     // These should be recognized as control flow particles
-    assert!(
-        is_conditional_particle("ει"),
-        "εἰ should be conditional"
-    );
-    assert!(
-        is_conditional_particle("εαν"),
-        "ἐάν should be conditional"
-    );
-    assert!(
-        is_conditional_particle("ην"),
-        "ἤν should be conditional"
-    );
+    assert!(is_conditional_particle("ει"), "εἰ should be conditional");
+    assert!(is_conditional_particle("εαν"), "ἐάν should be conditional");
+    assert!(is_conditional_particle("ην"), "ἤν should be conditional");
 }
 
 #[test]
@@ -219,10 +210,7 @@ fn test_lexicon_else_particle() {
     use glossa::morphology::*;
 
     // "εἰ δὲ μή" is the else pattern
-    assert!(
-        is_else_pattern("ει δε μη"),
-        "εἰ δὲ μή should be else"
-    );
+    assert!(is_else_pattern("ει δε μη"), "εἰ δὲ μή should be else");
 }
 
 #[test]
@@ -233,14 +221,8 @@ fn test_lexicon_loop_particles() {
         is_loop_particle("εως"),
         "ἕως should be loop particle (while)"
     );
-    assert!(
-        is_loop_particle("δια"),
-        "διά should be loop particle (for)"
-    );
-    assert!(
-        is_range_particle("απο"),
-        "ἀπό should be range start"
-    );
+    assert!(is_loop_particle("δια"), "διά should be loop particle (for)");
+    assert!(is_range_particle("απο"), "ἀπό should be range start");
     assert!(
         is_range_particle("μεχρι"),
         "μέχρι should be range end (exclusive)"
@@ -252,20 +234,14 @@ fn test_lexicon_loop_control() {
     use glossa::morphology::*;
 
     assert!(is_break_verb("παυε"), "παῦε should be break");
-    assert!(
-        is_continue_verb("συνεχιζε"),
-        "συνέχιζε should be continue"
-    );
+    assert!(is_continue_verb("συνεχιζε"), "συνέχιζε should be continue");
 }
 
 #[test]
 fn test_lexicon_match_particle() {
     use glossa::morphology::*;
 
-    assert!(
-        is_match_particle("κατα"),
-        "κατά should be match particle"
-    );
+    assert!(is_match_particle("κατα"), "κατά should be match particle");
 }
 
 #[test]

--- a/tests/control_flow_tests.rs
+++ b/tests/control_flow_tests.rs
@@ -197,73 +197,73 @@ fn test_continue() {
 
 #[test]
 fn test_lexicon_conditional_particles() {
-    use glossa::morphology::lexicon;
+    use glossa::morphology::*;
 
     // These should be recognized as control flow particles
     assert!(
-        lexicon::is_conditional_particle("ει"),
+        is_conditional_particle("ει"),
         "εἰ should be conditional"
     );
     assert!(
-        lexicon::is_conditional_particle("εαν"),
+        is_conditional_particle("εαν"),
         "ἐάν should be conditional"
     );
     assert!(
-        lexicon::is_conditional_particle("ην"),
+        is_conditional_particle("ην"),
         "ἤν should be conditional"
     );
 }
 
 #[test]
 fn test_lexicon_else_particle() {
-    use glossa::morphology::lexicon;
+    use glossa::morphology::*;
 
     // "εἰ δὲ μή" is the else pattern
     assert!(
-        lexicon::is_else_pattern("ει δε μη"),
+        is_else_pattern("ει δε μη"),
         "εἰ δὲ μή should be else"
     );
 }
 
 #[test]
 fn test_lexicon_loop_particles() {
-    use glossa::morphology::lexicon;
+    use glossa::morphology::*;
 
     assert!(
-        lexicon::is_loop_particle("εως"),
+        is_loop_particle("εως"),
         "ἕως should be loop particle (while)"
     );
     assert!(
-        lexicon::is_loop_particle("δια"),
+        is_loop_particle("δια"),
         "διά should be loop particle (for)"
     );
     assert!(
-        lexicon::is_range_particle("απο"),
+        is_range_particle("απο"),
         "ἀπό should be range start"
     );
     assert!(
-        lexicon::is_range_particle("μεχρι"),
+        is_range_particle("μεχρι"),
         "μέχρι should be range end (exclusive)"
     );
 }
 
 #[test]
 fn test_lexicon_loop_control() {
-    use glossa::morphology::lexicon;
+    use glossa::morphology::*;
 
-    assert!(lexicon::is_break_verb("παυε"), "παῦε should be break");
+    assert!(is_break_verb("παυε"), "παῦε should be break");
     assert!(
-        lexicon::is_continue_verb("συνεχιζε"),
+        is_continue_verb("συνεχιζε"),
         "συνέχιζε should be continue"
     );
 }
 
 #[test]
 fn test_lexicon_match_particle() {
-    use glossa::morphology::lexicon;
+    use glossa::morphology::*;
 
     assert!(
-        lexicon::is_match_particle("κατα"),
+        is_match_particle("κατα"),
         "κατά should be match particle"
     );
 }

--- a/tests/forge_control_flow_coverage.rs
+++ b/tests/forge_control_flow_coverage.rs
@@ -1,5 +1,5 @@
 use glossa::ast::{Clause, Expr, Statement, Word};
-use glossa::semantic::analyzer::analyze_statement;
+use glossa::semantic::analyze_statement;
 use glossa::semantic::{GlossaType, Scope};
 use smol_str::SmolStr;
 

--- a/tests/havoc_deep_ast.rs
+++ b/tests/havoc_deep_ast.rs
@@ -26,5 +26,5 @@ fn test_deep_ast_overflow_analyzer() {
     };
 
     // 💥 DETONATE: This will cause a fatal stack overflow (SIGABRT)
-    let _res = glossa::semantic::analyzer::analyze_program(&prog);
+    let _res = glossa::semantic::analyze_program(&prog);
 }

--- a/tests/havoc_fuzz_assembler.rs
+++ b/tests/havoc_fuzz_assembler.rs
@@ -1,5 +1,5 @@
 use glossa::morphology::{Case, MorphAnalysis, Number, PartOfSpeech};
-use glossa::semantic::assembly::Assembler;
+use glossa::semantic::Assembler;
 use proptest as prop;
 use proptest::prelude::*;
 use std::borrow::Cow;

--- a/tests/havoc_proptest_lexicon.rs
+++ b/tests/havoc_proptest_lexicon.rs
@@ -1,4 +1,4 @@
-use glossa::morphology::lexicon::lookup;
+use glossa::morphology::lookup;
 use proptest::prelude::*;
 
 proptest! {

--- a/tests/havoc_proptest_normalization.rs
+++ b/tests/havoc_proptest_normalization.rs
@@ -52,10 +52,10 @@ proptest! {
 // Actually, proptest strings are valid UTF-8, which is good enough to fuzz parser.
 
 use glossa::morphology::Declension;
-use glossa::morphology::conjugation::analyze_verb;
-use glossa::morphology::declension::{analyze_noun, get_stem};
-use glossa::morphology::disambiguation::analyze_article;
-use glossa::morphology::participle::analyze_participle;
+use glossa::morphology::analyze_verb;
+use glossa::morphology::{analyze_noun, get_stem};
+use glossa::morphology::analyze_article;
+use glossa::morphology::analyze_participle;
 
 proptest! {
     #[test]
@@ -84,7 +84,7 @@ proptest! {
     }
 }
 
-use glossa::semantic::assembly::Assembler;
+use glossa::semantic::Assembler;
 
 proptest! {
     #[test]

--- a/tests/havoc_proptest_normalization.rs
+++ b/tests/havoc_proptest_normalization.rs
@@ -52,10 +52,10 @@ proptest! {
 // Actually, proptest strings are valid UTF-8, which is good enough to fuzz parser.
 
 use glossa::morphology::Declension;
-use glossa::morphology::analyze_verb;
-use glossa::morphology::{analyze_noun, get_stem};
 use glossa::morphology::analyze_article;
 use glossa::morphology::analyze_participle;
+use glossa::morphology::analyze_verb;
+use glossa::morphology::{analyze_noun, get_stem};
 
 proptest! {
     #[test]

--- a/tests/havoc_proptest_pest.rs
+++ b/tests/havoc_proptest_pest.rs
@@ -1,4 +1,4 @@
-use glossa::parser::grammar::parse;
+use glossa::parser::parse;
 use proptest::prelude::*;
 
 proptest! {

--- a/tests/lambda_tests.rs
+++ b/tests/lambda_tests.rs
@@ -5,7 +5,7 @@
 
 #[cfg(test)]
 mod cycle1_participle_morphology {
-    use glossa::morphology::participle::*;
+    use glossa::morphology::*;
     use glossa::morphology::{Case, Gender, Number, Tense, Voice};
 
     #[test]

--- a/tests/morphology_models_test.rs
+++ b/tests/morphology_models_test.rs
@@ -1,4 +1,4 @@
-use glossa::morphology::models::*;
+use glossa::morphology::*;
 
 #[test]
 fn test_morph_analysis_creation() {

--- a/tests/narrator_coverage.rs
+++ b/tests/narrator_coverage.rs
@@ -285,7 +285,7 @@ fn test_bard_exprs() {
 
     test_expr_tale(
         AnalyzedExprKind::UnaryOp {
-            op: glossa::morphology::lexicon::UnaryOp::Not,
+            op: glossa::morphology::UnaryOp::Not,
             operand: Box::new(AnalyzedExpr {
                 expr: AnalyzedExprKind::BooleanLiteral(true),
                 glossa_type: GlossaType::Boolean,

--- a/tests/option_result_tests.rs
+++ b/tests/option_result_tests.rs
@@ -98,43 +98,43 @@ fn test_optative_aorist_passive() {
 
 #[test]
 fn test_ouden_is_none() {
-    use glossa::morphology::lexicon;
 
-    let entry = lexicon::lookup("ουδεν");
+
+    let entry = glossa::morphology::lookup("ουδεν");
     assert!(entry.is_some());
     assert_eq!(entry.unwrap().rust_equiv, Some("None"));
 }
 
 #[test]
 fn test_ti_is_some() {
-    use glossa::morphology::lexicon;
 
-    let entry = lexicon::lookup("τι");
+
+    let entry = glossa::morphology::lookup("τι");
     assert!(entry.is_some());
     assert_eq!(entry.unwrap().rust_equiv, Some("Some"));
 }
 
 #[test]
 fn test_epitychia_is_ok() {
-    use glossa::morphology::lexicon;
 
-    let entry = lexicon::lookup("επιτυχια");
+
+    let entry = glossa::morphology::lookup("επιτυχια");
     assert!(entry.is_some());
     assert_eq!(entry.unwrap().rust_equiv, Some("Ok"));
 }
 
 #[test]
 fn test_sphalma_is_err() {
-    use glossa::morphology::lexicon;
 
-    let entry = lexicon::lookup("σφαλμα");
+
+    let entry = glossa::morphology::lookup("σφαλμα");
     assert!(entry.is_some());
     assert_eq!(entry.unwrap().rust_equiv, Some("Err"));
 }
 
 #[test]
 fn test_is_none_word_helper() {
-    use glossa::morphology::lexicon::is_none_word;
+    use glossa::morphology::is_none_word;
 
     assert!(is_none_word("ουδεν"));
     assert!(!is_none_word("τι"));
@@ -142,7 +142,7 @@ fn test_is_none_word_helper() {
 
 #[test]
 fn test_is_some_word_helper() {
-    use glossa::morphology::lexicon::is_some_word;
+    use glossa::morphology::is_some_word;
 
     assert!(is_some_word("τι"));
     assert!(!is_some_word("ουδεν"));
@@ -150,7 +150,7 @@ fn test_is_some_word_helper() {
 
 #[test]
 fn test_is_ok_word_helper() {
-    use glossa::morphology::lexicon::is_ok_word;
+    use glossa::morphology::is_ok_word;
 
     assert!(is_ok_word("επιτυχια"));
     assert!(!is_ok_word("σφαλμα"));
@@ -158,7 +158,7 @@ fn test_is_ok_word_helper() {
 
 #[test]
 fn test_is_err_word_helper() {
-    use glossa::morphology::lexicon::is_err_word;
+    use glossa::morphology::is_err_word;
 
     assert!(is_err_word("σφαλμα"));
     assert!(!is_err_word("επιτυχια"));

--- a/tests/option_result_tests.rs
+++ b/tests/option_result_tests.rs
@@ -98,8 +98,6 @@ fn test_optative_aorist_passive() {
 
 #[test]
 fn test_ouden_is_none() {
-
-
     let entry = glossa::morphology::lookup("ουδεν");
     assert!(entry.is_some());
     assert_eq!(entry.unwrap().rust_equiv, Some("None"));
@@ -107,8 +105,6 @@ fn test_ouden_is_none() {
 
 #[test]
 fn test_ti_is_some() {
-
-
     let entry = glossa::morphology::lookup("τι");
     assert!(entry.is_some());
     assert_eq!(entry.unwrap().rust_equiv, Some("Some"));
@@ -116,8 +112,6 @@ fn test_ti_is_some() {
 
 #[test]
 fn test_epitychia_is_ok() {
-
-
     let entry = glossa::morphology::lookup("επιτυχια");
     assert!(entry.is_some());
     assert_eq!(entry.unwrap().rust_equiv, Some("Ok"));
@@ -125,8 +119,6 @@ fn test_epitychia_is_ok() {
 
 #[test]
 fn test_sphalma_is_err() {
-
-
     let entry = glossa::morphology::lookup("σφαλμα");
     assert!(entry.is_some());
     assert_eq!(entry.unwrap().rust_equiv, Some("Err"));

--- a/tests/semantic_model_coverage_tests.rs
+++ b/tests/semantic_model_coverage_tests.rs
@@ -146,14 +146,14 @@ fn test_analyzed_expr_kind_debug_all_variants() {
                 expr: AnalyzedExprKind::None,
                 glossa_type: glossa::semantic::GlossaType::Unknown,
             }),
-            op: glossa::morphology::lexicon::BinaryOp::Add,
+            op: glossa::morphology::BinaryOp::Add,
             right: Box::new(AnalyzedExpr {
                 expr: AnalyzedExprKind::None,
                 glossa_type: glossa::semantic::GlossaType::Unknown,
             }),
         },
         AnalyzedExprKind::UnaryOp {
-            op: glossa::morphology::lexicon::UnaryOp::Not,
+            op: glossa::morphology::UnaryOp::Not,
             operand: Box::new(AnalyzedExpr {
                 expr: AnalyzedExprKind::None,
                 glossa_type: glossa::semantic::GlossaType::Unknown,

--- a/tests/sentry_assembler_coverage_tests.rs
+++ b/tests/sentry_assembler_coverage_tests.rs
@@ -1,7 +1,7 @@
 use glossa::morphology::analyze;
-use glossa::morphology::lexicon::BinaryOp;
+use glossa::morphology::BinaryOp;
 use glossa::semantic::Assembler;
-use glossa::semantic::assembly::Literal;
+use glossa::semantic::Literal;
 
 #[test]
 fn test_assembler_comparison_operator() {

--- a/tests/sentry_assembler_coverage_tests.rs
+++ b/tests/sentry_assembler_coverage_tests.rs
@@ -1,5 +1,5 @@
-use glossa::morphology::analyze;
 use glossa::morphology::BinaryOp;
+use glossa::morphology::analyze;
 use glossa::semantic::Assembler;
 use glossa::semantic::Literal;
 

--- a/tests/sentry_morphology_empty_string.rs
+++ b/tests/sentry_morphology_empty_string.rs
@@ -1,6 +1,6 @@
-use glossa::morphology::analyze_verb;
 use glossa::morphology::analyze_noun;
 use glossa::morphology::analyze_participle;
+use glossa::morphology::analyze_verb;
 
 #[test]
 fn test_morphology_empty_string_does_not_panic() {

--- a/tests/sentry_morphology_empty_string.rs
+++ b/tests/sentry_morphology_empty_string.rs
@@ -1,6 +1,6 @@
-use glossa::morphology::conjugation::analyze_verb;
-use glossa::morphology::declension::analyze_noun;
-use glossa::morphology::participle::analyze_participle;
+use glossa::morphology::analyze_verb;
+use glossa::morphology::analyze_noun;
+use glossa::morphology::analyze_participle;
 
 #[test]
 fn test_morphology_empty_string_does_not_panic() {

--- a/tests/sentry_participle_tests.rs
+++ b/tests/sentry_participle_tests.rs
@@ -1,4 +1,4 @@
-use glossa::morphology::{Case, Gender, Number, Tense, Voice, participle::analyze_participle};
+use glossa::morphology::{Case, Gender, Number, Tense, Voice, analyze_participle};
 
 #[test]
 fn test_participle_analysis_coverage() {

--- a/tests/warden_neg_overflow.rs
+++ b/tests/warden_neg_overflow.rs
@@ -1,5 +1,5 @@
 use glossa::codegen::generate_rust;
-use glossa::morphology::lexicon::UnaryOp;
+use glossa::morphology::UnaryOp;
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };

--- a/tests/warden_overflow_sim.rs
+++ b/tests/warden_overflow_sim.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "nova")]
-use glossa::morphology::lexicon::{BinaryOp, UnaryOp};
+use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };


### PR DESCRIPTION
🕸️ Tangle: The `src/morphology`, `src/parser`, and `src/semantic` modules were using `pub mod` for their internal submodules, exposing raw implementation details (the "Leaky Abstraction" smell) and increasing coupling across the codebase. Tests were importing deeply nested paths directly.

📐 Blueprint: Converted all `pub mod` declarations to `pub(crate) mod` within these core domain folders to enforce proper encapsulation. I exposed only the intended public APIs through `pub use` statements at the module roots (The Facade pattern). Tests were updated to reflect these cleaner, public-facing imports.

🧱 Stability: Reduced coupling by enforcing strict module boundaries. The public API is now a clean contract, preventing external code from depending on internal module structure.

🔬 Verification: Ran `cargo check` and `cargo test --all-targets --all-features`. All 290+ tests pass successfully, confirming that the new structural boundaries do not break functionality while maintaining the correct public API surface.

---
*PR created automatically by Jules for task [3443312873156885466](https://jules.google.com/task/3443312873156885466) started by @madmax983*