### PR TITLE
🔒 Warden: Update rand crate to 0.9.3

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -116,3 +116,6 @@ Signed,
 **2026-04-10 - [Unbounded File Read DoS in nova_coverage Test]**
 **Threat:** The `test_run_weave_success` test in `tests/nova_coverage.rs` was using `std::fs::read_to_string`, which loads an entire file into memory without limits. An attacker could theoretically use a massive file to exhaust memory and crash the test environment (DoS).
 **Defense:** Replaced the unbounded read with a capped reader using `std::io::Read::take()` and `1024 * 1024 + 1` limit, preventing memory exhaustion.
+**2026-04-10 - [Rand Crate Unsoundness]**
+**Threat:** The dependency `rand` version 0.9.2 had a known vulnerability (RUSTSEC-2026-0097) where it is unsound with a custom logger using `rand::rng()`.
+**Defense:** Updated the `rand` crate to version 0.9.3 to resolve the vulnerability.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,9 +873,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
🦠 Threat: The dependency `rand` version 0.9.2 had a known vulnerability (RUSTSEC-2026-0097) where it is unsound with a custom logger using `rand::rng()`.
🛡️ Defense: Updated the `rand` crate to version 0.9.3 to resolve the vulnerability.
💥 Severity: Moderate (Unsoundness).
🧪 Verification: Confirmed clean `cargo audit` and verified that tests pass.

---
*PR created automatically by Jules for task [4339589011520530860](https://jules.google.com/task/4339589011520530860) started by @madmax983*