### PR TITLE
🪒 Razor: Eliminate TraitMethodParts struct

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -126,3 +126,8 @@
 **Bloat:** `QuantifierFlags` struct in `src/semantic/patterns.rs` was an unnecessary abstraction over two booleans (`is_any`, `is_all`).
 **Cut:** Deleted the struct and its `from` implementation, replacing it with a simple `get_quantifier_flags` function returning a `(bool, bool)` tuple.
 **Saved:** Removed unnecessary struct definition and simplified function signatures across `process_adjectives` and `process_explicit_quantifiers`.
+
+## [Reduction]
+**Bloat:** `TraitMethodParts` struct in `src/codegen.rs` was an unnecessary abstraction over a tuple.
+**Cut:** Deleted the `TraitMethodParts` struct and updated `generate_trait_method_parts` to return a `(Ident, Vec<TokenStream>, Option<TokenStream>)` tuple directly.
+**Saved:** Removed unnecessary struct definition and simplified function returns.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -713,13 +713,9 @@ fn generate_struct_def(name: &str, fields: &[(smol_str::SmolStr, GlossaType)]) -
     }
 }
 
-struct TraitMethodParts {
-    name: Ident,
-    params: Vec<TokenStream>,
-    return_type: Option<TokenStream>,
-}
-
-fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
+fn generate_trait_method_parts(
+    method: &AnalyzedMethod,
+) -> (Ident, Vec<TokenStream>, Option<TokenStream>) {
     let method_name = sanitize_ident(&method.name);
 
     let param_tokens: Vec<TokenStream> = method
@@ -739,11 +735,7 @@ fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
 
     let ret_tokens = method.return_type.as_ref().map(generate_type_tokens);
 
-    TraitMethodParts {
-        name: method_name,
-        params: param_tokens,
-        return_type: ret_tokens,
-    }
+    (method_name, param_tokens, ret_tokens)
 }
 
 fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
@@ -761,11 +753,9 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
     let method_tokens: Vec<TokenStream> = methods
         .iter()
         .map(|method| {
-            let parts = generate_trait_method_parts(method);
-            let method_name = parts.name;
-            let param_tokens = parts.params;
+            let (method_name, param_tokens, return_type) = generate_trait_method_parts(method);
 
-            if let Some(ret_ty) = parts.return_type {
+            if let Some(ret_ty) = return_type {
                 if let Some(body) = &method.body {
                     let body_stmts = generate_statements(body);
                     quote! {
@@ -827,9 +817,7 @@ fn generate_trait_impl(
     let method_tokens: Vec<TokenStream> = methods
         .iter()
         .map(|method| {
-            let parts = generate_trait_method_parts(method);
-            let method_name = parts.name;
-            let param_tokens = parts.params;
+            let (method_name, param_tokens, return_type) = generate_trait_method_parts(method);
 
             // Generate method body
             let body_stmts: Vec<TokenStream> = if let Some(body) = &method.body {
@@ -838,7 +826,7 @@ fn generate_trait_impl(
                 Vec::new()
             };
 
-            if let Some(ret_ty) = parts.return_type {
+            if let Some(ret_ty) = return_type {
                 quote! {
                     fn #method_name(#(#param_tokens),*) -> #ret_ty {
                         #(#body_stmts)*
@@ -1638,20 +1626,20 @@ mod tests {
                 return_type: Some(GlossaType::Boolean),
             };
 
-            let parts = generate_trait_method_parts(&method);
+            let (method_name, param_tokens, return_type) = generate_trait_method_parts(&method);
 
-            assert_eq!(parts.name.to_string(), "g_test_method");
+            assert_eq!(method_name.to_string(), "g_test_method");
 
             // Check params
-            let params_str: Vec<String> = parts.params.iter().map(|t| t.to_string()).collect();
+            let params_str: Vec<String> = param_tokens.iter().map(|t| t.to_string()).collect();
             assert_eq!(params_str.len(), 2);
             assert_eq!(params_str[0], "& self");
             assert!(params_str[1].contains("g_arg1"));
             assert!(params_str[1].contains("i64"));
 
             // Check return type
-            assert!(parts.return_type.is_some());
-            assert_eq!(parts.return_type.unwrap().to_string(), "bool");
+            assert!(return_type.is_some());
+            assert_eq!(return_type.unwrap().to_string(), "bool");
         }
 
         #[test]


### PR DESCRIPTION
## [Reduction]
**Bloat:** `TraitMethodParts` struct in `src/codegen.rs` was an unnecessary abstraction over a tuple.
**Cut:** Deleted the `TraitMethodParts` struct and updated `generate_trait_method_parts` to return a `(Ident, Vec<TokenStream>, Option<TokenStream>)` tuple directly.
**Saved:** Removed unnecessary struct definition and simplified function returns.

---
*PR created automatically by Jules for task [5197202020533866534](https://jules.google.com/task/5197202020533866534) started by @madmax983*