### PR TITLE
🪒 Razor: Flatten ScopeGuard boilerplate using with_scope closures

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -10,3 +10,7 @@
 **Bloat:** Unused deprecated `expressions()` method in `Statement` struct in `src/ast.rs`.
 **Cut:** Deleted the `expressions()` method.
 **Saved:** 13 lines of code.
+## [Reduction]
+**Bloat:** `ScopeGuard` RAII struct in `src/semantic/resolver.rs`. It used `Drop`, `Deref`, and `DerefMut` to manage scope lifetimes.
+**Cut:** Replaced `ScopeGuard` and `enter_scope` with a single higher-order `with_scope` method that takes a closure, manages `enter` and `exit`, and executes the closure.
+**Saved:** Dozens of lines of boilerplate code in `resolver.rs`. Replaced an unnecessary wrapper struct, three trait implementations, and error-prone local variable scoping patterns with a cleaner block-based syntax.

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -128,10 +128,12 @@ fn analyze_statement_recursive(
         let mut analyzed = Vec::new();
         // Create a child scope for the block
         // This ensures variables defined inside the block don't leak out
-        let mut block_scope = scope.enter_scope();
-        for s in block_stmts {
-            analyzed.extend(analyze_statement_recursive(s, &mut block_scope, depth + 1)?);
-        }
+        scope.with_scope(|block_scope| {
+            for s in block_stmts {
+                analyzed.extend(analyze_statement_recursive(s, block_scope, depth + 1)?);
+            }
+            Ok::<(), GlossaError>(())
+        })?;
         return Ok(analyzed);
     }
 

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -264,13 +264,12 @@ fn parse_for_range_loop(
         is_propagate: false,
     };
 
-    // Use a scope guard to ensure the loop variable is removed after parsing
-    let body_analyzed = {
-        let mut loop_scope = scope.enter_scope();
+    // Use with_scope to ensure the loop variable is removed after parsing
+    let body_analyzed = scope.with_scope(|loop_scope| {
         loop_scope.define(variable.clone(), GlossaType::Number);
 
-        analyze_statement(&body_stmt, &mut loop_scope)?
-    };
+        analyze_statement(&body_stmt, loop_scope)
+    })?;
 
     Ok(Some(AnalyzedStatement::For {
         variable,
@@ -353,13 +352,12 @@ fn parse_for_iteration_loop(
     };
 
     // Use scope guard for loop variable
-    let body_analyzed = {
-        let mut loop_scope = scope.enter_scope();
+    let body_analyzed = scope.with_scope(|loop_scope| {
         // TODO: Infer element type from collection type
         loop_scope.define(variable.clone(), GlossaType::String);
 
-        analyze_statement(&body_stmt, &mut loop_scope)?
-    };
+        analyze_statement(&body_stmt, loop_scope)
+    })?;
 
     Ok(Some(AnalyzedStatement::For {
         variable,

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -146,17 +146,17 @@ pub fn analyze_trait_definition(
             let body = if let Some(body_stmts) = &method.body {
                 let mut analyzed_body = Vec::with_capacity(body_stmts.len());
                 // Create a child scope for the method
-                {
-                    let mut scope = scope.enter_scope();
+                scope.with_scope(|scope| {
                     // Add method parameters to scope (including self)
                     for (param_name, param_type) in &params {
                         scope.define(param_name.clone(), param_type.clone());
                     }
                     // Properly analyze statements in the body using unified helper
                     for body_stmt in body_stmts {
-                        analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
+                        analyzed_body.extend(analyze_statement(body_stmt, scope)?);
                     }
-                }
+                    Ok::<(), GlossaError>(())
+                })?;
                 Some(analyzed_body)
             } else {
                 Some(vec![])
@@ -248,8 +248,7 @@ pub fn analyze_trait_impl(
 
         // Create a child scope for the method body with self bound
         let mut analyzed_body = Vec::with_capacity(method.body.len());
-        {
-            let mut scope = scope.enter_scope();
+        scope.with_scope(|scope| {
             scope.define("self".to_string(), struct_type.clone());
 
             // Also bind parameters
@@ -259,9 +258,10 @@ pub fn analyze_trait_impl(
 
             // Analyze the method body using unified helper
             for body_stmt in &method.body {
-                analyzed_body.extend(analyze_statement(body_stmt, &mut scope)?);
+                analyzed_body.extend(analyze_statement(body_stmt, scope)?);
             }
-        }
+            Ok::<(), GlossaError>(())
+        })?;
 
         let return_type = infer_return_type_from_body(&analyzed_body);
 
@@ -369,11 +369,10 @@ pub fn parse_function_definition(
     // Extract parameters (dative words) from the header
     let params = extract_parameters_from_expr(header_expr, scope)?;
 
-    // Use enter_scope() to create a child scope that inherits types/traits
+    // Use with_scope() to create a child scope that inherits types/traits
     // We can pre-allocate since we know exactly how many expressions form the body
     let mut body_statements = Vec::with_capacity(clause.expressions.len().saturating_sub(1));
-    {
-        let mut function_scope = scope.enter_scope();
+    scope.with_scope(|function_scope| {
         for (param_name, param_type) in &params {
             let glossa_type = param_type.clone().unwrap_or(GlossaType::Unknown);
             function_scope.define(param_name.clone(), glossa_type);
@@ -396,9 +395,10 @@ pub fn parse_function_definition(
             };
 
             // Analyze each body expression using unified helper
-            body_statements.extend(analyze_statement(&clause_stmt, &mut function_scope)?);
+            body_statements.extend(analyze_statement(&clause_stmt, function_scope)?);
         }
-    }
+        Ok::<(), GlossaError>(())
+    })?;
 
     // Infer return type from return statements
     let return_type = infer_return_type_from_body(&body_statements);
@@ -547,13 +547,12 @@ pub fn analyze_test_declaration(
     let mut analyzed_body = Vec::with_capacity(test_decl.body.len());
 
     // Create a child scope for the test
-    {
-        let mut test_scope = scope.enter_scope();
-
+    scope.with_scope(|test_scope| {
         for body_stmt in &test_decl.body {
-            analyzed_body.extend(analyze_statement(body_stmt, &mut test_scope)?);
+            analyzed_body.extend(analyze_statement(body_stmt, test_scope)?);
         }
-    }
+        Ok::<(), GlossaError>(())
+    })?;
 
     Ok(AnalyzedStatement::TestDeclaration {
         name: test_name,

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -9,7 +9,6 @@
 //! The resolver uses a stack-based lexical environment:
 //! * **[`Scope`]**: The entire environment, containing a stack of [`ScopeLevel`]s.
 //! * **[`ScopeLevel`]**: A single dictionary (using `FxHashMap` for speed) mapping names to [`Binding`]s.
-//! * **[`ScopeGuard`]**: An RAII (Resource Acquisition Is Initialization) guard returned by [`Scope::enter_scope`].
 //!   When the guard goes out of scope, it automatically drops the deepest `ScopeLevel`.
 //!
 //! This design guarantees that variable shadowing works correctly and that symbols
@@ -24,10 +23,9 @@
 //! let mut scope = Scope::new();
 //! scope.define("ἡλικία", GlossaType::Number); // Let age be a Number
 //!
-//! {
-//!     let mut inner_scope = scope.enter_scope();
+//! scope.with_scope(|inner_scope| {
 //!     inner_scope.define("ὄνομα", GlossaType::String); // Name exists only here
-//! } // `inner_scope` is dropped, removing "ὄνομα"
+//! }); // `inner_scope` is exited, removing "ὄνομα"
 //!
 //! assert!(scope.lookup("ἡλικία").is_some());
 //! assert!(scope.lookup("ὄνομα").is_none());
@@ -97,30 +95,6 @@ pub struct FunctionSignature {
     pub return_type: Option<GlossaType>,
 }
 
-/// A RAII guard for a scope level. Exits the scope when dropped.
-pub struct ScopeGuard<'a> {
-    scope: &'a mut Scope,
-}
-
-impl<'a> Drop for ScopeGuard<'a> {
-    fn drop(&mut self) {
-        self.scope.exit();
-    }
-}
-
-impl<'a> std::ops::Deref for ScopeGuard<'a> {
-    type Target = Scope;
-    fn deref(&self) -> &Scope {
-        self.scope
-    }
-}
-
-impl<'a> std::ops::DerefMut for ScopeGuard<'a> {
-    fn deref_mut(&mut self) -> &mut Scope {
-        self.scope
-    }
-}
-
 /// A tracked variable binding with type and metadata.
 ///
 /// Bindings are resolved when a variable is used (e.g., retrieving its value).
@@ -161,7 +135,7 @@ impl Scope {
         self.levels.push(ScopeLevel::new());
     }
 
-    /// Creates a nested lexical scope and returns a RAII [`ScopeGuard`].
+    /// Creates a nested lexical scope, executes a closure within it, and then exits the scope.
     ///
     /// The returned guard allows defining symbols that only exist within the block.
     /// When the guard goes out of scope and is dropped, the inner scope level
@@ -176,21 +150,23 @@ impl Scope {
     /// let mut scope = Scope::new();
     /// scope.define("a", GlossaType::Number); // Parent level
     ///
-    /// {
-    ///     // Enters child scope level
-    ///     let mut child_scope = scope.enter_scope();
+    /// // Enters child scope level
+    /// scope.with_scope(|child_scope| {
     ///     child_scope.define("b", GlossaType::String);
     ///
     ///     assert!(child_scope.is_defined("a")); // Inherits parent scope
     ///     assert!(child_scope.is_defined("b")); // Defines own scope
-    /// } // `child_scope` is dropped, child level is destroyed
+    /// }); // child level is exited and destroyed
     ///
     /// assert!(scope.is_defined("a"));
     /// assert!(!scope.is_defined("b")); // "b" no longer exists
     /// ```
-    pub fn enter_scope(&mut self) -> ScopeGuard<'_> {
+    /// Creates a nested lexical scope, executes a closure within it, and then exits the scope.
+    pub fn with_scope<R, F: FnOnce(&mut Scope) -> R>(&mut self, f: F) -> R {
         self.enter();
-        ScopeGuard { scope: self }
+        let result = f(self);
+        self.exit();
+        result
     }
 
     /// Exit the current scope level
@@ -447,12 +423,11 @@ impl Scope {
     /// let mut scope = Scope::new();
     /// scope.define("a", GlossaType::Boolean);
     ///
-    /// {
-    ///     let mut inner = scope.enter_scope();
+    /// scope.with_scope(|inner| {
     ///     assert!(!inner.is_defined_locally("a")); // "a" is an ancestor, not local
     ///     inner.define("b", GlossaType::Number);
     ///     assert!(inner.is_defined_locally("b"));
-    /// }
+    /// });
     /// ```
     pub fn is_defined_locally(&self, name: &str) -> bool {
         self.levels
@@ -625,9 +600,10 @@ mod tests {
         let mut parent = Scope::new();
         parent.define("ξ".to_string(), GlossaType::Number);
 
-        let child = parent.enter_scope();
-        assert!(child.is_defined("ξ"));
-        assert_eq!(child.lookup("ξ"), Some(&GlossaType::Number));
+        parent.with_scope(|child| {
+            assert!(child.is_defined("ξ"));
+            assert_eq!(child.lookup("ξ"), Some(&GlossaType::Number));
+        });
     }
 
     #[test]
@@ -635,10 +611,10 @@ mod tests {
         let mut parent = Scope::new();
         parent.define("ξ".to_string(), GlossaType::Number);
 
-        let mut child = parent.enter_scope();
-        child.define("ξ".to_string(), GlossaType::String);
-
-        assert_eq!(child.lookup("ξ"), Some(&GlossaType::String));
+        parent.with_scope(|child| {
+            child.define("ξ".to_string(), GlossaType::String);
+            assert_eq!(child.lookup("ξ"), Some(&GlossaType::String));
+        });
     }
 
     #[test]
@@ -751,10 +727,11 @@ mod tests {
         let mut parent = Scope::new();
         parent.define_mut("π".to_string(), GlossaType::Number);
 
-        let child = parent.enter_scope();
-        let binding = child.lookup_binding("π").unwrap();
-        assert_eq!(binding.name, "π");
-        assert!(binding.mutable);
+        parent.with_scope(|child| {
+            let binding = child.lookup_binding("π").unwrap();
+            assert_eq!(binding.name, "π");
+            assert!(binding.mutable);
+        });
     }
 
     #[test]


### PR DESCRIPTION
Replaces the complex RAII `ScopeGuard` struct with a clean higher-order `with_scope` method.

---
*PR created automatically by Jules for task [10200965771351975769](https://jules.google.com/task/10200965771351975769) started by @madmax983*