### PR TITLE
⚡ Bolt: [performance improvement] Cell::new formatting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,6 @@
 **[Optimizing Scholar Docs Generator String Formats]
 **Learning:** Found an unnecessary intermediate heap allocation and `Vec` creation in `src/tools/scholar.rs` resulting from `.map(|t| format!("{}", t)).collect::<Vec<_>>().join(", ")`, alongside many intermediate `format!()` strings being pushed to the buffer.
 **Action:** Replaced `md.push_str(&format!(...))` and `.collect::<Vec<_>>().join(...)` with direct `std::fmt::Write` macro usage (`write!`, `writeln!`) directly into a pre-allocated `String::with_capacity(4096)` buffer.
+**[Removing unnecessary format! for integers]
+**Learning:** Cell::new takes T: ToString. Using format!("{}", num) creates an unnecessary String allocation and formatting overhead compared to passing the integer directly which uses fast itoa conversion.
+**Action:** Pass integers directly to Cell::new instead of formatting them first.

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -100,7 +100,7 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
                 }
                 Err(e) => {
                     table.add_row(vec![
-                        Cell::new(format!("{}", i + 1)),
+                        Cell::new(i + 1),
                         Cell::new(format!("Error: {}", e)).fg(Color::Red),
                         Cell::new(""),
                         Cell::new(""),
@@ -119,7 +119,7 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
                 _ => "Unknown",
             };
             table.add_row(vec![
-                Cell::new(format!("{}", i + 1)),
+                Cell::new(i + 1),
                 Cell::new(type_name)
                     .fg(Color::Blue)
                     .add_attribute(Attribute::Italic),
@@ -359,7 +359,7 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
     let other_column = format_other_column(asm);
 
     table.add_row(vec![
-        Cell::new(format!("{}", line)),
+        Cell::new(line),
         Cell::new(full_subject),
         Cell::new(verb),
         Cell::new(object),


### PR DESCRIPTION
💡 What: Replaced `Cell::new(format!("{}", i))` with `Cell::new(i)` in `src/tools/mosaic.rs`.
🎯 Why: `Cell::new` from `comfy_table` accepts any `T: ToString`. Wrapping an integer in `format!` creates an unnecessary `String` allocation and formatting overhead before the conversion. Passing the integer directly uses the fast `itoa` implementation under the hood.
📊 Impact: Reduces intermediate string allocations and improves tight loop formatting performance for line numbers when generating the syntax assembly table in the mosaic tool.
🔬 Measurement: Verified with `cargo clippy` and `cargo test mosaic`. Added journal learning entry to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [5568286429065464726](https://jules.google.com/task/5568286429065464726) started by @madmax983*