### PR TITLE
🎨 Mosaic: UI Polish for Papyrus

### DIFF
--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -1,6 +1,8 @@
 use crate::semantic::{AnalyzedStatement, GlossaType};
 use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
+use comfy_table::{Attribute, Cell, Color, Table, presets};
+use crossterm::style::Stylize;
 use miette::Result;
 use std::path::Path;
 
@@ -49,7 +51,25 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
         }
     }
 
-    println!("{}", output);
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   P A P Y R U S".bold().cyan());
+    println!("   {}", "SQL Schema".italic().dim());
+    println!();
+
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL);
+
+    table.set_header(vec![
+        Cell::new("SQL Schema")
+            .add_attribute(Attribute::Bold)
+            .fg(Color::Cyan),
+    ]);
+
+    let formatted_code = format!("```sql\n{}\n```", output.trim());
+    table.add_row(vec![Cell::new(formatted_code)]);
+
+    println!("{table}");
+    println!();
 
     Ok(())
 }


### PR DESCRIPTION
🖌️ **Before:**
The Papyrus tool generated SQL CREATE TABLE scripts and printed them to standard output as a raw block of text.

✨ **After:**
The output is now stylized using the `comfy_table` crate. It includes a bold title, an italic description, and renders the SQL within a clean tabular layout, improving visual hierarchy.

🖼️ **Visuals:**
The output adopts the repository's established UI pattern (e.g. `Mosaic`, `Alchemist`), ensuring consistent terminal UX for Nova features.

---
*PR created automatically by Jules for task [6885342599711897966](https://jules.google.com/task/6885342599711897966) started by @madmax983*