### PR TITLE
🛡️ Sentry: [test coverage improvement] Semantic Fallbacks and Boundaries

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,6 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+**[Semantic Control Flow Branches]
+**Learning:** Found coverage gaps in `src/semantic/control_flow.rs` for `parse_match_pattern` fallbacks, and in `src/semantic/patterns.rs` for `parse_struct_args`. Specifically, verifying the boundary behaviors and variable mappings of bare words vs expressions.
+**Action:** Wrote explicit table-driven or isolated tests for both to ensure all paths are covered safely without relying entirely on generic parse fallbacks.

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -888,6 +888,35 @@ mod tests {
         let err = parse_match_pattern(&word_undef, &mut scope);
         assert!(err.is_err());
 
+        // Single Word wildcard
+        let word_wildcard = Expr::Word(Word::new("ἄλλο"));
+        let res = parse_match_pattern(&word_wildcard, &mut scope).unwrap();
+        if let AnalyzedExprKind::BooleanLiteral(b) = res.expr {
+            assert!(b);
+        } else {
+            panic!("Expected boolean literal");
+        }
+
+        // Single Word numeral
+        let word_numeral = Expr::Word(Word::new("δύο"));
+        let res = parse_match_pattern(&word_numeral, &mut scope).unwrap();
+        if let AnalyzedExprKind::NumberLiteral(n) = res.expr {
+            assert_eq!(n, 2);
+        } else {
+            panic!("Expected number literal");
+        }
+
+        // Single Word defined variable
+        scope.define("defined_var", GlossaType::Number);
+        let word_defined = Expr::Word(Word::new("defined_var"));
+        let res = parse_match_pattern(&word_defined, &mut scope).unwrap();
+        if let AnalyzedExprKind::Variable(ref name) = res.expr {
+            assert_eq!(name, "defined_var");
+            assert_eq!(res.glossa_type, GlossaType::Number);
+        } else {
+            panic!("Expected variable 'defined_var'");
+        }
+
         // Phrase with boolean literal at the beginning
         let phrase_bool = Expr::Phrase(vec![Expr::BooleanLiteral(true)]);
         let err = parse_match_pattern(&phrase_bool, &mut scope);

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -1479,6 +1479,83 @@ mod coverage_tests {
     }
 
     #[test]
+    fn test_parse_struct_args_coverage() {
+        let mut scope = Scope::new();
+        scope.define("def_var", GlossaType::Number);
+
+        let fields = vec![
+            ("f1".into(), GlossaType::Number),
+            ("f2".into(), GlossaType::Number),
+        ];
+
+        let terms = vec![
+            crate::ast::Expr::Word(crate::ast::Word::new("42")),
+            crate::ast::Expr::Word(crate::ast::Word::new("πέντε")),
+            crate::ast::Expr::Word(crate::ast::Word::new("def_var")),
+            crate::ast::Expr::Word(crate::ast::Word::new("undef_var")),
+            crate::ast::Expr::NumberLiteral(10),
+            crate::ast::Expr::BooleanLiteral(true),
+            crate::ast::Expr::StringLiteral("test".into()),
+        ];
+
+        let result = parse_struct_args(&terms, &fields, &scope);
+        assert!(result.is_some());
+        let args = result.unwrap();
+        assert_eq!(args.len(), 7);
+
+        // Word parsing to i64
+        if let AnalyzedExprKind::NumberLiteral(n) = args[0].expr {
+            assert_eq!(n, 42);
+        } else {
+            panic!("Expected NumberLiteral(42)");
+        }
+
+        // Word parsing numeral
+        if let AnalyzedExprKind::NumberLiteral(n) = args[1].expr {
+            assert_eq!(n, 5);
+        } else {
+            panic!("Expected NumberLiteral(5)");
+        }
+
+        // Word mapping to defined var
+        if let AnalyzedExprKind::Variable(ref name) = args[2].expr {
+            assert_eq!(name, "def_var");
+            assert_eq!(args[2].glossa_type, GlossaType::Number);
+        } else {
+            panic!("Expected Variable('def_var')");
+        }
+
+        // Word mapping to undefined var
+        if let AnalyzedExprKind::Variable(ref name) = args[3].expr {
+            assert_eq!(name, "undef_var");
+            assert_eq!(args[3].glossa_type, GlossaType::Unknown);
+        } else {
+            panic!("Expected Variable('undef_var')");
+        }
+
+        // NumberLiteral
+        if let AnalyzedExprKind::NumberLiteral(n) = args[4].expr {
+            assert_eq!(n, 10);
+        } else {
+            panic!("Expected NumberLiteral(10)");
+        }
+
+        // BooleanLiteral
+        if let AnalyzedExprKind::BooleanLiteral(b) = args[5].expr {
+            assert!(b);
+        } else {
+            panic!("Expected BooleanLiteral(true)");
+        }
+
+        // StringLiteral
+        if let AnalyzedExprKind::StringLiteral(ref s) = args[6].expr {
+            assert_eq!(s, "test");
+        } else {
+            panic!("Expected StringLiteral('test')");
+        }
+    }
+
+    #[test]
     fn test_process_find_no_predicate_coverage() {
         let scope = Scope::new();
         let asm_stmt = AssembledStatement::default();


### PR DESCRIPTION
🎯 Target: `src/semantic/control_flow.rs` (`parse_match_pattern`) and `src/semantic/patterns.rs` (`parse_struct_args`)
💣 Risk: Uncovered branches when matching single-word patterns or parsing heterogeneous struct parameters could behave unexpectedly or panic silently when refactored.
🧪 Strategy: Added `test_parse_match_pattern_uncovered` to verify single-word fallbacks for wildcard (`ἄλλο`), numerals (`δύο`), defined, and undefined variable resolutions. Added `test_parse_struct_args_coverage` to cover structural bounds matching against numeric strings, greek literals, defined vars, undef vars, and AST literals.
🔬 Verification: `cargo test test_parse_match_pattern_uncovered test_parse_struct_args_coverage`

---
*PR created automatically by Jules for task [3968030369709805217](https://jules.google.com/task/3968030369709805217) started by @madmax983*