### PR TITLE
⚡ Bolt: Return iterator instead of allocating Vec in Scope::unused_bindings

### DIFF
--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,11 @@
+--- src/semantic/resolver.rs
++++ src/semantic/resolver.rs
+@@ -532,6 +532,8 @@
+     /// assert_eq!(unused.len(), 1);
+     /// assert_eq!(unused[0].name, "forgotten");
+     /// ```
++    /// ⚡ Bolt Optimization: Returns an `impl Iterator` instead of allocating a `Vec`
++    /// to avoid unnecessary heap allocations when the caller only needs to iterate.
+     pub fn unused_bindings(&self) -> impl Iterator<Item = &Binding> + '_ {
+         self.levels
+             .iter()

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -528,16 +528,17 @@ impl Scope {
     /// let mut scope = Scope::new();
     /// scope.define("forgotten", GlossaType::Number);
     ///
-    /// let unused = scope.unused_bindings();
+    /// let unused: Vec<_> = scope.unused_bindings().collect();
     /// assert_eq!(unused.len(), 1);
     /// assert_eq!(unused[0].name, "forgotten");
     /// ```
-    pub fn unused_bindings(&self) -> Vec<&Binding> {
+    /// ⚡ Bolt Optimization: Returns an `impl Iterator` instead of allocating a `Vec`
+    /// to avoid unnecessary heap allocations when the caller only needs to iterate.
+    pub fn unused_bindings(&self) -> impl Iterator<Item = &Binding> + '_ {
         self.levels
             .iter()
             .flat_map(|l| l.variables.values())
             .filter(|b| !b.used)
-            .collect()
     }
 
     /// Recites the names and signatures of all known actions ([`FunctionSignature`]) that can shape reality.
@@ -718,7 +719,7 @@ mod tests {
         scope.define("υ".to_string(), GlossaType::String);
         scope.mark_used("ξ");
 
-        let unused = scope.unused_bindings();
+        let unused: Vec<_> = scope.unused_bindings().collect();
         assert_eq!(unused.len(), 1);
         assert_eq!(unused[0].name, "υ");
     }


### PR DESCRIPTION
💡 What: Refactored `Scope::unused_bindings` in `src/semantic/resolver.rs` to return an `impl Iterator<Item = &Binding> + '_` rather than collecting and returning a `Vec<&Binding>`.

🎯 Why: The original implementation eagerly collected filtered elements into a `Vec`, causing unnecessary heap allocations. Callers can iterate over the lazy sequence themselves.

📊 Impact: Eliminates one `Vec` heap allocation per call to `unused_bindings()`, creating a zero-cost abstraction.

🔬 Measurement: Run `cargo bench` or `cargo build --release` and trace allocations during compilation. Run `cargo test` and `cargo test --doc` to verify there are no logic regressions.

---
*PR created automatically by Jules for task [1887469195365922442](https://jules.google.com/task/1887469195365922442) started by @madmax983*