### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -617,6 +617,21 @@ impl Drop for Expr {
 }
 
 /// Binary operators in GLOSSA
+///
+/// # Why it exists
+///
+/// This enum represents the various mathematical and logical operations that can
+/// be performed between two expressions. It translates Ancient Greek concepts
+/// like `καί` (and), `ἤ` (or), and `μεῖζον` (greater) into abstract semantic nodes.
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::ast::BinOperator;
+///
+/// let addition = BinOperator::Add;
+/// let and_op = BinOperator::And;
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinOperator {
     // Arithmetic
@@ -653,6 +668,19 @@ pub enum BinOperator {
 }
 
 /// Unary operators in GLOSSA
+///
+/// # Why it exists
+///
+/// This enum represents logical inversions or operations that apply to a single
+/// operand, such as logical negation (`οὐκ`, "not").
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::ast::UnaryOperator;
+///
+/// let not_op = UnaryOperator::Not;
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnaryOperator {
     /// Logical Negation - `οὐ`, `οὐκ`, `οὐχ`

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -451,6 +451,34 @@ pub fn generate_rust_file(program: &AnalyzedProgram) -> String {
 }
 
 /// Generate Rust code for a single analyzed statement
+///
+/// # Why it exists
+///
+/// This function acts as a bridge between the AST semantic analysis phase and the Rust source
+/// text generation. While most of the internal code generation relies heavily on the `TokenStream`
+/// structure provided by the `quote` crate (which handles things like syntactic validation and
+/// hygiene internally), it is sometimes necessary to obtain a raw `String` representation of a
+/// translated statement, such as when embedding fragments or writing out to a file.
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::semantic::{AnalyzedStatement, AnalyzedExpr, AnalyzedExprKind, GlossaType};
+/// use smol_str::SmolStr;
+/// use glossa::codegen::generate_statement_code;
+///
+/// let stmt = AnalyzedStatement::Binding {
+///     name: SmolStr::new("ξ"),
+///     value: AnalyzedExpr {
+///         expr: AnalyzedExprKind::NumberLiteral(5),
+///         glossa_type: GlossaType::Number,
+///     },
+///     mutable: false,
+/// };
+///
+/// let rust_code = generate_statement_code(&stmt);
+/// // The resulting code string is `let g__u3be_ = 5i64 ;`
+/// ```
 pub fn generate_statement_code(stmt: &AnalyzedStatement) -> String {
     generate_statement(stmt).to_string()
 }

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -71,6 +71,30 @@ use crate::ast::Statement;
 use crate::errors::GlossaError;
 
 /// Analyze a single statement using the slot-based assembler
+///
+/// # Why it exists
+///
+/// This function is the main entry point into the slot-based assembly system for a complete
+/// statement. Instead of manually feeding words and expressions to an [`Assembler`] and
+/// tracking context, this function coordinates the parsing of all clauses within a statement.
+/// It creates the assembler, iterates over the clauses and their constituent expressions, and
+/// handles the disambiguation context automatically before finalizing the assembled semantic structure.
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::parser::parse;
+/// use glossa::semantic::assemble_statement;
+///
+/// // Create an AST with a single statement: "Say hello."
+/// let ast = parse("«χαῖρε» λέγε.").unwrap();
+///
+/// // Assemble the statement into grammatical slots
+/// let assembled = assemble_statement(&ast.statements[0]).unwrap();
+///
+/// // The verb slot should be filled
+/// assert!(assembled.verb.is_some());
+/// ```
 pub fn assemble_statement(stmt: &Statement) -> Result<AssembledStatement, GlossaError> {
     let mut asm = Assembler::new();
     asm.set_query(stmt.is_query());


### PR DESCRIPTION
📖 Chapter: Documented `BinOperator` and `UnaryOperator` in `ast.rs`, `generate_statement_code` in `codegen.rs`, and `assemble_statement` in `semantic/mod.rs`.
🔦 Insight: Explained the rationale and internal usage for previously undocumented core structural elements that lacked a clear "Why it exists" explanation. 
🧪 Example: Added 4 executable, copy-pasteable doctests demonstrating typical usage of these types and functions.
🖼️ Preview: Documentation is now richer and compiles cleanly without warnings when using `cargo doc`.

---
*PR created automatically by Jules for task [13620341474013797168](https://jules.google.com/task/13620341474013797168) started by @madmax983*