### PR TITLE
🪒 Razor: Remove dead `trait_count` field from `ProgramStats`

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -126,3 +126,8 @@
 **Bloat:** `QuantifierFlags` struct in `src/semantic/patterns.rs` was an unnecessary abstraction over two booleans (`is_any`, `is_all`).
 **Cut:** Deleted the struct and its `from` implementation, replacing it with a simple `get_quantifier_flags` function returning a `(bool, bool)` tuple.
 **Saved:** Removed unnecessary struct definition and simplified function signatures across `process_adjectives` and `process_explicit_quantifiers`.
+
+## [Reduction]
+**Bloat:** The `trait_count` field in `ProgramStats` was calculated and stored but never displayed or used.
+**Cut:** Deleted the field and its initialization logic.
+**Saved:** Unnecessary iterations and 2 lines of dead code.

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -37,9 +37,6 @@ pub struct ProgramStats {
     pub function_count: usize,
     /// Number of user-defined types (structs)
     pub type_count: usize,
-    /// Number of trait definitions
-    #[allow(dead_code)]
-    pub trait_count: usize,
     /// Number of loops (while, for)
     pub loop_count: usize,
     /// Number of conditional branches (if, match) - a proxy for complexity
@@ -70,7 +67,6 @@ impl ProgramStats {
         let mut stats = ProgramStats {
             function_count: program.scope.functions().count(),
             type_count: program.scope.types().count(),
-            trait_count: program.scope.traits().count(),
             ..ProgramStats::default()
         };
 


### PR DESCRIPTION
Removed the `trait_count` field from `ProgramStats` as it was explicitly allowed as dead code (`#[allow(dead_code)]`) and completely unused anywhere in the application's reporting output, saving unnecessary calculation iterations and reducing struct bloat. Logged the reduction in the Razor persona journal.

---
*PR created automatically by Jules for task [5532462943410964264](https://jules.google.com/task/5532462943410964264) started by @madmax983*