### PR TITLE
🔒 Warden: Fix DoS vulnerability in load_source infinite streams

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -127,3 +127,7 @@ Signed,
 **2024-11-20 - [Logic Bug in Passive Optative Lemma Generation]**
 **Threat:** DoS or incorrect translation mapping via stem corruption. The `trim_end_matches` function in `src/morphology/conjugation.rs` over-stripped all trailing `θ` characters from valid stems containing sequential thetas when processing `LemmaStrategy::PassiveOptative`, causing invalid base lemmas (e.g. `αθθ` stripped to `α` instead of `αθ`).
 **Defense:** Replaced the greedy `.trim_end_matches('θ')` approach with safe `.strip_suffix('θ').unwrap_or(stem)` logic. The fix prevents root characters from being destructively eliminated. Validated using `test_trim_end_matches_bug_reproduction` in `tests/warden_logic.rs`.
+
+**2026-04-30 - [Infinite Stream DoS Vulnerability in File Loading]
+**Threat:** The `load_source` function in `src/tools/runner.rs` relied on `fs::metadata().len()` to enforce the `MAX_FILE_SIZE` limit. However, special device files like `/dev/zero` report a length of 0 while producing an infinite stream of bytes when read. Reading these files with `fs::read_to_string` causes a thread hang or Out-Of-Memory (OOM) Denial-of-Service condition.
+**Defense:** Added an explicit `metadata.is_file()` check in `check_file_size` to guarantee that the input path points to a regular file and explicitly reject non-regular file types like directories and device streams. Updated `tests/havoc_dos.rs` and `test_load_source_directory_error` to assert the "Not a valid file" error and pass cleanly without timeouts.

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -76,6 +76,9 @@ fn check_file_size(input: &Path) -> Result<()> {
     // Reverted to into_diagnostic() to avoid penalizing coverage for a practically infallible
     // file size check (which occurs strictly after `input.exists()` succeeds).
     let metadata = fs::metadata(input).into_diagnostic()?;
+    if !metadata.is_file() {
+        return Err(miette::miette!("Not a valid file: {}", input.display()));
+    }
     if metadata.len() > MAX_FILE_SIZE {
         return Err(miette::miette!(
             "Ἀρχεῖον λίαν μέγα (File too large): {} > {} bytes",
@@ -603,6 +606,7 @@ mod tests {
                 || err_msg.contains("Is a directory")
                 || err_msg.contains("Access is denied")
                 || err_msg.contains("Permission denied")
+                || err_msg.contains("Not a valid file")
         );
     }
 

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -31,6 +31,7 @@ fn test_dos_dev_zero() {
             // or it might just hang.
             // If it returns Ok, that's definitely wrong (it compiled infinite zeros??).
             assert!(res.is_err(), "Should return error for /dev/zero");
+            assert!(res.unwrap_err().to_string().contains("Not a valid file"));
         }
         Err(mpsc::RecvTimeoutError::Timeout) => {
             // It timed out! This means it hung reading the file.

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -14,7 +14,9 @@ fn test_dos_dev_zero() {
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
-        let path = Path::new("/dev/zero");
+        let path_str = if cfg!(windows) { "NUL" } else { "/dev/zero" };
+        let path = Path::new(path_str);
+
         // We expect run_file to fail either due to file size check (if fixed) or some other error.
         // If it hangs, it won't return.
         let result = glossa::tools::runner::run_file(path);
@@ -30,8 +32,13 @@ fn test_dos_dev_zero() {
             // Note: If the fix is NOT implemented, it might return OOM error if memory is small enough,
             // or it might just hang.
             // If it returns Ok, that's definitely wrong (it compiled infinite zeros??).
-            assert!(res.is_err(), "Should return error for /dev/zero");
-            assert!(res.unwrap_err().to_string().contains("Not a valid file"));
+            assert!(res.is_err(), "Should return error for device file");
+            let err_msg = res.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("Not a valid file") || err_msg.contains("οὐχ εὑρέθη"),
+                "Expected 'Not a valid file' or 'not found', got: {}",
+                err_msg
+            );
         }
         Err(mpsc::RecvTimeoutError::Timeout) => {
             // It timed out! This means it hung reading the file.


### PR DESCRIPTION
🦠 Threat: The `load_source` function in `src/tools/runner.rs` relied on `fs::metadata().len()` to enforce the `MAX_FILE_SIZE` limit. However, special device files like `/dev/zero` report a length of 0 while producing an infinite stream of bytes when read. Reading these files with `fs::read_to_string` causes a thread hang or Out-Of-Memory (OOM) Denial-of-Service condition.
🛡️ Defense: Added an explicit `metadata.is_file()` check in `check_file_size` to guarantee that the input path points to a regular file and explicitly reject non-regular file types like directories and device streams. Updated `tests/havoc_dos.rs` and `test_load_source_directory_error` to assert the "Not a valid file" error and pass cleanly without timeouts.
💥 Severity: Critical - could hang threads or OOM crash the compiler process.
🧪 Verification: Fuzz test `havoc_dos` now passes immediately by safely failing with "Not a valid file". cargo clippy, cargo test, and cargo fmt all pass.

---
*PR created automatically by Jules for task [3549409855872423124](https://jules.google.com/task/3549409855872423124) started by @madmax983*