### PR TITLE
📜 Codex: ADR 018 & Architecture Diagram Update

### DIFF
--- a/docs/adr/018-auditor-tool.md
+++ b/docs/adr/018-auditor-tool.md
@@ -1,0 +1,17 @@
+# 018. Add Auditor Tool
+
+**Status:** Proposed
+
+## Context
+
+With the expansion of the Nova developer experience toolkit, we need a way to perform static analysis on user code to detect common code smells such as unused variables and mutable bindings that are never reassigned. The codebase currently lacks a dedicated linter for catching these semantic issues early in the compilation process.
+
+## Decision
+
+Introduce a new `Auditor` tool (`src/tools/auditor.rs`) to traverse the semantically analyzed Abstract Syntax Tree (`AnalyzedProgram`). The tool acts as an AST visitor that records variable declarations, mutations, and usages, issuing warnings when anomalies are detected.
+
+## Consequences
+
+- The Auditor provides immediate feedback on redundant code, improving code quality.
+- This creates an additional traversal pass over the AST during the analysis phase.
+- Further rules and code smell checks can be cleanly integrated into the visitor implementation within `src/tools/auditor.rs`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,7 @@ C4Container
 
     Container_Boundary(tools, "Developer Experience (Nova)") {
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
+        Container(auditor, "The Auditor", "src/tools/auditor.rs", "Static analysis to find unused variables and mutations")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -66,6 +67,7 @@ C4Container
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")
     Rel(semantic, alchemist, "Analyzed Program")
+    Rel(semantic, auditor, "Analyzed Program")
     Rel(semantic, labyrinth, "Analyzed Program")
     Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")


### PR DESCRIPTION
🧠 **Decision:** Recorded the move to add `src/tools/auditor.rs` for static analysis on AST (unused variables, unbound mutations).
🗺️ **Visuals:** Updated C4 Component diagram to show the new Auditor boundaries in the Developer Experience Toolkit.
🔗 **Link:** See `docs/adr/018-auditor-tool.md`.

---
*PR created automatically by Jules for task [5381317746068838503](https://jules.google.com/task/5381317746068838503) started by @madmax983*