### PR TITLE
🎻 Bard: Document Assembly Structs and remove warning

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -53,3 +53,6 @@
 ## 2026-03-19 - Broken Intra-Doc Links Resolved
 **Confusion:** The `cargo doc` command was throwing warnings about unresolved intra-doc links to `ScopeGuard` in `src/semantic/resolver.rs` and linking to the private struct `GlossaReport` in `src/tools/runner.rs`.
 **Clarification:** I replaced the intra-doc link `[`ScopeGuard`]` with `` `ScopeGuard` `` because the type itself was not explicitly defined (maybe handled as a closure via `with_scope`). For `GlossaReport`, since it is not public in `tools::mod.rs` by default without features/exports, I replaced the intra-doc link with `` `GlossaReport` `` to avoid linking issues to private types in public function docs.
+## 2026-03-19 - [Empty Code Blocks in Assembly Structs]
+**Confusion:** The structs `AssembledStatement` and `Constituent` in `src/semantic/assembly.rs` had placeholder documentation containing empty rust code blocks, leading to `cargo doc` warnings ("Rust code block is empty").
+**Clarification:** I populated these documentation blocks with executable, concrete `doctests` demonstrating how to construct these types using realistic Ancient Greek morphology examples and explicit `crate::` path imports, providing tangible usage context while eliminating compiler warnings.

--- a/src/semantic/assembly.rs
+++ b/src/semantic/assembly.rs
@@ -138,7 +138,24 @@ use unicode_normalization::UnicodeNormalization;
 /// If we parse the sentence "the user says the name" (`ὁ χρήστης τὸ ὄνομα λέγει`):
 ///
 /// ```rust
-/// // Internal struct for assembled statements
+/// use glossa::semantic::{AssembledStatement, Constituent};
+/// use smol_str::SmolStr;
+/// use glossa::morphology::{Case, Number, Gender, Person};
+///
+/// let mut stmt = AssembledStatement::default();
+///
+/// // Simulating "the user" (ὁ χρήστης)
+/// stmt.subject = Some(Constituent {
+///     lemma: SmolStr::new("χρηστης"),
+///     original: SmolStr::new("χρήστης"),
+///     normalized: SmolStr::new("χρηστης"),
+///     case: Case::Nominative,
+///     number: Some(Number::Singular),
+///     gender: Some(Gender::Masculine),
+///     person: Some(Person::Third),
+/// });
+///
+/// assert!(stmt.subject.is_some());
 /// ```
 #[derive(Clone, Default)]
 pub struct AssembledStatement {
@@ -260,7 +277,21 @@ impl std::fmt::Debug for AssembledStatement {
 /// Creating a constituent representing the subject "the man" (`ὁ ἄνθρωπος`):
 ///
 /// ```rust
-/// // Internal struct representing a constituent
+/// use glossa::semantic::Constituent;
+/// use smol_str::SmolStr;
+/// use glossa::morphology::{Case, Number, Gender, Person};
+///
+/// let subject = Constituent {
+///     lemma: SmolStr::new("ανθρωπος"),
+///     original: SmolStr::new("ἄνθρωπος"),
+///     normalized: SmolStr::new("ανθρωπος"),
+///     case: Case::Nominative,
+///     number: Some(Number::Singular),
+///     gender: Some(Gender::Masculine),
+///     person: Some(Person::Third),
+/// };
+///
+/// assert_eq!(subject.case, Case::Nominative);
 /// ```
 #[derive(Clone)]
 #[allow(dead_code)]


### PR DESCRIPTION
📖 Chapter: The `Assembly` Structs
🔦 Insight: Explained how to manually construct `AssembledStatement` and `Constituent` instances with concrete data.
🧪 Example: Added 2 executable doctests demonstrating data structures replacing placeholder empty code blocks.
🖼️ Preview: Resolved cargo doc warnings about empty code blocks.

---
*PR created automatically by Jules for task [7357772021622953574](https://jules.google.com/task/7357772021622953574) started by @madmax983*