### PR TITLE
🎻 Bard: Fix missing assembly documentation and intra-doc links

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -63,3 +63,6 @@
 ## 2026-03-20 - [The Assembler Documentation Duplication]
 **Confusion:** The documentation for the `Assembler` struct in `src/semantic/assembly.rs` was duplicated three times, causing a wall of text that was redundant and confusing.
 **Clarification:** I deleted the duplicated documentation blocks, leaving only one clean, descriptive rustdoc comment with its code example. This makes the generated HTML documentation much easier to read and maintain.
+## 2026-03-21 - [Missing Documentation Warnings]
+**Confusion:** Building documentation with `RUSTDOCFLAGS="-W missing_docs" cargo doc` threw warnings for `src/semantic/assembly/mod.rs` regarding the `model` module, and the compiler output warnings for missing intra-doc links.
+**Clarification:** Added module-level documentation `//!` to `src/semantic/assembly/model.rs` and moved the struct documentation for `Assembler` immediately above its definition. Resolved intra-doc links by ensuring they reference paths accessible in scope (e.g. `[`crate::semantic::assembly::Assembler`]`).

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -148,9 +148,14 @@ struct StatementContext {
     has_delimiter: bool,
     is_match_arm: bool,
 }
-/// The Assembler orchestrates semantic construction.
+pub mod model;
+pub use model::*;
+
+/// The `Assembler` orchestrates semantic construction.
 ///
-/// It feeds AST elements and maps them to semantic roles (subjects, verbs, objects).
+/// It acts as a state machine that collects morphologically analyzed tokens
+/// and routes them into the correct semantic "slots" (Subject, Verb, Object)
+/// based on their grammatical case, enabling free word order parsing.
 ///
 /// # Examples
 ///
@@ -159,9 +164,6 @@ struct StatementContext {
 /// let mut asm = Assembler::new();
 /// // Then feed analysis and finalise statement
 /// ```
-pub mod model;
-pub use model::*;
-
 pub struct Assembler {
     state: AssembledStatement,
 }

--- a/src/semantic/assembly/model.rs
+++ b/src/semantic/assembly/model.rs
@@ -1,3 +1,9 @@
+//! Data models representing the intermediate state of an assembled sentence.
+//!
+//! The `model` module defines the structural components (like `AssembledStatement`
+//! and `Constituent`) that the `Assembler` populates as it routes words into
+//! grammatical slots based on their morphological case.
+
 use crate::ast::Expr;
 use crate::morphology::lexicon::BinaryOp;
 use crate::morphology::{Case, Gender, Mood, Number, Person, Tense, Voice};
@@ -120,7 +126,7 @@ pub enum Literal {
 /// In the grammatical world of ΓΛΩΣΣΑ, a `Constituent` is the physical manifestation of a noun,
 /// pronoun, or adjective acting as a primary sentence component (e.g., Subject, Object).
 /// It bridges the raw morphological analysis ([`crate::morphology::models::MorphAnalysis`])
-/// with the structural needs of the [`Assembler`].
+/// with the structural needs of the [`crate::semantic::assembly::Assembler`].
 ///
 /// # Why it exists
 /// The parser gives us isolated words, but to build a sentence, we need to know *what* each word is doing.


### PR DESCRIPTION
📖 Chapter: The `assembly` and `model` modules in the semantic analyzer.
🔦 Insight: The `Assembler` struct's documentation was mistakenly attached to a `pub mod model;` declaration, causing `cargo doc` warnings and generating a confusing HTML layout. The `model.rs` file was completely undocumented as a module.
🧪 Example: Reordered module declarations, added full `//!` documentation, and resolved intra-doc links.
🖼️ Preview: (Ran `cargo doc --no-deps` and confirmed zero warnings with `RUSTDOCFLAGS="-W missing_docs"`).

---
*PR created automatically by Jules for task [12002771302210109880](https://jules.google.com/task/12002771302210109880) started by @madmax983*