### PR TITLE
⚡ Bolt: Refactor string concatenation in Alchemist tool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,10 @@
 **[Optimizing Collections in iterators]**
 **Learning:** Checking for `.is_empty()` after `.collect::<Vec<_>>()` forces an unnecessary heap allocation. We can check if an iterator is empty dynamically using `.peekable()`. Additionally, if strings from `&'a str` need to be converted to `Cow<'static, str>`, we must use `.to_string()` as `.into()` or `Cow::Borrowed` will result in static lifetime compilation errors.
 **Action:** Replace `Vec<_> = iter.collect()` with `.peekable()` for emptiness checking whenever possible, and be mindful of `Cow` lifetimes.
+**[Replacing `push_str(&format!(...))` with `write!/writeln!`]
+**Learning:** `push_str(&format!(...))` is an anti-pattern that creates a short-lived `String` allocation just to copy its contents into another `String`.
+**Action:** Always use `write!(buf, ...)` or `writeln!(buf, ...)` from `std::fmt::Write` to format directly into an existing `String` buffer without intermediate allocations.
+
+**[The `Vec::with_capacity` + `.extend()` vs `.collect()` Illusion]
+**Learning:** Attempting to manually pre-allocate a `Vec` and calling `.extend()` over a simple `.map()` iterator is a placebo optimization. Rust's `.collect::<Vec<_>>()` already uses `Iterator::size_hint()` and internal traits (like `TrustedLen`) to perfectly pre-allocate the required capacity before inserting elements.
+**Action:** Do not replace idiomatic `.collect()` calls with manual capacity pre-allocation when working with standard iterators, as it introduces verbosity with zero performance gain.

--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -131,7 +131,7 @@ fn transpile_statement(stmt: &AnalyzedStatement, indent: usize) -> String {
         AnalyzedStatement::Expression(exprs) => {
             let mut out = String::new();
             for expr in exprs {
-                out.push_str(&format!("{}{}\n", ind, transpile_expr(expr)));
+                let _ = writeln!(out, "{}{}", ind, transpile_expr(expr));
             }
             out.trim_end().to_string()
         }
@@ -167,21 +167,19 @@ fn transpile_if(
     let ind = "    ".repeat(indent);
     let mut out = format!("{}if {}:\n", ind, transpile_expr(condition));
     if then_body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in then_body {
-            out.push_str(&transpile_statement(b_stmt, indent + 1));
-            out.push('\n');
+            let _ = writeln!(out, "{}", transpile_statement(b_stmt, indent + 1));
         }
     }
     if let Some(ebody) = else_body {
-        out.push_str(&format!("{}else:\n", ind));
+        let _ = writeln!(out, "{}else:", ind);
         if ebody.is_empty() {
-            out.push_str(&format!("{}    pass\n", ind));
+            let _ = writeln!(out, "{}    pass", ind);
         } else {
             for b_stmt in ebody {
-                out.push_str(&transpile_statement(b_stmt, indent + 1));
-                out.push('\n');
+                let _ = writeln!(out, "{}", transpile_statement(b_stmt, indent + 1));
             }
         }
     }
@@ -192,11 +190,10 @@ fn transpile_while(condition: &AnalyzedExpr, body: &[AnalyzedStatement], indent:
     let ind = "    ".repeat(indent);
     let mut out = format!("{}while {}:\n", ind, transpile_expr(condition));
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
-            out.push_str(&transpile_statement(b_stmt, indent + 1));
-            out.push('\n');
+            let _ = writeln!(out, "{}", transpile_statement(b_stmt, indent + 1));
         }
     }
     out.trim_end().to_string()
@@ -216,11 +213,10 @@ fn transpile_for(
         transpile_expr(iterator)
     );
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
-            out.push_str(&transpile_statement(b_stmt, indent + 1));
-            out.push('\n');
+            let _ = writeln!(out, "{}", transpile_statement(b_stmt, indent + 1));
         }
     }
     out.trim_end().to_string()
@@ -243,7 +239,7 @@ fn transpile_function_def(
     out.push_str("):\n");
 
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for (i, b_stmt) in body.iter().enumerate() {
             let mut is_last_expr = false;
@@ -255,15 +251,14 @@ fn transpile_function_def(
                 if let AnalyzedStatement::Expression(exprs) = b_stmt {
                     for (j, expr) in exprs.iter().enumerate() {
                         if j == exprs.len() - 1 {
-                            out.push_str(&format!("{}    return {}\n", ind, transpile_expr(expr)));
+                            let _ = writeln!(out, "{}    return {}", ind, transpile_expr(expr));
                         } else {
-                            out.push_str(&format!("{}    {}\n", ind, transpile_expr(expr)));
+                            let _ = writeln!(out, "{}    {}", ind, transpile_expr(expr));
                         }
                     }
                 }
             } else {
-                out.push_str(&transpile_statement(b_stmt, indent + 1));
-                out.push('\n');
+                let _ = writeln!(out, "{}", transpile_statement(b_stmt, indent + 1));
             }
         }
     }
@@ -283,10 +278,10 @@ fn transpile_type_def(
         sanitize_ident(name)
     );
     if fields.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for (f_name, _) in fields {
-            out.push_str(&format!("{}    {}: Any\n", ind, sanitize_ident(f_name)));
+            let _ = writeln!(out, "{}    {}: Any", ind, sanitize_ident(f_name));
         }
     }
     out.trim_end().to_string()
@@ -298,11 +293,10 @@ fn transpile_test_declaration(name: &str, body: &[AnalyzedStatement], indent: us
     let safe_name = name.replace(" ", "_").replace("-", "_").replace("\"", "");
     let mut out = format!("{}def test_{}():\n", ind, safe_name);
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
-            out.push_str(&transpile_statement(b_stmt, indent + 1));
-            out.push('\n');
+            let _ = writeln!(out, "{}", transpile_statement(b_stmt, indent + 1));
         }
     }
     out.trim_end().to_string()
@@ -317,17 +311,12 @@ fn transpile_match(
     // Python 3.10+ match statement
     let mut out = format!("{}match {}:\n", ind, transpile_expr(scrutinee));
     for (pattern_expr, arm_body) in arms {
-        out.push_str(&format!(
-            "{}    case {}:\n",
-            ind,
-            transpile_expr(pattern_expr)
-        ));
+        let _ = writeln!(out, "{}    case {}:", ind, transpile_expr(pattern_expr));
         if arm_body.is_empty() {
-            out.push_str(&format!("{}        pass\n", ind));
+            let _ = writeln!(out, "{}        pass", ind);
         } else {
             for b_stmt in arm_body {
-                out.push_str(&transpile_statement(b_stmt, indent + 2));
-                out.push('\n');
+                let _ = writeln!(out, "{}", transpile_statement(b_stmt, indent + 2));
             }
         }
     }


### PR DESCRIPTION
Replaced all instances of out.push_str with writeln! in src/tools/alchemist.rs to avoid unnecessary temporary heap allocations for strings just to append them.

---
*PR created automatically by Jules for task [4636276744647735984](https://jules.google.com/task/4636276744647735984) started by @madmax983*