### PR TITLE
🗣️ Echo: Fix missing semantic error messages causing silent failures and ICE

### DIFF
--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -712,7 +712,12 @@ impl Assembler {
         {
             return Ok(());
         }
-        if ctx.is_match_arm {
+        if ctx.is_match_arm
+            && self.state.object.is_none()
+            && self.state.nominatives.is_empty()
+            && self.state.adjectives.is_empty()
+            && self.state.subject.is_some()
+        {
             return Ok(());
         }
         Err(AssemblyError::MissingVerb)

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -648,10 +648,7 @@ impl Assembler {
                 is_multiple_nominatives: !self.state.nominatives.is_empty(),
                 is_array: !self.state.arrays.is_empty(),
                 has_delimiter: self.state.has_delimiter_preposition,
-                is_match_arm: !self.state.adjectives.is_empty()
-                    || (self.state.subject.is_some()
-                        && self.state.object.is_none()
-                        && self.state.literals.is_empty()),
+                is_match_arm: !self.state.adjectives.is_empty(),
             };
             self.check_missing_verb(&ctx)?;
         }
@@ -662,7 +659,6 @@ impl Assembler {
             if !self.state.nominatives.is_empty()
                 && self.state.operators.is_empty()
                 && !crate::morphology::lexicon::is_binding_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_print_verb(&verb.lemma)
                 && !crate::morphology::lexicon::is_find_verb(&verb.lemma)
             {
                 return Err(AssemblyError::DoubleSubject);
@@ -716,15 +712,7 @@ impl Assembler {
         {
             return Ok(());
         }
-        if ctx.is_match_arm
-            && self.state.object.is_none()
-            && self.state.nominatives.is_empty()
-            && self.state.adjectives.is_empty()
-            && let Some(subject) = self.state.subject.as_ref()
-        {
-            if subject.lemma == "ανθρωπος" {
-                return Err(AssemblyError::MissingVerb);
-            }
+        if ctx.is_match_arm {
             return Ok(());
         }
         Err(AssemblyError::MissingVerb)

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -954,25 +954,42 @@ fn try_print_default(
     let mut args =
         build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 
-    if let Some(ref subj) = asm_stmt.subject
-        && let Some(var_type) = scope.lookup(&subj.lemma)
-    {
-        args.insert(
-            0,
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: var_type.clone(),
-            },
-        );
+    if let Some(ref subj) = asm_stmt.subject {
+        if let Some(var_type) = scope.lookup(&subj.lemma) {
+            args.insert(
+                0,
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                    glossa_type: var_type.clone(),
+                },
+            );
+        } else if scope.is_defined(&subj.lemma) {
+            args.insert(
+                0,
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                    glossa_type: GlossaType::Unknown,
+                },
+            );
+        } else if !crate::morphology::lexicon::is_find_verb(subj.lemma.as_str()) {
+            return Err(GlossaError::undefined(subj.lemma.as_str()));
+        }
     }
 
-    if let Some(ref obj) = asm_stmt.object
-        && let Some(var_type) = scope.lookup(&obj.lemma)
-    {
-        args.push(AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-            glossa_type: var_type.clone(),
-        });
+    if let Some(ref obj) = asm_stmt.object {
+        if let Some(var_type) = scope.lookup(&obj.lemma) {
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+                glossa_type: var_type.clone(),
+            });
+        } else if scope.is_defined(&obj.lemma) {
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+                glossa_type: GlossaType::Unknown,
+            });
+        } else if !crate::morphology::lexicon::is_find_verb(obj.lemma.as_str()) {
+            return Err(GlossaError::undefined(obj.lemma.as_str()));
+        }
     }
 
     Ok(args)
@@ -1158,11 +1175,17 @@ fn classify_expression(
     // Fallback: If no literals/ops, check Subject/Object
     if exprs.is_empty() {
         if let Some(ref subj) = asm_stmt.subject {
+            if !scope.is_defined(&subj.lemma) && !crate::morphology::lexicon::is_find_verb(subj.lemma.as_str()) {
+                return Err(GlossaError::undefined(subj.lemma.as_str()));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
             });
         } else if let Some(ref obj) = asm_stmt.object {
+            if !scope.is_defined(&obj.lemma) && !crate::morphology::lexicon::is_find_verb(obj.lemma.as_str()) {
+                return Err(GlossaError::undefined(obj.lemma.as_str()));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,

--- a/tests/havoc_issue_echo.rs
+++ b/tests/havoc_issue_echo.rs
@@ -3,6 +3,7 @@ use glossa::parser::parse;
 use glossa::semantic::analyze_program;
 
 #[test]
+#[should_panic(expected = "DoubleSubject")]
 fn test_double_subject_should_pass_havoc_constraint() {
     let source = "ὁ ἄνθρωπος ὁ θεὸς λέγει.";
     let ast = parse(source).unwrap();
@@ -12,23 +13,11 @@ fn test_double_subject_should_pass_havoc_constraint() {
 }
 
 #[test]
+#[should_panic(expected = "UndefinedName")]
 fn test_undefined_variable_evaluates_to_zero_silently() {
     let source = "ἄγνωστος λέγε."; // 'unknown say' -> undefined variable
     let ast = parse(source).unwrap();
-    let prog = analyze_program(&ast).unwrap();
-
-    // The previous implementation was completely ignoring undefined variables and producing an empty print.
-    // Let's assert it generates an empty print instead of crashing.
-    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0]
-        && expressions.is_empty()
-    {
-        // It silently became empty/zero!
-        return;
-    }
-    panic!(
-        "Did not evaluate to empty/zero silently! It got {:?}",
-        prog.statements[0]
-    );
+    let _ = analyze_program(&ast).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
🤦 **The Confusion:**
Users reading the `README.md` tried testing out the advertised Ancient Greek error messages like "Οὐκ οἶδα τὸ ὄνομα" (Undefined variable), "Διπλοῦν ὑποκείμενον" (Double Subject), and "Ῥῆμα οὐχ εὑρέθη" (Missing verb), but they either compiled cleanly with zero errors or crashed the compiler.

🕵️ **The Reality:**
- **Double Subject** was specifically ignoring print verbs, bypassing the error state for sentences like `ὁ ἄνθρωπος ὁ θεὸς λέγει.`.
- **Undefined Variable** was failing to properly throw the `UndefinedName` error, instead silently falling back to treating undefined nouns as `Unknown` typed expressions.
- **Missing Verb** checks inside the statement assembler were incorrectly classifying any standalone nominative noun as a `is_match_arm` condition. Because of a hard-coded check, this bypassed `AssemblyError::MissingVerb`, causing the compiler to continue with invalid verbless expressions, crashing during `codegen` with an Internal Compiler Error.

💡 **The Fix:**
- Removed the print verb bypass from the `DoubleSubject` check in `src/semantic/assembly/mod.rs`.
- Updated `try_print_default` and `classify_expression` in `src/semantic/conversion.rs` to verify identifiers using `scope.is_defined(name)`. If missing and not a 'find' verb, an `UndefinedName` error is correctly propagated.
- Corrected the `is_match_arm` boolean flag condition in `Assembler::finalize()` so that a standalone subject expression properly fails with `AssemblyError::MissingVerb` and doesn't reach codegen.
- Fixed constraints in `havoc_issue_echo.rs` tests to specifically assert that the correct panics (`DoubleSubject`, `UndefinedName`, and `MissingVerb`) are thrown.

---
*PR created automatically by Jules for task [11607343615951508393](https://jules.google.com/task/11607343615951508393) started by @madmax983*