### PR TITLE
🪒 Razor: flatten unnecessary TraitMethodParts abstraction

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -2,3 +2,7 @@
 **Bloat:** `CFGBuilder` in `src/tools/labyrinth.rs` used an object-oriented builder pattern for a simple logic flow.
 **Cut:** Flattened the object into pure functions passing mutable references to `nodes`, `edges`, and `node_counter` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+## [Reduction]
+**Bloat:** `TraitMethodParts` factory struct in `src/codegen.rs` serving merely to return three distinct values.
+**Cut:** Flattened by removing the struct entirely and just returning a standard tuple `(Ident, Vec<TokenStream>, Option<TokenStream>)` from `generate_trait_method_parts`.
+**Saved:** 5 LOC and reduced cognitive load by removing an unnecessary abstraction.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -764,13 +764,9 @@ fn generate_struct_def(name: &str, fields: &[(smol_str::SmolStr, GlossaType)]) -
     }
 }
 
-struct TraitMethodParts {
-    name: Ident,
-    params: Vec<TokenStream>,
-    return_type: Option<TokenStream>,
-}
-
-fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
+fn generate_trait_method_parts(
+    method: &AnalyzedMethod,
+) -> (Ident, Vec<TokenStream>, Option<TokenStream>) {
     let method_name = sanitize_ident(&method.name);
 
     let param_tokens = method
@@ -789,11 +785,7 @@ fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
 
     let ret_tokens = method.return_type.as_ref().map(generate_type_tokens);
 
-    TraitMethodParts {
-        name: method_name,
-        params: param_tokens.collect(),
-        return_type: ret_tokens,
-    }
+    (method_name, param_tokens.collect(), ret_tokens)
 }
 
 fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
@@ -809,11 +801,9 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
 
     // Generate method signatures
     let method_tokens = methods.iter().map(|method| {
-        let parts = generate_trait_method_parts(method);
-        let method_name = parts.name;
-        let param_tokens = parts.params;
+        let (method_name, param_tokens, return_type) = generate_trait_method_parts(method);
 
-        if let Some(ret_ty) = parts.return_type {
+        if let Some(ret_ty) = return_type {
             if let Some(body) = &method.body {
                 let body_stmts = generate_statements(body);
                 quote! {
@@ -872,9 +862,7 @@ fn generate_trait_impl(
 
     // Generate method implementations
     let method_tokens = methods.iter().map(|method| {
-        let parts = generate_trait_method_parts(method);
-        let method_name = parts.name;
-        let param_tokens = parts.params;
+        let (method_name, param_tokens, return_type) = generate_trait_method_parts(method);
 
         // Generate method body
         let body_stmts: Vec<TokenStream> = if let Some(body) = &method.body {
@@ -883,7 +871,7 @@ fn generate_trait_impl(
             Vec::new()
         };
 
-        if let Some(ret_ty) = parts.return_type {
+        if let Some(ret_ty) = return_type {
             quote! {
                 fn #method_name(#(#param_tokens),*) -> #ret_ty {
                     #(#body_stmts)*
@@ -1648,20 +1636,20 @@ mod tests {
                 return_type: Some(GlossaType::Boolean),
             };
 
-            let parts = generate_trait_method_parts(&method);
+            let (method_name, param_tokens, return_type) = generate_trait_method_parts(&method);
 
-            assert_eq!(parts.name.to_string(), "g_test_method");
+            assert_eq!(method_name.to_string(), "g_test_method");
 
             // Check params
-            let params_str: Vec<String> = parts.params.iter().map(|t| t.to_string()).collect();
+            let params_str: Vec<String> = param_tokens.iter().map(|t| t.to_string()).collect();
             assert_eq!(params_str.len(), 2);
             assert_eq!(params_str[0], "& self");
             assert!(params_str[1].contains("g_arg1"));
             assert!(params_str[1].contains("i64"));
 
             // Check return type
-            assert!(parts.return_type.is_some());
-            assert_eq!(parts.return_type.unwrap().to_string(), "bool");
+            assert!(return_type.is_some());
+            assert_eq!(return_type.unwrap().to_string(), "bool");
         }
 
         #[test]


### PR DESCRIPTION
🪒 **Razor: Removal of `TraitMethodParts` Abstraction**

**The Essential Cuts:**
In accordance with Razor's strict adherence to the KISS principle and the "De-Abstract" directive, this PR removes the unnecessary `TraitMethodParts` struct from the codegen module.

*   **Bloat:** The `TraitMethodParts` struct was serving as a mini "factory" object, simply collecting an `Ident`, a vector of parameters, and an optional return type to pass them back to the caller.
*   **The Cut:** Removed the struct and refactored `generate_trait_method_parts` to directly return a standard tuple: `(Ident, Vec<TokenStream>, Option<TokenStream>)`.
*   **The Result:** Callers (`generate_trait_def` and `generate_trait_impl`) now cleanly destructure the tuple immediately upon assignment, removing intermediate object state and shrinking the overall code surface area.

**Verification:**
*   `cargo clippy --all-targets --all-features -- -D warnings` -> Clean
*   `cargo test` -> All tests pass (including manual AST fallback tests)
*   `cargo fmt --all` -> Adheres to format

Recorded in `.jules/razor.md`.

---
*PR created automatically by Jules for task [18427140607369892309](https://jules.google.com/task/18427140607369892309) started by @madmax983*