### PR TITLE
🛡️ Sentry: 100% semantic patterns coverage

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -84,3 +84,7 @@
 **[Quote Token Spacing in Codegen Tests]**
 **Learning:** When asserting on stringified token streams produced by `quote!` in `src/codegen.rs` unit tests (like `test_generate_collection_index_bounds_check`), `quote!` automatically inserts spaces between certain tokens (e.g., `expect ("...")` instead of `expect("...")`). String containment assertions will fail if they don't account for this spacing.
 **Action:** Always print or inspect the `.to_string()` output of a `TokenStream` when writing exact string containment assertions to avoid brittle test failures caused by macro formatting.
+
+**[Semantic Patterns Coverage]**
+**Learning:** In `src/semantic/patterns.rs`, the logic for parsing unsupported argument types in struct instantiations (`parse_struct_args`), processing `find` without a predicate (`process_find`), and falling back to unstripped suffix matches during genitive comparisons (`extract_comparison_value`) were missing test coverage. Furthermore, when writing tests targeting `process_find` with no predicate, the code actually transforms it to `.find(|_| true)` instead of `.next()`, so asserting against `"next"` causes a test failure.
+**Action:** When adding missing edge case coverage, carefully review the inner implementations before constructing the test assertions to match the actual, generated `AnalyzedExpr` nodes instead of assuming idealized shortcuts. Also ensure the setup correctly puts the mock values into the `Scope` using the correct key mapping.

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -1056,6 +1056,62 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_comparison_value_stripped_suffix_es() {
+        let mut scope = Scope::new();
+        scope.define("αγαπ", GlossaType::Number);
+
+        let mut stmt = AssembledStatement::default();
+        stmt.genitives.push(Constituent {
+            lemma: "dummy".into(),
+            original: "αγαπης".into(),
+            normalized: "αγαπης".into(),
+            case: crate::morphology::Case::Genitive,
+            number: None,
+            gender: None,
+            person: None,
+        });
+
+        let expr = extract_comparison_value(&stmt, &scope);
+        if let AnalyzedExprKind::Variable(name) = expr.expr {
+            assert_eq!(
+                name, "αγαπ",
+                "Expected stripped name 'αγαπ', got '{}'",
+                name
+            );
+        } else {
+            panic!("Expected variable");
+        }
+    }
+
+    #[test]
+    fn test_extract_comparison_value_stripped_suffix_on() {
+        let mut scope = Scope::new();
+        scope.define("μετρ", GlossaType::Number);
+
+        let mut stmt = AssembledStatement::default();
+        stmt.genitives.push(Constituent {
+            lemma: "dummy".into(),
+            original: "μετρων".into(),
+            normalized: "μετρων".into(),
+            case: crate::morphology::Case::Genitive,
+            number: None,
+            gender: None,
+            person: None,
+        });
+
+        let expr = extract_comparison_value(&stmt, &scope);
+        if let AnalyzedExprKind::Variable(name) = expr.expr {
+            assert_eq!(
+                name, "μετρ",
+                "Expected stripped name 'μετρ', got '{}'",
+                name
+            );
+        } else {
+            panic!("Expected variable");
+        }
+    }
+
+    #[test]
     fn test_extract_comparison_value_stripped() {
         let mut scope = Scope::new();
         scope.define("θ", GlossaType::Number);
@@ -1135,6 +1191,28 @@ mod tests {
         } else {
             panic!("Expected variable");
         }
+    }
+
+
+    #[test]
+    fn test_try_parse_struct_instantiation_empty_terms() {
+        let mut scope = Scope::new();
+        let stmt = crate::ast::Statement::Regular {
+            clauses: vec![crate::ast::Clause {
+                expressions: vec![crate::ast::Expr::Phrase(vec![
+                    crate::ast::Expr::Word(crate::ast::Word::new("var")),
+                    crate::ast::Expr::Word(crate::ast::Word::new("νεον")),
+                    crate::ast::Expr::Word(crate::ast::Word::new("Type")),
+                    crate::ast::Expr::NumberLiteral(5),
+                ])],
+            }],
+            is_query: false,
+            is_propagate: false,
+        };
+
+        let result = try_parse_struct_instantiation(&stmt, &mut scope);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
     }
 
     #[test]
@@ -1390,23 +1468,37 @@ mod coverage_tests {
     }
 
     #[test]
-    fn test_try_parse_struct_instantiation_empty_terms() {
-        let mut scope = Scope::new();
-        let stmt = crate::ast::Statement::Regular {
-            clauses: vec![crate::ast::Clause {
-                expressions: vec![crate::ast::Expr::Phrase(vec![
-                    crate::ast::Expr::Word(crate::ast::Word::new("var")),
-                    crate::ast::Expr::Word(crate::ast::Word::new("νεον")),
-                    crate::ast::Expr::Word(crate::ast::Word::new("Type")),
-                    crate::ast::Expr::NumberLiteral(5),
-                ])],
-            }],
-            is_query: false,
-            is_propagate: false,
+    fn test_parse_struct_args_unsupported_type() {
+        let scope = Scope::new();
+        let fields = vec![("x".into(), GlossaType::Number)];
+
+        // Pass an unsupported expression type (e.g., a phrase)
+        let terms = vec![crate::ast::Expr::Phrase(vec![])];
+
+        let result = parse_struct_args(&terms, &fields, &scope);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_process_find_no_predicate_coverage() {
+        let scope = Scope::new();
+        let asm_stmt = AssembledStatement::default();
+        let mut current_expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(1),
+            glossa_type: GlossaType::Number,
         };
 
-        let result = try_parse_struct_instantiation(&stmt, &mut scope);
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        // No operators -> found_predicate = false
+        process_find(&asm_stmt, &scope, &mut current_expr);
+
+        // Expected to be a MethodCall to "next" with no args
+        if let AnalyzedExprKind::MethodCall { method, args, .. } = current_expr.expr {
+            assert_eq!(method, "find");
+            assert_eq!(args.len(), 1);
+        } else {
+            panic!("Expected MethodCall 'find'");
+        }
     }
+
+
 }

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -1193,7 +1193,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn test_try_parse_struct_instantiation_empty_terms() {
         let mut scope = Scope::new();
@@ -1499,6 +1498,4 @@ mod coverage_tests {
             panic!("Expected MethodCall 'find'");
         }
     }
-
-
 }


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]
🎯 Target: `src/semantic/patterns.rs` (`process_find`, `parse_struct_args`, and `extract_comparison_value` suffix stripping fallback).
💣 Risk: Edge cases around unsupported inputs to semantic pattern detection logic and unhandled default variable resolution.
🧪 Strategy: Added specific unit tests under `tests` mapping to isolated logic inside `patterns.rs` using `cargo llvm-cov`. 
🔬 Verification: `cargo llvm-cov --no-report | grep "patterns.rs"` yields 100% test coverage.

---
*PR created automatically by Jules for task [11891441524376883869](https://jules.google.com/task/11891441524376883869) started by @madmax983*