### PR TITLE
🪒 Razor: Replace single-use struct in tester.rs with tuple

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -40,3 +40,8 @@
 **Bloat:** Undefined variables silently decaying into literal `0` integers deep within semantic parsing (`extract_value`), and critical sentence structure checks (`MissingVerb`) being ignored or throwing silent raw Rust codegen errors.
 **Cut:** Removed silent variable decay defaults. Flattened statement validation into `check_undefined_variables` where scoping and AST context are available, actively preventing undefined names. Placed explicit MissingVerb catching inside `Assembler::finalize`.
 **Saved:** Multiple paths that historically led to compiler crashes / malformed semantic models. Unified missing-verb catching, and prevented dozens of lines of unneeded checks later down in the codegen toolchain.
+
+## [Reduction]
+**Bloat:** The `TestResult` struct in `src/tools/tester.rs` was a single-use data structure used only within the tester module to pair a `String` name and a `TestStatus` enum. This added unnecessary encapsulation boilerplate without providing any additional behavior.
+**Cut:** Replaced the `TestResult` struct with a direct `(String, TestStatus)` tuple.
+**Saved:** Eliminated a redundant struct definition and simplified result instantiation and access across the tester tool, enforcing KISS.

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -57,13 +57,7 @@ enum TestStatus {
     Ignored,
 }
 
-#[derive(Debug)]
-struct TestResult {
-    name: String,
-    status: TestStatus,
-}
-
-fn parse_test_output(output: &str) -> Vec<TestResult> {
+fn parse_test_output(output: &str) -> Vec<(String, TestStatus)> {
     let mut results = Vec::new();
     for line in output.lines() {
         // Standard rustc test output line format: "test test_name ... status"
@@ -84,10 +78,7 @@ fn parse_test_output(output: &str) -> Vec<TestResult> {
                     "ignored" => TestStatus::Ignored,
                     _ => continue,
                 };
-                results.push(TestResult {
-                    name: name.to_string(),
-                    status,
-                });
+                results.push((name.to_string(), status));
             }
         }
     }
@@ -178,7 +169,7 @@ fn extract_failures(output: &str) -> Vec<(String, String)> {
 /// it compiles it with `rustc --test`. This creates a test harness that runs all functions
 /// marked with `#[test]` (which `codegen` generates for `TestDeclaration` nodes).
 fn compile_test_harness(temp_path: &Path, exe_path: &Path, status: Status) -> Result<Status> {
-    let rustc_cmd = std::env::var("GLOSSA_RUSTC_CMD").unwrap_or_else(|_| "rustc".to_string());
+    let rustc_cmd = std::env::var("GLOSSA_RUSTC_CMD").unwrap_or("rustc".to_string());
 
     let rustc_output = Command::new(rustc_cmd)
         .arg("--test")
@@ -246,7 +237,7 @@ fn execute_test_binary(exe_path: &Path, status: &mut Status) -> Result<std::proc
     Ok(test_output)
 }
 
-fn print_test_results(results: &[TestResult], test_output: &std::process::Output, stdout: &str) {
+fn print_test_results(results: &[(String, TestStatus)], test_output: &std::process::Output, stdout: &str) {
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
     println!("   {}", "Unit Test Results".italic().dim());
@@ -284,7 +275,7 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         ]);
 
         for result in results {
-            let status_cell = match result.status {
+            let status_cell = match result.1 {
                 TestStatus::Ok => Cell::new("PASSED").fg(Color::Green),
                 TestStatus::Failed => Cell::new("FAILED")
                     .fg(Color::Red)
@@ -294,7 +285,7 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
 
             // Clean up test name (remove module prefix if any)
             // e.g., "tests::test_name" -> "test_name"
-            let display_name = result.name.split("::").last().unwrap_or(&result.name);
+            let display_name = result.0.split("::").last().unwrap_or(&result.0);
 
             table.add_row(vec![Cell::new(display_name), status_cell]);
         }
@@ -408,14 +399,16 @@ pub fn run_tests(input: &Path) -> Result<()> {
     // 4. Determine output path for the test binary
     let exe_name = temp_path
         .file_stem()
-        .ok_or_else(|| miette::miette!("Σφάλμα: Could not extract file stem from temp path"))?
+        .ok_or(miette::miette!(
+            "Σφάλμα: Could not extract file stem from temp path"
+        ))?
         .to_string_lossy()
         .into_owned();
     let exe_path = temp_path
         .parent()
-        .ok_or_else(|| {
-            miette::miette!("Σφάλμα: Could not extract parent directory from temp path")
-        })?
+        .ok_or(miette::miette!(
+            "Σφάλμα: Could not extract parent directory from temp path"
+        ))?
         .join(if cfg!(windows) {
             format!("{}.exe", exe_name)
         } else {
@@ -490,10 +483,10 @@ test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 ";
         let results = parse_test_output(output);
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].name, "test_one");
-        assert_eq!(results[0].status, TestStatus::Ok);
-        assert_eq!(results[1].name, "test_two");
-        assert_eq!(results[1].status, TestStatus::Ok);
+        assert_eq!(results[0].0, "test_one");
+        assert_eq!(results[0].1, TestStatus::Ok);
+        assert_eq!(results[1].0, "test_two");
+        assert_eq!(results[1].1, TestStatus::Ok);
     }
 
     #[test]
@@ -517,10 +510,10 @@ test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; 
 ";
         let results = parse_test_output(output);
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].name, "test_one");
-        assert_eq!(results[0].status, TestStatus::Failed);
-        assert_eq!(results[1].name, "test_two");
-        assert_eq!(results[1].status, TestStatus::Ok);
+        assert_eq!(results[0].0, "test_one");
+        assert_eq!(results[0].1, TestStatus::Failed);
+        assert_eq!(results[1].0, "test_two");
+        assert_eq!(results[1].1, TestStatus::Ok);
     }
 
     #[test]
@@ -533,8 +526,8 @@ test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; fini
 ";
         let results = parse_test_output(output);
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].name, "test_ignore");
-        assert_eq!(results[0].status, TestStatus::Ignored);
+        assert_eq!(results[0].0, "test_ignore");
+        assert_eq!(results[0].1, TestStatus::Ignored);
     }
 
     #[test]

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -237,7 +237,11 @@ fn execute_test_binary(exe_path: &Path, status: &mut Status) -> Result<std::proc
     Ok(test_output)
 }
 
-fn print_test_results(results: &[(String, TestStatus)], test_output: &std::process::Output, stdout: &str) {
+fn print_test_results(
+    results: &[(String, TestStatus)],
+    test_output: &std::process::Output,
+    stdout: &str,
+) {
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
     println!("   {}", "Unit Test Results".italic().dim());


### PR DESCRIPTION
Replaced single-use `TestResult` struct with `(String, TestStatus)` tuple. Enforces KISS principle by removing unnecessary boilerplate.

---
*PR created automatically by Jules for task [4541705807163999323](https://jules.google.com/task/4541705807163999323) started by @madmax983*