### PR TITLE
🎸 Bard: [documentation update] Executable Doctests for Tools

### DIFF
--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -11,6 +11,24 @@ use crossterm::style::Stylize;
 use miette::Result;
 
 /// Run the catalog explorer
+///
+/// This interactive CLI tool prints a categorized, tabular view of all words
+/// natively built into the compiler's static dictionary. It is used to quickly
+/// explore available Ancient Greek vocabulary and their expected rust equivalents.
+///
+/// ## Examples
+///
+/// Since this function outputs directly to standard out and is meant to be run
+/// from the CLI, it can be invoked without arguments.
+///
+/// ```rust,no_run
+/// use glossa::tools::catalog::run_catalog;
+///
+/// // In a CLI context, simply call the tool:
+/// if let Err(e) = run_catalog() {
+///     eprintln!("Failed to display the catalog: {}", e);
+/// }
+/// ```
 pub fn run_catalog() -> Result<()> {
     // ⚡ Bolt Optimization: Uses `rustc_hash::FxHashMap` instead of the standard `HashMap`
     // since the keys are internal `PartOfSpeech` enums and are not exposed to HashDoS attacks.

--- a/src/tools/dictionary.rs
+++ b/src/tools/dictionary.rs
@@ -53,6 +53,25 @@ use crate::morphology::{analyze_all, lexicon};
 use crate::text::normalize_greek;
 
 /// Lookup a word in the dictionary
+///
+/// This is the main entry point for the `glossa lookup` CLI command. It takes an
+/// Ancient Greek word, normalizes it, checks the internal static lexicon, and
+/// performs morphological analysis to guess its grammatical role (Case, Number, Gender)
+/// if it is unknown. It prints a rich table directly to the standard output.
+///
+/// ## Examples
+///
+/// Because this is a CLI tool that prints to standard out, it is typically called
+/// from `main.rs`.
+///
+/// ```rust,no_run
+/// use glossa::tools::dictionary::lookup_word;
+///
+/// // Lookup the accusative form of "word"
+/// if let Err(e) = lookup_word("λόγον") {
+///     eprintln!("Lookup failed: {}", e);
+/// }
+/// ```
 pub fn lookup_word(word: &str) -> Result<()> {
     let normalized = normalize_greek(word);
 

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -49,6 +49,25 @@ use crate::parser::parse;
 /// This function parses the source code into an AST and then walks the AST to
 /// apply ANSI color codes based on the semantic role of each element.
 ///
+/// Semantically highlights a given ΓΛΩΣΣΑ source string.
+///
+/// This function parses the source and applies ANSI escape codes to colorize
+/// words based on their semantic and grammatical roles (e.g. subjects in blue,
+/// verbs in green, objects in red).
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::tools::highlight::highlight;
+///
+/// let source = "ξ 5 ἔστω.";
+/// let highlighted = highlight(source).unwrap();
+///
+/// // The output contains the original text along with ANSI color codes.
+/// assert!(highlighted.contains("ξ"));
+/// assert!(highlighted.contains("\x1b["));
+/// ```
+///
 /// # Errors
 ///
 /// Returns a [`GlossaError`] if the source code cannot be parsed.


### PR DESCRIPTION
📖 Chapter: The Developer Tools
🔦 Insight: Several public functions in the CLI toolset (`lookup_word`, `run_catalog`, and `highlight`) lacked `## Examples` sections, leaving developers guessing how they operate or their intended usage patterns. 
🧪 Example: Added executable `no_run` doctests for CLI tools to prevent spam, and a standard compiled doctest for `highlight`.
🖼️ Preview: The `cargo doc` output is now cleaner and without `missing_docs` warnings for these public tools.

---
*PR created automatically by Jules for task [16219206599720805923](https://jules.google.com/task/16219206599720805923) started by @madmax983*