### PR TITLE
⚡ Bolt: Optimize SQL schema generation by eliminating intermediate format! allocations

### DIFF
--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -4,6 +4,7 @@ use crate::tools::ui::Status;
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
+use std::fmt::Write;
 use std::path::Path;
 
 /// Run the Papyrus tool on a file
@@ -41,11 +42,12 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
 
     for stmt in &program.statements {
         if let AnalyzedStatement::TypeDefinition { name, fields } = stmt {
-            output.push_str(&format!("CREATE TABLE {} (\n", name));
+            // ⚡ Bolt Optimization: Eliminated `format!` allocations by writing directly to `output`
+            let _ = writeln!(output, "CREATE TABLE {} (", name);
             for (i, (field_name, field_type)) in fields.iter().enumerate() {
                 let sql_type = glossa_type_to_sql(field_type);
                 let comma = if i < fields.len() - 1 { "," } else { "" };
-                output.push_str(&format!("    {} {}{}\n", field_name, sql_type, comma));
+                let _ = writeln!(output, "    {} {}{}", field_name, sql_type, comma);
             }
             output.push_str(");\n\n");
         }


### PR DESCRIPTION
💡 **What**: Replaced intermediate `format!` allocations with `writeln!` in the `run_papyrus` function within `src/tools/papyrus.rs`.
🎯 **Why**: Using `output.push_str(&format!("...", ...))` creates a temporary heap-allocated `String` for the formatted result just to copy its contents into the `output` string and then drop the temporary string. Writing directly into the `output` string using `writeln!(output, "...", ...)` avoids these intermediate allocations.
📊 **Impact**: Reduces heap allocations, making the code faster and more efficient, especially when dealing with large models having many fields.
🔬 **Measurement**: Run the test suite using `cargo test` and verify that the Papyrus SQL generation remains intact while generating zero intermediate string allocations for `format!` macros inside its main formatting loop.

---
*PR created automatically by Jules for task [6432601072960715491](https://jules.google.com/task/6432601072960715491) started by @madmax983*