### PR TITLE
🪒 Razor: Simplify Cache initialization generic soup

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -31,3 +31,7 @@
 **Bloat:** Complex `DoubleSubject` and Missing Verb state checks spread out in `Assembler::finalize()` which were bypassed by certain verbs and nested phrases.
 **Cut:** Removed duplicate and misfiring checks in `finalize()`. Placed a single unified `DoubleSubject` check at the beginning of `classify_expression` in `src/semantic/conversion.rs`.
 **Saved:** Avoided messy verb classification bypassing and consolidated grammatical validation to where semantic structure is actually clear.
+## [Reduction]
+**Bloat:** Generic closure `F: FnOnce() -> Option<PathBuf>` and lazy `.or_else()` used in `Cache::with_dirs` merely for test dependency injection. This is a classic case of "Generic Soup" and over-engineering for simple fallback logic.
+**Cut:** Replaced the generic closure parameter with a concrete, eagerly evaluated `Option<PathBuf>` and used `.or()` instead of `.or_else()`.
+**Saved:** Reduced cognitive load and avoided unnecessary monomorphization/generic typing for a simple initialization method.

--- a/src/tools/cache.rs
+++ b/src/tools/cache.rs
@@ -60,16 +60,13 @@ impl Cache {
     /// let cache = Cache::new();
     /// ```
     pub fn new() -> Self {
-        Self::with_dirs(dirs_next::cache_dir(), dirs_next::home_dir)
+        Self::with_dirs(dirs_next::cache_dir(), dirs_next::home_dir())
     }
 
     /// Internal constructor that allows dependency injection for tests
-    pub(crate) fn with_dirs<F>(cache_dir: Option<PathBuf>, home_dir_fn: F) -> Self
-    where
-        F: FnOnce() -> Option<PathBuf>,
-    {
+    pub(crate) fn with_dirs(cache_dir: Option<PathBuf>, home_dir: Option<PathBuf>) -> Self {
         let base_dir = cache_dir
-            .or_else(home_dir_fn)
+            .or(home_dir)
             .unwrap_or_else(|| PathBuf::from("."))
             .join(".glossa")
             .join("cache");
@@ -221,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_cache_with_dirs_fallback() {
-        let cache = Cache::with_dirs(None, || None);
+        let cache = Cache::with_dirs(None, None);
         assert!(cache.base_dir.ends_with("cache"));
         assert_eq!(
             cache.base_dir,


### PR DESCRIPTION
🪒 **Razor: Strict Unslop Mode Initiated**

This PR targets the "Generic Soup" and speculative generality found in the `Cache` initialization logic inside `src/tools/cache.rs`.

**The Enterprise FizzBuzz:**
The `with_dirs` method used a generic closure `F: FnOnce() -> Option<PathBuf>` purely so it could lazily evaluate the home directory fallback, primarily for a single test's dependency injection. This added unnecessary cognitive load and type complexity for a trivial initialization.

**The Cut:**
- Replaced the generic `F` closure with a concrete, eagerly evaluated `Option<PathBuf>`.
- Replaced `.or_else(home_dir_fn)` with a simpler `.or(home_dir)`.
- Updated `Cache::new()` and `test_cache_with_dirs_fallback` to pass eager parameters instead of closures.

All tests and Clippy warnings have been verified and pass successfully.

Grandma Test: "We pass the home directory path directly instead of passing a function that returns the home directory path."

---
*PR created automatically by Jules for task [14251199315057660452](https://jules.google.com/task/14251199315057660452) started by @madmax983*