### PR TITLE
🎨 Mosaic: UI Polish for tester

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -330,18 +330,11 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                     "FAILED:".red().bold(),
                     name.cyan().bold().underlined()
                 );
-                // Create a box for the error message
-                let border_top =
-                    "╭───────────────────────────────────────────────────────────────────╮".red();
-                let border_bottom =
-                    "╰───────────────────────────────────────────────────────────────────╯".red();
-
-                println!("{}", border_top);
-                for line in msg.lines() {
-                    // Wrap extremely long lines if needed, but for now simple print
-                    println!("{} {}", "│".red(), line);
-                }
-                println!("{}", border_bottom);
+                // Create a table for the error message
+                let mut err_table = Table::new();
+                err_table.load_preset(presets::UTF8_FULL);
+                err_table.add_row(vec![Cell::new(msg).fg(Color::Red)]);
+                println!("{}", err_table);
                 println!();
             }
         } else {


### PR DESCRIPTION
🖌️ **Before:** The tester module (`src/tools/tester.rs`) used raw ASCII characters (`╭─────────────────...`) to manually draw boxes around test failure outputs. This lacked structure, consistency with the rest of the CLI, and could lead to misaligned output depending on terminal widths.

✨ **After:** Refactored the tester to use `comfy-table` with `presets::UTF8_FULL` to print test errors. This standardizes the UI, creating a robust structural component that elegantly wraps text and maintains the visual hierarchy of the "Z-Pattern" scan.

🖼️ **Visuals:** Now, when a test panics, the reason is clearly encapsulated within a standardized bordered table, matching the styling of `report`, `dictionary`, and other `glossa` tools.

---
*PR created automatically by Jules for task [12546063314830867118](https://jules.google.com/task/12546063314830867118) started by @madmax983*