### PR TITLE
📜 Codex: ADR 020 & Architecture Diagram Update

### DIFF
--- a/docs/adr/020-enforce-double-subject.md
+++ b/docs/adr/020-enforce-double-subject.md
@@ -1,0 +1,29 @@
+# 20. Document early structural error checking
+
+Date: 2026-04-18
+Status: Proposed
+
+## Context
+
+The compiler was failing to report expected error messages described in the "Troubleshooting" guide of the documentation. Specifically:
+- `DoubleSubject` ("Διπλοῦν ὑποκείμενον"): `ὁ ἄνθρωπος ὁ θεὸς λέγει.` compiled silently instead of throwing an error.
+- `UndefinedName` ("Οὐκ οἶδα τὸ ὄνομα"): `ἄγνωστος λέγε.` compiled silently and defaulted to `0` instead of throwing an error.
+
+The root cause for the `DoubleSubject` issue was that the check was happening too late (inside `Assembler::finalize()`), where it could be bypassed by certain verb classifications (like `is_print_verb` or `is_binding_verb`) or completely missed if the assembler didn't flag it under specific operator conditions.
+For `UndefinedName`, there was a missing validation in the value extraction step for standalone noun fallbacks.
+
+These issues fall under the purview of bugfixes affecting core logic semantics.
+
+## Decision
+
+We propose that the semantic phase must handle early structural and reference error checking during the conversion phase rather than relying on delayed checks or fallback structures.
+- The `DoubleSubject` enforcement must be moved to the very beginning of the expression classification phase (`classify_expression` in `src/semantic/conversion.rs`) to ensure multiple nominatives are strictly caught early.
+- For `UndefinedName`, we propose adding explicit `extract_subject_fallback` checks during value extraction to verify that a noun acting as a subject (or object fallback) actually exists in the current scope, and throw an error immediately if absent.
+
+As Codex, I have created this ADR to formally record the architectural decision and updated the Mermaid map, but I will not directly alter the compiler logic, leaving the bug fix execution to a different persona or a future task to ensure adherence to scope boundaries.
+
+## Consequences
+
+- We now formally recognize `conversion.rs` as the correct layer for these structural error checks.
+- The `docs/architecture.md` map has been updated to clarify that `conversion` validates early error enforcements (DoubleSubject, Undefined).
+- This record serves as the architectural foundation for subsequent PRs that will implement these fixes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,7 @@ C4Component
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
         Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
+        %% Note: Conversion handles early Error Enforcement (DoubleSubject, Undefined)
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")
         Component(types, "Type System", "src/semantic/types.rs", "GlossaType definitions and utilities")
@@ -113,7 +114,7 @@ C4Component
     Rel(control_flow, expressions, "Analyzes conditions")
     Rel(control_flow, model, "Produces")
 
-    Rel(conversion, assembly, "Uses Assembler")
+    Rel(conversion, assembly, "Uses Assembler & Validates Structure")
     Rel(assembly, morphology, "Uses")
     Rel(assembly, expressions, "Feeds sub-expressions")
 


### PR DESCRIPTION
🧠 **Decision:** Recorded the proposal to enforce early semantic checking (DoubleSubject, UndefinedName) within `conversion.rs` rather than relying on delayed checks or fallback structures.
🗺️ **Visuals:** Updated C4 Component diagram to show new validation boundaries for the conversion module.
🔗 **Link:** See `docs/adr/020-enforce-double-subject.md`.

---
*PR created automatically by Jules for task [845401002899135354](https://jules.google.com/task/845401002899135354) started by @madmax983*