### PR TITLE
🪒 Razor: Remove dead code `Statement::expressions`

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -121,3 +121,7 @@
 **Bloat:** `AssemblyError` in `src/errors/assembly.rs` contained two variants (`MissingVerb` and `GenderMismatch`) that were defined but completely unused anywhere in the codebase, leading to dead code.
 **Cut:** Deleted the `MissingVerb` and `GenderMismatch` error variants and the unused `Gender` import.
 **Saved:** Removed 13 lines of dead code and simplified the error variant surface area.
+## Reduction: Removed dead code `Statement::expressions`
+**Bloat:** Unused `pub fn expressions(&self) -> Box<dyn Iterator<Item = &Expr> + '_>` in `src/ast.rs` that needlessly allocated a Box for a dynamic iterator.
+**Cut:** Deleted the method entirely and removed its associated assertions in the test suite.
+**Saved:** ~15 lines of code and eliminated an unnecessary heap allocation.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -221,19 +221,6 @@ impl std::fmt::Debug for Statement {
 }
 
 impl Statement {
-    /// Get all expressions flattened (for backwards compatibility)
-    pub fn expressions(&self) -> Box<dyn Iterator<Item = &Expr> + '_> {
-        match self {
-            Statement::Regular { clauses, .. } => {
-                Box::new(clauses.iter().flat_map(|c| c.expressions.iter()))
-            }
-            Statement::TypeDefinition(_) => Box::new(std::iter::empty()),
-            Statement::TraitDefinition(_) => Box::new(std::iter::empty()),
-            Statement::TraitImpl(_) => Box::new(std::iter::empty()),
-            Statement::TestDeclaration(_) => Box::new(std::iter::empty()),
-        }
-    }
-
     /// Check if this is a query statement
     pub fn is_query(&self) -> bool {
         match self {

--- a/tests/ast_coverage_tests.rs
+++ b/tests/ast_coverage_tests.rs
@@ -370,7 +370,6 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 
     let stmt = Statement::TypeDefinition(TypeDef {
         name: Word::new("t"),
@@ -379,7 +378,6 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 
     let stmt = Statement::TraitDefinition(TraitDef {
         name: Word::new("t"),
@@ -388,7 +386,6 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 
     let stmt = Statement::TraitImpl(TraitImplDef {
         type_name: Word::new("t"),
@@ -398,5 +395,4 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 }


### PR DESCRIPTION
## Reduction
**Bloat:** Unused `pub fn expressions(&self) -> Box<dyn Iterator<Item = &Expr> + '_>` in `src/ast.rs` that needlessly allocated a Box for a dynamic iterator.
**Cut:** Deleted the method entirely and removed its associated assertions in the test suite.
**Saved:** ~15 lines of code and eliminated an unnecessary heap allocation.

---
*PR created automatically by Jules for task [6064579651077806680](https://jules.google.com/task/6064579651077806680) started by @madmax983*