### PR TITLE
⚡ Bolt: Optimize AST node cloning in iterator patterns

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 **[Optimizing Collections in iterators]**
 **Learning:** Checking for `.is_empty()` after `.collect::<Vec<_>>()` forces an unnecessary heap allocation. We can check if an iterator is empty dynamically using `.peekable()`. Additionally, if strings from `&'a str` need to be converted to `Cow<'static, str>`, we must use `.to_string()` as `.into()` or `Cow::Borrowed` will result in static lifetime compilation errors.
 **Action:** Replace `Vec<_> = iter.collect()` with `.peekable()` for emptiness checking whenever possible, and be mindful of `Cow` lifetimes.
+
+**[Optimizing AST Node Cloning with `std::mem::replace`]**
+**Learning:** During iterative AST tree building (e.g., when wrapping an expression in successive `MethodCall`s like `.iter().map().filter().collect()`), the previous expression `current_expr` had to be passed into the new node. Because it's stored in a `Box`, using `Box::new(current_expr.clone())` causes an expensive deep clone of the entire recursive AST structure for each method in the chain. However, since the old node is entirely moved into the new node (and we overwrite `current_expr` immediately after), we can use `std::mem::replace(&mut current_expr, AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unknown })` to safely extract the old tree without a single allocation, effectively a zero-cost transfer of ownership.
+**Action:** Use `std::mem::replace` to avoid deep cloning of AST nodes when building recursive or iterative tree structures in place.

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -582,7 +582,13 @@ fn process_adjectives(
             // Wrap current expr
             let new_expr = AnalyzedExpr {
                 expr: AnalyzedExprKind::MethodCall {
-                    receiver: Box::new(current_expr.clone()),
+                    receiver: Box::new(std::mem::replace(
+                        current_expr,
+                        AnalyzedExpr {
+                            expr: AnalyzedExprKind::None,
+                            glossa_type: GlossaType::Unknown,
+                        },
+                    )),
                     method: method.into(),
                     args: vec![filter_closure],
                 },
@@ -656,7 +662,13 @@ fn process_fold_participle(
 
         let new_expr = AnalyzedExpr {
             expr: AnalyzedExprKind::MethodCall {
-                receiver: Box::new(current_expr.clone()),
+                receiver: Box::new(std::mem::replace(
+                    current_expr,
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::None,
+                        glossa_type: GlossaType::Unknown,
+                    },
+                )),
                 method: "fold".into(),
                 args: vec![init_expr, fold_closure],
             },
@@ -726,7 +738,13 @@ fn process_map_participle(
 
         let new_expr = AnalyzedExpr {
             expr: AnalyzedExprKind::MethodCall {
-                receiver: Box::new(current_expr.clone()),
+                receiver: Box::new(std::mem::replace(
+                    current_expr,
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::None,
+                        glossa_type: GlossaType::Unknown,
+                    },
+                )),
                 method: "map".into(),
                 args: vec![closure],
             },
@@ -796,7 +814,13 @@ fn process_explicit_quantifiers(
 
             let new_expr = AnalyzedExpr {
                 expr: AnalyzedExprKind::MethodCall {
-                    receiver: Box::new(current_expr.clone()),
+                    receiver: Box::new(std::mem::replace(
+                        current_expr,
+                        AnalyzedExpr {
+                            expr: AnalyzedExprKind::None,
+                            glossa_type: GlossaType::Unknown,
+                        },
+                    )),
                     method: method.into(),
                     args: vec![any_all_closure],
                 },
@@ -826,7 +850,13 @@ fn process_find(asm_stmt: &AssembledStatement, scope: &Scope, current_expr: &mut
 
                 let new_expr = AnalyzedExpr {
                     expr: AnalyzedExprKind::MethodCall {
-                        receiver: Box::new(current_expr.clone()),
+                        receiver: Box::new(std::mem::replace(
+                            current_expr,
+                            AnalyzedExpr {
+                                expr: AnalyzedExprKind::None,
+                                glossa_type: GlossaType::Unknown,
+                            },
+                        )),
                         method: "find".into(),
                         args: vec![find_closure],
                     },
@@ -862,7 +892,13 @@ fn process_find(asm_stmt: &AssembledStatement, scope: &Scope, current_expr: &mut
 
         let new_expr = AnalyzedExpr {
             expr: AnalyzedExprKind::MethodCall {
-                receiver: Box::new(current_expr.clone()),
+                receiver: Box::new(std::mem::replace(
+                    current_expr,
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::None,
+                        glossa_type: GlossaType::Unknown,
+                    },
+                )),
                 method: "find".into(),
                 args: vec![find_first_closure],
             },
@@ -877,7 +913,13 @@ fn finalize_iterator_chain(current_expr: &mut AnalyzedExpr) {
     // Add .collect() at the end
     let new_expr = AnalyzedExpr {
         expr: AnalyzedExprKind::MethodCall {
-            receiver: Box::new(current_expr.clone()),
+            receiver: Box::new(std::mem::replace(
+                current_expr,
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::None,
+                    glossa_type: GlossaType::Unknown,
+                },
+            )),
             method: "collect".into(),
             args: vec![],
         },


### PR DESCRIPTION
💡 **What:** Replaced `Box::new(current_expr.clone())` with `Box::new(std::mem::replace(&mut current_expr, AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unknown }))` across 7 method chaining sites in `src/semantic/patterns.rs`. 
🎯 **Why:** `current_expr` is a recursive enum that represents an Abstract Syntax Tree (AST). Since these expressions can get quite deep in iterator chains (e.g. `.iter().map().filter().collect()`), calling `.clone()` causes a massive performance hit due to repetitive, unnecessary deep cloning of the existing tree on each successive wrapping.
📊 **Impact:** Reduces deep heap allocations during compilation when building iterator chains natively, providing a true zero-cost abstraction for shifting ownership of the previous node.
🔬 **Measurement:** Pass `cargo bench` and observe reduced allocation churn when profiling. Validated against the extensive compiler unit and integration tests.

---
*PR created automatically by Jules for task [13024512515791078756](https://jules.google.com/task/13024512515791078756) started by @madmax983*