### PR TITLE
🛡️ Sentry: Test codegen runtime expect panics for checked operations

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,3 +1,13 @@
-1. **Fix cargo fmt:** The CI failed on `cargo fmt --all -- --check`. I will run `cargo fmt --all` to format the code properly.
-2. **Fix coverage:** The CI failed on `codecov/patch`. I need to ensure the new lines of code I added have proper test coverage. The changes I made in `src/tools/auditor.rs` (formatting logic) need a test case to cover the new header printing logic, or at least run the auditor test successfully so it covers those lines. I will add a test in `src/tools/auditor.rs` (or see if one already exists that I can trigger or run properly).
-3. **Submit:** Submit the changes again.
+1. We need to add tests for the generated `.expect(...)` panics from `generate_checked_op` when used with BinaryOps (e.g., Add, Sub, Mul, Div, Mod).
+2. The `tests/sentry_codegen_perf.rs` currently tests:
+   - `test_codegen_runtime_unwrap_panic` (for `.expect("attempted to unwrap an empty value")`)
+   - `test_codegen_runtime_large_index_panic` (for `.expect("index out of bounds: too large")`)
+   - `test_codegen_runtime_index_panic` (for unchecked `[idx]`)
+   - `test_codegen_runtime_neg_panic` (for `.expect("arithmetic overflow")` in `generate_unary_op`)
+   - `test_codegen_runtime_negative_index_panic` (for `panic!("index out of bounds: negative index {}")`)
+3. However, there are no runtime integration tests that cover `generate_checked_op` specifically triggered by binary operations.
+4. Add `test_codegen_runtime_add_overflow_panic` to `tests/sentry_codegen_perf.rs` to compile a program with `i64::MAX + 1` (or equivalent via `AnalyzedExpr`) and assert it panics with "arithmetic overflow" at runtime.
+5. Add `test_codegen_runtime_div_by_zero_panic` to `tests/sentry_codegen_perf.rs` to compile a program with `1 / 0` and assert it panics with "arithmetic overflow" or similar (Wait, div by zero produces "division by zero" via `checked_div`).
+6. I will add `test_codegen_runtime_add_overflow_panic` and `test_codegen_runtime_div_by_zero_panic` to `tests/sentry_codegen_perf.rs`.
+7. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
+8. Submit the change.

--- a/tests/sentry_codegen_perf.rs
+++ b/tests/sentry_codegen_perf.rs
@@ -363,3 +363,129 @@ fn test_codegen_runtime_negative_index_panic() {
         stderr
     );
 }
+
+#[test]
+fn test_codegen_runtime_add_overflow_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let rs_path = dir.path().join("test_add_overflow.rs");
+
+    use glossa::morphology::BinaryOp;
+
+    let left_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(i64::MAX),
+        glossa_type: GlossaType::Number,
+    };
+
+    let right_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(1),
+        glossa_type: GlossaType::Number,
+    };
+
+    let add_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::BinOp {
+            op: BinaryOp::Add,
+            left: Box::new(left_expr),
+            right: Box::new(right_expr),
+        },
+        glossa_type: GlossaType::Number,
+    };
+
+    let stmt = AnalyzedStatement::Expression(vec![add_expr]);
+    let program = AnalyzedProgram {
+        statements: vec![stmt],
+        scope: Scope::new(),
+    };
+
+    let code = generate_rust_file(&program);
+    fs::write(&rs_path, code).unwrap();
+
+    let exe_path = dir.path().join("test_add_overflow");
+    let rustc_status = Command::new("rustc")
+        .arg(&rs_path)
+        .arg("-o")
+        .arg(&exe_path)
+        .status()
+        .expect("Failed to execute rustc");
+
+    assert!(
+        rustc_status.success(),
+        "Generated Rust code failed to compile"
+    );
+
+    let output = Command::new(&exe_path)
+        .output()
+        .expect("Failed to run executable");
+
+    assert!(!output.status.success(), "Executable should have panicked");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("arithmetic overflow")
+            || String::from_utf8_lossy(&output.stdout).contains("Arithmetic overflow")
+            || stderr.contains("Ὑπερχείλισις ἀριθμοῦ"),
+        "Missing panic message: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_codegen_runtime_div_by_zero_panic() {
+    let dir = tempfile::tempdir().unwrap();
+    let rs_path = dir.path().join("test_div_by_zero.rs");
+
+    use glossa::morphology::BinaryOp;
+
+    let left_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(1),
+        glossa_type: GlossaType::Number,
+    };
+
+    let right_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(0),
+        glossa_type: GlossaType::Number,
+    };
+
+    let div_expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::BinOp {
+            op: BinaryOp::Div,
+            left: Box::new(left_expr),
+            right: Box::new(right_expr),
+        },
+        glossa_type: GlossaType::Number,
+    };
+
+    let stmt = AnalyzedStatement::Expression(vec![div_expr]);
+    let program = AnalyzedProgram {
+        statements: vec![stmt],
+        scope: Scope::new(),
+    };
+
+    let code = generate_rust_file(&program);
+    fs::write(&rs_path, code).unwrap();
+
+    let exe_path = dir.path().join("test_div_by_zero");
+    let rustc_status = Command::new("rustc")
+        .arg(&rs_path)
+        .arg("-o")
+        .arg(&exe_path)
+        .status()
+        .expect("Failed to execute rustc");
+
+    assert!(
+        rustc_status.success(),
+        "Generated Rust code failed to compile"
+    );
+
+    let output = Command::new(&exe_path)
+        .output()
+        .expect("Failed to run executable");
+
+    assert!(!output.status.success(), "Executable should have panicked");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Division by zero")
+            || String::from_utf8_lossy(&output.stdout).contains("Division by zero")
+            || stderr.contains("Διαίρεσις διὰ τοῦ μηδενός"),
+        "Missing panic message: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: src/codegen.rs generate_checked_op
💣 Risk: Code generated for binary operations outputs .expect() calls which could potentially panic if arithmetic overflow or division by zero occurs, but these branches were not previously verified with runtime integration tests.
🧪 Strategy: Added tests `test_codegen_runtime_add_overflow_panic` and `test_codegen_runtime_div_by_zero_panic` in `tests/sentry_codegen_perf.rs` to compile actual code mimicking extreme values and ensure it triggers the expected message dynamically.
🔬 Verification: Run `cargo test --test sentry_codegen_perf`

---
*PR created automatically by Jules for task [16550013766122719538](https://jules.google.com/task/16550013766122719538) started by @madmax983*