### PR TITLE
👺 Havoc: Codegen Stack Overflow via Deeply Nested Expressions

### DIFF
--- a/tests/havoc_codegen_stack_overflow.rs
+++ b/tests/havoc_codegen_stack_overflow.rs
@@ -1,0 +1,46 @@
+use glossa::codegen::generate_rust;
+use glossa::semantic::{
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
+};
+
+#[test]
+#[ignore = "Demonstrates a SIGABRT stack overflow when directly generating code for deeply nested ASTs"]
+fn test_codegen_deep_ast_overflow() {
+    let depth = 50_000;
+
+    // 👺 Havoc: Direct Stack Overflow in Codegen
+    // We construct a deeply nested Analyzed AST manually, simulating a scenario where
+    // either the parser/analyzer limits are bypassed, or an internal macro expands
+    // into an unboundedly deep AST.
+    //
+    // The `generate_expr` function in `src/codegen.rs` does not use `stacker::maybe_grow`.
+    // It relies entirely on standard Rust recursive function calls.
+    // At a depth of 50,000, this will immediately blow the thread's stack limit
+    // and crash the compiler backend with a fatal SIGABRT.
+
+    let mut expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(1),
+        glossa_type: GlossaType::Number,
+    };
+
+    for _ in 0..depth {
+        expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::MethodCall {
+                receiver: Box::new(expr),
+                method: "clone".into(),
+                args: vec![],
+            },
+            glossa_type: GlossaType::Number,
+        };
+    }
+
+    let stmt = AnalyzedStatement::Expression(vec![expr]);
+
+    let program = AnalyzedProgram {
+        statements: vec![stmt],
+        scope: Scope::new(),
+    };
+
+    // 💥 DETONATE
+    let _rust = generate_rust(&program);
+}


### PR DESCRIPTION
🧨 **The Trigger:** Directly generating Rust code from a deeply nested AST (e.g., `AnalyzedExprKind::MethodCall` or `AnalyzedExprKind::PropertyAccess` nested 50,000 times). The parsing limits (`MAX_PARSE_DEPTH`) restrict deep strings, but if an internal macro or API consumer generates a deep `AnalyzedProgram`, the `generate_expr` function in `src/codegen.rs` will stack overflow because it does not use `stacker::maybe_grow`.

📉 **The Stack Trace:**
```
thread 'test_codegen_deep_ast_overflow' has overflowed its stack
fatal runtime error: stack overflow, aborting
signal: 6, SIGABRT: process abort signal
```

🧪 **Reproduction:** Run `cargo test --test havoc_codegen_stack_overflow -- --ignored`.

😈 **Comment:** You protected the parser with `check_recursion_depth`, and you protected the `Debug` and `Clone` traits with `stacker`. But you forgot to protect the actual code generator! A sufficiently complex macro expansion or a malicious API consumer will blow the thread stack and crash the entire compiler backend. I left the wreckage in `tests/havoc_codegen_stack_overflow.rs`.

---
*PR created automatically by Jules for task [14313455360940875921](https://jules.google.com/task/14313455360940875921) started by @madmax983*