### PR TITLE
🎨 Mosaic: UI Polish for Catalog Module

### DIFF
--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -6,6 +6,7 @@
 
 use crate::morphology::models::PartOfSpeech;
 use comfy_table::presets::UTF8_FULL;
+use crossterm::style::Stylize;
 use comfy_table::{Cell, Color, Table};
 use miette::Result;
 
@@ -26,6 +27,9 @@ pub fn run_catalog() -> Result<()> {
     let mut pos_keys: Vec<_> = entries_by_pos.keys().copied().collect();
     // Sort keys based on debug formatting since they don't implement Ord natively
     pos_keys.sort_by_key(|k| format!("{:?}", k));
+
+    println!("\n   {}", "Γ Λ Ω Σ Σ Α   C A T A L O G".cyan().bold());
+    println!("   {}\n", "The Lexicon Explorer".dim().italic());
 
     for pos in pos_keys {
         let mut table = Table::new();
@@ -48,7 +52,7 @@ pub fn run_catalog() -> Result<()> {
             ]);
         }
 
-        println!("\n=== {:?} ===", pos);
+        println!("\n  {}", format!("{:?} Lexicon", pos).yellow().bold());
         println!("{table}");
     }
 

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -6,8 +6,8 @@
 
 use crate::morphology::models::PartOfSpeech;
 use comfy_table::presets::UTF8_FULL;
-use crossterm::style::Stylize;
 use comfy_table::{Cell, Color, Table};
+use crossterm::style::Stylize;
 use miette::Result;
 
 /// Run the catalog explorer


### PR DESCRIPTION
🖌️ **Before:** The catalog command output raw `=== Verb ===` style headers and lacked a unified identity.
✨ **After:** The terminal output now features the standard cyan bold header structure (`Γ Λ Ω Σ Σ Α   C A T A L O G`) and stylized section headers for each lexicon type.
🖼️ **Visuals:** Follows the established "Z-Pattern" scanning layout to make lexicon categories pop.

---
*PR created automatically by Jules for task [10112033611644168336](https://jules.google.com/task/10112033611644168336) started by @madmax983*