### PR TITLE
🗺️ Atlas: [architectural change] Encapsulate internal tool modules and limits

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -131,3 +131,8 @@
 **[Title]** Enforcing the Facade Pattern in src/lib.rs
 **Tangle:** The `glossa` crate previously exposed all its internal modules (`ast`, `codegen`, `limits`, `morphology`, `parser`, `semantic`, `text`) as fully public (`pub mod`). This leaked implementation details and created a sprawling public API, violating the principle of encapsulation and making it difficult for downstream users to know which functions to use.
 **Blueprint:** Refactored `src/lib.rs` to change these modules to `pub(crate) mod` (or kept `pub mod` only where explicitly needed by the `glossa` binary or integration tests) and added explicit `pub use` statements for the true public API: `ast::Program`, `codegen::generate_rust`, `parser::parse`, `semantic::{AnalyzedProgram, analyze_program}`. This creates a clean "Facade" that hides messy internal sub-modules while exposing only what the user needs.
+
+## [Breaking The Leak: Encapsulating Tools and Limits]
+**Tangle:** Internal modules like `limits` in `src/lib.rs` and various tool submodules (`alchemist`, `cartographer`, `interpreter`, `mentor`, `mosaic`, `report`, `ui`, `weave`) in `src/tools/mod.rs` were needlessly exposed via `pub mod`. This broke clear module boundaries and leaked implementation details.
+**Blueprint:** Upgraded `pub mod` to `pub(crate) mod` for `limits` in `src/lib.rs` and the specified tool submodules in `src/tools/mod.rs`. Explicitly re-exported required tool runner functions using `pub use` to maintain the public API surface while keeping internal modules private.
+**Stability:** Enforced high cohesion and low coupling by ensuring strict encapsulation and clean public interfaces.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 pub mod ast;
 pub mod codegen;
 pub mod errors;
-pub mod limits;
+pub(crate) mod limits;
 pub mod morphology;
 pub mod parser;
 pub mod semantic;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
 
         #[cfg(feature = "nova")]
         Some(Commands::Mentor) => {
-            glossa::tools::mentor::run_mentor()?;
+            glossa::tools::run_mentor()?;
         }
 
         Some(Commands::Build { input, output }) => {
@@ -54,22 +54,22 @@ fn main() -> Result<()> {
 
         #[cfg(feature = "nova")]
         Some(Commands::Mosaic { input }) => {
-            glossa::tools::mosaic::run_mosaic(&input)?;
+            glossa::tools::run_mosaic(&input)?;
         }
 
         #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
-            glossa::tools::cartographer::run_map(&input)?;
+            glossa::tools::run_map(&input)?;
         }
 
         #[cfg(feature = "nova")]
         Some(Commands::Weave { input }) => {
-            glossa::tools::weave::run_weave(&input)?;
+            glossa::tools::run_weave(&input)?;
         }
 
         #[cfg(feature = "nova")]
         Some(Commands::Alchemist { input }) => {
-            glossa::tools::alchemist::run_alchemist(&input)?;
+            glossa::tools::run_alchemist(&input)?;
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -25,6 +25,7 @@ pub enum Value {
     Number(i64),
     String(String),
     Boolean(bool),
+    #[allow(dead_code)]
     Unit,
     // Future: List(Vec<Value>), Struct(HashMap<String, Value>), etc.
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,24 +17,37 @@
 //! * [`ui`]: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
 
 #[cfg(feature = "nova")]
-pub mod alchemist;
+pub(crate) mod alchemist;
 pub mod cache;
 #[cfg(feature = "nova")]
-pub mod cartographer;
+pub(crate) mod cartographer;
 pub mod cli;
 pub mod dictionary;
 pub mod highlight;
 #[cfg(feature = "nova")]
-pub mod interpreter;
+pub(crate) mod interpreter;
 #[cfg(feature = "nova")]
-pub mod mentor;
+pub(crate) mod mentor;
 #[cfg(feature = "nova")]
-pub mod mosaic;
+pub(crate) mod mosaic;
 pub mod narrator;
 pub mod repl;
-pub mod report;
+pub(crate) mod report;
 pub mod runner;
 pub mod tester;
-pub mod ui;
+pub(crate) mod ui;
 #[cfg(feature = "nova")]
-pub mod weave;
+pub(crate) mod weave;
+
+#[cfg(feature = "nova")]
+pub use alchemist::{run_alchemist, transpile_to_python};
+#[cfg(feature = "nova")]
+pub use cartographer::run_map;
+#[cfg(feature = "nova")]
+pub use interpreter::Interpreter;
+#[cfg(feature = "nova")]
+pub use mentor::run_mentor;
+#[cfg(feature = "nova")]
+pub use mosaic::{run_mosaic, run_mosaic_inner};
+#[cfg(feature = "nova")]
+pub use weave::run_weave;

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -55,6 +55,7 @@ impl Status {
     /// let status = Status::start("Compiling...");
     /// status.success();
     /// ```
+    #[allow(dead_code)]
     pub fn start(message: impl Into<String>) -> Self {
         Self::start_with_symbol(message, "⚡")
     }

--- a/tests/alchemist_coverage.rs
+++ b/tests/alchemist_coverage.rs
@@ -4,7 +4,7 @@ use glossa::morphology::lexicon::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::alchemist::{run_alchemist, transpile_to_python};
+use glossa::tools::{run_alchemist, transpile_to_python};
 use std::io::Write;
 use tempfile::Builder;
 

--- a/tests/mosaic_coverage.rs
+++ b/tests/mosaic_coverage.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "nova")]
 
-use glossa::tools::mosaic::run_mosaic_inner;
+use glossa::tools::run_mosaic_inner;
 
 #[test]
 fn test_mosaic_comprehensive_coverage() {

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -16,7 +16,7 @@ fn test_run_weave_success() {
     let source = "«χαῖρε κόσμε» λέγε.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::weave::run_weave(temp_file.path());
+    let result = glossa::tools::run_weave(temp_file.path());
     assert!(result.is_ok(), "Weave failed: {:?}", result.err());
 
     let output_path = temp_file.path().with_extension("md");

--- a/tests/warden_overflow_sim.rs
+++ b/tests/warden_overflow_sim.rs
@@ -3,7 +3,7 @@ use glossa::morphology::lexicon::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::interpreter::Interpreter;
+use glossa::tools::Interpreter;
 
 #[test]
 fn test_warden_overflow_sim_defense() {


### PR DESCRIPTION
🗺️ Atlas: [architectural change] Encapsulate internal tool modules and limits

🕸️ Tangle: The internal modules like `limits` in `src/lib.rs` and various tool submodules (`alchemist`, `cartographer`, `interpreter`, `mentor`, `mosaic`, `report`, `ui`, `weave`) in `src/tools/mod.rs` were fully public via `pub mod`. This leaked implementation details and violated module boundaries.
📐 Blueprint: Changed `pub mod` to `pub(crate) mod` for these internal modules to restrict their visibility. Added explicit `pub use` statements in `src/tools/mod.rs` to selectively re-export necessary items (like `run_alchemist`, `Interpreter`, etc.) for `main.rs` and integration tests.
🧱 Stability: Enforced strict encapsulation, maintaining a cleaner public API surface.
🔬 Verification: Ran `cargo check` and `cargo test` with all targets and features. Verified module visibility without breaking existing integrations.

---
*PR created automatically by Jules for task [14443031174839030314](https://jules.google.com/task/14443031174839030314) started by @madmax983*