### PR TITLE
🪒 Razor: Remove TraitMethodCall variant from AnalyzedExprKind

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -126,3 +126,8 @@
 **Bloat:** `QuantifierFlags` struct in `src/semantic/patterns.rs` was an unnecessary abstraction over two booleans (`is_any`, `is_all`).
 **Cut:** Deleted the struct and its `from` implementation, replacing it with a simple `get_quantifier_flags` function returning a `(bool, bool)` tuple.
 **Saved:** Removed unnecessary struct definition and simplified function signatures across `process_adjectives` and `process_explicit_quantifiers`.
+
+## [Reduction]
+**Bloat:** `AnalyzedExprKind::TraitMethodCall` was an unused enum variant. Trait method calls were actually parsed as regular `MethodCall`s in `try_parse_trait_method_call`, rendering `TraitMethodCall` speculative generality and dead code that unnecessarily bloated downstream pattern matching.
+**Cut:** Deleted the `TraitMethodCall` variant and all corresponding handler logic, tests, and formatting across 5 files (`model.rs`, `validation.rs`, `codegen.rs`, `narrator.rs`, `report.rs`).
+**Saved:** Removed unused dead code and reduced complexity (~60 lines saved).

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -938,13 +938,6 @@ fn generate_expr(expr: &AnalyzedExpr) -> TokenStream {
             args,
         } => generate_method_call(receiver, method, args),
 
-        AnalyzedExprKind::TraitMethodCall {
-            receiver,
-            method_name,
-            args,
-            ..
-        } => generate_trait_method_call(receiver, method_name, args),
-
         AnalyzedExprKind::VerbCall { verb, args }
         | AnalyzedExprKind::FunctionCall { func: verb, args } => generate_function_call(verb, args),
 
@@ -1310,19 +1303,6 @@ fn generate_method_call(
         sanitize_ident(method)
     };
 
-    // ⚡ Bolt Optimization: Removed intermediate `.collect::<Vec<_>>()` allocation.
-    let arg_tokens = args.iter().map(generate_expr);
-    quote! { #recv.#method_ident(#(#arg_tokens),*) }
-}
-
-fn generate_trait_method_call(
-    receiver: &AnalyzedExpr,
-    method_name: &str,
-    args: &[AnalyzedExpr],
-) -> TokenStream {
-    // Treat as regular method call
-    let recv = generate_expr(receiver);
-    let method_ident = sanitize_ident(method_name);
     // ⚡ Bolt Optimization: Removed intermediate `.collect::<Vec<_>>()` allocation.
     let arg_tokens = args.iter().map(generate_expr);
     quote! { #recv.#method_ident(#(#arg_tokens),*) }

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -10,7 +10,7 @@ use super::declarations::{
     analyze_type_definition, parse_function_definition,
 };
 use super::expressions::contains_function_definition_verb;
-use super::patterns::{try_parse_struct_instantiation, try_parse_trait_method_call};
+use super::patterns::{try_parse_method_call, try_parse_struct_instantiation};
 use super::{AnalyzedStatement, GlossaType, Scope, assemble_statement};
 use crate::ast::{Expr, Program, Statement};
 use crate::errors::GlossaError;
@@ -118,8 +118,8 @@ fn analyze_statement_recursive(
         return Ok(vec![struct_inst]);
     }
 
-    // 4. Check for trait method call pattern
-    if let Some(method_call) = try_parse_trait_method_call(stmt, scope)? {
+    // 4. Check for standalone method call pattern
+    if let Some(method_call) = try_parse_method_call(stmt, scope)? {
         return Ok(vec![method_call]);
     }
 

--- a/src/semantic/model.rs
+++ b/src/semantic/model.rs
@@ -592,21 +592,6 @@ pub enum AnalyzedExprKind {
         args: Vec<AnalyzedExpr>,
     },
 
-    /// Trait method call `receiver.<TraitName>::method(args)` (from trait impl)
-    ///
-    /// # Example
-    /// `user.Show::print()`
-    TraitMethodCall {
-        /// The entity demonstrating its learned behavior.
-        receiver: Box<AnalyzedExpr>,
-        /// The character (`χαρακτήρ`) that defines this behavior.
-        trait_name: SmolStr,
-        /// The specific behavior being enacted.
-        method_name: SmolStr,
-        /// The necessary context for the behavior.
-        args: Vec<AnalyzedExpr>,
-    },
-
     /// Struct instantiation: `variable νέον type_name args... ἔστω`
     ///
     /// # Example
@@ -719,18 +704,6 @@ impl std::fmt::Debug for AnalyzedExprKind {
                 .debug_struct("MethodCall")
                 .field("receiver", receiver)
                 .field("method", method)
-                .field("args", args)
-                .finish(),
-            AnalyzedExprKind::TraitMethodCall {
-                receiver,
-                trait_name,
-                method_name,
-                args,
-            } => f
-                .debug_struct("TraitMethodCall")
-                .field("receiver", receiver)
-                .field("trait_name", trait_name)
-                .field("method_name", method_name)
                 .field("args", args)
                 .finish(),
             AnalyzedExprKind::StructInstantiation {

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -46,7 +46,7 @@ use crate::errors::GlossaError;
 use crate::text::normalize_greek;
 use smol_str::SmolStr;
 
-/// Try to parse a trait method call: `method_name receiver`
+/// Try to parse a standalone method call: `method_name receiver`
 ///
 /// This looks for a specific phrase pattern where a method name is immediately
 /// followed by its receiver (the object it acts upon).
@@ -60,8 +60,8 @@ use smol_str::SmolStr;
 /// λέγε ζῷον.
 /// ```
 ///
-/// Returns `Some(analyzed_statement)` if this is a trait method call, `None` otherwise.
-pub fn try_parse_trait_method_call(
+/// Returns `Some(analyzed_statement)` if this is a method call, `None` otherwise.
+pub fn try_parse_method_call(
     stmt: &Statement,
     scope: &mut Scope,
 ) -> Result<Option<AnalyzedStatement>, GlossaError> {

--- a/src/semantic/validation.rs
+++ b/src/semantic/validation.rs
@@ -129,8 +129,7 @@ fn check_expr_depth(expr: &AnalyzedExpr, depth: usize) -> Result<(), GlossaError
             check_expr_depth(array, depth + 1)?;
             check_expr_depth(index, depth + 1)?;
         }
-        AnalyzedExprKind::MethodCall { receiver, args, .. }
-        | AnalyzedExprKind::TraitMethodCall { receiver, args, .. } => {
+        AnalyzedExprKind::MethodCall { receiver, args, .. } => {
             check_expr_depth(receiver, depth + 1)?;
             for arg in args {
                 check_expr_depth(arg, depth + 1)?;
@@ -161,7 +160,6 @@ fn check_expr_depth(expr: &AnalyzedExpr, depth: usize) -> Result<(), GlossaError
 mod tests {
     use super::*;
     use crate::semantic::GlossaType;
-    use smol_str::SmolStr;
 
     #[test]
     fn test_statement_depth_limit() {
@@ -204,25 +202,6 @@ mod tests {
             value: Some(Box::new(expr)),
         };
         let result = check_statement_depth(&stmt, 0);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_trait_method_call_depth() {
-        let receiver = AnalyzedExpr {
-            expr: AnalyzedExprKind::None,
-            glossa_type: GlossaType::Unknown,
-        };
-        let expr = AnalyzedExpr {
-            expr: AnalyzedExprKind::TraitMethodCall {
-                receiver: Box::new(receiver),
-                method_name: SmolStr::new("test_method"),
-                trait_name: SmolStr::new("test_trait"),
-                args: vec![],
-            },
-            glossa_type: GlossaType::Unknown,
-        };
-        let result = check_expr_depth(&expr, 0);
         assert!(result.is_ok());
     }
 }

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -492,12 +492,6 @@ pub(crate) fn tell_expr(expr: &AnalyzedExpr) -> String {
             method,
             args,
         } => tell_method_call(receiver, method, args),
-        AnalyzedExprKind::TraitMethodCall {
-            receiver,
-            trait_name,
-            method_name,
-            args,
-        } => tell_trait_method_call(receiver, trait_name, method_name, args),
         AnalyzedExprKind::StructInstantiation {
             type_name,
             fields,
@@ -534,21 +528,6 @@ fn tell_function_call(func: &str, args: &[AnalyzedExpr]) -> String {
 
 fn tell_method_call(receiver: &AnalyzedExpr, method: &str, args: &[AnalyzedExpr]) -> String {
     format!("{}.{}({})", tell_expr(receiver), method, format_exprs(args))
-}
-
-fn tell_trait_method_call(
-    receiver: &AnalyzedExpr,
-    trait_name: &str,
-    method_name: &str,
-    args: &[AnalyzedExpr],
-) -> String {
-    format!(
-        "{} as {}::{}({})",
-        tell_expr(receiver),
-        trait_name,
-        method_name,
-        format_exprs(args)
-    )
 }
 
 fn tell_struct_instantiation(

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -217,8 +217,7 @@ impl ProgramStats {
                     self.visit_expr(arg);
                 }
             }
-            AnalyzedExprKind::MethodCall { receiver, args, .. }
-            | AnalyzedExprKind::TraitMethodCall { receiver, args, .. } => {
+            AnalyzedExprKind::MethodCall { receiver, args, .. } => {
                 self.visit_expr(receiver);
                 for arg in args {
                     self.visit_expr(arg);
@@ -711,18 +710,6 @@ mod tests {
                 },
                 glossa_type: GlossaType::Unknown,
             },
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::TraitMethodCall {
-                    receiver: Box::new(AnalyzedExpr {
-                        expr: AnalyzedExprKind::NumberLiteral(1),
-                        glossa_type: GlossaType::Number,
-                    }),
-                    trait_name: "Trait".into(),
-                    method_name: "method".into(),
-                    args: vec![],
-                },
-                glossa_type: GlossaType::Unknown,
-            },
         ]));
 
         let stats = ProgramStats::new(&program);
@@ -970,18 +957,6 @@ mod tests {
                             glossa_type: GlossaType::Number,
                         }),
                         method: "abs".into(),
-                        args: vec![],
-                    },
-                    glossa_type: GlossaType::Number,
-                },
-                AnalyzedExpr {
-                    expr: AnalyzedExprKind::TraitMethodCall {
-                        receiver: Box::new(AnalyzedExpr {
-                            expr: AnalyzedExprKind::NumberLiteral(1),
-                            glossa_type: GlossaType::Number,
-                        }),
-                        trait_name: "Num".into(),
-                        method_name: "abs".into(),
                         args: vec![],
                     },
                     glossa_type: GlossaType::Number,

--- a/tests/codegen_coverage.rs
+++ b/tests/codegen_coverage.rs
@@ -62,29 +62,6 @@ fn test_generate_method_call_optimization() {
     assert!(code.contains("g_abs (10i64)"));
 }
 
-#[test]
-fn test_generate_trait_method_call_optimization() {
-    let receiver = Box::new(AnalyzedExpr {
-        expr: AnalyzedExprKind::NumberLiteral(5),
-        glossa_type: GlossaType::Number,
-    });
-    let args = vec![AnalyzedExpr {
-        expr: AnalyzedExprKind::NumberLiteral(10),
-        glossa_type: GlossaType::Number,
-    }];
-    let expr = AnalyzedExprKind::TraitMethodCall {
-        receiver,
-        trait_name: "Num".to_string().into(),
-        method_name: "add".to_string().into(),
-        args,
-    };
-    let stmt = AnalyzedStatement::Expression(vec![AnalyzedExpr {
-        expr,
-        glossa_type: GlossaType::Number,
-    }]);
-    let code = glossa::codegen::generate_statement_code(&stmt);
-    assert!(code.contains("g_add (10i64)"));
-}
 
 #[test]
 fn test_generate_function_call_optimization() {

--- a/tests/narrator_coverage.rs
+++ b/tests/narrator_coverage.rs
@@ -384,19 +384,6 @@ fn test_bard_exprs() {
     );
 
     test_expr_tale(
-        AnalyzedExprKind::TraitMethodCall {
-            receiver: Box::new(AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable("obj".into()),
-                glossa_type: GlossaType::Unknown,
-            }),
-            trait_name: "T".into(),
-            method_name: "m".into(),
-            args: vec![],
-        },
-        "`obj` as T::m()",
-    );
-
-    test_expr_tale(
         AnalyzedExprKind::StructInstantiation {
             type_name: "S".into(),
             fields: vec!["f".into()],

--- a/tests/semantic_model_coverage_tests.rs
+++ b/tests/semantic_model_coverage_tests.rs
@@ -214,15 +214,6 @@ fn test_analyzed_expr_kind_debug_all_variants() {
             method: SmolStr::new("method"),
             args: vec![],
         },
-        AnalyzedExprKind::TraitMethodCall {
-            receiver: Box::new(AnalyzedExpr {
-                expr: AnalyzedExprKind::None,
-                glossa_type: glossa::semantic::GlossaType::Unknown,
-            }),
-            trait_name: SmolStr::new("Trait"),
-            method_name: SmolStr::new("method"),
-            args: vec![],
-        },
         AnalyzedExprKind::StructInstantiation {
             type_name: SmolStr::new("Type"),
             fields: vec![],


### PR DESCRIPTION
## [Reduction]
**Bloat:** `AnalyzedExprKind::TraitMethodCall` was an unused enum variant. Trait method calls were actually parsed as regular `MethodCall`s in `try_parse_trait_method_call`, rendering `TraitMethodCall` speculative generality and dead code that unnecessarily bloated downstream pattern matching.
**Cut:** Deleted the `TraitMethodCall` variant and all corresponding handler logic, tests, and formatting across 5 files (`model.rs`, `validation.rs`, `codegen.rs`, `narrator.rs`, `report.rs`), and renamed `try_parse_trait_method_call` to `try_parse_method_call` to be truthful to its output.
**Saved:** Removed unused dead code and reduced complexity (~60 lines saved).

---
*PR created automatically by Jules for task [15511656758547697795](https://jules.google.com/task/15511656758547697795) started by @madmax983*