### PR TITLE
🪒 Razor: Replace Sanitizer with sanitize_to_string function

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -1,4 +1,8 @@
 ## [Reduction]
+**Bloat:** `Sanitizer<'a>` RAII structure with explicit `Display` trait implementation in `src/codegen.rs` which added verbosity and abstraction bloat.
+**Cut:** Replaced `Sanitizer<'a>` with a single function `sanitize_to_string(name, capitalize)`.
+**Saved:** 15 lines of boilerplate structs and trait implementations. Reduced cognitive load for string formatting.
+## [Reduction]
 **Bloat:** `TraitMethodCall` enum variant in `AnalyzedExprKind` and its specialized processing functions (like `generate_trait_method_call` and `tell_trait_method_call`). It represented speculative generality where a trait method call had identical compilation and parsing paths to a regular object method.
 **Cut:** Removed `TraitMethodCall` entirely and consolidated its path into the existing `MethodCall` node, treating trait methods as regular methods dynamically checked in type space.
 **Saved:** Dozens of lines of repeated boilerplate matching rules across parsing, codegen, reporting, and narrative tools. Simplifies the AST and standardizes behavior.

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,0 @@
-All tests pass! The whole test suite is perfectly green!
-This means my logic catches `MissingVerb` and `DoubleSubject` exactly where they should be caught without breaking existing functionality or verbless queries, iterator closures, and enum match arms!
-
-I will now submit the PR using the `submit` tool as requested. The persona is "Razor" 🪒, so I will format the PR according to Razor's guidelines:
-Title: `🪒 Razor: [Title]`
-Description with `🖼️ Before:` and `✨ After:`.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -108,38 +108,22 @@ use quote::{format_ident, quote};
 
 /// Helper to sanitize a name and format it as an Ident
 pub(crate) fn sanitize_ident(name: &str) -> Ident {
-    format_ident!(
-        "{}",
-        Sanitizer {
-            name,
-            capitalize: false
-        }
-        .to_string()
-    )
+    format_ident!("{}", sanitize_to_string(name, false))
 }
 
 /// Zero-allocation sanitizer for Rust identifiers
-struct Sanitizer<'a> {
-    name: &'a str,
-    capitalize: bool,
-}
-
-impl<'a> std::fmt::Display for Sanitizer<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.capitalize {
-            f.write_str("G_")?;
-        } else {
-            f.write_str("g_")?;
-        }
-
-        transliterate_fmt(self.name, f)?;
-
-        if self.name.is_empty() {
-            f.write_str("_var_empty")?;
-        }
-
-        Ok(())
+pub(crate) fn sanitize_to_string(name: &str, capitalize: bool) -> String {
+    let mut s = String::new();
+    if capitalize {
+        s.push_str("G_");
+    } else {
+        s.push_str("g_");
     }
+    transliterate_fmt(name, &mut s).unwrap();
+    if name.is_empty() {
+        s.push_str("_var_empty");
+    }
+    s
 }
 
 /// Sanitize a Greek name for use as a Rust identifier
@@ -172,12 +156,7 @@ impl<'a> std::fmt::Display for Sanitizer<'a> {
 /// assert_eq!(sanitize_name("if"), "g_if");
 /// ```
 pub fn sanitize_name(name: &str) -> String {
-    // Use the zero-allocation Sanitizer to generate the string
-    Sanitizer {
-        name,
-        capitalize: false,
-    }
-    .to_string()
+    sanitize_to_string(name, false)
 }
 
 /// Transliterate Greek to Latin characters via Hex Encoding
@@ -288,11 +267,7 @@ pub fn to_rust_type(ty: &GlossaType) -> String {
             format!("Result<{}, {}>", to_rust_type(ok), to_rust_type(err))
         }
         GlossaType::Unit => "()".to_string(),
-        GlossaType::Struct { name, .. } => Sanitizer {
-            name,
-            capitalize: true,
-        }
-        .to_string(),
+        GlossaType::Struct { name, .. } => sanitize_to_string(name, true),
         // TODO: Better representation for function types if they appear in type signatures
         GlossaType::Function { .. } => "fn".to_string(),
         GlossaType::Unknown => "_".to_string(),
@@ -333,14 +308,7 @@ pub fn generate_type_tokens(ty: &GlossaType) -> TokenStream {
         GlossaType::Unit => quote! { () },
         GlossaType::Struct { name, .. } => {
             // Directly sanitize and create identifier without intermediate string allocation for the type name
-            let ident = format_ident!(
-                "{}",
-                Sanitizer {
-                    name,
-                    capitalize: true
-                }
-                .to_string()
-            );
+            let ident = format_ident!("{}", sanitize_to_string(name, true));
             quote! { #ident }
         }
         // Function types are not fully supported in type signatures yet, fallback to generic
@@ -708,14 +676,7 @@ fn generate_fn_def(
 
 fn generate_struct_def(name: &str, fields: &[(smol_str::SmolStr, GlossaType)]) -> TokenStream {
     // Capitalize struct name for Rust conventions
-    let struct_name = format_ident!(
-        "{}",
-        Sanitizer {
-            name,
-            capitalize: true
-        }
-        .to_string()
-    );
+    let struct_name = format_ident!("{}", sanitize_to_string(name, true));
 
     // Generate field list
     let field_tokens = fields.iter().map(|(field_name, field_type)| {
@@ -766,14 +727,7 @@ fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
 
 fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
     // Capitalize trait name for Rust conventions
-    let trait_name = format_ident!(
-        "{}",
-        Sanitizer {
-            name,
-            capitalize: true
-        }
-        .to_string()
-    );
+    let trait_name = format_ident!("{}", sanitize_to_string(name, true));
 
     // Generate method signatures
     let method_tokens = methods.iter().map(|method| {
@@ -821,22 +775,8 @@ fn generate_trait_impl(
     methods: &[AnalyzedMethod],
 ) -> TokenStream {
     // Capitalize trait and type names for Rust conventions
-    let trait_ident = format_ident!(
-        "{}",
-        Sanitizer {
-            name: trait_name,
-            capitalize: true
-        }
-        .to_string()
-    );
-    let type_ident = format_ident!(
-        "{}",
-        Sanitizer {
-            name: type_name,
-            capitalize: true
-        }
-        .to_string()
-    );
+    let trait_ident = format_ident!("{}", sanitize_to_string(trait_name, true));
+    let type_ident = format_ident!("{}", sanitize_to_string(type_name, true));
 
     // Generate method implementations
     let method_tokens = methods.iter().map(|method| {
@@ -1072,14 +1012,7 @@ fn generate_struct_lit(
     args: &[AnalyzedExpr],
 ) -> TokenStream {
     // Capitalize struct name for Rust conventions
-    let struct_name = format_ident!(
-        "{}",
-        Sanitizer {
-            name: type_name,
-            capitalize: true
-        }
-        .to_string()
-    );
+    let struct_name = format_ident!("{}", sanitize_to_string(type_name, true));
 
     // Generate field: value pairs using actual field names
     let field_assignments = fields.iter().zip(args.iter()).map(|(field_name, arg)| {


### PR DESCRIPTION
## 🪒 Razor: Replace Sanitizer with sanitize_to_string function

**Bloat:** `Sanitizer<'a>` RAII structure with explicit `Display` trait implementation in `src/codegen.rs` which added verbosity and abstraction bloat.
**Cut:** Replaced `Sanitizer<'a>` with a single function `sanitize_to_string(name, capitalize)`.
**Saved:** 15 lines of boilerplate structs and trait implementations. Reduced cognitive load for string formatting.

---
*PR created automatically by Jules for task [12910964926390549946](https://jules.google.com/task/12910964926390549946) started by @madmax983*