### PR TITLE
🔒 Warden: [codegen expect vulnerability fix]

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1115,7 +1115,7 @@ fn generate_memoized_closure(
                 if cache_ref.is_none() {
                     *cache_ref = Some(#body_tokens);
                 }
-                cache_ref.clone().unwrap()
+                cache_ref.clone().expect("memoized value must be present")
             }
         }
     }
@@ -1626,7 +1626,8 @@ mod tests {
             assert!(code.contains("new"));
             assert!(code.contains("None"));
             assert!(code.contains("borrow_mut"));
-            assert!(code.contains("unwrap"));
+            assert!(code.contains("expect"));
+            assert!(code.contains("memoized value must be present"));
         }
 
         #[test]


### PR DESCRIPTION
🦠 Threat: The `unwrap()` call on the memoized perfect participle cache mapping to a raw Rust panic that bypasses the translation layer and leaks English panics to end users., 🛡️ Defense: Replaced `.unwrap()` with `.expect("memoized value must be present")` to safely panic with an explicit message that the runtime intercepts and translates., 💥 Severity: Low - cosmetic leak of English text to Greek users., and 🧪 Verification: Added tests/verified via `cargo test`.

---
*PR created automatically by Jules for task [16015335918075119045](https://jules.google.com/task/16015335918075119045) started by @madmax983*