### PR TITLE
🪒 Razor: Delete unused expressions method from Statement

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -6,3 +6,7 @@
 **Bloat:** `try_parse_trait_method_call` function in `src/semantic/patterns.rs`. The logic was overly specialized for traits, leading to "Speculative Generality", as regular object methods and trait methods share the identical AST representation and compilation behavior.
 **Cut:** Refactored `try_parse_trait_method_call` to `try_parse_method_call` in `src/semantic/patterns.rs`, removing the trait-specific checks (`scope.has_trait_method`) to apply parsing broadly for any standalone method call.
 **Saved:** Unnecessary trait method logic constraints. Avoids duplicating method parsing logic by generalizing the single abstract rule to a single concrete parsing rule.
+## [Reduction]
+**Bloat:** Unused deprecated `expressions()` method in `Statement` struct in `src/ast.rs`.
+**Cut:** Deleted the `expressions()` method.
+**Saved:** 13 lines of code.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -240,19 +240,6 @@ impl std::fmt::Debug for Statement {
 }
 
 impl Statement {
-    /// Get all expressions flattened (for backwards compatibility)
-    pub fn expressions(&self) -> Box<dyn Iterator<Item = &Expr> + '_> {
-        match self {
-            Statement::Regular { clauses, .. } => {
-                Box::new(clauses.iter().flat_map(|c| c.expressions.iter()))
-            }
-            Statement::TypeDefinition(_) => Box::new(std::iter::empty()),
-            Statement::TraitDefinition(_) => Box::new(std::iter::empty()),
-            Statement::TraitImpl(_) => Box::new(std::iter::empty()),
-            Statement::TestDeclaration(_) => Box::new(std::iter::empty()),
-        }
-    }
-
     /// Check if this is a query statement
     pub fn is_query(&self) -> bool {
         match self {

--- a/tests/ast_coverage_tests.rs
+++ b/tests/ast_coverage_tests.rs
@@ -371,7 +371,6 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 
     let stmt = Statement::TypeDefinition(TypeDef {
         name: Word::new("t"),
@@ -380,7 +379,6 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 
     let stmt = Statement::TraitDefinition(TraitDef {
         name: Word::new("t"),
@@ -389,7 +387,6 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 
     let stmt = Statement::TraitImpl(TraitImplDef {
         type_name: Word::new("t"),
@@ -399,5 +396,4 @@ fn test_statement_methods() {
     assert!(!stmt.is_query());
     assert!(!stmt.is_propagate());
     assert_eq!(stmt.clauses().len(), 0);
-    assert_eq!(stmt.expressions().count(), 0);
 }


### PR DESCRIPTION
🖼️ Before:
The `Statement` enum in `src/ast.rs` included an `expressions()` method that returned an iterator over its expressions, originally intended for backwards compatibility. However, this method was found to be completely unused across the codebase.

✨ After:
The unused `expressions()` method has been safely deleted, reducing bloat and enforcing the YAGNI principle without affecting any functionality.

---
*PR created automatically by Jules for task [18434149657232522361](https://jules.google.com/task/18434149657232522361) started by @madmax983*