### PR TITLE
🎨 Mosaic: UI Polish for Missing Tool Headers

### DIFF
--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -410,6 +410,11 @@ pub fn highlight_file(input: &Path) -> Result<()> {
     };
 
     status.success();
+
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   H I G H L I G H T".bold().cyan());
+    println!("   {}", "Semantic Source Colors".italic().dim());
+    println!();
     println!("{}", highlighted);
 
     Ok(())
@@ -455,6 +460,11 @@ pub fn bard_file(input: &Path) -> Result<()> {
 
     let tale = tell_tale(&analyzed);
     status.success();
+
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   B A R D".bold().cyan());
+    println!("   {}", "The Scroll of Logic".italic().dim());
+    println!();
     println!("{}", tale);
 
     Ok(())


### PR DESCRIPTION
Submit a PR titled '🎨 Mosaic: UI Polish for Missing Tool Headers' with a description detailing the before state of missing standard headers in bard and highlight tools, the after state of added styled 'B A R D' and 'H I G H L I G H T' headers with subtitles, and visuals showing a dashboard-like CLI output with standard spacing.

---
*PR created automatically by Jules for task [13103175405990177153](https://jules.google.com/task/13103175405990177153) started by @madmax983*