### PR TITLE
🎻 Bard: Remove broken intra-doc links to private items

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -40,3 +40,6 @@
 ## 2024-04-03 - Fixing Broken Intra-Doc Links
 **Confusion:** The documentation contained broken links to internal private modules (`parser::grammar` and `cache`), causing warnings during `cargo doc`.
 **Clarification:** Updated the intra-doc links to point to the exported, public equivalents (`parser` and `Cache`) so that the documentation correctly resolves and is warning-free.
+## 2024-04-03 - Fixing Broken Intra-Doc Links
+**Confusion:** The documentation contained broken links to internal private modules (`parser::grammar` and `cache`), causing warnings during `cargo doc`.
+**Clarification:** Updated the intra-doc links to point to the exported, public equivalents (`parser` and `Cache`) so that the documentation correctly resolves and is warning-free.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@
 //! * [`highlight`]: **The Painter** - Semantic syntax highlighting for the CLI.
 //! * [`morphology`]: **The Analyst** - Word analysis, lexicon lookup, and participle parsing.
 //! * [`parser`]: **The Builder and Gatekeeper** - Constructs the AST from the raw parse tree using a PEG parser that defines the valid syntax.
-//! * [`tools::report`]: **The Scribe** - Report generation and statistics.
+//! * `tools::report`: **The Scribe** - Report generation and statistics.
 //! * [`tools::narrator`]: **The Bard** - Code-to-story translator for debugging and learning.
 //! * [`semantic`]: **The Assembler** - The slot-based engine that assembles sentences from words.
 //! * [`text`]: **The Sizer** - Text utilities and normalization (polytonic -> monotonic).

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -9,12 +9,12 @@
 //! * [`runner`]: **The Engine Room** - Orchestrates the full compilation pipeline (load -> analyze -> compile -> run).
 //! * [`repl`]: **The Playground** - An interactive Read-Eval-Print Loop for experimentation.
 //! * [`highlight`]: **The Painter** - Syntax highlighting for terminal output.
-//! * [`report`]: **The Scribe** - Detailed compilation reports and error diagnostics.
+//! * `report`: **The Scribe** - Detailed compilation reports and error diagnostics.
 //! * [`Cache`]: **The Vault** - Incremental compilation cache to speed up builds.
 //! * [`dictionary`]: **The Lexicon** - Word lookup utility for the built-in dictionary.
 //! * [`narrator`]: **The Bard** - Experimental "code-to-story" translator.
 //! * [`tester`]: **The Judge** - Built-in test runner for unit tests defined in ΓΛΩΣΣΑ files.
-//! * [`ui`]: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
+//! * `ui`: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
 
 #[cfg(feature = "nova")]
 pub mod alchemist;

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -331,7 +331,7 @@ fn execute_binary(executable: &Path) -> Result<()> {
 /// Verifies the syntax and semantics of a ΓΛΩΣΣΑ file.
 ///
 /// This function loads the source code, parses it, and performs semantic analysis
-/// without generating any output code or binaries. It prints a [`GlossaReport`]
+/// without generating any output code or binaries. It prints a `GlossaReport`
 /// summarizing the program's statistics if successful.
 ///
 /// ## Errors


### PR DESCRIPTION
📖 Chapter: The Core and Tools documentation.
🔦 Insight: Replaced broken intra-doc links pointing to private items with simple inline code segments to fix `cargo doc` warnings.
🧪 Example: N/A
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [14588897603806807740](https://jules.google.com/task/14588897603806807740) started by @madmax983*