### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -43,3 +43,6 @@
 ## 2024-04-03 - Fixing Broken Intra-Doc Links
 **Confusion:** The documentation contained broken links to internal private modules (`parser::grammar` and `cache`), causing warnings during `cargo doc`.
 **Clarification:** Updated the intra-doc links to point to the exported, public equivalents (`parser` and `Cache`) so that the documentation correctly resolves and is warning-free.
+## 2024-05-27 - Documenting internal pub fns
+**Confusion:** Writing doc-tests for `pub fn` functions inside `pub(crate)` modules (like `analyze_verb_all_into`) fails compilation because doc-tests run as an external crate and cannot access `pub(crate)` items.
+**Clarification:** Use ````text` blocks instead of ````rust` for doc-tests on functions that cannot be tested externally due to module visibility, or structure the code so public APIs are testable.

--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -558,6 +558,20 @@ fn try_analyze_infinitive(
     }
 }
 
+/// Analyze a verb and append all possible morphological interpretations to an existing vector.
+///
+/// This exists to allow callers to collect analyses without allocating a new `Vec`
+/// each time. By passing in a mutable reference to an existing collection, you can
+/// accumulate results across multiple words or fallback strategies efficiently.
+///
+/// ## Examples
+///
+/// ```text
+/// let mut analyses = Vec::new();
+/// // Append all analyses of "γράφω" into our vector
+/// analyze_verb_all_into("γραφω", &mut analyses);
+/// assert!(!analyses.is_empty());
+/// ```
 pub fn analyze_verb_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
     let start_len = analyses.len();
 

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -43,6 +43,25 @@ pub fn run_labyrinth(input: &Path) -> miette::Result<()> {
     Ok(())
 }
 
+/// Generate a Mermaid.js flowchart representation of the program's control flow.
+///
+/// This function translates the semantic AST (`AnalyzedProgram`) into a Mermaid
+/// graph definition string. It maps statements (like `If`, `While`, `Match`) to
+/// nodes and control flow edges, providing a visual representation of the logic.
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::tools::labyrinth::generate_cfg;
+/// use glossa::semantic::analyze_program;
+/// use glossa::parser::parse;
+///
+/// let source = "ξ 5 ἔστω.";
+/// let ast = parse(source).unwrap();
+/// let program = analyze_program(&ast).unwrap();
+/// let cfg = generate_cfg(&program);
+/// assert!(cfg.contains("graph TD"));
+/// ```
 pub fn generate_cfg(program: &AnalyzedProgram) -> String {
     let mut builder = CFGBuilder::new();
     builder.build_program(program);

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -294,6 +294,31 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
     }
 }
 
+/// Run unit tests defined within a ΓΛΩΣΣΑ file.
+///
+/// This tool allows developers to execute `δοκιμή` (test) blocks directly from their source
+/// files. It works by orchestrating the compilation pipeline, generating a Rust file with
+/// `#[test]` attributes, compiling it using `rustc --test`, and then executing the resulting
+/// test harness binary. It finally parses the output to present a clean, language-specific
+/// test report to the user.
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::tools::tester::run_tests;
+/// use std::path::PathBuf;
+/// use std::fs;
+/// use tempfile::tempdir;
+///
+/// let dir = tempdir().unwrap();
+/// let input = dir.path().join("tests.γλ");
+///
+/// // Create a temporary Glossa file with a test declaration
+/// fs::write(&input, "δοκιμή «example».\n  ξ 5 ἔστω.\nτέλος.").unwrap();
+///
+/// // Execute the test harness
+/// run_tests(&input).unwrap();
+/// ```
 pub fn run_tests(input: &Path) -> Result<()> {
     // 1 & 2. Validation & Compilation (Lex -> Parse -> Analyze -> Codegen)
     let source = crate::tools::runner::load_source(input)?;


### PR DESCRIPTION
📖 Chapter: Added documentation for CLI orchestrators `run_tests` and `generate_cfg` and internal compiler utility `analyze_verb_all_into`.
💡 Insight: Explained that `analyze_verb_all_into` avoids allocations, `generate_cfg` translates AST to Mermaid.js, and `run_tests` orchestrates `rustc --test`.
🧪 Example: Added executable `cargo test --doc` examples for `run_tests` and `generate_cfg`.
🖼️ Preview: All doc tests compile successfully with appropriate attributes.

---
*PR created automatically by Jules for task [11313398839140925723](https://jules.google.com/task/11313398839140925723) started by @madmax983*