### PR TITLE
👺 Havoc: Semantic AST Drop Stack Overflow

### DIFF
--- a/tests/havoc_semantic_overflow.rs
+++ b/tests/havoc_semantic_overflow.rs
@@ -1,0 +1,27 @@
+use glossa::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1))]
+    #[test]
+    #[ignore]
+    fn test_havoc_semantic_overflow_proptest(_seed in 0..1) {
+        let mut expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(1),
+            glossa_type: GlossaType::Number,
+        };
+
+        for _ in 0..100_000 {
+            expr = AnalyzedExpr {
+                expr: AnalyzedExprKind::PropertyAccess {
+                    owner: Box::new(expr),
+                    property: "prop".into(),
+                },
+                glossa_type: GlossaType::Number,
+            };
+        }
+
+        // Dropping this deeply nested expression will cause a stack overflow!
+        drop(expr);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Deeply nested AST nodes `AnalyzedExpr` and `AnalyzedStatement` without proper stacker guards during implicit dropping.
📉 **The Stack Trace:** fatal runtime error: stack overflow, aborting
🧪 **Reproduction:** Run `cargo test --test havoc_semantic_overflow -- --ignored`
😈 **Comment:** You assumed the compiler-generated drop would magically fit in your puny stack. You were wrong.

---
*PR created automatically by Jules for task [2971468352359856738](https://jules.google.com/task/2971468352359856738) started by @madmax983*