### PR TITLE
🗺️ Atlas: Enforce Facade Pattern and Remove Leaky Abstractions

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -131,3 +131,6 @@
 **[Title]** Enforcing the Facade Pattern in src/lib.rs
 **Tangle:** The `glossa` crate previously exposed all its internal modules (`ast`, `codegen`, `limits`, `morphology`, `parser`, `semantic`, `text`) as fully public (`pub mod`). This leaked implementation details and created a sprawling public API, violating the principle of encapsulation and making it difficult for downstream users to know which functions to use.
 **Blueprint:** Refactored `src/lib.rs` to change these modules to `pub(crate) mod` (or kept `pub mod` only where explicitly needed by the `glossa` binary or integration tests) and added explicit `pub use` statements for the true public API: `ast::Program`, `codegen::generate_rust`, `parser::parse`, `semantic::{AnalyzedProgram, analyze_program}`. This creates a clean "Facade" that hides messy internal sub-modules while exposing only what the user needs.
+**Fix Public API Leaks**
+**Tangle:** Internal modules like `morphology::conjugation` and `parser::grammar` were exposed as `pub mod` causing leaky abstractions.
+**Blueprint:** Used `pub(crate)` to enforce boundaries while selectively re-exporting only what is necessary in the Facade.

--- a/src/morphology/mod.rs
+++ b/src/morphology/mod.rs
@@ -19,13 +19,13 @@
 //! Disambiguation uses syntactic context (article agreement, verb agreement) in the
 //! semantic analysis phase.
 
-pub mod conjugation;
-pub mod declension;
-pub mod disambiguation;
+pub(crate) mod conjugation;
+pub(crate) mod declension;
+pub(crate) mod disambiguation;
 pub mod lexicon;
 pub(crate) mod matcher;
 pub mod models;
-pub mod participle;
+pub(crate) mod participle;
 
 pub use conjugation::*;
 pub use declension::*;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -25,7 +25,7 @@
 pub(crate) mod common;
 pub(crate) mod declarations;
 pub(crate) mod expressions;
-pub mod grammar;
+pub(crate) mod grammar;
 pub mod numerals;
 pub(crate) mod recursion;
 pub(crate) mod statements;

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -31,10 +31,10 @@
 //! This allows for authentic Greek syntax where emphasis is conveyed through word order
 //! without changing the semantic meaning.
 
-pub mod analyzer;
+pub(crate) mod analyzer;
 #[cfg(test)]
 mod assembler_tests;
-pub mod assembly;
+pub(crate) mod assembly;
 #[cfg(test)]
 mod classification_tests;
 pub(crate) mod control_flow;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,22 +17,22 @@
 //! * [`ui`]: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
 
 #[cfg(feature = "nova")]
-pub mod alchemist;
-pub mod cache;
+pub(crate) mod alchemist;
+pub(crate) mod cache;
 #[cfg(feature = "nova")]
-pub mod cartographer;
+pub(crate) mod cartographer;
 pub mod cli;
-pub mod dictionary;
+pub(crate) mod dictionary;
 pub mod highlight;
 #[cfg(feature = "nova")]
-pub mod interpreter;
+pub(crate) mod interpreter;
 #[cfg(feature = "nova")]
-pub mod mentor;
+pub(crate) mod mentor;
 #[cfg(feature = "nova")]
-pub mod mosaic;
-pub mod narrator;
-pub mod repl;
-pub mod report;
+pub(crate) mod mosaic;
+pub(crate) mod narrator;
+pub(crate) mod repl;
+pub(crate) mod report;
 /// The engine room for executing and building Glossa programs
 ///
 /// This module orchestrates the full compilation pipeline from source file to executable binary.
@@ -52,7 +52,7 @@ pub mod report;
 /// }
 /// ```
 pub mod runner;
-pub mod tester;
-pub mod ui;
+pub(crate) mod tester;
+pub(crate) mod ui;
 #[cfg(feature = "nova")]
-pub mod weave;
+pub(crate) mod weave;

--- a/tests/havoc_deep_ast.rs
+++ b/tests/havoc_deep_ast.rs
@@ -26,5 +26,5 @@ fn test_deep_ast_overflow_analyzer() {
     };
 
     // 💥 DETONATE: This will cause a fatal stack overflow (SIGABRT)
-    let _res = glossa::semantic::analyzer::analyze_program(&prog);
+    let _res = glossa::semantic::analyze_program(&prog);
 }


### PR DESCRIPTION
🕸️ **Tangle:** Internal sub-modules across `morphology`, `parser`, `semantic`, and `tools` were exposed as `pub mod` leading to a sprawling public API and leaky abstractions where integration tests tightly coupled to private structure paths.
📐 **Blueprint:** Converted internal `pub mod` declarations to `pub(crate) mod` enforcing a strict boundary. Implemented the Facade pattern using `pub use` inside root module files (e.g. `morphology/mod.rs`) to expose only necessary capabilities without leaking full directory trees.
🧱 **Stability:** Improved cohesion and reduced coupling. The public interface is now explicitly defined in parent `mod.rs` and `lib.rs` files, insulating the module graph from internal structural changes.
🔬 **Verification:** `cargo check`, `cargo test`, `cargo clippy`, and `cargo test --doc` execute successfully with zero warnings, proving external clients can function over the unified namespace.

---
*PR created automatically by Jules for task [11229404120245031263](https://jules.google.com/task/11229404120245031263) started by @madmax983*