### PR TITLE
📜 Codex: ADR 020 & Architecture Diagram Update

### DIFF
--- a/docs/adr/020-enforce-facade-pattern-in-tools.md
+++ b/docs/adr/020-enforce-facade-pattern-in-tools.md
@@ -1,0 +1,21 @@
+# 20. Enforce Facade Pattern in Tools Module
+
+Date: 2024-05-21
+
+## Status
+
+Proposed
+
+## Context
+
+The `src/tools/mod.rs` module historically exposed many of its internal submodules (such as `cli`, `dictionary`, `tester`, `runner`, `repl`, `narrator`, `alchemist`, and `auditor`) directly to the rest of the application using `pub mod`. This violated the principle of encapsulation, leaking internal implementation details and cluttering the public API. It made it difficult for developers to determine the intended public interface of the tools suite versus its internal machinery. An earlier ADR (016) addressed `ui` and `report`, but this needs to be applied universally across all internal tools.
+
+## Decision
+
+We have applied the Facade pattern to `src/tools/mod.rs`. The visibility of the internal tool submodules has been restricted from `pub mod` to `pub(crate) mod` (with `highlight` being an exception as it is needed publicly in some contexts). To ensure that external consumers (like `src/main.rs`, doc tests, and integration tests) still function correctly without being coupled to internal module structures, we have added explicit `pub use` statements in `src/tools/mod.rs` for the specifically required items (e.g., `run_file`, `Cli`, `Commands`).
+
+## Consequences
+
+*   **Positive:** The internal structure of the `tools` module is strictly encapsulated, hiding implementation details from the rest of the application.
+*   **Positive:** The public API of the `glossa::tools` crate is clean, flattened, and intentionally designed via the Facade pattern.
+*   **Negative:** Developers must remember to add a `pub use` statement in `src/tools/mod.rs` if a newly developed tool needs to be accessed by the CLI binary or external integration tests.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ C4Container
     Container(morphology, "Declension Resolver", "src/morphology", "Analyzes case, gender, number, and resolves agreement")
     Container(semantic, "Semantic Analyzer", "src/semantic", "Checks types, aspect, voice, and ownership")
 
-    Container_Boundary(tools, "Developer Experience (Nova)") {
+    Container_Boundary(tools, "Developer Experience (Nova) [Facade API]") {
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
         Container(auditor, "The Auditor", "src/tools/auditor.rs", "Static analysis to find unused variables and mutability smells")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,18 @@
-All tests pass! The whole test suite is perfectly green!
-This means my logic catches `MissingVerb` and `DoubleSubject` exactly where they should be caught without breaking existing functionality or verbless queries, iterator closures, and enum match arms!
+1. **Create an ADR for the Facade Pattern in Tools Module.**
+   - Since Atlas refactored `src/tools/mod.rs` to enforce the Facade pattern across almost all tool submodules (`cli`, `dictionary`, `tester`, `runner`, `repl`, `narrator`, `alchemist`, `auditor`, etc.) by changing their visibility to `pub(crate) mod`, and ADR 016 only specifically talks about `report` and `ui`, I will create a new ADR (e.g. `docs/adr/020-enforce-facade-pattern-in-tools.md`) to explicitly record this architectural decision.
+   - This ADR will follow the standard Nygard template (Title, Status, Context, Decision, Consequences) to document *why* this change was made (to prevent leaking implementation details and create a cleaner, flattened public API).
 
-I will now submit the PR using the `submit` tool as requested. The persona is "Razor" 🪒, so I will format the PR according to Razor's guidelines:
-Title: `🪒 Razor: [Title]`
-Description with `🖼️ Before:` and `✨ After:`.
+2. **Update the Architecture Diagrams (Mermaid).**
+   - Review `docs/architecture.md`.
+   - The current Container diagram (C4 Level 2) correctly shows all these tools nested within the "Developer Experience (Nova)" boundary. The arrows point correctly.
+   - The encapsulation is mostly a module-level boundary concern. If there's any specific relation to remove, I will check. But given `src/tools/mod.rs` acts as a facade, the C4 Component diagram of the Tools could be updated if it existed. The existing diagram is just a C4 Container list of tools inside a boundary. The current boundary nicely represents the facade.
+   - Therefore, the visual update is likely minimal, but I should ensure the descriptions in `docs/architecture.md` are aligned with the new structure if anything is glaringly missing. Wait, the system doesn't require me to change `docs/architecture.md` *unless* the structure actually changed in a way that affects the C4 model. However, since the internal tools are now technically behind a Facade (the `tools` module itself), I could consider adding a C4 Component diagram for the `Tools` module to show the Facade, or I'll just state that the C4 Container diagram already handles the grouping nicely.
+   - To be safe, I'll update the Container Diagram slightly to explicitly mention the facade in the boundary description or similar. Actually, the C4 Container Diagram already lists `tools` as a `Container_Boundary`. I will add a note about the Facade in the description.
+
+3. **Complete pre-commit steps.**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+4. **Submit the pull request.**
+   - I will use the Codex persona format to submit the changes.
+   - Title: `📜 Codex: ADR 020 & Architecture Diagram Update`
+   - Description with `🧠 **Decision:**`, `🗺️ **Visuals:**`, and `🔗 **Link:**`.


### PR DESCRIPTION
🧠 **Decision:** Recorded the architectural decision by Atlas to apply the Facade pattern in `src/tools/mod.rs`, which restricted the visibility of internal tool submodules (`cli`, `dictionary`, `tester`, `runner`, `repl`, `narrator`, `alchemist`, and `auditor`) from `pub mod` to `pub(crate) mod` and exposed only required public APIs.
🗺️ **Visuals:** Updated the Container Diagram (C4) in `docs/architecture.md` to note that the "Developer Experience (Nova)" boundary now explicitly acts as a "[Facade API]".
🔗 **Link:** See `docs/adr/020-enforce-facade-pattern-in-tools.md` for context and consequences.

---
*PR created automatically by Jules for task [12019816127146287381](https://jules.google.com/task/12019816127146287381) started by @madmax983*