### PR TITLE
🔒 Warden: Update rand to 0.9.3 to resolve RUSTSEC-2026-0097

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -116,3 +116,6 @@ Signed,
 **2026-04-10 - [Unbounded File Read DoS in nova_coverage Test]**
 **Threat:** The `test_run_weave_success` test in `tests/nova_coverage.rs` was using `std::fs::read_to_string`, which loads an entire file into memory without limits. An attacker could theoretically use a massive file to exhaust memory and crash the test environment (DoS).
 **Defense:** Replaced the unbounded read with a capped reader using `std::io::Read::take()` and `1024 * 1024 + 1` limit, preventing memory exhaustion.
+**2025-05-18 - [Cargo Audit: rand unsoundness]
+**Threat:** The `rand` crate version 0.9.2 was found to be unsound with a custom logger, as reported by RUSTSEC-2026-0097. This posed a security risk if the random number generator was used with malicious input or under certain conditions.
+**Defense:** Updated the `rand` crate to version 0.9.3 in `Cargo.lock` to fix the unsoundness and eliminate the vulnerability.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,9 +873,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/src/semantic/assembly.rs
+++ b/src/semantic/assembly.rs
@@ -138,7 +138,7 @@ use unicode_normalization::UnicodeNormalization;
 /// If we parse the sentence "the user says the name" (`ὁ χρήστης τὸ ὄνομα λέγει`):
 ///
 /// ```rust
-/// use glossa::semantic::assembly::AssembledStatement;
+/// use glossa::semantic::AssembledStatement;
 ///
 /// let mut stmt = AssembledStatement::default();
 /// // - "ὁ χρήστης" goes into `stmt.subject` (Nominative Case).
@@ -265,7 +265,7 @@ impl std::fmt::Debug for AssembledStatement {
 /// Creating a constituent representing the subject "the man" (`ὁ ἄνθρωπος`):
 ///
 /// ```rust
-/// use glossa::semantic::assembly::Constituent;
+/// use glossa::semantic::Constituent;
 /// use glossa::morphology::{Case, Number, Gender, Person};
 /// use smol_str::SmolStr;
 ///


### PR DESCRIPTION
🦠 **Threat:** The `rand` crate version 0.9.2 was found to be unsound with a custom logger, as reported by RUSTSEC-2026-0097. This posed a security risk if the random number generator was used with malicious input or under certain conditions.
🛡️ **Defense:** Updated the `rand` crate to version 0.9.3 in `Cargo.lock` to fix the unsoundness and eliminate the vulnerability. Also, fixed the doc tests in `src/semantic/assembly.rs` which were failing due to outdated imports.
💥 **Severity:** High - RUSTSEC-2026-0097 unsoundness.
🧪 **Verification:** Ran `cargo audit` to confirm the vulnerability is resolved. Ran `cargo test` and `cargo test --doc` to verify that existing functionality is not broken and doc tests pass. Run `cargo clippy` and `cargo fmt`.

---
*PR created automatically by Jules for task [1914626915451114761](https://jules.google.com/task/1914626915451114761) started by @madmax983*