### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 //! ΓΛΩΣΣΑ (GLOSSA) - A compiler where Ancient Greek morphology encodes programming semantics
 //!
 //! # The Philosophy

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 //! ΓΛΩΣΣΑ Compiler CLI
 //!
 //! A compiler for ΓΛΩΣΣΑ - where Ancient Greek morphology encodes programming semantics.


### PR DESCRIPTION
🦠 Threat: The codebase lacked a strict guarantee against memory safety vulnerabilities introduced by unsafe blocks. 🛡️ Defense: Added #![deny(unsafe_code)] to the crate roots (src/main.rs and src/lib.rs) to forbid unsafe Rust usage globally. 💥 Severity: Medium - preventing future introduction of memory unsafety. 🧪 Verification: Ran cargo clippy, cargo test, and cargo fmt.

---
*PR created automatically by Jules for task [2730830398564230640](https://jules.google.com/task/2730830398564230640) started by @madmax983*