### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -131,3 +131,6 @@
 **[Title]** Enforcing the Facade Pattern in src/lib.rs
 **Tangle:** The `glossa` crate previously exposed all its internal modules (`ast`, `codegen`, `limits`, `morphology`, `parser`, `semantic`, `text`) as fully public (`pub mod`). This leaked implementation details and created a sprawling public API, violating the principle of encapsulation and making it difficult for downstream users to know which functions to use.
 **Blueprint:** Refactored `src/lib.rs` to change these modules to `pub(crate) mod` (or kept `pub mod` only where explicitly needed by the `glossa` binary or integration tests) and added explicit `pub use` statements for the true public API: `ast::Program`, `codegen::generate_rust`, `parser::parse`, `semantic::{AnalyzedProgram, analyze_program}`. This creates a clean "Facade" that hides messy internal sub-modules while exposing only what the user needs.
+**[Tools Module Facade]
+**Tangle:** The `src/tools` submodules were fully exposed via `pub mod`, leaking private implementations to external consumers (like tests and main.rs) and violating encapsulation.
+**Blueprint:** Converted `pub mod` declarations in `src/tools/mod.rs` to `pub(crate) mod` and implemented a Facade using `pub use` to explicitly export only the required public API. Updated all integration and doctests to consume this flat, unified API.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,10 @@
 use clap::Parser;
 use miette::Result;
 
-use glossa::tools::cli::{Cli, Commands};
-use glossa::tools::dictionary::lookup_word;
-use glossa::tools::repl::run_repl;
-use glossa::tools::runner::{bard_file, build_file, check_file, highlight_file, run_file};
+use glossa::tools::lookup_word;
+use glossa::tools::run_repl;
+use glossa::tools::{Cli, Commands};
+use glossa::tools::{bard_file, build_file, check_file, highlight_file, run_file};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
 
         #[cfg(feature = "nova")]
         Some(Commands::Mentor) => {
-            glossa::tools::mentor::run_mentor()?;
+            glossa::tools::run_mentor()?;
         }
 
         Some(Commands::Build { input, output }) => {
@@ -49,27 +49,27 @@ fn main() -> Result<()> {
         }
 
         Some(Commands::Test { input }) => {
-            glossa::tools::tester::run_tests(&input)?;
+            glossa::tools::run_tests(&input)?;
         }
 
         #[cfg(feature = "nova")]
         Some(Commands::Mosaic { input }) => {
-            glossa::tools::mosaic::run_mosaic(&input)?;
+            glossa::tools::run_mosaic(&input)?;
         }
 
         #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
-            glossa::tools::cartographer::run_map(&input)?;
+            glossa::tools::run_map(&input)?;
         }
 
         #[cfg(feature = "nova")]
         Some(Commands::Weave { input }) => {
-            glossa::tools::weave::run_weave(&input)?;
+            glossa::tools::run_weave(&input)?;
         }
 
         #[cfg(feature = "nova")]
         Some(Commands::Alchemist { input }) => {
-            glossa::tools::alchemist::run_alchemist(&input)?;
+            glossa::tools::run_alchemist(&input)?;
         }
 
         Some(Commands::Repl) | None => {

--- a/src/tools/cache.rs
+++ b/src/tools/cache.rs
@@ -30,7 +30,7 @@ use std::time::SystemTime;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::cache::Cache;
+/// use glossa::tools::Cache;
 /// use std::path::Path;
 ///
 /// let cache = Cache::new();
@@ -56,7 +56,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::cache::Cache;
+    /// use glossa::tools::Cache;
     /// let cache = Cache::new();
     /// ```
     pub fn new() -> Self {
@@ -76,7 +76,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use glossa::tools::cache::Cache;
+    /// use glossa::tools::Cache;
     /// let cache = Cache::new();
     /// cache.init().unwrap(); // Creates ~/.cache/.glossa/cache
     /// ```
@@ -106,7 +106,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::cache::Cache;
+    /// use glossa::tools::Cache;
     /// use std::path::Path;
     ///
     /// let cache = Cache::new();
@@ -139,7 +139,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::cache::Cache;
+    /// use glossa::tools::Cache;
     /// use std::path::Path;
     ///
     /// let cache = Cache::new();
@@ -177,7 +177,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::cache::Cache;
+    /// use glossa::tools::Cache;
     /// use std::path::Path;
     ///
     /// let cache = Cache::new();

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -55,7 +55,7 @@ use std::path::PathBuf;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::cli::Cli;
+/// use glossa::tools::Cli;
 /// use clap::Parser;
 ///
 /// // You can parse arguments from an iterator, which is useful for testing!
@@ -84,7 +84,7 @@ pub struct Cli {
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::cli::Commands;
+/// use glossa::tools::Commands;
 /// use std::path::PathBuf;
 ///
 /// let run_cmd = Commands::Run { input: PathBuf::from("main.γλ") };

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -24,7 +24,7 @@
 //! # Usage
 //!
 //! ```rust
-//! use glossa::highlight::highlight;
+//! use glossa::tools::highlight;
 //!
 //! let source = "ὁ ἄνθρωπος τὸν λόγον λέγει.";
 //! let highlighted = highlight(source).unwrap();

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -78,7 +78,7 @@ pub enum EvalError {
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::Interpreter;
+/// use glossa::tools::Interpreter;
 ///
 /// let mut interp = Interpreter::new();
 /// // You could then run a program via `interp.run(&analyzed_program)`
@@ -106,7 +106,7 @@ impl Interpreter {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::interpreter::Interpreter;
+    /// use glossa::tools::Interpreter;
     ///
     /// let interp = Interpreter::new();
     /// assert_eq!(interp.get_output(), "");
@@ -123,7 +123,7 @@ impl Interpreter {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::interpreter::Interpreter;
+    /// use glossa::tools::Interpreter;
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
     ///

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,24 +17,47 @@
 //! * [`ui`]: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
 
 #[cfg(feature = "nova")]
-pub mod alchemist;
-pub mod cache;
+pub(crate) mod alchemist;
+pub(crate) mod cache;
 #[cfg(feature = "nova")]
-pub mod cartographer;
-pub mod cli;
-pub mod dictionary;
-pub mod highlight;
+pub(crate) mod cartographer;
+pub(crate) mod cli;
+pub(crate) mod dictionary;
+pub(crate) mod highlight;
 #[cfg(feature = "nova")]
-pub mod interpreter;
+pub(crate) mod interpreter;
 #[cfg(feature = "nova")]
-pub mod mentor;
+pub(crate) mod mentor;
 #[cfg(feature = "nova")]
-pub mod mosaic;
-pub mod narrator;
-pub mod repl;
-pub mod report;
-pub mod runner;
-pub mod tester;
-pub mod ui;
+pub(crate) mod mosaic;
+pub(crate) mod narrator;
+pub(crate) mod repl;
+pub(crate) mod report;
+pub(crate) mod runner;
+pub(crate) mod tester;
+pub(crate) mod ui;
 #[cfg(feature = "nova")]
-pub mod weave;
+pub(crate) mod weave;
+
+#[cfg(feature = "nova")]
+pub use alchemist::{run_alchemist, transpile_to_python};
+pub use cache::Cache;
+#[cfg(feature = "nova")]
+pub use cartographer::{generate_map, run_map};
+pub use cli::{Cli, Commands};
+pub use dictionary::lookup_word;
+#[cfg(feature = "nova")]
+pub use interpreter::Interpreter;
+#[cfg(feature = "nova")]
+pub use mentor::run_mentor;
+#[cfg(feature = "nova")]
+pub use mosaic::{run_mosaic, run_mosaic_inner};
+pub use narrator::tell_tale;
+pub use repl::run_repl;
+pub use report::{CompilationReport, GlossaReport, ProgramStats};
+pub use runner::{bard_file, build_file, check_file, highlight_file, run_file};
+pub use tester::run_tests;
+pub use ui::Status;
+#[cfg(feature = "nova")]
+pub use weave::run_weave;
+pub use highlight::highlight;

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -36,7 +36,7 @@ use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table};
 /// ```
 /// use glossa::parser::parse;
 /// use glossa::semantic::analyze_program;
-/// use glossa::tools::narrator::tell_tale;
+/// use glossa::tools::tell_tale;
 ///
 /// let source = "ξ 5 ἔστω.";
 /// let ast = parse(source).unwrap();

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -56,7 +56,7 @@ impl ProgramStats {
     /// ```rust
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
-    /// use glossa::tools::report::ProgramStats;
+    /// use glossa::tools::ProgramStats;
     ///
     /// let source = "ξ πέντε ἔστω.";
     /// let ast = parse(source).unwrap();
@@ -257,7 +257,7 @@ impl<'a> GlossaReport<'a> {
     /// ```rust
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
-    /// use glossa::tools::report::GlossaReport;
+    /// use glossa::tools::GlossaReport;
     ///
     /// let source = "ξ πέντε ἔστω.";
     /// let ast = parse(source).unwrap();
@@ -384,7 +384,7 @@ impl Display for GlossaReport<'_> {
 /// ```rust
 /// use glossa::parser::parse;
 /// use glossa::semantic::analyze_program;
-/// use glossa::tools::report::{CompilationReport, ProgramStats};
+/// use glossa::tools::{CompilationReport, ProgramStats};
 /// use std::path::PathBuf;
 /// use std::time::Duration;
 ///

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -110,7 +110,7 @@ pub(crate) fn load_source(input: &Path) -> Result<String> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::build_file;
+/// use glossa::tools::build_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -190,7 +190,7 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::run_file;
+/// use glossa::tools::run_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -319,7 +319,7 @@ pub fn run_file(input: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::check_file;
+/// use glossa::tools::check_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -366,7 +366,7 @@ pub fn check_file(input: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::highlight_file;
+/// use glossa::tools::highlight_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -404,7 +404,7 @@ pub fn highlight_file(input: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::bard_file;
+/// use glossa::tools::bard_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -31,7 +31,7 @@ use std::time::Instant;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::ui::Status;
+/// use glossa::tools::Status;
 ///
 /// let mut status = Status::start("Compiling");
 /// status.update("Analyzing");
@@ -51,7 +51,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let status = Status::start("Compiling...");
     /// status.success();
     /// ```
@@ -64,7 +64,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let status = Status::start_with_symbol("Testing", "🧪");
     /// status.success();
     /// ```
@@ -93,7 +93,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let mut status = Status::start("Running Phase 1");
     /// // ... work ...
     /// status.update("Running Phase 2");
@@ -114,7 +114,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let status = Status::start("Connecting");
     /// // ... work ...
     /// status.success(); // Prints "✓ Connecting (0.01s)"
@@ -139,7 +139,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let status = Status::start("Downloading");
     /// // ... fail ...
     /// status.error("Connection Refused"); // Prints "✕ Downloading" and then the error

--- a/tests/alchemist_coverage.rs
+++ b/tests/alchemist_coverage.rs
@@ -4,7 +4,7 @@ use glossa::morphology::lexicon::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::alchemist::{run_alchemist, transpile_to_python};
+use glossa::tools::{run_alchemist, transpile_to_python};
 use std::io::Write;
 use tempfile::Builder;
 

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -16,7 +16,7 @@ fn test_dos_dev_zero() {
         let path = Path::new("/dev/zero");
         // We expect run_file to fail either due to file size check (if fixed) or some other error.
         // If it hangs, it won't return.
-        let result = glossa::tools::runner::run_file(path);
+        let result = glossa::tools::run_file(path);
         // Send the result back
         // If run_file hangs, this line is never reached.
         let _ = tx.send(result);

--- a/tests/havoc_proptest_normalization.rs
+++ b/tests/havoc_proptest_normalization.rs
@@ -8,7 +8,7 @@ proptest! {
     }
 }
 
-use glossa::tools::highlight::highlight;
+use glossa::tools::highlight;
 
 proptest! {
     #[test]

--- a/tests/havoc_proptest_tools.rs
+++ b/tests/havoc_proptest_tools.rs
@@ -1,7 +1,7 @@
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
-use glossa::tools::highlight::highlight;
-use glossa::tools::narrator::tell_tale;
+use glossa::tools::highlight;
+use glossa::tools::tell_tale;
 use proptest::prelude::*;
 
 proptest! {

--- a/tests/havoc_transliteration.rs
+++ b/tests/havoc_transliteration.rs
@@ -1,4 +1,4 @@
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/mosaic_coverage.rs
+++ b/tests/mosaic_coverage.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "nova")]
 
-use glossa::tools::mosaic::run_mosaic_inner;
+use glossa::tools::run_mosaic_inner;
 
 #[test]
 fn test_mosaic_comprehensive_coverage() {

--- a/tests/narrator_coverage.rs
+++ b/tests/narrator_coverage.rs
@@ -2,7 +2,7 @@ use glossa::parser::parse;
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, CaptureMode, GlossaType, analyze_program,
 };
-use glossa::tools::narrator::tell_tale;
+use glossa::tools::tell_tale;
 
 fn compile_and_tell(source: &str) -> String {
     let ast = parse(source).expect("AST build failed");

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "nova")]
 
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
@@ -16,7 +16,7 @@ fn test_run_weave_success() {
     let source = "«χαῖρε κόσμε» λέγε.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::weave::run_weave(temp_file.path());
+    let result = glossa::tools::run_weave(temp_file.path());
     assert!(result.is_ok(), "Weave failed: {:?}", result.err());
 
     let output_path = temp_file.path().with_extension("md");

--- a/tests/sentry_tester_tests.rs
+++ b/tests/sentry_tester_tests.rs
@@ -1,4 +1,4 @@
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 use std::fs;
 
 #[test]

--- a/tests/warden_hashdos.rs
+++ b/tests/warden_hashdos.rs
@@ -1,4 +1,4 @@
-use glossa::tools::cache::Cache;
+use glossa::tools::Cache;
 use std::path::Path;
 
 #[test]

--- a/tests/warden_limits.rs
+++ b/tests/warden_limits.rs
@@ -1,4 +1,4 @@
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/warden_overflow_sim.rs
+++ b/tests/warden_overflow_sim.rs
@@ -3,7 +3,7 @@ use glossa::morphology::lexicon::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::interpreter::Interpreter;
+use glossa::tools::Interpreter;
 
 #[test]
 fn test_warden_overflow_sim_defense() {


### PR DESCRIPTION
🕸️ Tangle: The `src/tools` submodules (`cli`, `cache`, `report`, etc.) were fully exposed to external consumers (like `main.rs` and the `tests/` directory) via `pub mod`. This violated encapsulation and leaked private implementation details, creating a scattered API surface area.

📐 Blueprint: Applied the Facade pattern to `src/tools/mod.rs` by changing all `pub mod` declarations to `pub(crate) mod`. Explicitly exported the required public APIs at the root of `glossa::tools` using `pub use`.

🧱 Stability: Reduced coupling by completely hiding the internal structure of the `tools` module. External consumers now only interact with the unified, flattened API, making future refactoring of internal tools much safer.

🔬 Verification: Builds successfully (`cargo check --all-features`). All unit tests, integration tests, and doctests pass (`cargo test` and `cargo test --doc`) after updating their import paths to the new Facade. Code conforms to strict `clippy` warnings.

---
*PR created automatically by Jules for task [13768084135254401179](https://jules.google.com/task/13768084135254401179) started by @madmax983*