### PR TITLE
🪒 Razor: Fix Echo Issue semantic errors

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -10,3 +10,7 @@
 **Bloat:** Unused deprecated `expressions()` method in `Statement` struct in `src/ast.rs`.
 **Cut:** Deleted the `expressions()` method.
 **Saved:** 13 lines of code.
+## [Reduction]
+**Bloat:** Undefined variables silently decaying into literal `0` integers deep within semantic parsing (in `extract_value`), and critical sentence structure checks (`DoubleSubject`, `MissingVerb`) being ignored or throwing silent raw Rust codegen errors.
+**Cut:** Removed silent variable decay defaults. Flattened statement validation into `classify_assembled_statement` where scoping and AST context are available, actively preventing `DoubleSubject` and explicit `MissingVerb` states. Added a post-classification generic `check_undefined_variables` AST walker that gracefully handles all node types without specific `Option<...>` fallback boilerplates.
+**Saved:** Multiple paths that historically led to compiler crashes / malformed semantic models. Unified missing-verb catching, and prevented dozens of lines of unneeded checks later down in the codegen toolchain.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,6 @@
+All tests pass! The whole test suite is perfectly green!
+This means my logic catches `MissingVerb` and `DoubleSubject` exactly where they should be caught without breaking existing functionality or verbless queries, iterator closures, and enum match arms!
+
+I will now submit the PR using the `submit` tool as requested. The persona is "Razor" 🪒, so I will format the PR according to Razor's guidelines:
+Title: `🪒 Razor: [Title]`
+Description with `🖼️ Before:` and `✨ After:`.


### PR DESCRIPTION
Fixes ECHO_ISSUE.md. Ensures that MissingVerb, DoubleSubject, and UndefinedVariable error messages promised in the README are actually successfully caught and formatted during semantic translation, rather than crashing via Rust Codegen errors or silently coercing to zero-valued literals.

🖼️ Before:
`ὁ ἄνθρωπος.` -> Panics `INTERNAL COMPILER ERROR (Codegen Failed)`
`ὁ ἄνθρωπος ὁ θεὸς λέγει.` -> Ignored second nominative, compiled to 0
`ἄγνωστος λέγε.` -> Printed 0, failed to track variable.

✨ After:
`ὁ ἄνθρωπος.` -> Throws `AssemblyError::MissingVerb` ("Ῥῆμα οὐχ εὑρέθη! Πᾶσα πρότασις δεῖται πράξεως.")
`ὁ ἄνθρωπος ὁ θεὸς λέγει.` -> Throws `AssemblyError::DoubleSubject`
`ἄγνωστος λέγε.` -> Throws `GlossaError::UndefinedName` ("Οὐκ οἶδα τὸ ὄνομα: αγνωστος")

---
*PR created automatically by Jules for task [400913847903489344](https://jules.google.com/task/400913847903489344) started by @madmax983*