### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/022-encapsulate-internal-modules.md
+++ b/docs/adr/022-encapsulate-internal-modules.md
@@ -1,0 +1,24 @@
+# 022. Encapsulate Internal Modules
+
+Date: 2026-05-03
+
+## Status
+
+Accepted
+
+## Context
+
+Several utility and data-transfer modules within the compiler were unnecessarily exposed to the public API via `pub mod`. This included internal developer tools (`src/tools/cache.rs`, `src/tools/report.rs`, and `src/tools/ui.rs`) as well as internal data structures used during semantic assembly (`src/semantic/assembly/model.rs`). This sprawling public footprint violated encapsulation principles, increasing the risk of external dependencies on internal implementation details and creating a poorly-defined boundary for the system's public API.
+
+## Decision
+
+We restricted the visibility of these modules to their intended domains by changing their declarations to `pub(crate) mod`.
+Specifically:
+- In `src/tools/mod.rs`, the `cache`, `report`, and `ui` modules were marked as `pub(crate) mod`.
+- In `src/semantic/assembly/mod.rs`, the `model` module was marked as `pub(crate) mod`.
+
+## Consequences
+
+- **Positive:** Higher cohesion and a tighter boundary. Internal helpers and DTOs no longer leak into the public API of the crate.
+- **Positive:** Developers can refactor internal modules like `report` and `ui` with confidence that changes won't break external consumers.
+- **Negative:** Other modules within the workspace must correctly import these components via internal paths, requiring some internal import adjustments when this change was made.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,11 +35,12 @@ C4Container
     Container_Boundary(tools, "Developer Experience (Nova)") {
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
         Container(auditor, "The Auditor", "src/tools/auditor.rs", "Static analysis to find unused variables and mutability smells")
-        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
+        Container(cache, "Cache [Internal]", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(catalog, "The Catalog", "src/tools/catalog.rs", "Lexicon Explorer (CLI)")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
         Container(dictionary, "The Lexicon", "src/tools/dictionary.rs", "The Source of Truth for Words (Dictionary)")
+        Container(gnomon, "Gnomon", "src/tools/gnomon.rs", "Estimates Big-O time complexity")
         Container(highlight, "Highlighter", "src/tools/highlight.rs", "Semantic syntax highlighting")
         Container(interpreter, "Interpreter", "src/tools/interpreter.rs", "In-memory tree-walk simulator")
         Container(labyrinth, "Labyrinth", "src/tools/labyrinth.rs", "Visualizes the control flow graph as a Mermaid flowchart")
@@ -48,10 +49,10 @@ C4Container
         Container(narrator, "The Bard", "src/tools/narrator.rs", "Generates English narrative ('Scroll of Logic') from AST")
         Container(papyrus, "Papyrus", "src/tools/papyrus.rs", "Generates SQL CREATE TABLE schemas")
         Container(repl, "REPL", "src/tools/repl.rs", "Interactive Read-Eval-Print Loop")
-        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+        Container(report, "Reporter [Internal]", "src/tools/report.rs", "Generates statistics and structured reports")
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
-        Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(ui, "The Stage [Internal]", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
         Container(weave, "Weave", "src/tools/weave.rs", "Rosetta Stone Markdown Exporter")
     }
 
@@ -73,6 +74,7 @@ C4Container
     Rel(semantic, labyrinth, "Analyzed Program")
     Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, papyrus, "Analyzed Program")
+    Rel(semantic, gnomon, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")
@@ -96,7 +98,7 @@ C4Component
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
         Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
-        Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
+        Component(assembly_model, "Assembly Model [Internal]", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")


### PR DESCRIPTION
🧠 **Decision:** Recorded the encapsulation of internal tool and semantic modules (`cache`, `report`, `ui`, `assembly/model`) as `pub(crate)` to prevent public API leakage.
🗺️ **Visuals:** Updated the C4 Component and Container Mermaid diagrams in `docs/architecture.md` to show the new boundaries and added the missing `gnomon` tool to the Developer Experience container.
🔗 **Link:** See `docs/adr/022-encapsulate-internal-modules.md`.

---
*PR created automatically by Jules for task [2272571136498358148](https://jules.google.com/task/2272571136498358148) started by @madmax983*