### PR TITLE
⚡ Bolt: Replace HashMap with FxHashMap in tools/catalog.rs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,7 @@
 **Optimization of string join patterns**
 **Learning:** Removing intermediate heap allocations for string concatenations using string formatting in a pre-allocated `String` with `write!` eliminates memory overhead when formatting output strings. However, `[T]::join` on array slice already allocates a single `String` directly and avoiding it doesn't help. We should only avoid `.collect::<Vec<_>>().join(" ")`.
 **Action:** Replace `format!(..., parts.join(" "))` with a `String::with_capacity` buffer and `write!` macro directly, avoiding intermediate `Vec` allocations.
+
+**[HashMap to FxHashMap in tools/catalog.rs]**
+**Learning:** `std::collections::HashMap` introduces unnecessary hashing overhead for internal keys (`PartOfSpeech` enum variants). Switching to `rustc_hash::FxHashMap` is a safe, zero-cost optimization since the map is entirely internal and does not process unvalidated string inputs that could be vulnerable to HashDoS.
+**Action:** Replaced `std::collections::HashMap` with `rustc_hash::FxHashMap` in `src/tools/catalog.rs` for `entries_by_pos`.

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -12,10 +12,12 @@ use miette::Result;
 
 /// Run the catalog explorer
 pub fn run_catalog() -> Result<()> {
-    let mut entries_by_pos: std::collections::HashMap<
+    // ⚡ Bolt Optimization: Uses `rustc_hash::FxHashMap` instead of the standard `HashMap`
+    // since the keys are internal `PartOfSpeech` enums and are not exposed to HashDoS attacks.
+    let mut entries_by_pos: rustc_hash::FxHashMap<
         PartOfSpeech,
         Vec<(&str, &crate::morphology::lexicon::LexiconEntry)>,
-    > = std::collections::HashMap::new();
+    > = rustc_hash::FxHashMap::default();
 
     for (word, entry) in crate::morphology::lexicon::entries() {
         entries_by_pos


### PR DESCRIPTION
💡 What: Replaced `std::collections::HashMap` with `rustc_hash::FxHashMap` for mapping lexicon entries by `PartOfSpeech`.
🎯 Why: `PartOfSpeech` keys are an internal enum. They are not exposed to user-provided strings and cannot cause HashDoS. The default standard library `HashMap`'s SipHash algorithm adds unnecessary cryptographic hashing overhead that we do not need for internal grouping logic.
📊 Impact: Eliminates expensive SipHash calculations when cataloging the Lexicon, marginally speeding up the catalog explorer tool generation. Reduces zero-cost abstractions overhead.
🔬 Measurement: Run `cargo test tools::catalog::tests` or execute `cargo run catalog`.

---
*PR created automatically by Jules for task [16674418726525140129](https://jules.google.com/task/16674418726525140129) started by @madmax983*