### PR TITLE
📜 Codex: ADR 017 & Architecture Diagram Update

### DIFF
--- a/docs/adr/017-revert-encapsulation-unblock-tests.md
+++ b/docs/adr/017-revert-encapsulation-unblock-tests.md
@@ -1,0 +1,23 @@
+# 17. Revert Encapsulation of Internal Modules to Unblock Tests
+
+Date: 2026-04-08
+
+## Status
+
+Accepted
+
+## Context
+
+Previously, we strictly encapsulated our internal modules by using `pub(crate) mod` to prevent leaking implementation details into the public API (as noted in ADR 016). While this successfully created a clean boundary for the crate, it severely hindered our testing infrastructure.
+
+Because the Rust `tests/` directory operates as an external consumer of the `glossa` crate, integration tests located there can only access items that are explicitly declared as `pub`. By sealing off internal modules like `src/tools/report.rs` or `src/tools/ui.rs`, we inadvertently broke critical test coverage. Deeply nested tests or specialized testing tools were unable to import the structures they needed to verify internal compiler logic or perform isolated component testing. Refactoring all tests to live inside `src/` was deemed too invasive and convoluted.
+
+## Decision
+
+We have decided to partially revert the strict encapsulation of internal modules. Modules that require external testing or are imported by the test suite (such as `cache`, `report`, and `ui`) have been restored to `pub mod`. We rely on convention and documentation rather than Rust's visibility system to guide users towards the intended public API.
+
+## Consequences
+
+* **Positive:** The external test suite in `tests/` can now successfully import and verify internal components.
+* **Positive:** Unblocks development and stabilizes CI test pipelines without requiring massive restructuring of the testing architecture.
+* **Negative:** The crate's public API is once again sprawling and polluted with internal implementation details, which may confuse end users about what constitutes the stable compiler API.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ C4Container
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
-        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
+        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache (Public for Testing)")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
         Container(dictionary, "The Lexicon", "src/tools/dictionary.rs", "The Source of Truth for Words (Dictionary)")
@@ -44,10 +44,10 @@ C4Container
         Container(mosaic, "Mosaic", "src/tools/mosaic.rs", "Visualizes Semantic Assembly")
         Container(narrator, "The Bard", "src/tools/narrator.rs", "Generates English narrative ('Scroll of Logic') from AST")
         Container(repl, "REPL", "src/tools/repl.rs", "Interactive Read-Eval-Print Loop")
-        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports (Public for Testing)")
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
-        Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers (Public for Testing)")
         Container(weave, "Weave", "src/tools/weave.rs", "Rosetta Stone Markdown Exporter")
     }
 


### PR DESCRIPTION
🧠 **Decision:** Recorded the partial reversion of internal module encapsulation (`pub(crate)` to `pub` for `cache`, `report`, `ui`) to unblock integration tests.
🗺️ **Visuals:** Updated C4 Container diagram descriptions in `docs/architecture.md` to indicate which tools are explicitly Public for Testing.
🔗 **Link:** See `docs/adr/017-revert-encapsulation-unblock-tests.md`.

---
*PR created automatically by Jules for task [6768032110816982484](https://jules.google.com/task/6768032110816982484) started by @madmax983*