### PR TITLE
🔒 Warden: [codegen unwrap vulnerability]

### DIFF
--- a/tests/option_result_tests.rs
+++ b/tests/option_result_tests.rs
@@ -311,8 +311,8 @@ fn test_unwrap_in_expression() {
 
     // Should contain unwrap
     assert!(
-        output.contains("unwrap"),
-        "Expected 'unwrap' in output: {}",
+        output.contains("attempted to unwrap an empty value"),
+        "Expected 'attempted to unwrap an empty value' in output: {}",
         output
     );
 }
@@ -381,7 +381,7 @@ fn test_result_unwrap() {
         output
     );
     assert!(
-        output.contains("unwrap"),
+        output.contains("attempted to unwrap an empty value"),
         "Expected 'unwrap()' in output: {}",
         output
     );
@@ -544,8 +544,8 @@ fn test_unwrap_preserves_value() {
     let output = compile(source).unwrap();
 
     assert!(
-        output.contains("unwrap"),
-        "Expected 'unwrap' in: {}",
+        output.contains("attempted to unwrap an empty value"),
+        "Expected 'attempted to unwrap an empty value' in: {}",
         output
     );
 }
@@ -609,7 +609,11 @@ fn test_option_workflow() {
         println_count
     );
     // Should have unwrap call
-    assert!(output.contains("unwrap"), "Expected unwrap in: {}", output);
+    assert!(
+        output.contains("attempted to unwrap an empty value"),
+        "Expected 'attempted to unwrap an empty value' in: {}",
+        output
+    );
 }
 
 #[test]
@@ -683,10 +687,10 @@ fn test_multiple_unwraps_sequence() {
     let output = compile(source).unwrap();
 
     // Should have at least 2 unwrap calls
-    let unwrap_count = output.matches("unwrap").count();
+    let unwrap_count = output.matches("attempted to unwrap an empty value").count();
     assert!(
         unwrap_count >= 2,
-        "Expected at least 2 unwrap calls, got {}: {}",
+        "Expected at least 2 safe unwraps calls, got {}: {}",
         unwrap_count,
         output
     );
@@ -787,8 +791,8 @@ fn test_propagation_vs_unwrap() {
 
     // Unwrap should have .unwrap()
     assert!(
-        unwrap_output.contains("unwrap"),
-        "Expected unwrap in: {}",
+        unwrap_output.contains("attempted to unwrap an empty value"),
+        "Expected 'attempted to unwrap an empty value' in: {}",
         unwrap_output
     );
 


### PR DESCRIPTION
🦠 **Threat:** The test suite loosely checked for the presence of the word "unwrap" in generated code, which could allow a regression where the safe `.expect("attempted to unwrap an empty value")` is accidentally replaced with an unsafe `.unwrap()` without failing the tests.
🛡️ **Defense:** Replaced generic `.contains("unwrap")` assertions in `tests/option_result_tests.rs` with strict checks for the exact safe panic string (`.expect("attempted to unwrap an empty value")`).
💥 **Severity:** Low - Test Suite Hardening (preventative measure against future regressions).
🧪 **Verification:** Verified by running `cargo test` which confirmed the tests now strictly enforce the expected safe panic behavior.

---
*PR created automatically by Jules for task [5595772039634204183](https://jules.google.com/task/5595772039634204183) started by @madmax983*