### PR TITLE
🗺️ Atlas: Tools Facade Pattern

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -140,3 +140,7 @@
 **[Enforcing Tool Encapsulation]
 **Tangle:** The `src/tools/` directory exposed internal helper modules (`report` and `ui`) as fully public (`pub mod`). This leaked implementation details and created a sprawling public API.
 **Blueprint:** Changed the visibility of `report` and `ui` to `pub(crate) mod` to enforce the facade pattern. Fixed a dead code warning on an unused function in `ui` that resulted from the visibility reduction.
+
+**[Tools Facade Refactoring]
+**Tangle:** The `src/tools/` directory exposed all of its internal submodules (`alchemist`, `weaver`, `runner`, etc.) publicly as `pub mod`. This leaked internal implementation details and forced external consumers (like `main.rs` and the `tests/` integration directory) to rely on deep nested paths (`glossa::tools::runner::run_file`), breaking encapsulation and increasing structural coupling.
+**Blueprint:** Converted all internal tool submodules in `src/tools/mod.rs` to `pub(crate) mod` to enforce a strict boundary. Applied the Facade Pattern by explicitly re-exporting only the necessary functions and structs via a flattened public API (`pub use ...`). Updated `main.rs` and all integration tests to consume the clean, top-level `glossa::tools::*` namespace. Note: Integration tests compile as external crates and cannot access `pub(crate)` or `#[cfg(test)]` items from the library, so internal functions needed for testing were explicitly exported behind the `#[cfg(feature = "nova")]` feature flag rather than using test-specific configuration.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,10 @@
 use clap::Parser;
 use miette::Result;
 
-use glossa::tools::cli::{Cli, Commands};
-use glossa::tools::dictionary::lookup_word;
-use glossa::tools::repl::run_repl;
-use glossa::tools::runner::{
-    bard_file, build_file, check_file, highlight_file, report_file, run_file,
-};
+use glossa::tools::lookup_word;
+use glossa::tools::run_repl;
+use glossa::tools::{Cli, Commands};
+use glossa::tools::{bard_file, build_file, check_file, highlight_file, report_file, run_file};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -28,7 +26,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Mentor) => {
             #[cfg(feature = "nova")]
-            glossa::tools::mentor::run_mentor()?;
+            glossa::tools::run_mentor()?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(
@@ -61,12 +59,12 @@ fn main() -> Result<()> {
         }
 
         Some(Commands::Test { input }) => {
-            glossa::tools::tester::run_tests(&input)?;
+            glossa::tools::run_tests(&input)?;
         }
 
         Some(Commands::Mosaic { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::mosaic::run_mosaic(&input)?;
+            glossa::tools::run_mosaic(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -79,7 +77,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Map { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::cartographer::run_map(&input)?;
+            glossa::tools::run_map(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -92,7 +90,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Labyrinth { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::labyrinth::run_labyrinth(&input)?;
+            glossa::tools::run_labyrinth(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -105,7 +103,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Weave { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::weave::run_weave(&input)?;
+            glossa::tools::run_weave(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -118,7 +116,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Alchemist { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::alchemist::run_alchemist(&input)?;
+            glossa::tools::run_alchemist(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -131,7 +129,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Papyrus { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::papyrus::run_papyrus(&input)?;
+            glossa::tools::run_papyrus(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -144,7 +142,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Audit { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::auditor::run_auditor(&input)?;
+            glossa::tools::run_auditor(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -157,7 +155,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Catalog) => {
             #[cfg(feature = "nova")]
-            glossa::tools::catalog::run_catalog()?;
+            glossa::tools::run_catalog()?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,38 +17,37 @@
 //! * `ui`: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
 
 #[cfg(feature = "nova")]
-pub mod alchemist;
+pub(crate) mod alchemist;
 /// The Auditor (Λογιστής) tool for static analysis.
 ///
 /// This experimental tool analyzes Glossa code to detect unused variables,
 /// unnecessary mutable bindings, and other code quality issues.
 #[cfg(feature = "nova")]
-pub mod auditor;
+pub(crate) mod auditor;
 pub(crate) mod cache;
-pub use cache::Cache;
 #[cfg(feature = "nova")]
-pub mod cartographer;
+pub(crate) mod cartographer;
 #[cfg(feature = "nova")]
-pub mod catalog;
-pub mod cli;
-pub mod dictionary;
-pub mod highlight;
+pub(crate) mod catalog;
+pub(crate) mod cli;
+pub(crate) mod dictionary;
+pub(crate) mod highlight;
 #[cfg(feature = "nova")]
-pub mod interpreter;
+pub(crate) mod interpreter;
 #[cfg(feature = "nova")]
-pub mod labyrinth;
+pub(crate) mod labyrinth;
 #[cfg(feature = "nova")]
-pub mod mentor;
+pub(crate) mod mentor;
 #[cfg(feature = "nova")]
-pub mod mosaic;
-pub mod narrator;
+pub(crate) mod mosaic;
+pub(crate) mod narrator;
 /// The Papyrus (Πάπυρος) tool for SQL schema generation.
 ///
 /// This experimental tool reads Glossa type definitions and automatically
 /// generates corresponding SQL `CREATE TABLE` statements.
 #[cfg(feature = "nova")]
-pub mod papyrus;
-pub mod repl;
+pub(crate) mod papyrus;
+pub(crate) mod repl;
 pub(crate) mod report;
 /// The engine room for executing and building Glossa programs
 ///
@@ -68,8 +67,47 @@ pub(crate) mod report;
 ///     eprintln!("Execution failed: {}", e);
 /// }
 /// ```
-pub mod runner;
-pub mod tester;
+pub(crate) mod runner;
+pub(crate) mod tester;
 pub(crate) mod ui;
 #[cfg(feature = "nova")]
-pub mod weave;
+pub(crate) mod weave;
+
+pub use cli::{Cli, Commands};
+pub use dictionary::lookup_word;
+pub use highlight::highlight;
+pub use narrator::tell_tale;
+pub use repl::run_repl;
+pub use runner::{bard_file, build_file, check_file, highlight_file, report_file, run_file};
+pub use tester::run_tests;
+
+#[cfg(feature = "nova")]
+pub use alchemist::{run_alchemist, transpile_to_python};
+#[cfg(feature = "nova")]
+pub use auditor::run_auditor;
+#[cfg(feature = "nova")]
+pub use cartographer::run_map;
+#[cfg(feature = "nova")]
+pub use catalog::run_catalog;
+#[cfg(feature = "nova")]
+pub use interpreter::{EvalError, Interpreter, Value};
+#[cfg(feature = "nova")]
+pub use labyrinth::run_labyrinth;
+#[cfg(feature = "nova")]
+pub use mentor::run_mentor;
+#[cfg(feature = "nova")]
+pub use mosaic::run_mosaic;
+#[cfg(feature = "nova")]
+pub use papyrus::run_papyrus;
+#[cfg(feature = "nova")]
+pub use weave::run_weave;
+
+// Export inner functions unconditionally but gated by nova so tests can see them
+#[cfg(feature = "nova")]
+pub use labyrinth::{generate_cfg, run_labyrinth_inner};
+#[cfg(feature = "nova")]
+pub use mosaic::run_mosaic_inner;
+#[cfg(feature = "nova")]
+pub use papyrus::glossa_type_to_sql;
+
+pub use cache::Cache;

--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -112,7 +112,7 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
     Ok(())
 }
 
-fn glossa_type_to_sql(g_type: &GlossaType) -> String {
+pub fn glossa_type_to_sql(g_type: &GlossaType) -> String {
     match g_type {
         GlossaType::Number => "BIGINT NOT NULL".to_string(),
         GlossaType::String => "TEXT NOT NULL".to_string(),

--- a/tests/alchemist_coverage.rs
+++ b/tests/alchemist_coverage.rs
@@ -5,7 +5,7 @@ use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::alchemist::{run_alchemist, transpile_to_python};
+use glossa::tools::{run_alchemist, transpile_to_python};
 use std::io::Write;
 use tempfile::Builder;
 

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -17,7 +17,7 @@ fn test_dos_dev_zero() {
         let path = Path::new("/dev/zero");
         // We expect run_file to fail either due to file size check (if fixed) or some other error.
         // If it hangs, it won't return.
-        let result = glossa::tools::runner::run_file(path);
+        let result = glossa::tools::run_file(path);
         // Send the result back
         // If run_file hangs, this line is never reached.
         let _ = tx.send(result);

--- a/tests/havoc_proptest_normalization.rs
+++ b/tests/havoc_proptest_normalization.rs
@@ -9,7 +9,7 @@ proptest! {
     }
 }
 
-use glossa::tools::highlight::highlight;
+use glossa::tools::highlight;
 
 proptest! {
     #[test]

--- a/tests/havoc_proptest_tools.rs
+++ b/tests/havoc_proptest_tools.rs
@@ -1,8 +1,8 @@
 #![allow(missing_docs)]
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
-use glossa::tools::highlight::highlight;
-use glossa::tools::narrator::tell_tale;
+use glossa::tools::highlight;
+use glossa::tools::tell_tale;
 use proptest::prelude::*;
 
 proptest! {

--- a/tests/havoc_transliteration.rs
+++ b/tests/havoc_transliteration.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/labyrinth_coverage.rs
+++ b/tests/labyrinth_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::labyrinth::{run_labyrinth, run_labyrinth_inner};
+use glossa::tools::{run_labyrinth, run_labyrinth_inner};
 
 #[test]
 fn test_run_labyrinth_comfy_table_output() {

--- a/tests/mosaic_coverage.rs
+++ b/tests/mosaic_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::mosaic::run_mosaic_inner;
+use glossa::tools::run_mosaic_inner;
 
 #[test]
 fn test_mosaic_comprehensive_coverage() {

--- a/tests/narrator_coverage.rs
+++ b/tests/narrator_coverage.rs
@@ -3,7 +3,7 @@ use glossa::parser::parse;
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, CaptureMode, GlossaType, analyze_program,
 };
-use glossa::tools::narrator::tell_tale;
+use glossa::tools::tell_tale;
 
 fn compile_and_tell(source: &str) -> String {
     let ast = parse(source).expect("AST build failed");

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 
 use std::io::Read;
 use std::io::Write;
@@ -18,7 +18,7 @@ fn test_run_weave_success() {
     let source = "«χαῖρε κόσμε» λέγε.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::weave::run_weave(temp_file.path());
+    let result = glossa::tools::run_weave(temp_file.path());
     assert!(result.is_ok(), "Weave failed: {:?}", result.err());
 
     let output_path = temp_file.path().with_extension("md");
@@ -49,14 +49,14 @@ fn test_run_papyrus_success() {
     let source = "εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. ἡλικία ἀριθμοῦ. }. ξ 5 ἔστω.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_ok(), "Papyrus failed: {:?}", result.err());
 }
 
 #[test]
 fn test_run_papyrus_file_not_found() {
     let path = PathBuf::from("non_existent_file.gl");
-    let result = glossa::tools::papyrus::run_papyrus(&path);
+    let result = glossa::tools::run_papyrus(&path);
     assert!(result.is_err());
     assert!(
         result
@@ -79,7 +79,7 @@ fn test_run_papyrus_file_too_large() {
         f.write_all(&data).unwrap();
     }
 
-    let result = glossa::tools::papyrus::run_papyrus(&input_path);
+    let result = glossa::tools::run_papyrus(&input_path);
     assert!(result.is_err());
     assert!(
         result
@@ -98,7 +98,7 @@ fn test_run_papyrus_syntax_error() {
 
     write!(temp_file, "invalid syntax").expect("Failed to write");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Parse error"));
 }
@@ -112,7 +112,7 @@ fn test_run_papyrus_semantic_error() {
 
     write!(temp_file, "ψ πέντε γίγνεται.").expect("Failed to write");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_err());
     let err_str = result.unwrap_err().to_string();
     assert!(

--- a/tests/sentry_tester_tests.rs
+++ b/tests/sentry_tester_tests.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 use std::fs;
 
 #[test]

--- a/tests/warden_limits.rs
+++ b/tests/warden_limits.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/warden_overflow_sim.rs
+++ b/tests/warden_overflow_sim.rs
@@ -4,7 +4,7 @@ use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::interpreter::Interpreter;
+use glossa::tools::Interpreter;
 
 #[test]
 fn test_warden_overflow_sim_defense() {


### PR DESCRIPTION
🕸️ Tangle: The `src/tools/` directory leaked its internal submodules (`alchemist`, `runner`, `tester`, etc.) directly via `pub mod`. This forced external consumers (`src/main.rs` and the `tests/` directory) to rely on deeply nested paths (e.g., `glossa::tools::runner::run_file`), breaking encapsulation and increasing structural coupling.
📐 Blueprint: Applied the Facade Pattern by converting all internal tool submodules in `src/tools/mod.rs` to `pub(crate) mod` to enforce a strict boundary. Explicitly re-exported only the necessary functions and structs via a flattened public API (`pub use ...`). Updated `main.rs` and all integration tests to consume the clean, top-level `glossa::tools::*` namespace. 
🧱 Stability: Reduced coupling and enforced clear module boundaries. Integration tests correctly access required internal items explicitly exported via the feature flag `nova`.
🔬 Verification: Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all` successfully.

---
*PR created automatically by Jules for task [7167794910372483910](https://jules.google.com/task/7167794910372483910) started by @madmax983*