### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -60,3 +60,6 @@
 ## 2026-03-19 - The Missing Link in Tools
 **Confusion:** The `src/tools/` sub-modules like `runner.rs`, `papyrus.rs`, and `auditor.rs` lacked `//!` module-level documentation. This created "The Black Box" where complex modules were missing a high-level conceptual overview.
 **Clarification:** Added comprehensive `//!` documentation blocks to `src/tools/runner.rs`, `src/tools/papyrus.rs`, and `src/tools/auditor.rs`, explaining *what* they do and *how* they work. Also added executable doc tests to `analyze_source` and `load_source` to demonstrate usage.
+## 2026-03-20 - [The Assembler Documentation Duplication]
+**Confusion:** The documentation for the `Assembler` struct in `src/semantic/assembly.rs` was duplicated three times, causing a wall of text that was redundant and confusing.
+**Clarification:** I deleted the duplicated documentation blocks, leaving only one clean, descriptive rustdoc comment with its code example. This makes the generated HTML documentation much easier to read and maintain.

--- a/src/semantic/assembly.rs
+++ b/src/semantic/assembly.rs
@@ -453,28 +453,6 @@ struct StatementContext {
 /// let mut asm = Assembler::new();
 /// // Then feed analysis and finalise statement
 /// ```
-/// The Assembler orchestrates semantic construction.
-///
-/// It feeds AST elements and maps them to semantic roles (subjects, verbs, objects).
-///
-/// # Examples
-///
-/// ```rust
-/// use glossa::semantic::assembly::Assembler;
-/// let mut asm = Assembler::new();
-/// // Then feed analysis and finalise statement
-/// ```
-/// The Assembler orchestrates semantic construction.
-///
-/// It feeds AST elements and maps them to semantic roles (subjects, verbs, objects).
-///
-/// # Examples
-///
-/// ```rust
-/// use glossa::semantic::assembly::Assembler;
-/// let mut asm = Assembler::new();
-/// // Then feed analysis and finalise statement
-/// ```
 pub struct Assembler {
     state: AssembledStatement,
 }


### PR DESCRIPTION
📖 **Chapter:** The `Assembler` struct in `src/semantic/assembly.rs`
🔦 **Insight:** The documentation block for the `Assembler` struct was duplicated three times, creating a massive, redundant wall of text in the generated HTML docs. I have deleted the duplicated blocks, leaving a single, clean, cohesive rustdoc comment.
🧪 **Example:** The executable `use glossa::semantic::assembly::Assembler; let mut asm = Assembler::new();` doctest has been preserved in the single remaining block and verifies perfectly.
🖼️ **Preview:** (See clean `cargo doc` output for `glossa::semantic::assembly::Assembler`).

---
*PR created automatically by Jules for task [705922082587789732](https://jules.google.com/task/705922082587789732) started by @madmax983*