### PR TITLE
📜 Codex: Assembly ADR 021 & Architecture Diagram Update

### DIFF
--- a/docs/adr/021-split-assembly-module.md
+++ b/docs/adr/021-split-assembly-module.md
@@ -1,0 +1,24 @@
+# 021. Split Assembly Module
+
+Date: 2026-04-21
+
+## Status
+
+Proposed
+
+## Context
+
+The `src/semantic/assembly.rs` file was a monolithic module mixing Data Transfer Objects (DTOs) like `AssembledStatement` and `Constituent` with complex semantic assembly logic (`Assembler`). This mixed responsibility made the file difficult to navigate, test, and maintain as the compiler's semantic phase grew in complexity.
+
+## Decision
+
+We split the monolithic `assembly.rs` file into a dedicated module directory `src/semantic/assembly/`.
+The DTOs were extracted into `src/semantic/assembly/model.rs`, while the core assembly logic was moved to `src/semantic/assembly/mod.rs`.
+Dependent modules were updated to import from `crate::semantic::assembly`.
+
+## Consequences
+
+- Improved separation of concerns between data and logic.
+- Reduced file sizes, making the code easier to read and maintain.
+- Simpler testing structure for assembly components.
+- Existing imports had to be updated across internal tests and modules to reflect the new structure.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,7 @@ C4Component
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
         Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
+        Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")
@@ -115,7 +116,9 @@ C4Component
     Rel(control_flow, expressions, "Analyzes conditions")
     Rel(control_flow, model, "Produces")
 
-    Rel(conversion, assembly, "Uses Assembler")
+    Rel(conversion, assembly, "Uses")
+    Rel(conversion, assembly_model, "Consumes")
+    Rel(assembly, assembly_model, "Produces")
     Rel(assembly, morphology, "Uses")
     Rel(assembly, expressions, "Feeds sub-expressions")
 


### PR DESCRIPTION
🧠 **Decision:** Recorded the split of the monolithic src/semantic/assembly.rs file into logic (mod.rs) and DTOs (model.rs).
🗺️ **Visuals:** Updated C4 Component diagram for Semantic Analysis to include the new Assembly Model component.
🔗 **Link:** See docs/adr/021-split-assembly-module.md.

---
*PR created automatically by Jules for task [4302635192382880634](https://jules.google.com/task/4302635192382880634) started by @madmax983*