### PR TITLE
🎨 Mosaic: UI Polish for runner.rs

### DIFF
--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -231,12 +231,15 @@ pub fn run_file(input: &Path) -> Result<()> {
     // Check if we can use cached binary
     if cache.is_valid(input, &cached_exe) && cached_exe.exists() {
         println!();
-        println!("{}", "--- Ἐκτέλεσις (Execution) ---".dim());
+        println!("   {}", "Γ Λ Ω Σ Σ Α   R U N".bold().cyan());
+        println!("   {}", "Ἐκτέλεσις (Execution)".italic().dim());
+        println!();
 
         // Run cached binary directly
         let exit_status = Command::new(&cached_exe).status().into_diagnostic()?;
 
-        println!("{}", "--- Τέλος (End) ---".dim());
+        println!();
+        println!("   {}", "--- Τέλος (End) ---".dim());
 
         if !exit_status.success() {
             std::process::exit(exit_status.code().unwrap_or(1));
@@ -303,12 +306,15 @@ pub fn run_file(input: &Path) -> Result<()> {
     status.success();
 
     println!();
-    println!("{}", "--- Ἐκτέλεσις (Execution) ---".dim());
+    println!("   {}", "Γ Λ Ω Σ Σ Α   R U N".bold().cyan());
+    println!("   {}", "Ἐκτέλεσις (Execution)".italic().dim());
+    println!();
 
     // Run the compiled program
     let exit_status = Command::new(&cached_exe).status().into_diagnostic()?;
 
-    println!("{}", "--- Τέλος (End) ---".dim());
+    println!();
+    println!("   {}", "--- Τέλος (End) ---".dim());
 
     if !exit_status.success() {
         std::process::exit(exit_status.code().unwrap_or(1));


### PR DESCRIPTION
🖌️ **Before:** The CLI output for `run` (execution) was simple text (`--- Ἐκτέλεσις (Execution) ---`) directly dumped to the console, breaking the visual hierarchy established by the other tools.
✨ **After:** Applied the standard `Γ Λ Ω Σ Σ Α   R U N` cyan bold header and subtitle structure.
🖼️ **Visuals:** The runner now perfectly matches the Dashboard aesthetics (Z-pattern scanning) of `map`, `mosaic`, `bard`, and `report`.

---
*PR created automatically by Jules for task [14274376539268589198](https://jules.google.com/task/14274376539268589198) started by @madmax983*