### PR TITLE
🎨 Mosaic: UI Polish for Test Failures

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -156,6 +156,23 @@ fn capture_failure_message(lines: &mut std::iter::Peekable<std::str::Lines>) -> 
             continue;
         }
 
+        // Stop before stack trace
+        if trimmed.starts_with("stack backtrace:")
+            || current.starts_with("note: Some details are omitted")
+        {
+            lines.next();
+            while let Some(next) = lines.peek() {
+                let next_trimmed = next.trim();
+                if next_trimmed.starts_with("----") && next_trimmed.ends_with("stdout ----")
+                    || next_trimmed == "failures:"
+                {
+                    break;
+                }
+                lines.next();
+            }
+            continue;
+        }
+
         if let Some(clean_panic) = clean_panic_message(current) {
             message.push_str(&clean_panic);
             message.push('\n');


### PR DESCRIPTION
🎨 Mosaic: UI Polish for Test Failures

🖌️ **Before:**
Test failures in the CLI dumped massive, raw Rust stack backtraces straight to the terminal, burying the actual error message and overwhelming the user.

✨ **After:**
The tester now intercepts and safely discards raw `stack backtrace:` dumps. The UI remains clean, highlighting just the specific `FAILED:` assertions in styled boxes, keeping the terminal dashboard-like instead of a noisy log file.

🖼️ **Visuals:**
Failure messages are now cleanly stripped of `stack backtrace:` and `note: Some details are omitted` lines, retaining only the direct panic message and the formatted table.

---
*PR created automatically by Jules for task [4023537208877292808](https://jules.google.com/task/4023537208877292808) started by @madmax983*