### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-add-weave-and-alchemist.md
+++ b/docs/adr/016-add-weave-and-alchemist.md
@@ -1,0 +1,22 @@
+# 016. Add Weave and Alchemist Developer Tools
+
+Date: 2026-03-31
+Status: Proposed
+
+## Context
+
+The ΓΛΩΣΣΑ compiler ecosystem is expanding to include new tools that enhance the developer experience ("Nova"). We need to provide alternative export and compilation targets to prove the independence of the semantic phase from the Rust code generation phase, and to make it easier to see how Greek syntax maps to semantic meaning and compiled code.
+
+## Decision
+
+We introduced `Weave` (`src/tools/weave.rs`) as a Markdown exporter that generates a 'Rosetta Stone' document combining Glossa source code, semantic assembly logic, and generated Rust code. We also introduced `Alchemist` (ὁ Χημικός) (`src/tools/alchemist.rs`) as an experimental Python transpiler. Both tools are added to the `src/tools/` module and are gated behind the `#[cfg(feature = "nova")]` feature flag in `src/tools/mod.rs` to signify their experimental nature.
+
+## Consequences
+
+### Positive
+*   **Improved Developer Experience**: `Weave` provides an excellent educational and documentation tool by showing the mapping between Glossa source, semantics, and Rust code.
+*   **Validation of Architecture**: `Alchemist` proves that the semantic analysis phase produces an AST that is independent of the Rust codegen backend, allowing for alternative compilation targets.
+*   **Experimentation**: Gating these features behind `nova` allows for safe experimentation without affecting the core compiler stability.
+
+### Negative
+*   **Maintenance Overhead**: The addition of these tools increases the maintenance burden. `Alchemist` must be updated whenever the semantic model (`AnalyzedProgram`) changes, and `Weave` depends on both the semantic and codegen phases.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ C4Container
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
+        Container(alchemist, "Alchemist", "src/tools/alchemist.rs", "Experimental transpiler to Python")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -47,6 +48,7 @@ C4Container
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(weave, "Weave", "src/tools/weave.rs", "Generates Rosetta Stone Markdown documents")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -63,6 +65,8 @@ C4Container
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
+    Rel(semantic, alchemist, "Analyzed Program")
+    Rel(semantic, weave, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")
     Rel(parser, tester, "AST")


### PR DESCRIPTION
🧠 **Decision:** Recorded the introduction of the Weave and Alchemist tools as experimental developer experience utilities in `src/tools/`, gated behind the `nova` feature flag. Weave acts as an exporter generating a 'Rosetta Stone' Markdown document, while Alchemist serves as an experimental transpiler to Python.

🗺️ **Visuals:** Updated the C4 Container diagram in `docs/architecture.md` to map the new `Alchemist` and `Weave` tools within the Developer Experience (Nova) boundary, including their relationships to the Semantic Analyzer.

🔗 **Link:** See `docs/adr/016-add-weave-and-alchemist.md`.

---
*PR created automatically by Jules for task [1673721753358977672](https://jules.google.com/task/1673721753358977672) started by @madmax983*