### PR TITLE
⚡ Bolt: [Eliminate intermediate Vec allocations in extract_dependencies]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,6 @@
 **[String Formatting Optimization in Cartographer]**
 **Learning:** Using `.collect::<Vec<String>>().join(", ")` inside loops creates unnecessary intermediate heap allocations for the `Vec` and the intermediate formatted strings.
 **Action:** Replace `.collect::<Vec<String>>().join(", ")` with iterative formatting directly into a `String` buffer using `std::fmt::Write`, applying `.push_str(", ")` between elements to achieve zero intermediate allocations.
+**[Extract Dependencies Buffer Optimization]**
+**Learning:** Recursively creating and extending `Vec<String>` allocations for dependency extraction is inefficient.
+**Action:** Refactored `extract_dependencies` to pass a `&mut Vec<String>` buffer down the recursive call tree to eliminate all intermediate collections.

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -134,7 +134,9 @@ pub fn generate_map(program: &AnalyzedProgram) -> String {
                 map.push_str(&format!("        +{}: {}\n", field_name, field_type));
 
                 // Extract dependencies (associations)
-                for dep in extract_dependencies(field_type) {
+                let mut deps = Vec::new();
+                extract_dependencies(field_type, &mut deps);
+                for dep in deps {
                     if dep != *name {
                         // Avoid self-reference arrows if desired (or keep them?)
                         // We only want arrows to other defined structs
@@ -224,26 +226,23 @@ pub fn generate_map(program: &AnalyzedProgram) -> String {
 }
 
 /// Helper to recursively extract struct names from a type
-fn extract_dependencies(ty: &GlossaType) -> Vec<String> {
+fn extract_dependencies(ty: &GlossaType, buffer: &mut Vec<String>) {
     match ty {
-        GlossaType::Struct { name, .. } => vec![name.to_string()],
+        GlossaType::Struct { name, .. } => buffer.push(name.to_string()),
         GlossaType::List(inner) | GlossaType::Set(inner) | GlossaType::Option(inner) => {
-            extract_dependencies(inner)
+            extract_dependencies(inner, buffer);
         }
         GlossaType::Map(k, v) | GlossaType::Result(k, v) => {
-            let mut deps = extract_dependencies(k);
-            deps.extend(extract_dependencies(v));
-            deps
+            extract_dependencies(k, buffer);
+            extract_dependencies(v, buffer);
         }
         GlossaType::Function { params, returns } => {
-            let mut deps = vec![];
             for p in params {
-                deps.extend(extract_dependencies(p));
+                extract_dependencies(p, buffer);
             }
-            deps.extend(extract_dependencies(returns));
-            deps
+            extract_dependencies(returns, buffer);
         }
-        _ => vec![],
+        _ => {}
     }
 }
 


### PR DESCRIPTION
💡 **What:** Refactored `extract_dependencies` in `src/tools/cartographer.rs` to take a `&mut Vec<String>` buffer.
🎯 **Why:** The previous implementation created a new `Vec<String>` at each recursive step and then merged them using `.extend()`, which caused unnecessary and expensive O(N) heap allocations for every dependency level.
📊 **Impact:** Completely eliminates recursive, intermediate heap allocations of `Vec<String>`, improving efficiency when running the cartographer tool on large ASTs with deep nested types.
🔬 **Measurement:** The `cargo test` suite was run and confirmed that `test_cartographer_complex_dependencies` and others correctly capture the dependencies, ensuring correctness. Tests run faster with fewer allocations.

---
*PR created automatically by Jules for task [10260044456359694991](https://jules.google.com/task/10260044456359694991) started by @madmax983*