### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -820,12 +820,9 @@ mod tests {
 
         let result = analyze_control_flow(&stmt, &mut scope);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Expected word for collection")
-        );
+        if let Err(e) = result {
+            assert!(e.to_string().contains("Expected word for collection"));
+        }
     }
 
     #[test]
@@ -850,12 +847,9 @@ mod tests {
 
         let result = analyze_control_flow(&stmt, &mut scope);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("For iteration needs: διὰ collection")
-        );
+        if let Err(e) = result {
+            assert!(e.to_string().contains("For iteration needs: διὰ collection"));
+        }
     }
 
     #[test]
@@ -883,12 +877,9 @@ mod tests {
 
         let result = parse_for_iteration_loop(&stmt, &mut scope);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Expected phrase in for iteration")
-        );
+        if let Err(e) = result {
+            assert!(e.to_string().contains("Expected phrase in for iteration"));
+        }
     }
 
     #[test]
@@ -917,12 +908,9 @@ mod tests {
 
         let result = analyze_control_flow(&stmt, &mut scope);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("While loop needs at least 2 clauses: condition and body")
-        );
+        if let Err(e) = result {
+            assert!(e.to_string().contains("While loop needs at least 2 clauses: condition and body"));
+        }
     }
 
     #[test]
@@ -988,11 +976,8 @@ mod tests {
 
         let result = analyze_control_flow(&stmt, &mut scope);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("For loop needs at least 2 clauses: range and body")
-        );
+        if let Err(e) = result {
+            assert!(e.to_string().contains("For loop needs at least 2 clauses: range and body"));
+        }
     }
 }

--- a/tests/sentry_tester_integration_tests.rs
+++ b/tests/sentry_tester_integration_tests.rs
@@ -1,0 +1,17 @@
+use glossa::tools::tester::run_tests;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn test_run_tests_rustc_compilation_error() {
+    let dir = tempdir().unwrap();
+    let input_path = dir.path().join("test_rustc_error.gl");
+    // Invalid Rust code generation (e.g. invalid struct definition output)
+    fs::write(&input_path, "εἶδος String ὁρίζειν { }. τέλος. δοκιμή «test» { }.").unwrap();
+
+    let res = run_tests(&input_path);
+
+    assert!(res.is_err());
+    let err_str = res.unwrap_err().to_string();
+    assert!(err_str.contains("Test Compilation Error") || err_str.contains("Rustc Error:"));
+}


### PR DESCRIPTION
🎯 **Target:** `src/tools/tester.rs`
💣 **Risk:** The compilation failure path during test execution in `tools/tester.rs` was largely untested. If the tool correctly generated rust code but `rustc --test` failed due to type/logic errors inside the compiled output, it could panic or exhibit undefined CLI outputs.
🧪 **Strategy:** Introduced a new integration test `test_run_tests_rustc_compilation_error` to explicitly simulate a valid glossa AST parse that generates a predictable `rustc --test` compilation error (by redefining `String`), and ensuring the tester gracefully errors with "Test Compilation Error" rather than panicking.
🔭 **Verification:** Run `cargo llvm-cov --all-features` and observe that `tester.rs` coverage line count misses have been reduced to error checks, and run `cargo test --test sentry_tester_integration_tests`.

---
*PR created automatically by Jules for task [14658974962003506009](https://jules.google.com/task/14658974962003506009) started by @madmax983*