### PR TITLE
⚒️ Forge: Extract test reporting UI logic from God Function

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -245,6 +245,16 @@ pub fn run_tests(input: &Path) -> Result<()> {
         status.error("Ἀποτυχία (Failure)");
     }
 
+    print_test_results(&test_output, &stdout, &results);
+
+    if !test_output.status.success() {
+        return Err(miette::miette!("Tests failed"));
+    }
+
+    Ok(())
+}
+
+fn print_test_results(test_output: &std::process::Output, stdout: &str, results: &[TestResult]) {
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
     println!("   {}", "Unit Test Results".italic().dim());
@@ -281,7 +291,7 @@ pub fn run_tests(input: &Path) -> Result<()> {
             Cell::new("Status").add_attribute(Attribute::Bold),
         ]);
 
-        for result in &results {
+        for result in results {
             let status_cell = match result.status {
                 TestStatus::Ok => Cell::new("PASSED").fg(Color::Green),
                 TestStatus::Failed => Cell::new("FAILED")
@@ -319,7 +329,7 @@ pub fn run_tests(input: &Path) -> Result<()> {
         println!();
         println!("{}", "--- 📜 Λεπτoμέρειες (Details) ---".dim());
 
-        let failures = extract_failures(&stdout);
+        let failures = extract_failures(stdout);
 
         if !failures.is_empty() {
             for (name, msg) in failures {
@@ -350,12 +360,6 @@ pub fn run_tests(input: &Path) -> Result<()> {
             }
         }
     }
-
-    if !test_output.status.success() {
-        return Err(miette::miette!("Tests failed"));
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🚮 Smell: The `run_tests` function in `src/tools/tester.rs` was a "God Function" exceeding 200 lines, heavily bogged down by a massive block of terminal UI printing logic at the end. This violated the "Grandma Test" for readability.
✨ Solution: Extracted the entire test result formatting and reporting block into a dedicated private helper function `print_test_results`.
🧼 Benefit: Drastically flattens the execution path of the core compilation and execution flow in `run_tests`, drastically reducing cognitive load. The UI logic is now encapsulated.
🛡️ Verification: Ran `cargo test`, `cargo clippy`, and `cargo fmt`. Tests passed, no logic changed.

---
*PR created automatically by Jules for task [4615498646495420759](https://jules.google.com/task/4615498646495420759) started by @madmax983*