### PR TITLE
⚡ Bolt: Use FxHashSet instead of HashSet in cartographer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 **[Buffer Reuse Optimization in Loop]**
 **Learning:** Creating a new `Vec::new()` inside a tight loop creates an unnecessary heap allocation on every iteration. This is a common performance pitfall in graph or dependency extraction algorithms.
 **Action:** Declare a single mutable `Vec` (e.g., `let mut buffer = Vec::new();`) outside the loop, pass it by mutable reference `&mut buffer` into inner functions, and call `buffer.clear()` at the start of each loop iteration to reuse the same memory allocation without reallocating.
+**[Replace HashSet with FxHashSet in cartographer]**
+**Learning:** Standard HashSet is secure but slow due to SipHash. Since the keys here are just short predictable string representations within compiler phases and are not exposed to hash DOS attacks from users, using FxHashSet avoids significant hashing overhead.
+**Action:** Always prefer FxHashSet over HashSet for short internal keys when not exposed to untrusted inputs.

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -38,7 +38,7 @@ use crate::tools::ui::Status;
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 use std::path::Path;
 
 /// Run the Cartographer tool on a file
@@ -111,7 +111,12 @@ pub fn run_map(input: &Path) -> Result<()> {
 /// Generate a Mermaid class diagram from an analyzed program
 pub fn generate_map(program: &AnalyzedProgram) -> String {
     let mut map = String::from("classDiagram\n");
-    let mut dependencies = HashSet::new();
+
+    // ⚡ Bolt Optimization: Swapped `HashSet` for `FxHashSet` for performance.
+    // Standard `HashSet` uses SipHash, which is cryptographically secure but slower.
+    // For internal tracking of predictable short type names in the cartographer,
+    // where HashDoS isn't a concern, `FxHashSet` avoids unnecessary hashing overhead.
+    let mut dependencies = FxHashSet::default();
 
     use std::fmt::Write;
 
@@ -177,7 +182,7 @@ pub fn generate_map(program: &AnalyzedProgram) -> String {
     // 3. Add dependencies (struct field usage)
     // Only include dependencies if the target is actually a defined type/trait in the diagram
     // to avoid arrows to "Unknown" or external things if not modeled.
-    let defined_types: HashSet<String> = program
+    let defined_types: FxHashSet<String> = program
         .scope
         .types()
         .filter_map(|(_, ty)| {


### PR DESCRIPTION
💡 What: Switched `HashSet` to `FxHashSet` (from `rustc-hash`) in `src/tools/cartographer.rs`.
🎯 Why: Standard `HashSet` uses SipHash, which is secure against HashDoS attacks but slow. The cartographer uses hash sets to internally track short, predictable string type names. Removing the cryptographic hashing overhead speeds up map generation.
📊 Impact: Reduces CPU hashing overhead when generating dependency maps for large codebases.
🔬 Measurement: Run `cargo check` and run `map` command.

---
*PR created automatically by Jules for task [16050359968503807785](https://jules.google.com/task/16050359968503807785) started by @madmax983*