### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/022-expand-nova-toolset.md
+++ b/docs/adr/022-expand-nova-toolset.md
@@ -1,0 +1,24 @@
+# 022. Expand Nova Toolset
+
+Date: 2026-05-01
+
+## Status
+
+Proposed
+
+## Context
+
+The Developer Experience (Nova) toolset was expanded with three new capabilities directly analyzing the semantic AST:
+1. **Gnomon (ὁ Γνώμων):** Estimates Big-O execution time complexity by statistically analyzing loop depth in the AST.
+2. **Haruspex (ὁ Ἱεροσκόπος):** Inspects the raw `AnalyzedProgram` and translates it into a GraphViz DOT graph for debugging compiler internals.
+3. **Scholar (ὁ Σχολαστικός):** Generates Markdown API documentation for a ΓΛΩΣΣΑ program's types, traits, and functions.
+
+## Decision
+
+These tools have been added to the `src/tools/` directory (`gnomon.rs`, `haruspex.rs`, and `scholar.rs`) alongside existing Developer Experience tools like Labyrinth and Weave.
+
+## Consequences
+
+- Improves compiler transparency and user documentation generation.
+- The `semantic` module acts as the core provider of `AnalyzedProgram` representations to an increasing number of Nova tools, solidifying the AST as the primary interaction boundary.
+- Visualizations from Haruspex require `dot` to be installed on the host system to render the graphs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,9 @@ C4Container
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
         Container(weave, "Weave", "src/tools/weave.rs", "Rosetta Stone Markdown Exporter")
+        Container(gnomon, "Gnomon", "src/tools/gnomon.rs", "Estimates Big-O complexity from AST")
+        Container(haruspex, "Haruspex", "src/tools/haruspex.rs", "Visualizes Semantic AST via GraphViz DOT")
+        Container(scholar, "Scholar", "src/tools/scholar.rs", "Generates Markdown API docs")
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
@@ -72,6 +75,9 @@ C4Container
     Rel(semantic, auditor, "Analyzed Program")
     Rel(semantic, labyrinth, "Analyzed Program")
     Rel(semantic, weave, "Analyzed Program")
+    Rel(semantic, gnomon, "Analyzed Program")
+    Rel(semantic, haruspex, "Analyzed Program")
+    Rel(semantic, scholar, "Analyzed Program")
     Rel(semantic, papyrus, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 


### PR DESCRIPTION
🧠 **Decision:** Recorded the addition of Gnomon, Haruspex, and Scholar to the `src/tools/` directory.
🗺️ **Visuals:** Updated C4 Container diagram in `docs/architecture.md` to show new tools and their relationships to the semantic analyzer.
🔗 **Link:** See `docs/adr/022-expand-nova-toolset.md`.

---
*PR created automatically by Jules for task [7847250778092243268](https://jules.google.com/task/7847250778092243268) started by @madmax983*