### PR TITLE
👺 Havoc: AST Drop Stack Overflow Vulnerability

### DIFF
--- a/tests/havoc_nested_drop.rs
+++ b/tests/havoc_nested_drop.rs
@@ -1,0 +1,25 @@
+use proptest::prelude::*;
+use glossa::semantic::*;
+
+proptest! {
+    // We don't want a ton of runs because it crashes the test runner completely.
+    // Proptest is used here to prove we found a generic structural vulnerability.
+    #![proptest_config(ProptestConfig::with_cases(1))]
+    #[test]
+    fn test_ast_drop_stack_overflow(_ in ".*") {
+        let mut expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::BooleanLiteral(true),
+            glossa_type: GlossaType::Boolean,
+        };
+
+        // Nest deeply enough to blow the stack when the compiler automatically derives Drop
+        for _ in 0..100000 {
+            expr = AnalyzedExpr {
+                expr: AnalyzedExprKind::Some(Box::new(expr)),
+                glossa_type: GlossaType::Boolean,
+            };
+        }
+
+        // Explicitly letting it drop at the end of the scope
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Deeply nested AST node structures (e.g. `AnalyzedExprKind::Some(Box::new(AnalyzedExprKind::Some(...)))`) exhaust the call stack when the compiler automatically derives and executes the recursive `Drop` trait at the end of a scope.

📉 **The Stack Trace:**
```
thread 'test_ast_drop_stack_overflow' (17039) has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `--test havoc_nested_drop`
Caused by:
  process didn't exit successfully: `/app/target/debug/deps/havoc_nested_drop-6c840e631d4a78bc` (signal: 6, SIGABRT: process abort signal)
```

🧪 **Reproduction:** Run `cargo test --test havoc_nested_drop`.

😈 **Comment:** You assumed the AST would never grow deeper than the stack frame during deallocation. You were wrong. Attempting to manually implement `Drop` broke pattern-matching move semantics everywhere. Arena allocation might save you, but until then, your abstractions are lethal.

---
*PR created automatically by Jules for task [14983070858605876981](https://jules.google.com/task/14983070858605876981) started by @madmax983*