### PR TITLE
👺 Havoc: Stack Overflow on Drop/Clone in AnalyzedExpr

### DIFF
--- a/tests/stack_overflow.rs
+++ b/tests/stack_overflow.rs
@@ -28,7 +28,10 @@ fn test_analyzed_expr_clone_overflow() {
         .unwrap();
 
     let res = handle.join();
-    assert!(res.is_err(), "Thread should have panicked due to stack overflow");
+    assert!(
+        res.is_err(),
+        "Thread should have panicked due to stack overflow"
+    );
 }
 
 #[test]
@@ -55,5 +58,8 @@ fn test_analyzed_expr_drop_overflow() {
         .unwrap();
 
     let res = handle.join();
-    assert!(res.is_err(), "Thread should have panicked due to stack overflow");
+    assert!(
+        res.is_err(),
+        "Thread should have panicked due to stack overflow"
+    );
 }

--- a/tests/stack_overflow.rs
+++ b/tests/stack_overflow.rs
@@ -1,0 +1,59 @@
+use glossa::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
+use std::thread;
+
+const THREAD_STACK_SIZE: usize = 2 * 1024 * 1024; // 2MB
+
+#[test]
+#[ignore = "Demonstrates stack overflow panic during cloning a deeply nested AnalyzedExpr"]
+fn test_analyzed_expr_clone_overflow() {
+    let handle = thread::Builder::new()
+        .name("test_clone_overflow".to_string())
+        .stack_size(THREAD_STACK_SIZE)
+        .spawn(|| {
+            let mut expr = AnalyzedExpr {
+                expr: AnalyzedExprKind::BooleanLiteral(true),
+                glossa_type: GlossaType::Boolean,
+            };
+            for _ in 0..20000 {
+                expr = AnalyzedExpr {
+                    expr: AnalyzedExprKind::PropertyAccess {
+                        owner: Box::new(expr),
+                        property: String::from("prop").into(),
+                    },
+                    glossa_type: GlossaType::Boolean,
+                };
+            }
+            let _ = expr.clone();
+        })
+        .unwrap();
+
+    let res = handle.join();
+    assert!(res.is_err(), "Thread should have panicked due to stack overflow");
+}
+
+#[test]
+#[ignore = "Demonstrates stack overflow panic during dropping a deeply nested AnalyzedExpr"]
+fn test_analyzed_expr_drop_overflow() {
+    let handle = thread::Builder::new()
+        .name("test_drop_overflow".to_string())
+        .stack_size(THREAD_STACK_SIZE)
+        .spawn(|| {
+            let mut expr = AnalyzedExpr {
+                expr: AnalyzedExprKind::BooleanLiteral(true),
+                glossa_type: GlossaType::Boolean,
+            };
+            for _ in 0..20000 {
+                expr = AnalyzedExpr {
+                    expr: AnalyzedExprKind::PropertyAccess {
+                        owner: Box::new(expr),
+                        property: String::from("prop").into(),
+                    },
+                    glossa_type: GlossaType::Boolean,
+                };
+            }
+        })
+        .unwrap();
+
+    let res = handle.join();
+    assert!(res.is_err(), "Thread should have panicked due to stack overflow");
+}


### PR DESCRIPTION
🧨 **The Trigger:** Deeply nested AST nodes created 20000 layers deep cause recursive stack explosions on both Drop and Clone operations. 📉 **The Stack Trace:** fatal runtime error: stack overflow, aborting (signal: 6, SIGABRT: process abort signal). 🧪 **Reproduction:** Run `cargo test --test stack_overflow -- --ignored --test-threads=1`. 😈 **Comment:** You thought your AST would always fit neatly into RAM, but you forgot that a user can pipe an infinite stream of nested phrases into your semantic analyzer. I win.

---
*PR created automatically by Jules for task [418895084771411318](https://jules.google.com/task/418895084771411318) started by @madmax983*