### PR TITLE
🎨 Mosaic: UI Polish for test runner

### DIFF
--- a/src/semantic/assembly.rs
+++ b/src/semantic/assembly.rs
@@ -138,7 +138,7 @@ use unicode_normalization::UnicodeNormalization;
 /// If we parse the sentence "the user says the name" (`ὁ χρήστης τὸ ὄνομα λέγει`):
 ///
 /// ```rust
-/// use glossa::semantic::assembly::AssembledStatement;
+/// use glossa::semantic::AssembledStatement;
 ///
 /// let mut stmt = AssembledStatement::default();
 /// // - "ὁ χρήστης" goes into `stmt.subject` (Nominative Case).
@@ -265,7 +265,7 @@ impl std::fmt::Debug for AssembledStatement {
 /// Creating a constituent representing the subject "the man" (`ὁ ἄνθρωπος`):
 ///
 /// ```rust
-/// use glossa::semantic::assembly::Constituent;
+/// use glossa::semantic::Constituent;
 /// use glossa::morphology::{Case, Number, Gender, Person};
 /// use smol_str::SmolStr;
 ///

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -160,8 +160,12 @@ fn extract_failures(output: &str) -> Vec<(String, String)> {
                     continue;
                 }
 
-                // Hide backtrace hint
-                if current.starts_with("note: run with `RUST_BACKTRACE=1`") {
+                // Hide backtrace hint and temp file paths and carets
+                if current.starts_with("note: run with `RUST_BACKTRACE=1`")
+                    || current.contains("glossa_test_")
+                    || current.trim_start().starts_with("^^^")
+                    || current.contains("RUST_BACKTRACE")
+                {
                     lines.next();
                     continue;
                 }
@@ -213,7 +217,12 @@ fn compile_test_harness(temp_path: &Path, exe_path: &Path, status: Status) -> Re
             }
 
             // Skip the underline carets and empty pipes
-            if trimmed.starts_with('|') {
+            if trimmed.starts_with('|') || trimmed.starts_with('^') {
+                continue;
+            }
+
+            // Skip temporary file paths and backtrace info
+            if line.contains("glossa_test_") || line.contains("RUST_BACKTRACE") {
                 continue;
             }
 


### PR DESCRIPTION
🖌️ **Before:** Test failure details included noisy internal `rustc` artifacts such as temporary file paths (e.g. `/tmp/glossa_test_...`), pointer carets (`^^^`), and `RUST_BACKTRACE` environment variable hints, which made reading the actual cause of the failure confusing.
✨ **After:** The `extract_failures` and `compile_test_harness` functions in `src/tools/tester.rs` now properly filter out these specific compiler artifacts from both runtime output (for panic traces) and compilation logs (for harness build errors).
🖼️ **Visuals:** Test failures now display a clean message like `thread 'test_name' panicked` without trailing PIDs, backtrace notes, or `rustc` positional pipes.

---
*PR created automatically by Jules for task [14331873044686235886](https://jules.google.com/task/14331873044686235886) started by @madmax983*