### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,7 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+
+**[REPL Empty Statement Panic Fix]
+**Learning:** The `.unwrap()` call on `analyzed.statements.last()` panicked on empty or comment-only inputs because the previous check (`new_count <= self.statement_count`) did not catch the case when both values are 0.
+**Action:** When working with potentially empty collections returned by a parser, always use a safe match or `if let` pattern instead of `.unwrap()`, especially in user-facing REPLs where empty inputs are common.

--- a/fix_test_more.patch
+++ b/fix_test_more.patch
@@ -1,0 +1,7 @@
+--- tests/havoc_repl_empty.rs
++++ tests/havoc_repl_empty.rs
+@@ -1,3 +1,5 @@
++#![allow(missing_docs)]
++
+ use std::io::Write;
+ use std::process::{Command, Stdio};

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -347,7 +347,10 @@ impl ReplContext {
         // 5. Analyze Result
         // We only care about the *last* statement, because previous statements have already
         // been executed/processed in previous turns.
-        let last_stmt = analyzed.statements.last().unwrap();
+        let last_stmt = match analyzed.statements.last() {
+            Some(stmt) => stmt,
+            None => return Ok(ReplOutput::None),
+        };
         match last_stmt {
             AnalyzedStatement::Binding { name, mutable, .. } => {
                 // Lookup type from scope since it's no longer in the binding statement
@@ -647,5 +650,12 @@ mod tests {
         // The error message from GlossaError::ParseError starts with "Σφάλμα συντάξεως: ..."
         // Our formatting prints "× error_string".
         // We just want to ensure it printed.
+    }
+
+    #[test]
+    fn test_repl_empty_statement_panic() {
+        let mut context = ReplContext::new();
+        let output = context.execute("").unwrap();
+        assert!(matches!(output, ReplOutput::None));
     }
 }

--- a/tests/havoc_repl_empty.rs
+++ b/tests/havoc_repl_empty.rs
@@ -1,7 +1,22 @@
-use glossa::tools::repl::run_repl;
+use std::process::{Command, Stdio};
+use std::io::Write;
 
 // test wrapper for REPL crash
 #[test]
 fn havoc_repl_empty_panic_wrapper() {
-    let _ = run_repl;
+    let mut child = Command::new("cargo")
+        .args(["run", "--bin", "glossa", "--", "repl"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn glossa");
+
+    let mut stdin = child.stdin.take().expect("Failed to open stdin");
+    stdin.write_all(b"  // empty comments \n.exit\n").expect("Failed to write to stdin");
+    drop(stdin);
+
+    let output = child.wait_with_output().expect("Failed to wait on child");
+    let stderr_str = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr_str.contains("panicked"), "Panic detected!");
 }

--- a/tests/havoc_repl_empty.rs
+++ b/tests/havoc_repl_empty.rs
@@ -1,5 +1,7 @@
-use std::process::{Command, Stdio};
+#![allow(missing_docs)]
+
 use std::io::Write;
+use std::process::{Command, Stdio};
 
 // test wrapper for REPL crash
 #[test]
@@ -13,7 +15,9 @@ fn havoc_repl_empty_panic_wrapper() {
         .expect("Failed to spawn glossa");
 
     let mut stdin = child.stdin.take().expect("Failed to open stdin");
-    stdin.write_all(b"  // empty comments \n.exit\n").expect("Failed to write to stdin");
+    stdin
+        .write_all(b"  // empty comments \n.exit\n")
+        .expect("Failed to write to stdin");
     drop(stdin);
 
     let output = child.wait_with_output().expect("Failed to wait on child");


### PR DESCRIPTION
🎯 Target: `run_repl` in `src/tools/repl.rs`
💣 Risk: Triggered a panic via `.unwrap()` when users input empty statements or pure comments into the REPL.
🧪 Strategy: Safely handle the `.last()` element lookup returning `None` by matching and returning `ReplOutput::None` instead of panicking. Covered via unit tests.
🔬 Verification: `cargo test test_repl_empty_statement_panic`

---
*PR created automatically by Jules for task [9126667438385389493](https://jules.google.com/task/9126667438385389493) started by @madmax983*