### PR TITLE
🪒 Razor: Replace single-use structs with tuples

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -36,3 +36,8 @@
 **Bloat:** Generic closure `F: FnOnce() -> Option<PathBuf>` and deferred evaluation (`.or_else`) in `Cache::with_dirs`.
 **Cut:** Replaced generic with eager `Option<PathBuf>` parameter and used direct `Option::or`.
 **Saved:** 5 lines of code, simplified API signature.
+
+## [Reduction]
+**Bloat:** Single-use data-holding structs `TestResult` in `src/tools/tester.rs` and `TraitMethodParts` in `src/codegen.rs` that provided no additional encapsulation or behavior over simple groupings of data.
+**Cut:** Replaced these structs with native Rust tuples: `(String, TestStatus)` and `(Ident, Vec<TokenStream>, Option<TokenStream>)` respectively.
+**Saved:** Over 15 lines of struct definitions and named-field instantiation boilerplate, eliminating unnecessary abstractions in favor of idiomatic structural types.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -732,13 +732,9 @@ fn generate_struct_def(name: &str, fields: &[(smol_str::SmolStr, GlossaType)]) -
     }
 }
 
-struct TraitMethodParts {
-    name: Ident,
-    params: Vec<TokenStream>,
-    return_type: Option<TokenStream>,
-}
-
-fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
+fn generate_trait_method_parts(
+    method: &AnalyzedMethod,
+) -> (Ident, Vec<TokenStream>, Option<TokenStream>) {
     let method_name = sanitize_ident(&method.name);
 
     let param_tokens = method
@@ -757,11 +753,7 @@ fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
 
     let ret_tokens = method.return_type.as_ref().map(generate_type_tokens);
 
-    TraitMethodParts {
-        name: method_name,
-        params: param_tokens.collect(),
-        return_type: ret_tokens,
-    }
+    (method_name, param_tokens.collect(), ret_tokens)
 }
 
 fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
@@ -777,11 +769,9 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
 
     // Generate method signatures
     let method_tokens = methods.iter().map(|method| {
-        let parts = generate_trait_method_parts(method);
-        let method_name = parts.name;
-        let param_tokens = parts.params;
+        let (method_name, param_tokens, return_type) = generate_trait_method_parts(method);
 
-        if let Some(ret_ty) = parts.return_type {
+        if let Some(ret_ty) = return_type {
             if let Some(body) = &method.body {
                 let body_stmts = generate_statements(body);
                 quote! {
@@ -840,9 +830,7 @@ fn generate_trait_impl(
 
     // Generate method implementations
     let method_tokens = methods.iter().map(|method| {
-        let parts = generate_trait_method_parts(method);
-        let method_name = parts.name;
-        let param_tokens = parts.params;
+        let (method_name, param_tokens, return_type) = generate_trait_method_parts(method);
 
         // Generate method body
         let body_stmts: Vec<TokenStream> = if let Some(body) = &method.body {
@@ -851,7 +839,7 @@ fn generate_trait_impl(
             Vec::new()
         };
 
-        if let Some(ret_ty) = parts.return_type {
+        if let Some(ret_ty) = return_type {
             quote! {
                 fn #method_name(#(#param_tokens),*) -> #ret_ty {
                     #(#body_stmts)*
@@ -1615,20 +1603,20 @@ mod tests {
                 return_type: Some(GlossaType::Boolean),
             };
 
-            let parts = generate_trait_method_parts(&method);
+            let (name, params, return_type) = generate_trait_method_parts(&method);
 
-            assert_eq!(parts.name.to_string(), "g_test_method");
+            assert_eq!(name.to_string(), "g_test_method");
 
             // Check params
-            let params_str: Vec<String> = parts.params.iter().map(|t| t.to_string()).collect();
+            let params_str: Vec<String> = params.iter().map(|t| t.to_string()).collect();
             assert_eq!(params_str.len(), 2);
             assert_eq!(params_str[0], "& self");
             assert!(params_str[1].contains("g_arg1"));
             assert!(params_str[1].contains("i64"));
 
             // Check return type
-            assert!(parts.return_type.is_some());
-            assert_eq!(parts.return_type.unwrap().to_string(), "bool");
+            assert!(return_type.is_some());
+            assert_eq!(return_type.unwrap().to_string(), "bool");
         }
 
         #[test]

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -57,13 +57,7 @@ enum TestStatus {
     Ignored,
 }
 
-#[derive(Debug)]
-struct TestResult {
-    name: String,
-    status: TestStatus,
-}
-
-fn parse_test_output(output: &str) -> Vec<TestResult> {
+fn parse_test_output(output: &str) -> Vec<(String, TestStatus)> {
     let mut results = Vec::new();
     for line in output.lines() {
         // Standard rustc test output line format: "test test_name ... status"
@@ -84,10 +78,7 @@ fn parse_test_output(output: &str) -> Vec<TestResult> {
                     "ignored" => TestStatus::Ignored,
                     _ => continue,
                 };
-                results.push(TestResult {
-                    name: name.to_string(),
-                    status,
-                });
+                results.push((name.to_string(), status));
             }
         }
     }
@@ -246,7 +237,11 @@ fn execute_test_binary(exe_path: &Path, status: &mut Status) -> Result<std::proc
     Ok(test_output)
 }
 
-fn print_test_results(results: &[TestResult], test_output: &std::process::Output, stdout: &str) {
+fn print_test_results(
+    results: &[(String, TestStatus)],
+    test_output: &std::process::Output,
+    stdout: &str,
+) {
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
     println!("   {}", "Unit Test Results".italic().dim());
@@ -283,8 +278,8 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
             Cell::new("Status").add_attribute(Attribute::Bold),
         ]);
 
-        for result in results {
-            let status_cell = match result.status {
+        for (name, status) in results {
+            let status_cell = match status {
                 TestStatus::Ok => Cell::new("PASSED").fg(Color::Green),
                 TestStatus::Failed => Cell::new("FAILED")
                     .fg(Color::Red)
@@ -294,7 +289,7 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
 
             // Clean up test name (remove module prefix if any)
             // e.g., "tests::test_name" -> "test_name"
-            let display_name = result.name.split("::").last().unwrap_or(&result.name);
+            let display_name = name.split("::").last().unwrap_or(name);
 
             table.add_row(vec![Cell::new(display_name), status_cell]);
         }
@@ -490,10 +485,10 @@ test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 ";
         let results = parse_test_output(output);
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].name, "test_one");
-        assert_eq!(results[0].status, TestStatus::Ok);
-        assert_eq!(results[1].name, "test_two");
-        assert_eq!(results[1].status, TestStatus::Ok);
+        assert_eq!(results[0].0, "test_one");
+        assert_eq!(results[0].1, TestStatus::Ok);
+        assert_eq!(results[1].0, "test_two");
+        assert_eq!(results[1].1, TestStatus::Ok);
     }
 
     #[test]
@@ -517,10 +512,10 @@ test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
 ";
         let results = parse_test_output(output);
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].name, "test_one");
-        assert_eq!(results[0].status, TestStatus::Failed);
-        assert_eq!(results[1].name, "test_two");
-        assert_eq!(results[1].status, TestStatus::Ok);
+        assert_eq!(results[0].0, "test_one");
+        assert_eq!(results[0].1, TestStatus::Failed);
+        assert_eq!(results[1].0, "test_two");
+        assert_eq!(results[1].1, TestStatus::Ok);
     }
 
     #[test]
@@ -533,8 +528,8 @@ test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; fini
 ";
         let results = parse_test_output(output);
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].name, "test_ignore");
-        assert_eq!(results[0].status, TestStatus::Ignored);
+        assert_eq!(results[0].0, "test_ignore");
+        assert_eq!(results[0].1, TestStatus::Ignored);
     }
 
     #[test]


### PR DESCRIPTION
🪒 Razor: Replace single-use structs with tuples

Replaced `TestResult` in `src/tools/tester.rs` and `TraitMethodParts` in `src/codegen.rs` with native Rust tuples, flattening unnecessary data-holding abstractions. Updated `.jules/razor.md` journal.

---
*PR created automatically by Jules for task [4923232081853526666](https://jules.google.com/task/4923232081853526666) started by @madmax983*