### PR TITLE
👺 Havoc: Direct Stack Overflow in Codegen

### DIFF
--- a/tests/havoc_codegen_stack_overflow.rs
+++ b/tests/havoc_codegen_stack_overflow.rs
@@ -1,46 +1,56 @@
+#![allow(missing_docs)]
+
 use glossa::codegen::generate_rust;
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
+use std::env;
+use std::process::Command;
 
 #[test]
-#[ignore = "Demonstrates a SIGABRT stack overflow when directly generating code for deeply nested ASTs"]
 fn test_codegen_deep_ast_overflow() {
-    let depth = 50_000;
+    // If we are in the child process, execute the crashing code
+    if env::var("HAVOC_TRIGGER_CRASH_CODEGEN").is_ok() {
+        let depth = 50_000;
 
-    // 👺 Havoc: Direct Stack Overflow in Codegen
-    // We construct a deeply nested Analyzed AST manually, simulating a scenario where
-    // either the parser/analyzer limits are bypassed, or an internal macro expands
-    // into an unboundedly deep AST.
-    //
-    // The `generate_expr` function in `src/codegen.rs` does not use `stacker::maybe_grow`.
-    // It relies entirely on standard Rust recursive function calls.
-    // At a depth of 50,000, this will immediately blow the thread's stack limit
-    // and crash the compiler backend with a fatal SIGABRT.
-
-    let mut expr = AnalyzedExpr {
-        expr: AnalyzedExprKind::NumberLiteral(1),
-        glossa_type: GlossaType::Number,
-    };
-
-    for _ in 0..depth {
-        expr = AnalyzedExpr {
-            expr: AnalyzedExprKind::MethodCall {
-                receiver: Box::new(expr),
-                method: "clone".into(),
-                args: vec![],
-            },
+        let mut expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(1),
             glossa_type: GlossaType::Number,
         };
+
+        for _ in 0..depth {
+            expr = AnalyzedExpr {
+                expr: AnalyzedExprKind::MethodCall {
+                    receiver: Box::new(expr),
+                    method: "clone".into(),
+                    args: vec![],
+                },
+                glossa_type: GlossaType::Number,
+            };
+        }
+
+        let stmt = AnalyzedStatement::Expression(vec![expr]);
+
+        let program = AnalyzedProgram {
+            statements: vec![stmt],
+            scope: Scope::new(),
+        };
+
+        // 💥 DETONATE
+        let _rust = generate_rust(&program);
+        return;
     }
 
-    let stmt = AnalyzedStatement::Expression(vec![expr]);
+    // Otherwise, we are in the test runner. Spawn the child process.
+    let exe = env::current_exe().unwrap();
+    let status = Command::new(exe)
+        .arg("test_codegen_deep_ast_overflow")
+        .arg("--exact")
+        .arg("--test-threads=1")
+        .env("HAVOC_TRIGGER_CRASH_CODEGEN", "1")
+        .status()
+        .unwrap();
 
-    let program = AnalyzedProgram {
-        statements: vec![stmt],
-        scope: Scope::new(),
-    };
-
-    // 💥 DETONATE
-    let _rust = generate_rust(&program);
+    // The process should crash/abort (non-zero exit code)
+    assert!(!status.success(), "Process did not crash as expected!");
 }


### PR DESCRIPTION
🧨 **The Trigger:** Directly instantiating a deeply nested `AnalyzedExpr` structure (depth of 50,000) and passing it to the code generator (`generate_rust`) in `src/codegen.rs`.
📉 **The Stack Trace:**
```
thread 'test_codegen_deep_ast_overflow' (9338) has overflowed its stack
fatal runtime error: stack overflow, aborting
```
🧪 **Reproduction:** Run `cargo test --test havoc_codegen_stack_overflow` and witness the isolated crash in the child process.
😈 **Comment:** You assumed the AST depth limits in the parser/analyzer would protect the code generator. But what if an internal macro generates deep code or someone directly injects an Analyzed AST? The generator blindly recurses without `stacker::maybe_grow`. You left the back door wide open.

---
*PR created automatically by Jules for task [5417254828072156321](https://jules.google.com/task/5417254828072156321) started by @madmax983*