### PR TITLE
⚒️ Forge: Flatten Pyramids of Doom in semantic conversion

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -40,3 +40,6 @@
 **Refactoring God Functions in CLI Display Utilities**
 **Learning:** Functions that generate complex UI tables (like `add_row` in `src/tools/mosaic.rs`) often become God Functions (~150+ lines) as they aggregate many different data types and conditions into a single string. This creates a "Pyramid of Doom" of data preparation right before UI construction.
 **Action:** Extract the complex column data preparation logic into distinct formatting helper functions (e.g., `format_subject`, `format_other_column`), keeping the main row addition function focused solely on inserting the mapped columns into the table UI.
+**Iterator Chains vs Allocations**
+**Learning:** While replacing `.iter().map().collect::<Vec<_>>().join(", ")` with manual loops and `std::fmt::Write` reduces heap allocations and is a valid performance optimization (Bolt's domain), it directly contradicts Forge's strict principles which strongly favor concise iterator chains and the DRY principle. Over-optimizing at the cost of clarity and duplication is an anti-pattern for this persona.
+**Action:** Always prioritize clear, idiomatic iterator chains over manual `for` loops unless the specific persona directives explicitly demand zero-cost abstractions over readability.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -1109,30 +1109,8 @@ fn classify_expression(asm_stmt: &AssembledStatement) -> Result<AnalyzedStatemen
     // If we have operators but couldn't build a full expression from literals alone (usually implies literals < 2),
     // we should look for Subject/Object to complete the binary expression.
     if !asm_stmt.operators.is_empty() && asm_stmt.literals.len() < 2 {
-        let op = asm_stmt.operators[0];
-
-        let left = asm_stmt.subject.as_ref().map(|subj| AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-            glossa_type: GlossaType::Unknown,
-        });
-
-        // Try to get right operand from exprs (literal) or object or nominatives
-        let right = if let Some(lit_expr) = exprs.first() {
-            Some(lit_expr.clone())
-        } else if let Some(ref obj) = asm_stmt.object {
-            Some(AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                glossa_type: GlossaType::Unknown,
-            })
-        } else {
-            asm_stmt.nominatives.first().map(|nom| AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(nom.lemma.clone()),
-                glossa_type: GlossaType::Unknown,
-            })
-        };
-
-        if let (Some(l), Some(r)) = (left, right) {
-            let bin_expr = build_binary_expr(l, op, r);
+        #[allow(clippy::collapsible_if)]
+        if let Some(bin_expr) = build_fallback_binary_expr(asm_stmt, &exprs) {
             exprs = vec![bin_expr];
         }
     }
@@ -1164,6 +1142,36 @@ fn classify_expression(asm_stmt: &AssembledStatement) -> Result<AnalyzedStatemen
     }
 
     Ok(AnalyzedStatement::Expression(exprs))
+}
+
+/// Helper: Build a fallback binary expression when literals alone are insufficient
+fn build_fallback_binary_expr(
+    asm_stmt: &AssembledStatement,
+    exprs: &[AnalyzedExpr],
+) -> Option<AnalyzedExpr> {
+    let op = asm_stmt.operators[0];
+
+    let left = asm_stmt.subject.as_ref().map(|subj| AnalyzedExpr {
+        expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+        glossa_type: GlossaType::Unknown,
+    })?;
+
+    // Try to get right operand from exprs (literal) or object or nominatives
+    let right = if let Some(lit_expr) = exprs.first() {
+        Some(lit_expr.clone())
+    } else if let Some(ref obj) = asm_stmt.object {
+        Some(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+            glossa_type: GlossaType::Unknown,
+        })
+    } else {
+        asm_stmt.nominatives.first().map(|nom| AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(nom.lemma.clone()),
+            glossa_type: GlossaType::Unknown,
+        })
+    }?;
+
+    Some(build_binary_expr(left, op, right))
 }
 
 /// Helper: Common logic for genitive method call parsing
@@ -1582,32 +1590,36 @@ fn extract_object_fallback(
 ///     _ => panic!("Expected NumberLiteral"),
 /// }
 /// ```
+fn extract_complex_expression(
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<(AnalyzedExpr, GlossaType)>, GlossaError> {
+    if let Some(terms) = asm_stmt.nested_phrases.first() {
+        // Handle nested phrases (parenthesized expressions) which act as values
+        let phrase_expr = Expr::Phrase(terms.clone());
+        let analyzed = analyze_argument_expr(&phrase_expr, scope)?;
+        let ty = analyzed.glossa_type.clone();
+        return Ok(Some((analyzed, ty)));
+    }
+
+    if let Some(stmts) = asm_stmt.blocks.first() {
+        // Handle blocks (braced expressions) which act as values
+        // Note: analyze_argument_expr will call analyze_block, which enforces single-statement logic
+        let block_expr = Expr::Block(stmts.clone());
+        let analyzed = analyze_argument_expr(&block_expr, scope)?;
+        let ty = analyzed.glossa_type.clone();
+        return Ok(Some((analyzed, ty)));
+    }
+
+    Ok(None)
+}
+
 pub fn extract_value(
     asm_stmt: &AssembledStatement,
     scope: &Scope,
 ) -> Result<(AnalyzedExpr, GlossaType), GlossaError> {
-    if !asm_stmt.nested_phrases.is_empty() {
-        // Handle nested phrases (parenthesized expressions) which act as values
-        // Usually there is only one for a value expression
-        if let Some(terms) = asm_stmt.nested_phrases.first() {
-            let phrase_expr = Expr::Phrase(terms.clone());
-            // Analyze with recursion depth check reset (as it's a new analysis root)
-            let analyzed = analyze_argument_expr(&phrase_expr, scope)?;
-            let ty = analyzed.glossa_type.clone();
-            return Ok((analyzed, ty));
-        }
-    }
-
-    if !asm_stmt.blocks.is_empty() {
-        // Handle blocks (braced expressions) which act as values
-        if let Some(stmts) = asm_stmt.blocks.first() {
-            let block_expr = Expr::Block(stmts.clone());
-            // Analyze with recursion depth check reset (as it's a new analysis root)
-            // Note: analyze_argument_expr will call analyze_block, which now enforces single-statement logic
-            let analyzed = analyze_argument_expr(&block_expr, scope)?;
-            let ty = analyzed.glossa_type.clone();
-            return Ok((analyzed, ty));
-        }
+    if let Some(res) = extract_complex_expression(asm_stmt, scope)? {
+        return Ok(res);
     }
 
     if let Some(res) = extract_unwrap(asm_stmt, scope)? {


### PR DESCRIPTION
🚮 **Smell:** `semantic/conversion.rs` contained deeply nested "Pyramids of Doom" in `classify_expression` and `extract_value`, combining fallback binary operation assembly, phrase extraction, and block parsing into monolithic flows. This created high cognitive load and violated DRY principles.

✨ **Solution:** 
- Extracted `build_fallback_binary_expr` to cleanly handle assembling binary expressions when literals/operators are insufficient, using early returns (`?`) to replace nested `if let Some` blocks.
- Extracted `extract_complex_expression` from `extract_value` to isolate the logic for handling nested phrases and blocks, drastically reducing indentation and improving the readability of the main extraction pipeline.

🧼 **Benefit:** The logic is now flatter, strictly typed, and much easier to read without scrolling horizontally. It adheres to Forge's guard clauses and helper function extraction principles.

🛡️ **Verification:** Tests passed. No runtime behavior changed. Verified locally with `cargo check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`.

---
*PR created automatically by Jules for task [11241688356991279851](https://jules.google.com/task/11241688356991279851) started by @madmax983*