### PR TITLE
🌟 Nova: The Gnomon - Big-O Complexity Estimator

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -47,3 +47,8 @@
 **Concept:** A CLI tool (`glossa haruspex`) that exports the semantic AST (`AnalyzedProgram`) directly to a Graphviz DOT diagram.
 **Fate:** Merged
 **Lesson:** Provides a fast, dependency-free way (no huge third-party crates needed besides manual text serialization) to visualize exactly how the Assembler routed cases and typed nodes. Proves that the "Exporter" pattern is highly effective for exposing internal compiler phases to external developer tools.
+
+## 🌟 The Gnomon (ὁ Γνώμων)
+**Concept:** A CLI tool (`glossa gnomon`) that estimates the Big-O time complexity of a ΓΛΩΣΣΑ program by statically analyzing loop depth in the semantic AST.
+**Fate:** Proposed
+**Lesson:** Statically analyzing the semantic AST provides an easy and dependency-free way to estimate program complexity. The `AnalyzedStatement` enum variants effectively map the control flow (like `While` and `For` loops). Building a visitor pattern over these structures allows powerful tooling with minimal effort.

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,16 @@ fn main() -> Result<()> {
             );
         }
 
+        Some(Commands::Gnomon { input }) => {
+            #[cfg(feature = "nova")]
+            glossa::tools::gnomon::run_gnomon(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            miette::bail!(
+                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
+        }
+
         Some(Commands::Scholar { input }) => {
             #[cfg(feature = "nova")]
             glossa::tools::scholar::run_scholar(&input)?;

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -198,6 +198,12 @@ pub enum Commands {
         input: PathBuf,
     },
 
+    /// Estimate the Big-O time complexity of a program (Requires "nova" feature)
+    Gnomon {
+        /// Input file (.γλ)
+        input: PathBuf,
+    },
+
     /// Run the Auditor to find code smells (Requires "nova" feature)
     Audit {
         /// Input file (.γλ)

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -1,0 +1,218 @@
+//! The Gnomon (ὁ Γνώμων) - Big-O Complexity Estimator
+//!
+//! This module implements the "Gnomon" tool, which estimates the Big-O time complexity
+//! of a ΓΛΩΣΣΑ program by statically analyzing loop depth in the semantic AST.
+//!
+//! # Purpose
+//!
+//! A gnomon is the part of a sundial that casts a shadow, used to indicate the time.
+//! This tool casts a shadow over the program's AST to estimate its execution time complexity.
+
+use crate::semantic::AnalyzedStatement;
+use crate::tools::runner::load_source;
+use crate::tools::ui::Status;
+use comfy_table::presets::UTF8_FULL;
+use comfy_table::{Attribute, Cell, Color, Table};
+use crossterm::style::Stylize;
+use miette::Result;
+use std::path::Path;
+
+#[derive(Default)]
+pub struct GnomonVisitor {
+    pub current_depth: usize,
+    pub max_depth: usize,
+}
+
+impl GnomonVisitor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
+        match stmt {
+            AnalyzedStatement::While { body, .. } => {
+                self.current_depth += 1;
+                if self.current_depth > self.max_depth {
+                    self.max_depth = self.current_depth;
+                }
+                for s in body {
+                    self.visit_statement(s);
+                }
+                self.current_depth -= 1;
+            }
+            AnalyzedStatement::For { body, .. } => {
+                self.current_depth += 1;
+                if self.current_depth > self.max_depth {
+                    self.max_depth = self.current_depth;
+                }
+                for s in body {
+                    self.visit_statement(s);
+                }
+                self.current_depth -= 1;
+            }
+            AnalyzedStatement::If {
+                then_body,
+                else_body,
+                ..
+            } => {
+                for s in then_body {
+                    self.visit_statement(s);
+                }
+                if let Some(else_stmts) = else_body {
+                    for s in else_stmts {
+                        self.visit_statement(s);
+                    }
+                }
+            }
+            AnalyzedStatement::Match { arms, .. } => {
+                for (_, stmts) in arms {
+                    for s in stmts {
+                        self.visit_statement(s);
+                    }
+                }
+            }
+            AnalyzedStatement::FunctionDef { body, .. } => {
+                for s in body {
+                    self.visit_statement(s);
+                }
+            }
+            AnalyzedStatement::TestDeclaration { body, .. } => {
+                for s in body {
+                    self.visit_statement(s);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn run_gnomon(input: &Path) -> Result<()> {
+    if !input.exists() {
+        return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
+    }
+
+    let status = Status::start_with_symbol("Γνώμων (Estimating Complexity)", "⏳");
+
+    let source = match load_source(input) {
+        Ok(s) => s,
+        Err(e) => {
+            status.error("Σφάλμα ἀρχείου (File Error)");
+            return Err(e);
+        }
+    };
+
+    let program = match crate::tools::runner::analyze_source(&source) {
+        Ok(p) => p,
+        Err(e) => {
+            status.error("Σφάλμα (Error)");
+            return Err(e);
+        }
+    };
+
+    status.success();
+
+    let mut visitor = GnomonVisitor::new();
+    for stmt in &program.statements {
+        visitor.visit_statement(stmt);
+    }
+
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   G N O M O N".cyan().bold());
+    println!(
+        "   {}",
+        format!("Complexity Estimate for {}", input.display())
+            .italic()
+            .dim()
+    );
+    println!();
+
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL);
+    table.set_header(vec![
+        Cell::new("Metric")
+            .add_attribute(Attribute::Bold)
+            .fg(Color::Cyan),
+        Cell::new("Value").add_attribute(Attribute::Bold),
+    ]);
+
+    let complexity = if visitor.max_depth == 0 {
+        "O(1)".to_string()
+    } else if visitor.max_depth == 1 {
+        "O(N)".to_string()
+    } else {
+        format!("O(N^{})", visitor.max_depth)
+    };
+
+    table.add_row(vec![
+        Cell::new("Max Loop Depth"),
+        Cell::new(visitor.max_depth.to_string()),
+    ]);
+    table.add_row(vec![
+        Cell::new("Estimated Big-O"),
+        Cell::new(complexity).fg(if visitor.max_depth > 2 {
+            Color::Red
+        } else if visitor.max_depth == 2 {
+            Color::Yellow
+        } else {
+            Color::Green
+        }),
+    ]);
+
+    println!("{table}");
+    println!();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
+    use smol_str::SmolStr;
+
+    fn dummy_expr() -> Box<AnalyzedExpr> {
+        Box::new(AnalyzedExpr {
+            expr: AnalyzedExprKind::BooleanLiteral(true),
+            glossa_type: GlossaType::Boolean,
+        })
+    }
+
+    #[test]
+    fn test_gnomon_while_loop() {
+        let mut visitor = GnomonVisitor::new();
+        let stmt = AnalyzedStatement::While {
+            condition: dummy_expr(),
+            body: vec![],
+        };
+        visitor.visit_statement(&stmt);
+        assert_eq!(visitor.max_depth, 1);
+    }
+
+    #[test]
+    fn test_gnomon_for_loop() {
+        let mut visitor = GnomonVisitor::new();
+        let stmt = AnalyzedStatement::For {
+            variable: SmolStr::new("x"),
+            iterator: dummy_expr(),
+            body: vec![],
+        };
+        visitor.visit_statement(&stmt);
+        assert_eq!(visitor.max_depth, 1);
+    }
+
+    #[test]
+    fn test_gnomon_nested_loops() {
+        let mut visitor = GnomonVisitor::new();
+        let inner_loop = AnalyzedStatement::For {
+            variable: SmolStr::new("y"),
+            iterator: dummy_expr(),
+            body: vec![],
+        };
+        let outer_loop = AnalyzedStatement::While {
+            condition: dummy_expr(),
+            body: vec![inner_loop],
+        };
+        visitor.visit_statement(&outer_loop);
+        assert_eq!(visitor.max_depth, 2);
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -36,6 +36,8 @@ pub mod dictionary;
 ///
 /// This experimental tool exports the analyzed program as a Graphviz DOT diagram.
 #[cfg(feature = "nova")]
+pub mod gnomon;
+#[cfg(feature = "nova")]
 pub mod haruspex;
 pub mod highlight;
 #[cfg(feature = "nova")]


### PR DESCRIPTION
💡 **The Spark:**
I realized we analyze loops in the semantic phase but don't do anything with the structural depth. We can determine theoretical Big-O time complexity (e.g., O(N) for loops, O(N^2) for nested loops) using basic static analysis on the Analyzed AST!

🚀 **The Feature:**
Implemented `GnomonVisitor` inside `src/tools/gnomon.rs`, gated under the `nova` experimental feature. It traverses `AnalyzedStatement` to compute the `max_depth` and prints a summary report indicating `O(1)`, `O(N)`, `O(N^2)`, etc. Added corresponding CLI endpoint `glossa gnomon`.

🔮 **The Potential:**
This proves we can build sophisticated static analysis tools over the semantic AST very quickly without touching code generation. The visitor pattern can be expanded to catch infinite loops or estimate cyclomatic complexity accurately.

⚠️ **Risk:**
Zero. Code is fully isolated in `gnomon.rs` and gated entirely behind the `#[cfg(feature = "nova")]` flag. Does not touch or change existing compiler behavior or semantics. Tested independently.

---
*PR created automatically by Jules for task [14083435949629692840](https://jules.google.com/task/14083435949629692840) started by @madmax983*