### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-add-alchemist-and-weave.md
+++ b/docs/adr/016-add-alchemist-and-weave.md
@@ -1,0 +1,32 @@
+# 16. Add Alchemist and Weave to Developer Experience Tools
+
+Date: 2024-11-15
+Status: Proposed
+
+## Context
+
+As the ΓΛΩΣΣΑ compiler's "Developer Experience (Nova)" toolset expands, two new experimental exporter tools have been developed to enhance the language's interoperability and educational value:
+
+1.  **The Alchemist (`src/tools/alchemist.rs`)**: An experimental transpiler that converts ΓΛΩΣΣΑ programs into Python scripts. This provides a dynamic, scripting-oriented target that complements the primary Rust codegen backend, proving the backend-independence of the semantic analysis phase.
+2.  **Weave (`src/tools/weave.rs`)**: An exporter that generates a "Rosetta Stone" Markdown document. It combines the original Greek source code, the detailed semantic assembly logic, and the final generated Rust code into a single, structured view. This is designed to serve as a powerful educational and documentation tool.
+
+Currently, these tools exist in the codebase but are missing formal architectural representation, which violates the Codex principles of Architectural Transparency. We must explicitly define their roles and boundaries within the system context.
+
+## Decision
+
+We formally recognize "The Alchemist" and "Weave" as components within the "Developer Experience (Nova)" container (`src/tools/`).
+
+- We define **The Alchemist** as the Python Exporter / Transpiler tool.
+- We define **Weave** as the Markdown "Rosetta Stone" Exporter tool.
+
+Both tools will be integrated into the architecture diagram as containers that depend on the output of the `Semantic Analyzer`.
+
+## Consequences
+
+### Positive
+- **Architectural Clarity**: The roles of the new `alchemist` and `weave` modules are explicitly documented and visualized, maintaining the "no implicit decisions" rule.
+- **Demonstrated Modularity**: Recognizing The Alchemist highlights the decoupling of the semantic phase from the Rust-specific codegen phase.
+- **Enhanced Documentation**: The "Rosetta Stone" format produced by Weave explicitly supports the project's educational goals.
+
+### Negative
+- **Maintenance Surface**: The compiler now has two new tools that must be maintained as the semantic model (`AnalyzedProgram`) evolves. Breakages in the AST or HIR will require updates to both exporters.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ C4Container
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
+        Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter / Transpiler")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -47,6 +48,7 @@ C4Container
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(weave, "Weave", "src/tools/weave.rs", "Markdown 'Rosetta Stone' Exporter")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -55,6 +57,7 @@ C4Container
     Rel(parser, morphology, "AST (Unresolved)")
     Rel(parser, highlight, "AST (Unresolved)")
     Rel(morphology, semantic, "AST (Resolved Morphology)")
+    Rel(semantic, alchemist, "Analyzed Program")
     Rel(semantic, report, "Analyzed Program")
     Rel(semantic, narrator, "Analyzed Program")
     Rel(semantic, cartographer, "Analyzed Program")
@@ -63,6 +66,7 @@ C4Container
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
+    Rel(semantic, weave, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")
     Rel(parser, tester, "AST")


### PR DESCRIPTION
🧠 **Decision:** Recorded the addition of the "Alchemist" (Python Exporter) and "Weave" (Markdown 'Rosetta Stone' Exporter) tools to the Developer Experience (Nova) toolset.

🗺️ **Visuals:** Updated the C4 Container Component diagram in `docs/architecture.md` to show the new boundaries and relationships (Semantic Analyzer -> Alchemist/Weave).

🔗 **Link:** See `docs/adr/016-add-alchemist-and-weave.md`.

---
*PR created automatically by Jules for task [6563861277588883117](https://jules.google.com/task/6563861277588883117) started by @madmax983*