### PR TITLE
🪒 Razor: [Essentialism] Refactor parse_test_output string manipulation

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -36,3 +36,7 @@
 **Bloat:** Generic closure `F: FnOnce() -> Option<PathBuf>` and deferred evaluation (`.or_else`) in `Cache::with_dirs`.
 **Cut:** Replaced generic with eager `Option<PathBuf>` parameter and used direct `Option::or`.
 **Saved:** 5 lines of code, simplified API signature.
+## [Reduction]
+**Bloat:** Manual string slicing and hardcoded offset arithmetic (`line[5..idx]`, `idx < 5`) in `parse_test_output` in `src/tools/tester.rs` which increased cognitive load and was fragile.
+**Cut:** Replaced `starts_with("test ")` and manual slice arithmetic with idiomatic `line.strip_prefix("test ")`. This removed the need for the `idx < 5` bounds check because the prefix is already stripped before calling `rfind`.
+**Saved:** Removed 3 lines of complex bounds checking and simplified string extraction, replacing brittle indexing with safe, idiomatic Rust.

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -67,17 +67,14 @@ fn parse_test_output(output: &str) -> Vec<TestResult> {
     let mut results = Vec::new();
     for line in output.lines() {
         // Standard rustc test output line format: "test test_name ... status"
-        if line.starts_with("test ") {
-            #[allow(clippy::collapsible_if)]
-            if let Some(idx) = line.rfind(" ... ") {
-                if idx < 5 {
-                    continue;
-                }
-                let name = line[5..idx].trim();
+        #[allow(clippy::collapsible_if)]
+        if let Some(rest) = line.strip_prefix("test ") {
+            if let Some(idx) = rest.rfind(" ... ") {
+                let name = rest[..idx].trim();
                 if name.is_empty() {
                     continue;
                 }
-                let status_str = &line[idx + 5..];
+                let status_str = &rest[idx + 5..];
                 let status = match status_str {
                     "ok" => TestStatus::Ok,
                     "FAILED" => TestStatus::Failed,


### PR DESCRIPTION
🪒 **Razor:** Removed brittle string slice manipulation in the test parser.

**Bloat:** Manual string slicing and hardcoded offset arithmetic (`line[5..idx]`, `idx < 5`) in `parse_test_output` in `src/tools/tester.rs` which increased cognitive load and was fragile.
**Cut:** Replaced `starts_with("test ")` and manual slice arithmetic with idiomatic `line.strip_prefix("test ")`. This removed the need for the `idx < 5` bounds check because the prefix is already stripped before calling `rfind`.
**Saved:** Removed 3 lines of complex bounds checking and simplified string extraction, replacing brittle indexing with safe, idiomatic Rust.

---
*PR created automatically by Jules for task [6332892088953178415](https://jules.google.com/task/6332892088953178415) started by @madmax983*