### PR TITLE
👺 Havoc: Add AST depth validation pre-check to prevent SIGABRT stack overflow

### DIFF
--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -122,6 +122,8 @@ fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
 ///
 /// This is the entry point for semantic analysis.
 pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError> {
+    crate::semantic::validation::check_program_depth(program)?;
+
     let mut scope = Scope::new();
     // ⚡ Bolt Optimization: Uses `Vec::with_capacity` based on the program statements length to prevent reallocation.
     let mut analyzed_statements = Vec::with_capacity(program.statements.len());

--- a/src/semantic/validation.rs
+++ b/src/semantic/validation.rs
@@ -5,8 +5,96 @@
 //! DoS attacks like stack overflows from deeply nested expressions.
 
 use super::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
+use crate::ast::{Clause, Expr, Program, Statement};
 use crate::errors::GlossaError;
-use crate::limits::MAX_EXPRESSION_DEPTH;
+use crate::limits::{MAX_AST_DEPTH, MAX_EXPRESSION_DEPTH};
+
+/// Validates the raw AST program depth before semantic analysis begins.
+pub(crate) fn check_program_depth(program: &Program) -> Result<(), GlossaError> {
+    for stmt in &program.statements {
+        check_ast_statement_depth(stmt, 0)?;
+    }
+    Ok(())
+}
+
+fn check_ast_statement_depth(stmt: &Statement, depth: usize) -> Result<(), GlossaError> {
+    if depth > MAX_AST_DEPTH {
+        return Err(GlossaError::semantic(
+            "Recursion limit exceeded in statement analysis",
+        ));
+    }
+
+    match stmt {
+        Statement::Regular { clauses, .. } => {
+            for clause in clauses {
+                check_ast_clause_depth(clause, depth + 1)?;
+            }
+        }
+        Statement::TypeDefinition(_)
+        | Statement::TraitDefinition(_)
+        | Statement::TraitImpl(_)
+        | Statement::TestDeclaration(_) => {}
+    }
+    Ok(())
+}
+
+fn check_ast_clause_depth(clause: &Clause, depth: usize) -> Result<(), GlossaError> {
+    if depth > MAX_AST_DEPTH {
+        return Err(GlossaError::semantic(
+            "Recursion limit exceeded in clause analysis",
+        ));
+    }
+
+    for expr in &clause.expressions {
+        check_ast_expr_depth(expr, depth + 1)?;
+    }
+    Ok(())
+}
+
+fn check_ast_expr_depth(expr: &Expr, depth: usize) -> Result<(), GlossaError> {
+    if depth > MAX_AST_DEPTH {
+        return Err(GlossaError::semantic(
+            "Recursion limit exceeded in expression analysis",
+        ));
+    }
+
+    match expr {
+        Expr::Phrase(terms) | Expr::ArrayLiteral(terms) => {
+            for term in terms {
+                check_ast_expr_depth(term, depth + 1)?;
+            }
+        }
+        Expr::PropertyAccess { owner, property } => {
+            check_ast_expr_depth(owner, depth + 1)?;
+            check_ast_expr_depth(property, depth + 1)?;
+        }
+        Expr::IndexAccess { array, index } => {
+            check_ast_expr_depth(array, depth + 1)?;
+            check_ast_expr_depth(index, depth + 1)?;
+        }
+        Expr::Call { arguments, .. } => {
+            for arg in arguments {
+                check_ast_expr_depth(arg, depth + 1)?;
+            }
+        }
+        Expr::Binding { value, .. } => check_ast_expr_depth(value, depth + 1)?,
+        Expr::BinOp { left, right, .. } => {
+            check_ast_expr_depth(left, depth + 1)?;
+            check_ast_expr_depth(right, depth + 1)?;
+        }
+        Expr::UnaryOp { operand, .. } => check_ast_expr_depth(operand, depth + 1)?,
+        Expr::Block(statements) => {
+            for stmt in statements {
+                check_ast_statement_depth(stmt, depth + 1)?;
+            }
+        }
+        Expr::StringLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::Word(_) => {}
+    }
+    Ok(())
+}
 
 /// Validates the analyzed program to ensure it meets all semantic rules and limits.
 pub(crate) fn validate_program(program: &AnalyzedProgram) -> Result<(), GlossaError> {

--- a/tests/havoc_deep_ast.rs
+++ b/tests/havoc_deep_ast.rs
@@ -1,7 +1,6 @@
 use glossa::ast::{Clause, Expr, Program, Statement};
 
 #[test]
-#[ignore = "Demonstrates a SIGABRT stack overflow when directly analyzing deeply nested ASTs bypassing parser limits"]
 fn test_deep_ast_overflow_analyzer() {
     let depth = 50000;
 


### PR DESCRIPTION
🧨 **The Trigger:**
An API consumer, macro expansion, or malformed generation constructs an extraordinarily deep Abstract Syntax Tree (e.g. 50,000 nested `Expr::Phrase`s) completely bypassing the linear source parsing limits. This deep AST is passed directly into `glossa::semantic::analyzer::analyze_program`.

📉 **The Stack Trace:**
```
thread 'test_deep_ast_overflow_analyzer' (9120) has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `-p glossa --test havoc_deep_ast`

Caused by:
  process didn't exit successfully: `/app/target/debug/deps/havoc_deep_ast-443ec71537875137 --ignored` (signal: 6, SIGABRT: process abort signal)
```

🧪 **Reproduction:**
Run `cargo test --test havoc_deep_ast` with the `#[ignore]` flag removed from `test_deep_ast_overflow_analyzer`.

😈 **Comment:**
You assumed your parser's string length limits protected you from deep AST recursion. But what happens when the AST isn't parsed from a string? It crashes, that's what. I've added a pre-validation `check_program_depth` directly on the `Program` object so you're safe regardless of how the AST was constructed.

---
*PR created automatically by Jules for task [3855284153938333071](https://jules.google.com/task/3855284153938333071) started by @madmax983*