### PR TITLE
⚒️ Forge: Refactor `parse_test_output` in `tester.rs`

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -64,34 +64,31 @@ struct TestResult {
 }
 
 fn parse_test_output(output: &str) -> Vec<TestResult> {
-    let mut results = Vec::new();
-    for line in output.lines() {
-        // Standard rustc test output line format: "test test_name ... status"
-        if line.starts_with("test ") {
-            #[allow(clippy::collapsible_if)]
-            if let Some(idx) = line.rfind(" ... ") {
-                if idx < 5 {
-                    continue;
-                }
-                let name = line[5..idx].trim();
-                if name.is_empty() {
-                    continue;
-                }
-                let status_str = &line[idx + 5..];
-                let status = match status_str {
-                    "ok" => TestStatus::Ok,
-                    "FAILED" => TestStatus::Failed,
-                    "ignored" => TestStatus::Ignored,
-                    _ => continue,
-                };
-                results.push(TestResult {
-                    name: name.to_string(),
-                    status,
-                });
+    output
+        .lines()
+        .filter_map(|line| {
+            // Standard rustc test output line format: "test test_name ... status"
+            let rest = line.strip_prefix("test ")?;
+            let idx = rest.rfind(" ... ")?;
+
+            let name = rest[..idx].trim();
+            if name.is_empty() {
+                return None;
             }
-        }
-    }
-    results
+
+            let status = match &rest[idx + 5..] {
+                "ok" => TestStatus::Ok,
+                "FAILED" => TestStatus::Failed,
+                "ignored" => TestStatus::Ignored,
+                _ => return None,
+            };
+
+            Some(TestResult {
+                name: name.to_string(),
+                status,
+            })
+        })
+        .collect()
 }
 
 /// Extracts failed tests and their output from `rustc --test` output.


### PR DESCRIPTION
🚮 Smell: The `parse_test_output` function in `src/tools/tester.rs` suffered from a "Pyramid of Doom" (4 levels of nesting) due to a manual `for` loop combined with multiple `if` conditions and error-prone substring slicing.
✨ Solution: Refactored the function to use an idiomatic `.lines().filter_map(...).collect()` pipeline. Swapped `starts_with` and slicing for the safer `strip_prefix` and `?` operators to yield early returns.
🧼 Benefit: Significantly flattens the code structure, reducing cognitive load. Adheres strictly to idiomatic Rust, preventing manual bounds checking with better string handling capabilities while keeping the runtime logic and output identical.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [11578944325956403426](https://jules.google.com/task/11578944325956403426) started by @madmax983*