### PR TITLE
🗺️ Atlas: Enforce Facade pattern in tools module

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -140,3 +140,8 @@
 **[Enforcing Tool Encapsulation]
 **Tangle:** The `src/tools/` directory exposed internal helper modules (`report` and `ui`) as fully public (`pub mod`). This leaked implementation details and created a sprawling public API.
 **Blueprint:** Changed the visibility of `report` and `ui` to `pub(crate) mod` to enforce the facade pattern. Fixed a dead code warning on an unused function in `ui` that resulted from the visibility reduction.
+
+## [Enforcing Tool Encapsulation]
+**Tangle:** The `src/tools/` directory exposed internal submodules (`cli`, `dictionary`, `tester`, `runner`, `alchemist`, `auditor`, etc.) as fully public (`pub mod`), leaking implementation details and creating a sprawling API.
+**Blueprint:** Upgraded `pub mod` to `pub(crate) mod` for the internal tool submodules while retaining `pub mod highlight` as an exception, following the facade pattern. Added explicit `pub use` statements in `src/tools/mod.rs` to create a clean, flattened public API and refactored consumers (`main.rs`, doc tests, integration tests) to use this interface.
+**Stability:** Enforced high cohesion and low coupling by ensuring strict encapsulation and presenting a clean, manageable public interface for the tools module.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,9 @@
 use clap::Parser;
 use miette::Result;
 
-use glossa::tools::cli::{Cli, Commands};
-use glossa::tools::dictionary::lookup_word;
-use glossa::tools::repl::run_repl;
-use glossa::tools::runner::{
-    bard_file, build_file, check_file, highlight_file, report_file, run_file,
+use glossa::tools::{
+    Cli, Commands, bard_file, build_file, check_file, highlight_file, lookup_word, report_file,
+    run_file, run_repl,
 };
 
 fn main() -> Result<()> {
@@ -28,7 +26,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Mentor) => {
             #[cfg(feature = "nova")]
-            glossa::tools::mentor::run_mentor()?;
+            glossa::tools::run_mentor()?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(
@@ -61,12 +59,12 @@ fn main() -> Result<()> {
         }
 
         Some(Commands::Test { input }) => {
-            glossa::tools::tester::run_tests(&input)?;
+            glossa::tools::run_tests(&input)?;
         }
 
         Some(Commands::Mosaic { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::mosaic::run_mosaic(&input)?;
+            glossa::tools::run_mosaic(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -79,7 +77,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Map { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::cartographer::run_map(&input)?;
+            glossa::tools::run_map(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -92,7 +90,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Labyrinth { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::labyrinth::run_labyrinth(&input)?;
+            glossa::tools::run_labyrinth(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -105,7 +103,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Weave { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::weave::run_weave(&input)?;
+            glossa::tools::run_weave(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -118,7 +116,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Alchemist { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::alchemist::run_alchemist(&input)?;
+            glossa::tools::run_alchemist(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -131,7 +129,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Papyrus { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::papyrus::run_papyrus(&input)?;
+            glossa::tools::run_papyrus(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -144,7 +142,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Audit { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::auditor::run_auditor(&input)?;
+            glossa::tools::run_auditor(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -55,7 +55,7 @@ use std::path::PathBuf;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::cli::Cli;
+/// use glossa::tools::Cli;
 /// use clap::Parser;
 ///
 /// // You can parse arguments from an iterator, which is useful for testing!
@@ -85,7 +85,7 @@ pub struct Cli {
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::cli::Commands;
+/// use glossa::tools::Commands;
 /// use std::path::PathBuf;
 ///
 /// let run_cmd = Commands::Run { input: PathBuf::from("main.γλ") };

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -32,7 +32,7 @@ use std::fmt;
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::Value;
+/// use glossa::tools::Value;
 ///
 /// // Create a numerical truth
 /// let count = Value::Number(42);
@@ -79,7 +79,7 @@ impl fmt::Display for Value {
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::EvalError;
+/// use glossa::tools::EvalError;
 ///
 /// let missing_var = EvalError::VariableNotFound("x".into());
 /// assert!(missing_var.to_string().contains("μεταβλητὴ"));
@@ -135,7 +135,7 @@ pub enum EvalError {
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::Interpreter;
+/// use glossa::tools::Interpreter;
 ///
 /// let mut interp = Interpreter::new();
 /// // You could then run a program via `interp.run(&analyzed_program)`
@@ -163,7 +163,7 @@ impl Interpreter {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::interpreter::Interpreter;
+    /// use glossa::tools::Interpreter;
     ///
     /// let interp = Interpreter::new();
     /// assert_eq!(interp.get_output(), "");
@@ -180,7 +180,7 @@ impl Interpreter {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::interpreter::Interpreter;
+    /// use glossa::tools::Interpreter;
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
     ///

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -52,7 +52,7 @@ pub fn run_labyrinth(input: &Path) -> miette::Result<()> {
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::labyrinth::generate_cfg;
+/// use glossa::tools::generate_cfg;
 /// use glossa::semantic::analyze_program;
 /// use glossa::parser::parse;
 ///

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -35,7 +35,7 @@ use std::io::{BufRead, Write};
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::mentor::Lesson;
+/// use glossa::tools::Lesson;
 /// use glossa::semantic::AnalyzedProgram;
 ///
 /// let first_lesson = Lesson {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,28 +17,27 @@
 //! * `ui`: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
 
 #[cfg(feature = "nova")]
-pub mod alchemist;
+pub(crate) mod alchemist;
 #[cfg(feature = "nova")]
-pub mod auditor;
+pub(crate) mod auditor;
 pub(crate) mod cache;
-pub use cache::Cache;
 #[cfg(feature = "nova")]
-pub mod cartographer;
-pub mod cli;
-pub mod dictionary;
+pub(crate) mod cartographer;
+pub(crate) mod cli;
+pub(crate) mod dictionary;
 pub mod highlight;
 #[cfg(feature = "nova")]
-pub mod interpreter;
+pub(crate) mod interpreter;
 #[cfg(feature = "nova")]
-pub mod labyrinth;
+pub(crate) mod labyrinth;
 #[cfg(feature = "nova")]
-pub mod mentor;
+pub(crate) mod mentor;
 #[cfg(feature = "nova")]
-pub mod mosaic;
+pub(crate) mod mosaic;
 pub mod narrator;
 #[cfg(feature = "nova")]
-pub mod papyrus;
-pub mod repl;
+pub(crate) mod papyrus;
+pub(crate) mod repl;
 pub(crate) mod report;
 /// The engine room for executing and building Glossa programs
 ///
@@ -49,7 +48,7 @@ pub(crate) mod report;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::runner::run_file;
+/// use glossa::tools::run_file;
 /// use std::path::Path;
 ///
 /// // Execute a Glossa file directly from its path
@@ -58,8 +57,34 @@ pub(crate) mod report;
 ///     eprintln!("Execution failed: {}", e);
 /// }
 /// ```
-pub mod runner;
-pub mod tester;
+pub(crate) mod runner;
+pub(crate) mod tester;
 pub(crate) mod ui;
 #[cfg(feature = "nova")]
-pub mod weave;
+pub(crate) mod weave;
+
+pub use cache::Cache;
+pub use cli::{Cli, Commands};
+pub use dictionary::lookup_word;
+pub use repl::run_repl;
+pub use runner::{bard_file, build_file, check_file, highlight_file, report_file, run_file};
+pub use tester::run_tests;
+
+#[cfg(feature = "nova")]
+pub use alchemist::{run_alchemist, transpile_to_python};
+#[cfg(feature = "nova")]
+pub use auditor::run_auditor;
+#[cfg(feature = "nova")]
+pub use cartographer::run_map;
+#[cfg(feature = "nova")]
+pub use interpreter::{EvalError, Interpreter, Value};
+#[cfg(feature = "nova")]
+pub use labyrinth::{generate_cfg, run_labyrinth};
+#[cfg(feature = "nova")]
+pub use mentor::{Lesson, run_mentor};
+#[cfg(feature = "nova")]
+pub use mosaic::{run_mosaic, run_mosaic_inner};
+#[cfg(feature = "nova")]
+pub use papyrus::run_papyrus;
+#[cfg(feature = "nova")]
+pub use weave::run_weave;

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -53,7 +53,7 @@ impl ProgramStats {
     /// ```rust,ignore
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
-    /// use glossa::tools::report::ProgramStats;
+    /// use crate::tools::report::ProgramStats;
     ///
     /// let source = "ξ πέντε ἔστω.";
     /// let ast = parse(source).unwrap();
@@ -274,7 +274,7 @@ impl<'a> GlossaReport<'a> {
     /// ```rust,ignore
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
-    /// use glossa::tools::report::GlossaReport;
+    /// use crate::tools::report::GlossaReport;
     ///
     /// let source = "ξ πέντε ἔστω.";
     /// let ast = parse(source).unwrap();
@@ -404,7 +404,7 @@ impl Display for GlossaReport<'_> {
 /// ```rust,ignore
 /// use glossa::parser::parse;
 /// use glossa::semantic::analyze_program;
-/// use glossa::tools::report::{CompilationReport, ProgramStats};
+/// use crate::tools::report::{CompilationReport, ProgramStats};
 /// use std::path::PathBuf;
 /// use std::time::Duration;
 ///

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -110,7 +110,7 @@ pub(crate) fn load_source(input: &Path) -> Result<String> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::build_file;
+/// use glossa::tools::build_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -202,7 +202,7 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::run_file;
+/// use glossa::tools::run_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -342,7 +342,7 @@ fn execute_binary(executable: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::check_file;
+/// use glossa::tools::check_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -421,7 +421,7 @@ pub fn report_file(input: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::highlight_file;
+/// use glossa::tools::highlight_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -470,7 +470,7 @@ pub fn highlight_file(input: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::bard_file;
+/// use glossa::tools::bard_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -370,7 +370,7 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::tester::run_tests;
+/// use glossa::tools::run_tests;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -31,7 +31,7 @@ use std::time::Instant;
 /// # Examples
 ///
 /// ```rust,ignore
-/// use glossa::tools::ui::Status;
+/// use crate::tools::ui::Status;
 ///
 /// let mut status = Status::start("Compiling");
 /// status.update("Analyzing");
@@ -51,7 +51,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use crate::tools::ui::Status;
     /// let status = Status::start("Compiling...");
     /// status.success();
     /// ```
@@ -65,7 +65,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use crate::tools::ui::Status;
     /// let status = Status::start_with_symbol("Testing", "🧪");
     /// status.success();
     /// ```
@@ -94,7 +94,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use crate::tools::ui::Status;
     /// let mut status = Status::start("Running Phase 1");
     /// // ... work ...
     /// status.update("Running Phase 2");
@@ -115,7 +115,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use crate::tools::ui::Status;
     /// let status = Status::start("Connecting");
     /// // ... work ...
     /// status.success(); // Prints "✓ Connecting (0.01s)"
@@ -140,7 +140,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use crate::tools::ui::Status;
     /// let status = Status::start("Downloading");
     /// // ... fail ...
     /// status.error("Connection Refused"); // Prints "✕ Downloading" and then the error

--- a/tests/alchemist_coverage.rs
+++ b/tests/alchemist_coverage.rs
@@ -5,7 +5,7 @@ use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::alchemist::{run_alchemist, transpile_to_python};
+use glossa::tools::{run_alchemist, transpile_to_python};
 use std::io::Write;
 use tempfile::Builder;
 

--- a/tests/cli_coverage.rs
+++ b/tests/cli_coverage.rs
@@ -1,0 +1,10 @@
+#[cfg(test)]
+mod tests {
+    use glossa::tools::{Cli, Commands};
+
+    #[test]
+    fn coverage() {
+        let _ = Cli { file: None, command: None };
+        let _ = Commands::Repl;
+    }
+}

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -17,7 +17,7 @@ fn test_dos_dev_zero() {
         let path = Path::new("/dev/zero");
         // We expect run_file to fail either due to file size check (if fixed) or some other error.
         // If it hangs, it won't return.
-        let result = glossa::tools::runner::run_file(path);
+        let result = glossa::tools::run_file(path);
         // Send the result back
         // If run_file hangs, this line is never reached.
         let _ = tx.send(result);

--- a/tests/havoc_transliteration.rs
+++ b/tests/havoc_transliteration.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/mosaic_coverage.rs
+++ b/tests/mosaic_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::mosaic::run_mosaic_inner;
+use glossa::tools::run_mosaic_inner;
 
 #[test]
 fn test_mosaic_comprehensive_coverage() {

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 
 use std::io::Read;
 use std::io::Write;
@@ -18,7 +18,7 @@ fn test_run_weave_success() {
     let source = "«χαῖρε κόσμε» λέγε.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::weave::run_weave(temp_file.path());
+    let result = glossa::tools::run_weave(temp_file.path());
     assert!(result.is_ok(), "Weave failed: {:?}", result.err());
 
     let output_path = temp_file.path().with_extension("md");
@@ -49,14 +49,14 @@ fn test_run_papyrus_success() {
     let source = "εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. ἡλικία ἀριθμοῦ. }. ξ 5 ἔστω.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_ok(), "Papyrus failed: {:?}", result.err());
 }
 
 #[test]
 fn test_run_papyrus_file_not_found() {
     let path = PathBuf::from("non_existent_file.gl");
-    let result = glossa::tools::papyrus::run_papyrus(&path);
+    let result = glossa::tools::run_papyrus(&path);
     assert!(result.is_err());
     assert!(
         result
@@ -79,7 +79,7 @@ fn test_run_papyrus_file_too_large() {
         f.write_all(&data).unwrap();
     }
 
-    let result = glossa::tools::papyrus::run_papyrus(&input_path);
+    let result = glossa::tools::run_papyrus(&input_path);
     assert!(result.is_err());
     assert!(
         result
@@ -98,7 +98,7 @@ fn test_run_papyrus_syntax_error() {
 
     write!(temp_file, "invalid syntax").expect("Failed to write");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Parse error"));
 }
@@ -112,7 +112,7 @@ fn test_run_papyrus_semantic_error() {
 
     write!(temp_file, "ψ πέντε γίγνεται.").expect("Failed to write");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_err());
     let err_str = result.unwrap_err().to_string();
     assert!(

--- a/tests/sentry_tester_tests.rs
+++ b/tests/sentry_tester_tests.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 use std::fs;
 
 #[test]

--- a/tests/warden_limits.rs
+++ b/tests/warden_limits.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/warden_overflow_sim.rs
+++ b/tests/warden_overflow_sim.rs
@@ -4,7 +4,7 @@ use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::interpreter::Interpreter;
+use glossa::tools::Interpreter;
 
 #[test]
 fn test_warden_overflow_sim_defense() {


### PR DESCRIPTION
🕸️ **Tangle:** The `src/tools/` directory exposed internal submodules (`cli`, `dictionary`, `tester`, `runner`, `alchemist`, `auditor`, etc.) as fully public (`pub mod`), leaking implementation details and creating a sprawling API.

📐 **Blueprint:** 
1. Upgraded `pub mod` to `pub(crate) mod` for the internal tool submodules while retaining `pub mod highlight` as an exception.
2. Added explicit `pub use` statements in `src/tools/mod.rs` to create a clean, flattened public API.
3. Refactored consumers (`main.rs`, doc tests, integration tests) to use this interface instead of deeply nested module paths.

🧱 **Stability:** Enforced high cohesion and low coupling by ensuring strict encapsulation and presenting a clean, manageable public interface for the tools module.

🔬 **Verification:** `cargo check`, `cargo test`, `cargo test --doc`, and `cargo clippy` all pass with no warnings. All internal tests and external consumers successfully utilize the newly structured API.

---
*PR created automatically by Jules for task [17992541505114962651](https://jules.google.com/task/17992541505114962651) started by @madmax983*