### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update for Scholar

### DIFF
--- a/docs/adr/022-scholar-api-doc-generator.md
+++ b/docs/adr/022-scholar-api-doc-generator.md
@@ -1,0 +1,21 @@
+# 022. The Scholar (ὁ Σχολαστικός) - API Doc Generator
+
+Date: 2026-04-26
+
+## Status
+
+Proposed
+
+## Context
+
+We needed a way to generate API documentation from Glossa code, similar to `rustdoc`, but tailored to Glossa's linguistic structures. Users need to be able to understand the types, traits, and functions exposed by a program without having to read the source code manually.
+
+## Decision
+
+We implemented `src/tools/scholar.rs` as a new tool to parse the semantic model and output Markdown files documenting the APIs of the provided `.γλ` file. It iterates over the types, traits, and functions in the program's scope and generates a structured `.doc.md` file.
+
+## Consequences
+
+- Provides native documentation capabilities, improving the developer experience.
+- Developers can easily share API references for their Glossa code.
+- Requires maintaining another tool within the Nova boundary, increasing the complexity of the compiler's developer tools suite.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,7 @@ C4Container
         Container(repl, "REPL", "src/tools/repl.rs", "Interactive Read-Eval-Print Loop")
         Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
+        Container(scholar, "The Scholar", "src/tools/scholar.rs", "API Doc Generator")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
         Container(weave, "Weave", "src/tools/weave.rs", "Rosetta Stone Markdown Exporter")
@@ -73,6 +74,7 @@ C4Container
     Rel(semantic, labyrinth, "Analyzed Program")
     Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, papyrus, "Analyzed Program")
+    Rel(semantic, scholar, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")


### PR DESCRIPTION
🧠 **Decision:** Recorded the implementation of `src/tools/scholar.rs` as a new tool to parse the semantic model and output Markdown files documenting the APIs of the provided `.γλ` file.
🗺️ **Visuals:** Updated the C4 Container diagram in `docs/architecture.md` to show the new boundaries and relationship of the Scholar tool within the Nova boundary.
🔗 **Link:** See `docs/adr/022-scholar-api-doc-generator.md`.

---
*PR created automatically by Jules for task [2538914698937442725](https://jules.google.com/task/2538914698937442725) started by @madmax983*