### PR TITLE
📜 Codex: ADR 016 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-enforce-facade-pattern.md
+++ b/docs/adr/016-enforce-facade-pattern.md
@@ -1,0 +1,20 @@
+# 16. Enforce Facade Pattern in Public API
+
+Date: 2026-04-05
+Status: Accepted
+
+## Context
+
+The `glossa` crate previously exposed all its internal modules (`ast`, `codegen`, `limits`, `morphology`, `parser`, `semantic`, `text`) as fully public (`pub mod`). This leaked implementation details and created a sprawling public API, violating the principle of encapsulation and making it difficult for downstream users to know which functions to use.
+
+## Decision
+
+We have refactored `src/lib.rs` to change these internal modules to `pub(crate) mod` (keeping `pub mod` only where explicitly needed by the `glossa` binary or integration tests). We then added explicit `pub use` statements for the true public API: `ast::Program`, `codegen::generate_rust`, `parser::parse`, and `semantic::{AnalyzedProgram, analyze_program}`.
+
+This establishes a clean "Facade" pattern that hides messy internal sub-modules while exposing only the components the user actually needs.
+
+## Consequences
+
+*   **Encapsulation:** Internal implementation details of parsing, semantics, and morphology are safely hidden from consumers.
+*   **API Clarity:** The compiler's public interface is concise and discoverable, pointing clearly to the main parsing, analysis, and codegen pipeline functions.
+*   **Maintenance:** Internal structural changes are much less likely to break downstream code or integration tests.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,3 +116,38 @@ C4Component
 
     Rel(model, types, "Uses")
 ```
+
+## Public API (Facade Pattern)
+
+The `glossa` crate implements a Facade Pattern at its root (`src/lib.rs`). This pattern hides the complex internal hierarchy of the compiler modules and exposes a clean, high-level API for external consumers (like the CLI or language server).
+
+```mermaid
+classDiagram
+    title Glossa Crate Facade Pattern
+
+    class GlossaFacade {
+        <<Facade>>
+        +parse(source) Program
+        +analyze_program(ast) AnalyzedProgram
+        +generate_rust(analyzed_program) String
+    }
+
+    class Parser {
+        <<Internal>>
+        +parse(source) Result~Program, Error~
+    }
+
+    class SemanticAnalyzer {
+        <<Internal>>
+        +analyze_program(ast) Result~AnalyzedProgram, Error~
+    }
+
+    class CodeGenerator {
+        <<Internal>>
+        +generate_rust(hir) String
+    }
+
+    GlossaFacade ..> Parser : Delegates parse
+    GlossaFacade ..> SemanticAnalyzer : Delegates analyze_program
+    GlossaFacade ..> CodeGenerator : Delegates generate_rust
+```


### PR DESCRIPTION
🧠 **Decision:** Recorded the adoption of the Facade Pattern in `src/lib.rs` and the shift to `pub(crate)` encapsulation.
🗺️ **Visuals:** Added a Mermaid Class Diagram to `docs/architecture.md` showing the Facade API delegating to internal components.
🔗 **Link:** See `docs/adr/016-enforce-facade-pattern.md`.

---
*PR created automatically by Jules for task [6304675228886958508](https://jules.google.com/task/6304675228886958508) started by @madmax983*