### PR TITLE
⚒️ Forge: Extract invoke_rustc from compile_and_build

### DIFF
--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -258,6 +258,17 @@ fn compile_and_build(source: &str, cached_rs: &Path, cached_exe: &Path) -> Resul
 
     status.update("Οἰκοδόμησις (Building)");
 
+    if let Err(e) = invoke_rustc(cached_rs, cached_exe) {
+        status.error("Σφάλμα κώδικος (Codegen Error)");
+        return Err(e);
+    }
+
+    status.success();
+    Ok(())
+}
+
+/// Helper to invoke rustc and format internal compiler errors
+fn invoke_rustc(cached_rs: &Path, cached_exe: &Path) -> Result<()> {
     // Compile with rustc (hide output)
     let rustc_cmd = std::env::var("GLOSSA_RUSTC_CMD").unwrap_or_else(|_| "rustc".to_string());
 
@@ -274,7 +285,6 @@ fn compile_and_build(source: &str, cached_rs: &Path, cached_exe: &Path) -> Resul
 
     if !rustc_output.status.success() {
         let stderr = String::from_utf8_lossy(&rustc_output.stderr);
-        status.error("Σφάλμα κώδικος (Codegen Error)");
 
         // Format the error nicely
         let error_msg = format!(
@@ -296,7 +306,6 @@ fn compile_and_build(source: &str, cached_rs: &Path, cached_exe: &Path) -> Resul
         return Err(miette::miette!("{}\n{}\n\n{}", error_msg, help_msg, stderr));
     }
 
-    status.success();
     Ok(())
 }
 


### PR DESCRIPTION
🚮 Smell:
The `compile_and_build` orchestration function in `src/tools/runner.rs` was becoming a "God Function" (50+ lines) by intimately mixing high-level UI status updates, internal Glossa compilation, and low-level external `rustc` process invocation with complex box-drawing error formatting.

✨ Solution:
Extracted the entire `rustc` command execution and string-formatting block into a new, distinct `invoke_rustc` helper function. We also leveraged a `Result` boundary to allow the parent function to retain ownership of the `Status` object, avoiding `E0382` (use of moved value) errors.

🧼 Benefit:
Dramatically flattens the "Pyramid of Doom" in the main pipeline. `compile_and_build` is now a clean, readable orchestrator focused strictly on the sequence of events, while `invoke_rustc` encapsulates the messy process details.

🛡️ Verification:
Tests passed (`cargo test`). No logic changed. Code cleanly separates concerns.

---
*PR created automatically by Jules for task [30054437277225576](https://jules.google.com/task/30054437277225576) started by @madmax983*