### PR TITLE
🎨 Mosaic: UI Polish for Report Command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use miette::Result;
 use glossa::tools::cli::{Cli, Commands};
 use glossa::tools::dictionary::lookup_word;
 use glossa::tools::repl::run_repl;
-use glossa::tools::runner::{bard_file, build_file, check_file, highlight_file, run_file};
+use glossa::tools::runner::{
+    bard_file, build_file, check_file, highlight_file, report_file, run_file,
+};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -40,6 +42,10 @@ fn main() -> Result<()> {
 
         Some(Commands::Check { input }) => {
             check_file(&input)?;
+        }
+
+        Some(Commands::Report { input }) => {
+            report_file(&input)?;
         }
 
         Some(Commands::Highlight { input }) => {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -102,6 +102,12 @@ pub enum Commands {
         input: PathBuf,
     },
 
+    /// Generate a language metrics dashboard
+    Report {
+        /// Input file (.γλ)
+        input: PathBuf,
+    },
+
     /// Visualize the control flow graph as a map (Requires "nova" feature)
     Labyrinth {
         /// Input file (.γλ)

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -803,6 +803,19 @@ mod tests {
     }
 
     #[test]
+    fn test_report_file_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("report.gl");
+        {
+            let mut f = std::fs::File::create(&input_path).unwrap();
+            f.write_all("ξ πέντε ἔστω.".as_bytes()).unwrap();
+        }
+
+        let result = report_file(&input_path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_ui_error_cleanup_missing_file() {
         // By passing a path that doesn't exist, `load_source` fails.
         // This exercises the `status.error()` branches for all runner tools.

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -360,6 +360,32 @@ pub fn check_file(input: &Path) -> Result<()> {
     let source = load_source(input)?;
     let status = Status::start_with_symbol("Ἔλεγχος (Checking)", "🔍");
 
+    let _analyzed = match analyze_source(&source) {
+        Ok(a) => a,
+        Err(e) => {
+            status.error("Σφάλμα (Error)");
+            return Err(e);
+        }
+    };
+
+    status.success();
+    Ok(())
+}
+
+/// Generates a language metrics dashboard report for a ΓΛΩΣΣΑ file and prints it to the terminal.
+///
+/// This function loads the source code, parses it, and performs semantic analysis
+/// without generating any output code or binaries. It then prints a [`GlossaReport`]
+/// summarizing the program's statistics.
+///
+/// ## Errors
+///
+/// Returns an error if the input file does not exist, exceeds the size limit,
+/// or contains any syntax or semantic errors.
+pub fn report_file(input: &Path) -> Result<()> {
+    let source = load_source(input)?;
+    let status = Status::start_with_symbol("Ἀναφορά (Reporting)", "📊");
+
     let analyzed = match analyze_source(&source) {
         Ok(a) => a,
         Err(e) => {
@@ -794,6 +820,9 @@ mod tests {
         let bard_res = bard_file(&missing_path);
         assert!(bard_res.is_err());
 
+        let report_res = report_file(&missing_path);
+        assert!(report_res.is_err());
+
         let run_res = run_file(&missing_path);
         assert!(run_res.is_err());
     }
@@ -816,6 +845,9 @@ mod tests {
 
         let bard_res = bard_file(&input_path);
         assert!(bard_res.is_err());
+
+        let report_res = report_file(&input_path);
+        assert!(report_res.is_err());
 
         let run_res = run_file(&input_path);
         assert!(run_res.is_err());


### PR DESCRIPTION
🖌️ **Before:** The `glossa check` command would unnecessarily dump the entire Language Metrics Dashboard onto the terminal, cluttering the view for developers who only wanted to perform a quick syntax/semantic check. The `report` command did not exist, even though users expected it.

✨ **After:** The `check` command now only prints a clean success/error state. The Language Metrics Dashboard has been moved to a dedicated `glossa report` command, providing a clean separation of concerns and fulfilling user expectations. 

🖼️ **Visuals:** 
```
> glossa check examples/working_tests.γλ
🔍 Ἔλεγχος (Checking)...
✓ Ἔλεγχος (Checking)

> glossa report examples/working_tests.γλ
   Γ Λ Ω Σ Σ Α   R E P O R T
   Language Metrics Dashboard
... (Metrics Table) ...
```

---
*PR created automatically by Jules for task [802630460178921442](https://jules.google.com/task/802630460178921442) started by @madmax983*