### PR TITLE
⚒️ Forge: Refactor tester.rs extract_failures god function

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -13,3 +13,7 @@
 **[Auditor Visitor God Functions]**
 **Learning:** The `visit_statement` and `visit_expr` functions in `src/tools/auditor.rs` became "God Functions" containing massive `match` blocks.
 **Action:** Extract complex `match` arms for `If`, `While`, `For`, `Match`, and repetitive logic into private helper functions like `visit_if_statement` and `visit_exprs` to flatten nesting and clarify the match block routing.
+
+**[Tester God Function Refactor]**
+**Learning:** `extract_failures` in `src/tools/tester.rs` was a deeply nested function spanning ~75 lines to parse compiler output, hiding multiple concerns (skipping sections, parsing names, capturing multi-line messages, cleaning panic noise).
+**Action:** Extract logic into dedicated helpers (`parse_failure_name`, `capture_failure_message`, `clean_panic_message`) using early returns/guard clauses. This flattens the loop from 4-level deep nesting into a simple orchestrator.

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -112,64 +112,84 @@ fn extract_failures(output: &str) -> Vec<(String, String)> {
 
     // Scan for "---- <name> stdout ----"
     while let Some(line) = lines.next() {
-        if line.trim().starts_with("----") && line.trim().ends_with("stdout ----") {
-            // Extract name: "---- test_name stdout ----"
-            let trimmed = line.trim();
-            let name_part = trimmed
-                .trim_start_matches("---- ")
-                .trim_end_matches(" stdout ----");
-            // Remove module path if present for cleaner display
-            let name = name_part
-                .split("::")
-                .last()
-                .unwrap_or(name_part)
-                .to_string();
+        let Some(name) = parse_failure_name(line) else {
+            continue;
+        };
 
-            // Capture output until next "----" or empty line followed by "failures:"
-            let mut message = String::new();
-            while let Some(current) = lines.peek() {
-                if current.trim().starts_with("----") && current.trim().ends_with("stdout ----") {
-                    // Start of next failure
-                    break;
-                }
-                if current.trim() == "failures:" {
-                    // End of details section
-                    break;
-                }
-
-                // Hide internal Rust thread information and temp file paths
-                if current.starts_with("thread '")
-                    && current.contains("panicked at")
-                    && let Some(panicked_idx) = current.find("panicked at")
-                {
-                    let mut clean_panic = format!("{}panicked", &current[..panicked_idx]);
-                    // Remove the "(pid)" thread id
-                    if let Some(idx1) = clean_panic.find(" (")
-                        && let Some(idx2) = clean_panic[idx1..].find(") ")
-                    {
-                        clean_panic.replace_range(idx1..idx1 + idx2 + 2, " ");
-                    }
-                    message.push_str(&clean_panic);
-                    message.push('\n');
-                    lines.next();
-                    continue;
-                }
-
-                // Hide backtrace hint
-                if current.starts_with("note: run with `RUST_BACKTRACE=1`") {
-                    lines.next();
-                    continue;
-                }
-
-                message.push_str(current);
-                message.push('\n');
-                lines.next();
-            }
-            failures.push((name, message.trim().to_string()));
-        }
+        let message = capture_failure_message(&mut lines);
+        failures.push((name, message));
     }
 
     failures
+}
+
+fn parse_failure_name(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with("----") || !trimmed.ends_with("stdout ----") {
+        return None;
+    }
+
+    let name_part = trimmed
+        .trim_start_matches("---- ")
+        .trim_end_matches(" stdout ----");
+
+    // Remove module path if present for cleaner display
+    Some(
+        name_part
+            .split("::")
+            .last()
+            .unwrap_or(name_part)
+            .to_string(),
+    )
+}
+
+fn capture_failure_message(lines: &mut std::iter::Peekable<std::str::Lines>) -> String {
+    let mut message = String::new();
+    while let Some(current) = lines.peek() {
+        let trimmed = current.trim();
+        if (trimmed.starts_with("----") && trimmed.ends_with("stdout ----"))
+            || trimmed == "failures:"
+        {
+            break;
+        }
+
+        // Hide backtrace hint
+        if current.starts_with("note: run with `RUST_BACKTRACE=1`") {
+            lines.next();
+            continue;
+        }
+
+        if let Some(clean_panic) = clean_panic_message(current) {
+            message.push_str(&clean_panic);
+            message.push('\n');
+            lines.next();
+            continue;
+        }
+
+        message.push_str(current);
+        message.push('\n');
+        lines.next();
+    }
+    message.trim().to_string()
+}
+
+fn clean_panic_message(current: &str) -> Option<String> {
+    if !current.starts_with("thread '") {
+        return None;
+    }
+
+    let panicked_idx = current.find("panicked at")?;
+    let mut clean_panic = format!("{}panicked", &current[..panicked_idx]);
+
+    // Remove the "(pid)" thread id
+    #[allow(clippy::collapsible_if)]
+    if let Some(idx1) = clean_panic.find(" (") {
+        if let Some(idx2) = clean_panic[idx1..].find(") ") {
+            clean_panic.replace_range(idx1..idx1 + idx2 + 2, " ");
+        }
+    }
+
+    Some(clean_panic)
 }
 
 /// Run tests defined in a Glossa file


### PR DESCRIPTION
🚮 Smell: The `extract_failures` function in `src/tools/tester.rs` was a deeply nested "God block" of loops and boolean `if` branches designed to parse complex, multi-line `rustc --test` text output. It hid the business logic of filtering outputs, hiding backtrace hints, and cleaning panic messages.
✨ Solution: I extracted the internal logic of the text-parsing `match` arms into strictly-typed `parse_failure_name`, `capture_failure_message`, and `clean_panic_message` private helper functions. I used guard clauses (`let Some(...) = ... else { return }`) and early `continue` statements to dramatically flatten the tree. Also, added a journal learning to `.jules/forge.md` about God-functions handling CLI output formatting.
🧼 Benefit: Reduced cognitive load by replacing 4-level deep loops with simple orchestrator logic. Improved readability and isolated the logic responsible for hiding internal `rustc` thread messages.
🛡️ Verification: `cargo test` passes seamlessly. No semantic or parsing behavior was changed—it is strictly a visual refactor. `clippy` is warning-free.

---
*PR created automatically by Jules for task [6900513356027017172](https://jules.google.com/task/6900513356027017172) started by @madmax983*