### PR TITLE
🗣️ Echo: Error messages in Troubleshooting guide don't exist

### DIFF
--- a/ECHO_ISSUE.md
+++ b/ECHO_ISSUE.md
@@ -1,0 +1,14 @@
+# 🗣️ Echo: Error messages in Troubleshooting guide don't exist
+
+🤦 **The Confusion:**
+I was reading the `README.md` and saw the "Troubleshooting" section with some cool Ancient Greek error messages like "Οὐκ οἶδα τὸ ὄνομα" (Undefined variable), "Διπλοῦν ὑποκείμενον" (Double Subject), and "Ῥῆμα οὐχ εὑρέθη" (Missing verb). So, I tried to trigger them to learn how they work. I literally copy-pasted bad code like `ἄγνωστος λέγε.` (undefined variable) and `ὁ ἄνθρωπος.` (missing verb).
+
+🕵️ **The Reality:**
+None of these errors actually show up!
+- The undefined variable just compiled cleanly without telling me anything (apparently it evaluates to 0 in the background and silently fails).
+- The double subject `ὁ ἄνθρωπος ὁ θεὸς λέγει.` also compiled with zero errors.
+- The missing verb `ὁ ἄνθρωπος.` just straight up threw an **INTERNAL COMPILER ERROR (Codegen Failed)** with raw rustc output!
+The only one that works is `Ἀσυμφωνία` (Disagreement).
+
+💡 **The Fix:**
+Please either implement these helpful error messages so the compiler actually uses them, or remove them from the README! It is extremely confusing to tell users they will see friendly Greek errors when instead they get silent compilation or raw `rustc` aborts. Also, an undefined variable shouldn't just silently become 0!


### PR DESCRIPTION
🤦 **The Confusion:** 
I was reading the `README.md` and saw the "Troubleshooting" section with some cool Ancient Greek error messages like "Οὐκ οἶδα τὸ ὄνομα" (Undefined variable), "Διπλοῦν ὑποκείμενον" (Double Subject), and "Ῥῆμα οὐχ εὑρέθη" (Missing verb). So, I tried to trigger them to learn how they work. I literally copy-pasted bad code like `ἄγνωστος λέγε.` (undefined variable) and `ὁ ἄνθρωπος.` (missing verb).

🕵️ **The Reality:** 
None of these errors actually show up! 
- The undefined variable just compiled cleanly without telling me anything (apparently it evaluates to 0 in the background and silently fails).
- The double subject `ὁ ἄνθρωπος ὁ θεὸς λέγει.` also compiled with zero errors.
- The missing verb `ὁ ἄνθρωπος.` just straight up threw an **INTERNAL COMPILER ERROR (Codegen Failed)** with raw rustc output! 
The only one that works is `Ἀσυμφωνία` (Disagreement).

💡 **The Fix:** 
Please either implement these helpful error messages so the compiler actually uses them, or remove them from the README! It is extremely confusing to tell users they will see friendly Greek errors when instead they get silent compilation or raw `rustc` aborts. Also, an undefined variable shouldn't just silently become 0!

---
*PR created automatically by Jules for task [953360981293952002](https://jules.google.com/task/953360981293952002) started by @madmax983*