### PR TITLE
🎻 Bard: Fix broken intra-doc links in lib.rs and tools

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -37,3 +37,6 @@
 ## 2026-03-18 - [The Semantic Model]
 **Confusion:** Lack of documentation for the semantic models in `src/semantic/model.rs` which serves as the core data container.
 **Clarification:** Added comprehensive module-level documentation explaining the Atlas pattern, the separation of logic, types, and state, and included a code example illustrating an analyzed binding statement.
+## 2024-04-03 - Fixing Broken Intra-Doc Links
+**Confusion:** The documentation contained broken links to internal private modules (`parser::grammar` and `cache`), causing warnings during `cargo doc`.
+**Clarification:** Updated the intra-doc links to point to the exported, public equivalents (`parser` and `Cache`) so that the documentation correctly resolves and is warning-free.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! The compiler follows a standard multi-pass architecture, but with a unique "Assembler" phase:
 //!
-//! 1. **Parsing** ([`parser::grammar`]):
+//! 1. **Parsing** ([`parser`]):
 //!    * Uses a PEG grammar to tokenize the input.
 //!    * Normalizes polytonic Greek (with accents/breathings) to monotonic forms using [`text`].
 //!
@@ -96,10 +96,9 @@
 //! * [`ast`]: **The Skeleton** - Abstract Syntax Tree definitions that preserve the original Greek text.
 //! * [`codegen`]: **The Translator** - Logic that turns Greek semantics into Rust code.
 //! * [`errors`]: **The Oracle** - Greek-native error messages and diagnostics using `miette`.
-//! * [`parser::grammar`]: **The Gatekeeper** - PEG parser that defines the valid syntax.
 //! * [`highlight`]: **The Painter** - Semantic syntax highlighting for the CLI.
 //! * [`morphology`]: **The Analyst** - Word analysis, lexicon lookup, and participle parsing.
-//! * [`parser`]: **The Builder** - Constructs the AST from the raw parse tree.
+//! * [`parser`]: **The Builder and Gatekeeper** - Constructs the AST from the raw parse tree using a PEG parser that defines the valid syntax.
 //! * [`tools::report`]: **The Scribe** - Report generation and statistics.
 //! * [`tools::narrator`]: **The Bard** - Code-to-story translator for debugging and learning.
 //! * [`semantic`]: **The Assembler** - The slot-based engine that assembles sentences from words.

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -10,7 +10,7 @@
 //! * [`repl`]: **The Playground** - An interactive Read-Eval-Print Loop for experimentation.
 //! * [`highlight`]: **The Painter** - Syntax highlighting for terminal output.
 //! * [`report`]: **The Scribe** - Detailed compilation reports and error diagnostics.
-//! * [`cache`]: **The Vault** - Incremental compilation cache to speed up builds.
+//! * [`Cache`]: **The Vault** - Incremental compilation cache to speed up builds.
 //! * [`dictionary`]: **The Lexicon** - Word lookup utility for the built-in dictionary.
 //! * [`narrator`]: **The Bard** - Experimental "code-to-story" translator.
 //! * [`tester`]: **The Judge** - Built-in test runner for unit tests defined in ΓΛΩΣΣΑ files.


### PR DESCRIPTION
📖 Chapter: The Core and Tools Modules
🔦 Insight: Replaced broken, private intra-doc links (`parser::grammar` and `cache`) with their public equivalents (`parser` and `Cache`) to ensure documentation compiles without warnings.
🧪 Example: Running `cargo doc --no-deps` now succeeds with zero warnings.
🖼️ Preview: Documentation correctly links to `parser` and `Cache`.

---
*PR created automatically by Jules for task [9872068704517112457](https://jules.google.com/task/9872068704517112457) started by @madmax983*