### PR TITLE
⚡ Bolt: Replace push_str(&format!(...)) with write!

### DIFF
--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -131,7 +131,7 @@ fn transpile_statement(stmt: &AnalyzedStatement, indent: usize) -> String {
         AnalyzedStatement::Expression(exprs) => {
             let mut out = String::new();
             for expr in exprs {
-                out.push_str(&format!("{}{}\n", ind, transpile_expr(expr)));
+                writeln!(out, "{}{}", ind, transpile_expr(expr)).unwrap();
             }
             out.trim_end().to_string()
         }
@@ -167,7 +167,7 @@ fn transpile_if(
     let ind = "    ".repeat(indent);
     let mut out = format!("{}if {}:\n", ind, transpile_expr(condition));
     if then_body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        writeln!(out, "{}    pass", ind).unwrap();
     } else {
         for b_stmt in then_body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -175,9 +175,9 @@ fn transpile_if(
         }
     }
     if let Some(ebody) = else_body {
-        out.push_str(&format!("{}else:\n", ind));
+        writeln!(out, "{}else:", ind).unwrap();
         if ebody.is_empty() {
-            out.push_str(&format!("{}    pass\n", ind));
+            writeln!(out, "{}    pass", ind).unwrap();
         } else {
             for b_stmt in ebody {
                 out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -192,7 +192,7 @@ fn transpile_while(condition: &AnalyzedExpr, body: &[AnalyzedStatement], indent:
     let ind = "    ".repeat(indent);
     let mut out = format!("{}while {}:\n", ind, transpile_expr(condition));
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        writeln!(out, "{}    pass", ind).unwrap();
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -216,7 +216,7 @@ fn transpile_for(
         transpile_expr(iterator)
     );
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        writeln!(out, "{}    pass", ind).unwrap();
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -243,7 +243,7 @@ fn transpile_function_def(
     out.push_str("):\n");
 
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        writeln!(out, "{}    pass", ind).unwrap();
     } else {
         for (i, b_stmt) in body.iter().enumerate() {
             let mut is_last_expr = false;
@@ -255,9 +255,9 @@ fn transpile_function_def(
                 if let AnalyzedStatement::Expression(exprs) = b_stmt {
                     for (j, expr) in exprs.iter().enumerate() {
                         if j == exprs.len() - 1 {
-                            out.push_str(&format!("{}    return {}\n", ind, transpile_expr(expr)));
+                            writeln!(out, "{}    return {}", ind, transpile_expr(expr)).unwrap();
                         } else {
-                            out.push_str(&format!("{}    {}\n", ind, transpile_expr(expr)));
+                            writeln!(out, "{}    {}", ind, transpile_expr(expr)).unwrap();
                         }
                     }
                 }
@@ -283,10 +283,10 @@ fn transpile_type_def(
         sanitize_ident(name)
     );
     if fields.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        writeln!(out, "{}    pass", ind).unwrap();
     } else {
         for (f_name, _) in fields {
-            out.push_str(&format!("{}    {}: Any\n", ind, sanitize_ident(f_name)));
+            writeln!(out, "{}    {}: Any", ind, sanitize_ident(f_name)).unwrap();
         }
     }
     out.trim_end().to_string()
@@ -298,7 +298,7 @@ fn transpile_test_declaration(name: &str, body: &[AnalyzedStatement], indent: us
     let safe_name = name.replace(" ", "_").replace("-", "_").replace("\"", "");
     let mut out = format!("{}def test_{}():\n", ind, safe_name);
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        writeln!(out, "{}    pass", ind).unwrap();
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -317,13 +317,9 @@ fn transpile_match(
     // Python 3.10+ match statement
     let mut out = format!("{}match {}:\n", ind, transpile_expr(scrutinee));
     for (pattern_expr, arm_body) in arms {
-        out.push_str(&format!(
-            "{}    case {}:\n",
-            ind,
-            transpile_expr(pattern_expr)
-        ));
+        writeln!(out, "{}    case {}:", ind, transpile_expr(pattern_expr)).unwrap();
         if arm_body.is_empty() {
-            out.push_str(&format!("{}        pass\n", ind));
+            writeln!(out, "{}        pass", ind).unwrap();
         } else {
             for b_stmt in arm_body {
                 out.push_str(&transpile_statement(b_stmt, indent + 2));

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -19,6 +19,7 @@ use crate::semantic::{AnalyzedProgram, AnalyzedStatement};
 use crate::tools::ui::Status;
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
+use std::fmt::Write;
 use std::path::Path;
 
 /// Run the Labyrinth tool on a file
@@ -388,10 +389,11 @@ impl CFGBuilder {
     fn finish(self) -> String {
         let mut out = String::from("graph TD\n");
         for node in self.nodes {
-            out.push_str(&format!("    {}\n", node));
+            // ⚡ Bolt Optimization: Avoids intermediate String allocation by formatting directly into the buffer.
+            writeln!(out, "    {}", node).unwrap();
         }
         for edge in self.edges {
-            out.push_str(&format!("    {}\n", edge));
+            writeln!(out, "    {}", edge).unwrap();
         }
         out
     }

--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -4,6 +4,7 @@ use crate::tools::ui::Status;
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
+use std::fmt::Write;
 use std::path::Path;
 
 /// Run the Papyrus tool on a file
@@ -41,11 +42,12 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
 
     for stmt in &program.statements {
         if let AnalyzedStatement::TypeDefinition { name, fields } = stmt {
-            output.push_str(&format!("CREATE TABLE {} (\n", name));
+            // ⚡ Bolt Optimization: Avoids intermediate String allocation by formatting directly into the buffer.
+            writeln!(output, "CREATE TABLE {} (", name).unwrap();
             for (i, (field_name, field_type)) in fields.iter().enumerate() {
                 let sql_type = glossa_type_to_sql(field_type);
                 let comma = if i < fields.len() - 1 { "," } else { "" };
-                output.push_str(&format!("    {} {}{}\n", field_name, sql_type, comma));
+                writeln!(output, "    {} {}{}", field_name, sql_type, comma).unwrap();
             }
             output.push_str(");\n\n");
         }


### PR DESCRIPTION
💡 What: Replaced inefficient `buffer.push_str(&format!(...))` patterns with `writeln!(buffer, ...).unwrap()` across `src/tools/papyrus.rs`, `src/tools/alchemist.rs`, and `src/tools/labyrinth.rs`.
🎯 Why: Using `format!` creates an intermediate, heap-allocated `String` that is immediately discarded after its contents are appended. `writeln!` formats and appends directly to the existing buffer, completely avoiding the temporary allocation.
📊 Impact: Eliminates multiple temporary heap allocations during SQL schema generation (`papyrus`), Python transpilation (`alchemist`), and CFG Mermaid graph generation (`labyrinth`).
🔬 Measurement: Run `cargo test` to verify behavior remains identical, and review the code to see the removed `format!` macros.

---
*PR created automatically by Jules for task [13367727611613387261](https://jules.google.com/task/13367727611613387261) started by @madmax983*