### PR TITLE
⚡ Bolt: [Optimization] Eliminate intermediate string allocations in formatting tools

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,9 @@
 **[Optimizing AST Node Cloning with `std::mem::replace`]**
 **Learning:** During iterative AST tree building (e.g., when wrapping an expression in successive `MethodCall`s like `.iter().map().filter().collect()`), the previous expression `current_expr` had to be passed into the new node. Because it's stored in a `Box`, using `Box::new(current_expr.clone())` causes an expensive deep clone of the entire recursive AST structure for each method in the chain. However, since the old node is entirely moved into the new node (and we overwrite `current_expr` immediately after), we can use `std::mem::replace(&mut current_expr, AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unknown })` to safely extract the old tree without a single allocation, effectively a zero-cost transfer of ownership.
 **Action:** Use `std::mem::replace` to avoid deep cloning of AST nodes when building recursive or iterative tree structures in place.
+**[Remove Intermediate Allocs]
+**Learning:**  strings create intermediate heap allocations which drop immediately after pushing/writing them to a buffer.
+**Action:** Use  to write formatted text directly into a string buffer without intermediate allocations.
+**[Remove Intermediate Allocs]
+**Learning:** `format!()` strings create intermediate heap allocations which drop immediately after pushing/writing them to a buffer.
+**Action:** Use `writeln!(out, ...)` to write formatted text directly into a string buffer without intermediate allocations.

--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -131,7 +131,7 @@ fn transpile_statement(stmt: &AnalyzedStatement, indent: usize) -> String {
         AnalyzedStatement::Expression(exprs) => {
             let mut out = String::new();
             for expr in exprs {
-                out.push_str(&format!("{}{}\n", ind, transpile_expr(expr)));
+                let _ = writeln!(out, "{}{}", ind, transpile_expr(expr));
             }
             out.trim_end().to_string()
         }
@@ -167,7 +167,7 @@ fn transpile_if(
     let ind = "    ".repeat(indent);
     let mut out = format!("{}if {}:\n", ind, transpile_expr(condition));
     if then_body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in then_body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -175,9 +175,9 @@ fn transpile_if(
         }
     }
     if let Some(ebody) = else_body {
-        out.push_str(&format!("{}else:\n", ind));
+        let _ = writeln!(out, "{}else:", ind);
         if ebody.is_empty() {
-            out.push_str(&format!("{}    pass\n", ind));
+            let _ = writeln!(out, "{}    pass", ind);
         } else {
             for b_stmt in ebody {
                 out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -192,7 +192,7 @@ fn transpile_while(condition: &AnalyzedExpr, body: &[AnalyzedStatement], indent:
     let ind = "    ".repeat(indent);
     let mut out = format!("{}while {}:\n", ind, transpile_expr(condition));
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -216,7 +216,7 @@ fn transpile_for(
         transpile_expr(iterator)
     );
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -243,7 +243,7 @@ fn transpile_function_def(
     out.push_str("):\n");
 
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for (i, b_stmt) in body.iter().enumerate() {
             let mut is_last_expr = false;
@@ -255,9 +255,9 @@ fn transpile_function_def(
                 if let AnalyzedStatement::Expression(exprs) = b_stmt {
                     for (j, expr) in exprs.iter().enumerate() {
                         if j == exprs.len() - 1 {
-                            out.push_str(&format!("{}    return {}\n", ind, transpile_expr(expr)));
+                            let _ = writeln!(out, "{}    return {}", ind, transpile_expr(expr));
                         } else {
-                            out.push_str(&format!("{}    {}\n", ind, transpile_expr(expr)));
+                            let _ = writeln!(out, "{}    {}", ind, transpile_expr(expr));
                         }
                     }
                 }
@@ -283,10 +283,10 @@ fn transpile_type_def(
         sanitize_ident(name)
     );
     if fields.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for (f_name, _) in fields {
-            out.push_str(&format!("{}    {}: Any\n", ind, sanitize_ident(f_name)));
+            let _ = writeln!(out, "{}    {}: Any", ind, sanitize_ident(f_name));
         }
     }
     out.trim_end().to_string()
@@ -298,7 +298,7 @@ fn transpile_test_declaration(name: &str, body: &[AnalyzedStatement], indent: us
     let safe_name = name.replace(" ", "_").replace("-", "_").replace("\"", "");
     let mut out = format!("{}def test_{}():\n", ind, safe_name);
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -317,13 +317,9 @@ fn transpile_match(
     // Python 3.10+ match statement
     let mut out = format!("{}match {}:\n", ind, transpile_expr(scrutinee));
     for (pattern_expr, arm_body) in arms {
-        out.push_str(&format!(
-            "{}    case {}:\n",
-            ind,
-            transpile_expr(pattern_expr)
-        ));
+        let _ = writeln!(out, "{}    case {}:", ind, transpile_expr(pattern_expr));
         if arm_body.is_empty() {
-            out.push_str(&format!("{}        pass\n", ind));
+            let _ = writeln!(out, "{}        pass", ind);
         } else {
             for b_stmt in arm_body {
                 out.push_str(&transpile_statement(b_stmt, indent + 2));

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -20,6 +20,7 @@ use crate::tools::ui::Status;
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use std::path::Path;
+use std::fmt::Write;
 
 /// Run the Labyrinth tool on a file
 pub fn run_labyrinth(input: &Path) -> miette::Result<()> {
@@ -146,10 +147,12 @@ pub fn generate_cfg(program: &AnalyzedProgram) -> String {
 
     let mut out = String::from("graph TD\n");
     for node in nodes {
-        out.push_str(&format!("    {}\n", node));
+        // ⚡ Bolt Optimization: Removed intermediate format string allocation.
+        let _ = writeln!(out, "    {}", node);
     }
     for edge in edges {
-        out.push_str(&format!("    {}\n", edge));
+        // ⚡ Bolt Optimization: Removed intermediate format string allocation.
+        let _ = writeln!(out, "    {}", edge);
     }
     out
 }

--- a/src/tools/weave.rs
+++ b/src/tools/weave.rs
@@ -18,6 +18,7 @@ use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
 use std::fs;
 use std::path::Path;
+use std::fmt::Write;
 
 /// Run the Weave tool on a file
 ///
@@ -62,7 +63,8 @@ pub fn run_weave(input: &Path) -> Result<()> {
 
     let filename = input.file_name().unwrap_or_default().to_string_lossy();
 
-    md.push_str(&format!("# Rosetta Stone: `{}`\n\n", filename));
+    // ⚡ Bolt Optimization: Removed intermediate format string allocation.
+    let _ = writeln!(md, "# Rosetta Stone: `{}`\n", filename);
 
     md.push_str("## 📜 ΓΛΩΣΣΑ Source\n\n");
     md.push_str("```glossa\n");


### PR DESCRIPTION
💡 What: Replaced `push_str(&format!(...))` with `write!` or `writeln!` macros across `src/tools/alchemist.rs`, `src/tools/weave.rs`, and `src/tools/labyrinth.rs`.
🎯 Why: `format!(...)` inside `push_str` forces an immediate, short-lived heap allocation that is dropped right after pushing, leading to unnecessary memory churn in serialization paths.
📊 Impact: Eliminates a large number of intermediate string allocations during code and graph generation.
🔭 Measurement: Verify memory utilization drops using benchmarks/profilers, or check that `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test` pass cleanly.

---
*PR created automatically by Jules for task [5603688966165050658](https://jules.google.com/task/5603688966165050658) started by @madmax983*