### PR TITLE
⚡ Bolt: avoid vec intermediate allocation in interpreter

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,6 @@
 **[Removing unnecessary format! for integers]
 **Learning:** Cell::new takes T: ToString. Using format!("{}", num) creates an unnecessary String allocation and formatting overhead compared to passing the integer directly which uses fast itoa conversion.
 **Action:** Pass integers directly to Cell::new instead of formatting them first.
+**Optimization of string join patterns**
+**Learning:** Removing intermediate heap allocations for string concatenations using string formatting in a pre-allocated `String` with `write!` eliminates memory overhead when formatting output strings. However, `[T]::join` on array slice already allocates a single `String` directly and avoiding it doesn't help. We should only avoid `.collect::<Vec<_>>().join(" ")`.
+**Action:** Replace `format!(..., parts.join(" "))` with a `String::with_capacity` buffer and `write!` macro directly, avoiding intermediate `Vec` allocations.

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -215,11 +215,15 @@ impl Interpreter {
                 self.assign_var(name, val)?;
             }
             AnalyzedStatement::Print(exprs) => {
-                let mut parts = Vec::new();
-                for expr in exprs {
-                    parts.push(self.eval_expr(expr)?.to_string());
+                use std::fmt::Write;
+                // ⚡ Bolt Optimization: Removed intermediate `.collect::<Vec<_>>()` allocation and `.join(" ")`.
+                let mut line = String::with_capacity(exprs.len() * 16);
+                for (i, expr) in exprs.iter().enumerate() {
+                    if i > 0 {
+                        line.push(' ');
+                    }
+                    let _ = write!(&mut line, "{}", self.eval_expr(expr)?);
                 }
-                let line = parts.join(" ");
                 println!("{}", line);
                 self.output.push(line);
             }

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -609,3 +609,47 @@ mod tests {
         ));
     }
 }
+
+#[cfg(test)]
+mod extra_tests {
+    use super::*;
+    use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType};
+
+    #[test]
+    fn test_interpreter_print_multiple() {
+        let mut interpreter = Interpreter::new();
+        let program = AnalyzedProgram {
+            statements: vec![AnalyzedStatement::Print(vec![
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::NumberLiteral(1),
+                    glossa_type: GlossaType::Number,
+                },
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::NumberLiteral(2),
+                    glossa_type: GlossaType::Number,
+                },
+            ])],
+            scope: crate::semantic::Scope::new(),
+        };
+
+        interpreter.run(&program).unwrap();
+        assert_eq!(interpreter.get_output(), "1 2");
+    }
+
+    #[test]
+    fn test_interpreter_print_single() {
+        let mut interpreter = Interpreter::new();
+        let program = AnalyzedProgram {
+            statements: vec![AnalyzedStatement::Print(vec![
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::NumberLiteral(1),
+                    glossa_type: GlossaType::Number,
+                },
+            ])],
+            scope: crate::semantic::Scope::new(),
+        };
+
+        interpreter.run(&program).unwrap();
+        assert_eq!(interpreter.get_output(), "1");
+    }
+}

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -613,7 +613,9 @@ mod tests {
 #[cfg(test)]
 mod extra_tests {
     use super::*;
-    use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType};
+    use crate::semantic::{
+        AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType,
+    };
 
     #[test]
     fn test_interpreter_print_multiple() {
@@ -640,12 +642,10 @@ mod extra_tests {
     fn test_interpreter_print_single() {
         let mut interpreter = Interpreter::new();
         let program = AnalyzedProgram {
-            statements: vec![AnalyzedStatement::Print(vec![
-                AnalyzedExpr {
-                    expr: AnalyzedExprKind::NumberLiteral(1),
-                    glossa_type: GlossaType::Number,
-                },
-            ])],
+            statements: vec![AnalyzedStatement::Print(vec![AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(1),
+                glossa_type: GlossaType::Number,
+            }])],
             scope: crate::semantic::Scope::new(),
         };
 


### PR DESCRIPTION
💡 What: Formatted printing of statements in the interpreter directly to a pre-allocated string buffer `String::with_capacity(..)` with `write!` instead of utilizing `parts.join(" ")` backed by a `Vec<String>`.
🎯 Why: Avoiding an intermediate collection step and vector allocations for output formatting reduces heap allocations and copying on print paths.
📊 Impact: Removes the need for allocating a temporary vector and the intermediary strings for `.to_string()`. Reduces memory allocations per printed expression row.
🔬 Measurement: Run `cargo run -- repl` and issue a sequence of variable assignments followed by prints to verify functionality. Check the memory profile to observe lowered allocations.

---
*PR created automatically by Jules for task [4326294036990517779](https://jules.google.com/task/4326294036990517779) started by @madmax983*