### PR TITLE
🎸 Bard: Fix intra-doc link warning for GlossaReport

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -43,3 +43,6 @@
 ## 2024-04-03 - Fixing Broken Intra-Doc Links
 **Confusion:** The documentation contained broken links to internal private modules (`parser::grammar` and `cache`), causing warnings during `cargo doc`.
 **Clarification:** Updated the intra-doc links to point to the exported, public equivalents (`parser` and `Cache`) so that the documentation correctly resolves and is warning-free.
+## 2024-04-11 - Tolerating broken links for private modules
+**Confusion:** Resolving intra-doc link warnings for `GlossaReport` fails when following persona rules that mandate making items clickable using `[GlossaReport]`. It fails since `report` module is internal (`pub(crate)`) and making `GlossaReport` public without exposing the `report` module would cause tests to fail since `[GlossaReport]` still cannot resolve or tests expecting proper module privacy paths will fail. Making `report` module public just for the sake of the docs also violates keeping internal implementations private.
+**Clarification:** I learned that it is completely fine to remove the `[ ]` characters and use `` `GlossaReport` `` to render the name as an inline code snippet. This resolves the `cargo doc` warnings and does not break tests or compromise module privacy, while still looking professional in the HTML output.

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -8,11 +8,14 @@
 //! Compiler feedback should be more than just "Error" or "Success".
 //! ΓΛΩΣΣΑ strives to provide **insights** into the code:
 //!
+//!
+//! # Understanding the output
+//! The report contains the cyclomatic complexity of a given file. This is generally proxy by the conditional_count value
 //! * How complex is the program? (Cyclomatic complexity proxy via `conditional_count`)
 //! * How deep is the nesting? (`max_depth`)
 //! * How "functional" vs "imperative" is the style? (Expression vs Statement count)
 //!
-//! The [`GlossaReport`] provides a dashboard-style summary of these metrics.
+//! The `GlossaReport` provides a dashboard-style summary of these metrics.
 
 use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -375,7 +375,7 @@ pub fn check_file(input: &Path) -> Result<()> {
 /// Generates a language metrics dashboard report for a ΓΛΩΣΣΑ file and prints it to the terminal.
 ///
 /// This function loads the source code, parses it, and performs semantic analysis
-/// without generating any output code or binaries. It then prints a [`GlossaReport`]
+/// without generating any output code or binaries. It then prints a `GlossaReport`
 /// summarizing the program's statistics.
 ///
 /// ## Errors


### PR DESCRIPTION
📖 Chapter: The "Runner" tool module.
💡 Insight: Explains how to properly fix `cargo doc` warnings for private struct references without breaking the internal `pub(crate)` module boundaries or failing tests.
🧪 Example: Removed `[` and `]` brackets while retaining backticks.
🖼️ Preview: Documentation for `report_file` now correctly avoids broken links while still indicating a code identifier.

---
*PR created automatically by Jules for task [12107881579080150917](https://jules.google.com/task/12107881579080150917) started by @madmax983*