### PR TITLE
📜 Codex: Enforce Facade Pattern ADR & Architecture Diagram Update

### DIFF
--- a/docs/adr/021-enforce-facade-pattern.md
+++ b/docs/adr/021-enforce-facade-pattern.md
@@ -1,0 +1,25 @@
+# 021. Enforce Facade Pattern in src/lib.rs
+
+Date: 2026-05-18
+
+## Status
+
+Accepted
+
+## Context
+
+The `glossa` crate previously exposed all its internal modules (`ast`, `codegen`, `limits`, `morphology`, `parser`, `semantic`, `text`) as fully public (`pub mod`). This leaked implementation details and created a sprawling public API, violating the principle of encapsulation and making it difficult for downstream users to know which functions to use.
+
+## Decision
+
+We have refactored `src/lib.rs` to change these internal modules to `pub(crate) mod` (or kept `pub mod` only where explicitly needed by the `glossa` binary or integration tests) and added explicit `pub use` statements for the true public API:
+- `ast::Program`
+- `codegen::generate_rust`
+- `parser::parse`
+- `semantic::{AnalyzedProgram, analyze_program}`
+
+## Consequences
+
+- **Encapsulation:** Creates a clean "Facade" that hides messy internal sub-modules.
+- **Usability:** Exposes only what the user needs, making the public API more intentional and easier to navigate.
+- **Coupling:** Reduces tight coupling between external consumers and the crate's internal module layout.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,3 +128,33 @@ C4Component
 
     Rel(model, types, "Uses")
 ```
+
+## Public API (Facade Pattern)
+
+To simplify external usage and encapsulate internal complexity, ΓΛΩΣΣΑ employs the Facade pattern at its root (`src/lib.rs`).
+
+```mermaid
+classDiagram
+    class Consumer {
+        <<External>>
+    }
+    class GlossaFacade {
+        +parse(source)
+        +analyze_program(ast)
+        +generate_rust(analyzed_program)
+    }
+    class Parser {
+        <<Internal>>
+    }
+    class Semantic {
+        <<Internal>>
+    }
+    class Codegen {
+        <<Internal>>
+    }
+
+    Consumer --> GlossaFacade : Uses
+    GlossaFacade --> Parser : Delegates to
+    GlossaFacade --> Semantic : Delegates to
+    GlossaFacade --> Codegen : Delegates to
+```

--- a/plan.md
+++ b/plan.md
@@ -1,44 +1,14 @@
-1. **Refactoring the God Function `generate_expr` in `src/codegen.rs`:**
-   - I will extract logic from `generate_expr` in `src/codegen.rs` without returning `Option` or using `unreachable!()`.
-   - I will use `replace_with_git_merge_diff` to restructure `generate_expr`. I will create smaller helper functions and route to them, but the main match block in `generate_expr` will remain exhaustive.
-   - Wait, `generate_expr` already delegates to `generate_literal_string`, `generate_literal_number`, `generate_collection_array`. The "God Object" issue is probably related to the inline logic for `Some`, `None`, `Ok`, `Err`, `Try`, `Unwrap`. I will extract these into `generate_expr_some`, `generate_expr_none`, `generate_expr_ok`, `generate_expr_err`, `generate_expr_try`, `generate_expr_unwrap` returning `TokenStream`, and call them directly from the arms of the `match` block in `generate_expr`.
-   - Let's look at `generate_statement`. It delegates everything already. `AnalyzedStatement::Binding { ... } => generate_statement_binding(...)`, etc.
-
-Wait, if `generate_expr` is already delegating to helpers for most cases, what exactly was I supposed to refactor?
-Ah! Let's examine `generate_expr` again.
-
-```rust
-        AnalyzedExprKind::Some(inner) => {
-            let inner_tokens = generate_expr(inner);
-            quote! { Some(#inner_tokens) }
-        }
-```
-
-This inline logic can be extracted to:
-```rust
-fn generate_expr_some(inner: &AnalyzedExpr) -> TokenStream {
-    let inner_tokens = generate_expr(inner);
-    quote! { Some(#inner_tokens) }
-}
-```
-
-And in `generate_expr`:
-```rust
-        AnalyzedExprKind::Some(inner) => generate_expr_some(inner),
-```
-
-This makes the `match` a pure router.
-
-Let's also extract `Ok`, `Err`, `Try`, `Unwrap`.
-
-2. **Verify Changes:**
-   - Run `git diff`.
-
-3. **Run Validations:**
-   - `cargo fmt`, `cargo test`, `cargo clippy`.
-
-4. **Pre-commit Steps:**
-   - Pre-commit checks.
-
-5. **Submit:**
-   - Submit the change.
+1. **Draft ADR `docs/adr/021-enforce-facade-pattern.md`**
+   - Title: Enforcing the Facade Pattern in src/lib.rs
+   - Status: Accepted
+   - Context: The `glossa` crate previously exposed all its internal modules (`ast`, `codegen`, `limits`, `morphology`, `parser`, `semantic`, `text`) as fully public (`pub mod`), leaking implementation details and creating a sprawling API.
+   - Decision: Refactored `src/lib.rs` to change these modules to `pub(crate) mod` and added explicit `pub use` statements for the true public API (`ast::Program`, `codegen::generate_rust`, `parser::parse`, `semantic::{AnalyzedProgram, analyze_program}`).
+   - Consequences: This creates a clean "Facade" that hides messy internal sub-modules while exposing only what the user needs.
+2. **Update `docs/architecture.md`**
+   - Add a new section `## Public API (Facade Pattern)` with a Mermaid Class Diagram illustrating the Facade pattern. The diagram should show the external consumer accessing only the Facade (`glossa::lib`), which then delegates to the internal, hidden submodules (`parser`, `semantic`, `codegen`, `ast`).
+   - Add `Catalog` to `docs/architecture.md` if it isn't there already (wait, it's already in the C4 container diagram as "Container(catalog, ...)").
+3. **Run Pre-Commit Checks**
+   - Call `pre_commit_instructions` tool to run verification.
+4. **Submit**
+   - Title: "📜 Codex: Enforce Facade Pattern ADR & Architecture Diagram Update"
+   - Description formatted as required by Codex.


### PR DESCRIPTION
🧠 **Decision:** Recorded the move to enforce the Facade pattern in `src/lib.rs` to encapsulate internal modules.
🗺️ **Visuals:** Added a Mermaid Class Diagram illustrating the Facade boundary.
🔗 **Link:** See `docs/adr/021-enforce-facade-pattern.md`.

---
*PR created automatically by Jules for task [2195407964262108800](https://jules.google.com/task/2195407964262108800) started by @madmax983*