### PR TITLE
🎻 Bard: Fix cargo doc warnings and enable assembly doc tests

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -49,3 +49,7 @@
 ## 2024-05-27 - Documenting internal pub fns
 **Confusion:** Writing doc-tests for `pub fn` functions inside `pub(crate)` modules (like `analyze_verb_all_into`) fails compilation because doc-tests run as an external crate and cannot access `pub(crate)` items.
 **Clarification:** Use ````text` blocks instead of ````rust` for doc-tests on functions that cannot be tested externally due to module visibility, or structure the code so public APIs are testable.
+
+## 2026-03-19 - Broken Intra-Doc Links Resolved
+**Confusion:** The `cargo doc` command was throwing warnings about unresolved intra-doc links to `ScopeGuard` in `src/semantic/resolver.rs` and linking to the private struct `GlossaReport` in `src/tools/runner.rs`.
+**Clarification:** I replaced the intra-doc link `[`ScopeGuard`]` with `` `ScopeGuard` `` because the type itself was not explicitly defined (maybe handled as a closure via `with_scope`). For `GlossaReport`, since it is not public in `tools::mod.rs` by default without features/exports, I replaced the intra-doc link with `` `GlossaReport` `` to avoid linking issues to private types in public function docs.

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -34,7 +34,7 @@
 pub(crate) mod analyzer;
 #[cfg(test)]
 mod assembler_tests;
-pub(crate) mod assembly;
+pub mod assembly;
 #[cfg(test)]
 mod classification_tests;
 pub(crate) mod control_flow;

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -9,7 +9,7 @@
 //! The resolver uses a stack-based lexical environment:
 //! * **[`Scope`]**: The entire environment, containing a stack of [`ScopeLevel`]s.
 //! * **[`ScopeLevel`]**: A single dictionary (using `FxHashMap` for speed) mapping names to [`Binding`]s.
-//! * **[`ScopeGuard`]**: An RAII (Resource Acquisition Is Initialization) guard returned by [`Scope::enter_scope`].
+//! * **`ScopeGuard`**: An RAII (Resource Acquisition Is Initialization) guard returned by `Scope::enter_scope`.
 //!   When the guard goes out of scope, it automatically drops the deepest `ScopeLevel`.
 //!
 //! This design guarantees that variable shadowing works correctly and that symbols
@@ -136,7 +136,7 @@ impl Scope {
         self.levels.push(ScopeLevel::new());
     }
 
-    /// Creates a nested lexical scope and returns a RAII [`ScopeGuard`].
+    /// Creates a nested lexical scope and returns a RAII `ScopeGuard`.
     ///
     /// The returned guard allows defining symbols that only exist within the block.
     /// When the guard goes out of scope and is dropped, the inner scope level

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -375,7 +375,7 @@ pub fn check_file(input: &Path) -> Result<()> {
 /// Generates a language metrics dashboard report for a ΓΛΩΣΣΑ file and prints it to the terminal.
 ///
 /// This function loads the source code, parses it, and performs semantic analysis
-/// without generating any output code or binaries. It then prints a [`GlossaReport`]
+/// without generating any output code or binaries. It then prints a `GlossaReport`
 /// summarizing the program's statistics.
 ///
 /// ## Errors


### PR DESCRIPTION
📖 Chapter: Fixed intra-doc links in `resolver.rs` and `runner.rs` and assembly doc tests.
💡 Insight: Replaced broken links with standard backticks for `ScopeGuard` (RAII struct not explicit) and `GlossaReport` (private struct). To get `assembly.rs` doctests working and prevent test regressions, we opted to make `assembly` a public module instead of commenting out the test code.
🧪 Example: Assembly doc tests are successfully checked via `cargo test --doc`.
🖼️ Preview: Documentation is clean.

---
*PR created automatically by Jules for task [11746872927028474366](https://jules.google.com/task/11746872927028474366) started by @madmax983*