### PR TITLE
🎨 Mosaic: UI Polish for runner.rs

### DIFF
--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -410,6 +410,11 @@ pub fn highlight_file(input: &Path) -> Result<()> {
     };
 
     status.success();
+
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   H I G H L I G H T".bold().cyan());
+    println!("   {}", "Semantic Colors".italic().dim());
+    println!();
     println!("{}", highlighted);
 
     Ok(())
@@ -455,6 +460,11 @@ pub fn bard_file(input: &Path) -> Result<()> {
 
     let tale = tell_tale(&analyzed);
     status.success();
+
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   B A R D".bold().cyan());
+    println!("   {}", "The Scroll of Logic".italic().dim());
+    println!();
     println!("{}", tale);
 
     Ok(())


### PR DESCRIPTION
🖌️ **Before:** The `glossa bard` and `glossa highlight` commands output their results directly to the terminal without any contextual headers, breaking the visual consistency established by other tools like `mosaic`, `map`, and `check`.

✨ **After:** Added standard `Γ Λ Ω Σ Σ Α` stylized headers to both `bard_file` and `highlight_file` in `src/tools/runner.rs` to match the rest of the CLI dashboard experience. The user now gets clear context about which tool is producing the output before the results are displayed.

🖼️ **Visuals:** Both tools now start with a blank line, a cyan bold title (e.g., `Γ Λ Ω Σ Σ Α   B A R D`), a dim italic subtitle (e.g., `The Scroll of Logic`), and another blank line before their respective table or colorized text output.

---
*PR created automatically by Jules for task [5192845245682236758](https://jules.google.com/task/5192845245682236758) started by @madmax983*