### PR TITLE
🛡️ Sentry: [test coverage improvement] Execution testing for generated panics

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,0 @@
-All tests pass! The whole test suite is perfectly green!
-This means my logic catches `MissingVerb` and `DoubleSubject` exactly where they should be caught without breaking existing functionality or verbless queries, iterator closures, and enum match arms!
-
-I will now submit the PR using the `submit` tool as requested. The persona is "Razor" 🪒, so I will format the PR according to Razor's guidelines:
-Title: `🪒 Razor: [Title]`
-Description with `🖼️ Before:` and `✨ After:`.

--- a/src/semantic/assembly.rs
+++ b/src/semantic/assembly.rs
@@ -138,7 +138,7 @@ use unicode_normalization::UnicodeNormalization;
 /// If we parse the sentence "the user says the name" (`ὁ χρήστης τὸ ὄνομα λέγει`):
 ///
 /// ```rust
-/// use glossa::semantic::assembly::AssembledStatement;
+/// use glossa::semantic::AssembledStatement;
 ///
 /// let mut stmt = AssembledStatement::default();
 /// // - "ὁ χρήστης" goes into `stmt.subject` (Nominative Case).
@@ -265,7 +265,7 @@ impl std::fmt::Debug for AssembledStatement {
 /// Creating a constituent representing the subject "the man" (`ὁ ἄνθρωπος`):
 ///
 /// ```rust
-/// use glossa::semantic::assembly::Constituent;
+/// use glossa::semantic::Constituent;
 /// use glossa::morphology::{Case, Number, Gender, Person};
 /// use smol_str::SmolStr;
 ///

--- a/tests/sentry_codegen_panics.rs
+++ b/tests/sentry_codegen_panics.rs
@@ -1,0 +1,167 @@
+#![allow(missing_docs)]
+use glossa::codegen::generate_rust_file;
+use glossa::semantic::{
+    AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
+};
+use std::fs::File;
+use std::io::Write;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn test_sentry_bounds_check_execution() {
+    let cases = vec![
+        (-1, "index out of bounds: negative index"),
+        (999, "index out of bounds: index too large"),
+    ];
+
+    for (index_val, expected_err) in cases {
+        let array_expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::ArrayLiteral(vec![AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(10),
+                glossa_type: GlossaType::Number,
+            }]),
+            glossa_type: GlossaType::List(Box::new(GlossaType::Number)),
+        };
+
+        let index_expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(index_val),
+            glossa_type: GlossaType::Number,
+        };
+
+        let access_expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::IndexAccess {
+                array: Box::new(array_expr),
+                index: Box::new(index_expr),
+            },
+            glossa_type: GlossaType::Number,
+        };
+
+        let stmt = AnalyzedStatement::Expression(vec![access_expr]);
+
+        let program = AnalyzedProgram {
+            statements: vec![stmt],
+            scope: Scope::new(),
+        };
+
+        let code = generate_rust_file(&program);
+
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("main.rs");
+        let mut f = File::create(&file_path).unwrap();
+        f.write_all(code.as_bytes()).unwrap();
+
+        let rustc_cmd = std::env::var("GLOSSA_RUSTC_CMD").unwrap_or("rustc".to_string());
+
+        let build_output = Command::new(rustc_cmd)
+            .arg(&file_path)
+            .arg("--out-dir")
+            .arg(dir.path())
+            .output()
+            .expect("Failed to execute rustc");
+
+        assert!(
+            build_output.status.success(),
+            "Generated code failed to compile: {}",
+            String::from_utf8_lossy(&build_output.stderr)
+        );
+
+        let binary_path = dir.path().join("main");
+        let run_output = Command::new(binary_path)
+            .output()
+            .expect("Failed to run binary");
+
+        assert!(
+            !run_output.status.success(),
+            "Binary should have panicked for {}! status: {}, stdout: {}, stderr: {}",
+            expected_err,
+            run_output.status,
+            String::from_utf8_lossy(&run_output.stdout),
+            String::from_utf8_lossy(&run_output.stderr)
+        );
+
+        let stderr = String::from_utf8_lossy(&run_output.stderr);
+        assert!(
+            stderr.contains(expected_err)
+                || stderr.contains("Δείκτης ἐκτὸς ὁρίων")
+                || stderr.contains("Index out of bounds"),
+            "Expected stderr to contain '{}', but got: {}",
+            expected_err,
+            stderr
+        );
+    }
+}
+
+#[test]
+fn test_sentry_unwrap_execution() {
+    let unwrap_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::Unwrap(Box::new(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable("g_none_var".into()),
+            glossa_type: GlossaType::Number,
+        })),
+        glossa_type: GlossaType::Number,
+    };
+
+    let stmt = AnalyzedStatement::Expression(vec![unwrap_expr]);
+
+    let scope = Scope::new();
+    // In Rust, None for numbers is an Option<i64>
+    // We'll just generate the code and check if the unwrap panic happens.
+    // However, to make it compile, `none_var` needs to be defined in rust scope.
+    // So we'll wrap it in a function.
+    let program = AnalyzedProgram {
+        statements: vec![stmt],
+        scope,
+    };
+
+    let code = generate_rust_file(&program);
+
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("main.rs");
+    let mut f = File::create(&file_path).unwrap();
+
+    // Create a rust context where none_var is an Option that is None
+    let mut code = code;
+    code = code.replace("#![allow(non_snake_case, unused_imports)]", "");
+    code = code.replace("use std::convert::TryFrom;", "");
+
+    code = code.replace(
+        "fn main () {",
+        "fn main () {\nlet g_g_none_var: Option<i64> = None;",
+    );
+    f.write_all(code.as_bytes()).unwrap();
+
+    let rustc_cmd = std::env::var("GLOSSA_RUSTC_CMD").unwrap_or("rustc".to_string());
+
+    let build_output = Command::new(rustc_cmd)
+        .arg(&file_path)
+        .arg("--out-dir")
+        .arg(dir.path())
+        .output()
+        .expect("Failed to execute rustc");
+
+    assert!(
+        build_output.status.success(),
+        "Generated code failed to compile: {}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+
+    let binary_path = dir.path().join("main");
+    let run_output = Command::new(binary_path)
+        .output()
+        .expect("Failed to run binary");
+
+    assert!(
+        !run_output.status.success(),
+        "Binary should have panicked for unwrap empty value!"
+    );
+
+    let stderr = String::from_utf8_lossy(&run_output.stderr);
+    let expected_err = "attempted to unwrap an empty value";
+    assert!(
+        stderr.contains(expected_err) || stderr.contains("Σφάλμα ἐκτελέσεως"),
+        "Expected stderr to contain '{}', but got: {}",
+        expected_err,
+        stderr
+    );
+}


### PR DESCRIPTION
🎯 **Target**: Generated panic logic in `src/codegen.rs` (specifically array index bounds checking and empty value unwrap).
💥 **Risk**: The generated Rust code relies on `.expect("...")` strings (like `"index out of bounds"` or `"attempted to unwrap an empty value"`) to enforce panic invariants dynamically. Prior to this, tests only verified the *presence* of these `.expect()` strings in the generated code (`code.contains(...)`), leaving the actual explosion and bounds check execution completely untested. If a bounds check were incorrectly formulated or evaluated to `try_from` safely but returned garbage, the generated code would silently execute undefined behavior or panic with standard runtime messages instead of the structured compiler-provided localized strings.
🧪 **Strategy**: Wrote a table-driven integration test in `tests/sentry_codegen_panics.rs` that explicitly generates ASTs containing an array access using a `negative index (-1)` and an `index too large (999)`, as well as an AST with an invalid `unwrap` of `None`. The test then compiles these into Rust binaries via `Command::new(rustc_cmd)` and invokes the compiled binaries via a separate `Command::new(binary_path)` subprocess. It asserts that the exit status is a non-zero failure code (`!status.success()`) and that the standard error stream explicitly contains the localized `"index out of bounds"` or `"unwrap"` messages emitted by our runtime hook. 
🔭 **Verification**: Run `cargo test --test sentry_codegen_panics`

---
*PR created automatically by Jules for task [2303106664038360323](https://jules.google.com/task/2303106664038360323) started by @madmax983*