### PR TITLE
🛡️ Sentry: Add coverage for edge cases in tester and ui modules

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -616,6 +616,41 @@ failures:
 ",
                 expected_count: 0,
             },
+            TestCase {
+                name: "Missing end of test details block",
+                input: "
+failures:
+
+---- my_test_missing_end stdout ----
+Error message here
+",
+                expected_count: 1,
+            },
+            TestCase {
+                name: "Missing next test block",
+                input: "
+failures:
+
+---- my_test_next stdout ----
+Error 1
+---- my_test_next_missing stdout ----
+Error 2
+",
+                expected_count: 2,
+            },
+            TestCase {
+                name: "Thread panicked internal rust string stripped",
+                input: "
+failures:
+
+---- test_panicked stdout ----
+thread 'test_panicked' panicked at 'internal panic message', src/lib.rs:1:1
+   0: std::backtrace::Backtrace::create
+   1: core::panicking::panic_fmt
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+",
+                expected_count: 1, // It should still capture the failure but strip some internal messages
+            },
         ];
 
         for case in test_cases {

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -265,4 +265,12 @@ mod tests {
         // calling success again or error does nothing if already inactive
         status.success();
     }
+
+    #[test]
+    fn test_status_error_inactive() {
+        let mut status = Status::start("Test Error Inactive");
+        status.active = false;
+        // calling error does nothing if already inactive, we shouldn't see it print or panic
+        status.error("Simulated inactive error");
+    }
 }


### PR DESCRIPTION
🛡️ Sentry: Add coverage for edge cases in tester and ui modules

🎯 Target: `src/tools/tester.rs` (extract_failures) and `src/tools/ui.rs` (Status).
💣 Risk: Missing test cases could hide silent regressions in parsing test outputs and TUI error state handling.
🧪 Strategy: Added table-driven tests for missing test failure boundaries and covered inactive TUI error invocation.
🔬 Verification: Run `cargo test --lib`

---
*PR created automatically by Jules for task [5413497082405368153](https://jules.google.com/task/5413497082405368153) started by @madmax983*