### PR TITLE
🌟 Nova: The Tracer (ὁ Ἰχνηλάτης)

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -32,3 +32,8 @@
 **Concept:** A basic static analysis tool / linter (`glossa audit`) that traverses the semantic AST (`AnalyzedProgram`) to find code smells, such as unused variables and unnecessary mutable declarations.
 **Fate:** Merged
 **Lesson:** Iterating over the complex nested variants in `AnalyzedStatement` and `AnalyzedExpr` provides a strong foundation for building static analysis tools without modifying core logic.
+
+## The Tracer (ὁ Ἰχνηλάτης)
+**Concept:** An interactive execution tracer (`glossa trace`) that steps through a program, displaying the environment (`env`) after each evaluated statement to visualize variable mutations.
+**Fate:** Proposed
+**Lesson:** Providing a tool to visually walk through the state of the compiler's internal `Interpreter` reinforces the idea of the compiler as an educational tool for learning programming semantics.

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,19 @@ fn main() -> Result<()> {
             }
         }
 
+        Some(Commands::Trace { input }) => {
+            #[cfg(feature = "nova")]
+            glossa::tools::tracer::run_tracer(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'trace' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
+        }
+
         Some(Commands::Repl) | None => {
             run_repl()?;
         }

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -195,4 +195,10 @@ pub enum Commands {
         /// Input file (.γλ)
         input: PathBuf,
     },
+
+    /// Run the Tracer to step through state (Requires "nova" feature)
+    Trace {
+        /// Input file (.γλ)
+        input: PathBuf,
+    },
 }

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -143,10 +143,10 @@ pub enum EvalError {
 pub struct Interpreter {
     // Stack of scopes. For now, just one global scope for simplicity.
     // In a real implementation, this would be `Vec<HashMap<String, Value>>`.
-    env: Vec<HashMap<String, Value>>,
+    pub(crate) env: Vec<HashMap<String, Value>>,
 
     // Output buffer for capturing print statements (useful for testing/WASM)
-    output: Vec<String>,
+    pub(crate) output: Vec<String>,
 }
 
 impl Default for Interpreter {
@@ -204,7 +204,7 @@ impl Interpreter {
         self.output.join("\n")
     }
 
-    fn eval_statement(&mut self, stmt: &AnalyzedStatement) -> Result<(), EvalError> {
+    pub(crate) fn eval_statement(&mut self, stmt: &AnalyzedStatement) -> Result<(), EvalError> {
         match stmt {
             AnalyzedStatement::Binding { name, value, .. } => {
                 let val = self.eval_expr(value)?;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -60,6 +60,8 @@ pub(crate) mod report;
 /// ```
 pub mod runner;
 pub mod tester;
+#[cfg(feature = "nova")]
+pub mod tracer;
 pub(crate) mod ui;
 #[cfg(feature = "nova")]
 pub mod weave;

--- a/src/tools/tracer.rs
+++ b/src/tools/tracer.rs
@@ -1,0 +1,128 @@
+//! The Tracer (ὁ Ἰχνηλάτης)
+//!
+//! This module implements an experimental execution tracer that steps through
+//! a parsed ΓΛΩΣΣΑ program statement by statement, printing the internal
+//! state of the environment (`env`) after each step.
+//!
+//! # Purpose
+//!
+//! This provides transparency into the runtime execution, making it easier
+//! for developers and learners to see exactly how variables are mutated
+//! and when logic branches execute.
+
+use crate::tools::interpreter::Interpreter;
+// use crate::tools::narrator::tell_statement; // narrator currently only outputs table rows via `add_statement`
+use crate::tools::runner::load_source;
+use comfy_table::{Attribute, Cell, Color, Table, presets};
+use crossterm::style::Stylize;
+use miette::{IntoDiagnostic, Result};
+use std::path::Path;
+
+/// Run the Tracer tool on a file
+pub fn run_tracer(input: &Path) -> Result<()> {
+    if !input.exists() {
+        return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
+    }
+
+    let source = load_source(input)?;
+    let program = crate::tools::runner::analyze_source(&source)?;
+
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   T R A C E R".bold().cyan());
+    println!("   {}", "Execution State Tracker".italic().dim());
+    println!();
+
+    let mut interpreter = Interpreter::new();
+
+    for (i, stmt) in program.statements.iter().enumerate() {
+        let step_num = i + 1;
+        println!("{}", format!("➤ Step {}", step_num).bold().yellow());
+
+        // Let's just print the raw Statement debug derived from standard Debug
+        // to avoid refactoring narrator.rs which outputs directly to tables.
+        println!("  {}", format!("{:?}", stmt).italic().dim());
+
+        // Evaluate the statement
+        if let Err(e) = interpreter.eval_statement(stmt) {
+            println!("  {} {}", "Error:".red().bold(), e);
+            return Err(e).into_diagnostic();
+        }
+
+        // Print output if any (naive approach: just show what the interpreter has collected)
+        // Since we evaluate step by step, we check the length of output before and after
+        // To be precise we could track previous length, but for now we just show all scope vars
+
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL).set_header(vec![
+            Cell::new("Variable")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+            Cell::new("Value")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Green),
+        ]);
+
+        if let Some(scope) = interpreter.env.last() {
+            if scope.is_empty() {
+                table.add_row(vec![
+                    Cell::new("(empty)"),
+                    Cell::new(""),
+                ]);
+            } else {
+                let mut vars: Vec<_> = scope.iter().collect();
+                vars.sort_by_key(|k| k.0);
+                for (name, value) in vars {
+                    table.add_row(vec![
+                        Cell::new(name),
+                        Cell::new(value.to_string()),
+                    ]);
+                }
+            }
+        }
+
+        println!("{table}");
+        println!();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_tracer_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("trace_test.γλ");
+        {
+            let mut f = std::fs::File::create(&input_path).unwrap();
+            f.write_all("ξ 5 ἔστω. ξ λέγε.\n".as_bytes()).unwrap();
+        }
+
+        let result = run_tracer(&input_path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_tracer_file_not_found() {
+        let path = Path::new("non_existent_file.γλ");
+        let result = run_tracer(path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("οὐχ εὑρέθη"));
+    }
+
+    #[test]
+    fn test_tracer_semantic_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("semantic_error.γλ");
+        {
+            let mut f = std::fs::File::create(&input_path).unwrap();
+            f.write_all("ψ πέντε γίγνεται.\n".as_bytes()).unwrap(); // Assigning to undefined var
+        }
+
+        let result = run_tracer(&input_path);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
💡 **The Spark:** "I noticed we evaluate code using an internal `Interpreter` step by step, but users have no way to trace or visualize the runtime state. Can we build a tool to step through and track this environment visually?"

🚀 **The Feature:** "Implemented the `Tracer` tool (`glossa trace`). It acts as an experimental execution tracer that evaluates a parsed program statement by statement, printing the internal state of the environment (`env`) after each step using `comfy_table`."

🔮 **The Potential:** "Provides powerful transparency into the runtime execution. This transforms the compiler from a black box into a debugging and learning assistant, reinforcing the language's theme of explicit determinism."

⚠️ **Risk:** "Low. Isolated in `src/tools/tracer.rs` behind the `nova` feature flag. The core `Interpreter` was only modified slightly to make `env`, `output`, and `eval_statement` visible to the crate (`pub(crate)`), which is a safe, non-breaking architectural change."

---
*PR created automatically by Jules for task [10400431927787343737](https://jules.google.com/task/10400431927787343737) started by @madmax983*