### PR TITLE
🔒 Warden: Fix panic leak in unwrap codegen

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -131,3 +131,6 @@ Signed,
 **2026-04-30 - [Infinite Stream DoS Vulnerability in File Loading]
 **Threat:** The `load_source` function in `src/tools/runner.rs` relied on `fs::metadata().len()` to enforce the `MAX_FILE_SIZE` limit. However, special device files like `/dev/zero` report a length of 0 while producing an infinite stream of bytes when read. Reading these files with `fs::read_to_string` causes a thread hang or Out-Of-Memory (OOM) Denial-of-Service condition.
 **Defense:** Added an explicit `metadata.is_file()` check in `check_file_size` to guarantee that the input path points to a regular file and explicitly reject non-regular file types like directories and device streams. Updated `tests/havoc_dos.rs` and `test_load_source_directory_error` to assert the "Not a valid file" error and pass cleanly without timeouts.
+**2024-05-18 - [Fix English Panics Escaping on Unwraps]**
+**Threat:** The `Unwrap` expression kind generated an unchecked `.expect("attempted to unwrap an empty value")` call, which bypassed the translation layer and leaked English panics to end users.
+**Defense:** Added a new match arm to the `match msg` block in `src/codegen.rs` to intercept the `"attempted to unwrap an empty value"` string and map it to an appropriate Greek translation (`("Προσπάθεια ἀποκαλύψεως κενοῦ", "Attempted to unwrap an empty value")`).

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -447,6 +447,8 @@ fn generate_panic_hook() -> TokenStream {
                     ("Δείκτης ἐκτὸς ὁρίων", "Index out of bounds"),
                 s if s.starts_with("index out of bounds") =>
                     ("Δείκτης ἐκτὸς ὁρίων", "Index out of bounds"),
+                "attempted to unwrap an empty value" =>
+                    ("Προσπάθεια ἀποκαλύψεως κενοῦ", "Attempted to unwrap an empty value"),
                 _ => ("Σφάλμα ἐκτελέσεως", msg),
             };
 

--- a/tests/sentry_codegen_perf.rs
+++ b/tests/sentry_codegen_perf.rs
@@ -84,7 +84,7 @@ fn test_codegen_runtime_unwrap_panic() {
     assert!(!output.status.success(), "Executable should have panicked");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("attempted to unwrap an empty value") || stderr.contains("Unknown error"),
+        stderr.contains("Προσπάθεια ἀποκαλύψεως κενοῦ") || stderr.contains("Unknown error"),
         "Missing panic message: {}",
         stderr
     );


### PR DESCRIPTION
🦠 **Threat:** The `Unwrap` expression kind generated an unchecked `.expect("attempted to unwrap an empty value")` call, which bypassed the translation layer and leaked raw English panics to end users instead of translating them.
🛡️ **Defense:** Added a new match arm to the `match msg` block in `src/codegen.rs`'s error hook to explicitly map `"attempted to unwrap an empty value"` to the Greek translation `("Προσπάθεια ἀποκαλύψεως κενοῦ", "Attempted to unwrap an empty value")`.
💥 **Severity:** Low/Medium - Breaks the "Greek First" interface contract and causes confusion.
🧪 **Verification:** Updated `test_codegen_runtime_unwrap_panic` integration test to expect the translated Greek payload and ran `cargo test`.

---
*PR created automatically by Jules for task [6595190031615370204](https://jules.google.com/task/6595190031615370204) started by @madmax983*