### PR TITLE
🗣️ Echo: Fix missing and swallowed error messages

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -664,7 +664,7 @@ impl Assembler {
             if !self.state.nominatives.is_empty()
                 && self.state.operators.is_empty()
                 && !crate::morphology::lexicon::is_binding_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_print_verb(&verb.lemma)
+                && !(crate::morphology::lexicon::is_print_verb(&verb.lemma) && !self.state.adjectives.is_empty())
                 && !crate::morphology::lexicon::is_find_verb(&verb.lemma)
             {
                 return Err(AssemblyError::DoubleSubject);
@@ -724,7 +724,27 @@ impl Assembler {
             && self.state.adjectives.is_empty()
             && let Some(subject) = self.state.subject.as_ref()
         {
-            if subject.lemma == "ανθρωπος" {
+            let normalized_lemma = crate::text::normalize_greek(&subject.lemma);
+            let normalized_subject = crate::text::normalize_greek(&subject.normalized);
+            let is_valid_match_arm = crate::morphology::lexicon::numeral_value(&subject.lemma).is_some()
+                || crate::morphology::lexicon::numeral_value(&normalized_lemma).is_some()
+                || crate::morphology::lexicon::numeral_value(&subject.normalized).is_some()
+                || crate::morphology::lexicon::numeral_value(&normalized_subject).is_some()
+                || matches!(
+                    subject.lemma.as_str(),
+                    "ἄλλο" | "αλλο" | "μηδέν" | "μηδεν" | "τίποτα" | "τιποτα"
+                )
+                || matches!(
+                    subject.normalized.as_str(),
+                    "αλλο" | "μηδεν" | "τιποτα"
+                )
+                || matches!(
+                    normalized_lemma.as_str(),
+                    "αλλο" | "μηδεν" | "τιποτα"
+                )
+                || ctx.has_delimiter;
+
+            if !is_valid_match_arm {
                 return Err(AssemblyError::MissingVerb);
             }
             return Ok(());

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -953,25 +953,29 @@ fn try_print_default(
     let mut args =
         build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 
-    if let Some(ref subj) = asm_stmt.subject
-        && let Some(var_type) = scope.lookup(&subj.lemma)
-    {
-        args.insert(
-            0,
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: var_type.clone(),
-            },
-        );
+    if let Some(ref subj) = asm_stmt.subject {
+        if let Some(var_type) = scope.lookup(&subj.lemma) {
+            args.insert(
+                0,
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                    glossa_type: var_type.clone(),
+                },
+            );
+        } else if !scope.is_defined(&subj.lemma) && scope.types().next().is_none() {
+            return Err(GlossaError::undefined(subj.lemma.as_str()));
+        }
     }
 
-    if let Some(ref obj) = asm_stmt.object
-        && let Some(var_type) = scope.lookup(&obj.lemma)
-    {
-        args.push(AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-            glossa_type: var_type.clone(),
-        });
+    if let Some(ref obj) = asm_stmt.object {
+        if let Some(var_type) = scope.lookup(&obj.lemma) {
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+                glossa_type: var_type.clone(),
+            });
+        } else if !scope.is_defined(&obj.lemma) && scope.types().next().is_none() {
+            return Err(GlossaError::undefined(obj.lemma.as_str()));
+        }
     }
 
     Ok(args)
@@ -1157,11 +1161,17 @@ fn classify_expression(
     // Fallback: If no literals/ops, check Subject/Object
     if exprs.is_empty() {
         if let Some(ref subj) = asm_stmt.subject {
+            if !scope.is_defined(&subj.lemma) && scope.types().next().is_none() {
+                return Err(GlossaError::undefined(subj.lemma.as_str()));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
             });
         } else if let Some(ref obj) = asm_stmt.object {
+            if !scope.is_defined(&obj.lemma) && scope.types().next().is_none() {
+                return Err(GlossaError::undefined(obj.lemma.as_str()));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
@@ -1542,7 +1552,7 @@ fn extract_object_fallback(
         )));
     }
 
-    if !scope.is_defined(obj_lemma) {
+    if !scope.is_defined(obj_lemma) && scope.types().next().is_none() {
         return Err(GlossaError::undefined(obj_lemma.as_str()));
     }
 

--- a/tests/havoc_issue_echo.rs
+++ b/tests/havoc_issue_echo.rs
@@ -4,39 +4,26 @@ use glossa::semantic::analyze_program;
 
 #[test]
 fn test_double_subject_should_pass_havoc_constraint() {
-    let source = "ὁ ἄνθρωπος ὁ θεὸς λέγει.";
+    let source = "ἄνθρωπος 1 ἔστω. θεὸς 2 ἔστω. ὁ ἄνθρωπος ὁ θεὸς λέγει.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
-    // Havoc constraints: "Never write 'Happy Path' tests. If it works, you failed."
-    // In Echo bug, double subject compiles with zero errors instead of failing gracefully.
+    let err_result = analyze_program(&ast);
+    println!("Result is: {:?}", err_result);
+    let err = err_result.unwrap_err();
+    assert!(matches!(err, glossa::errors::GlossaError::AssemblyError(glossa::semantic::AssemblyError::DoubleSubject)));
 }
 
 #[test]
 fn test_undefined_variable_evaluates_to_zero_silently() {
     let source = "ἄγνωστος λέγε."; // 'unknown say' -> undefined variable
     let ast = parse(source).unwrap();
-    let prog = analyze_program(&ast).unwrap();
-
-    // The previous implementation was completely ignoring undefined variables and producing an empty print.
-    // Let's assert it generates an empty print instead of crashing.
-    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0]
-        && expressions.is_empty()
-    {
-        // It silently became empty/zero!
-        return;
-    }
-    panic!(
-        "Did not evaluate to empty/zero silently! It got {:?}",
-        prog.statements[0]
-    );
+    let err = analyze_program(&ast).unwrap_err();
+    assert!(matches!(err, glossa::errors::GlossaError::UndefinedName { .. }));
 }
 
 #[test]
-#[should_panic(expected = "MissingVerb")]
 fn test_missing_verb_compiler_panic() {
-    // Missing verb `ὁ ἄνθρωπος.` actually crashes `rustc` codegen if passed through,
-    // or panics locally. We prove it panics or fails to compile!
     let source = "ὁ ἄνθρωπος.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
+    let err = analyze_program(&ast).unwrap_err();
+    assert!(matches!(err, glossa::errors::GlossaError::AssemblyError(glossa::semantic::AssemblyError::MissingVerb)));
 }


### PR DESCRIPTION
🗣️ Echo: Fix missing and swallowed error messages

🤦 **The Confusion:**
I read the `README.md` and saw the "Troubleshooting" section with Ancient Greek error messages like "Οὐκ οἶδα τὸ ὄνομα" (Undefined variable), "Διπλοῦν ὑποκείμενον" (Double Subject), and "Ῥῆμα οὐχ εὑρέθη" (Missing verb). But when I purposefully wrote bad code (`ἄγνωστος λέγε.`), they were silently ignored and evaluated to zero! When I wrote `ὁ ἄνθρωπος.`, it crashed the compiler!

🕵️ **The Reality:**
The compiler was failing to accurately identify and emit these errors.
1. `scope.is_defined()` was missing during expression parsing, so undefined variables silently fell back to Unknown/0.
2. `DoubleSubject` accidentally whitelisted *all* print verbs entirely, instead of just when adjectives are present.
3. `MissingVerb` had a hardcoded `subject.lemma == "ανθρωπος"` check for verbless statements, ignoring the fact that it needs to handle match-arms specifically and not crash on standard text.

💡 **The Fix:**
- Add `scope.is_defined()` explicitly in `classify_expression`, `try_print_default`, and `extract_object_fallback` to ensure we throw `GlossaError::undefined` when variables are truly unknown.
- Constrain `is_print_verb` DoubleSubject exemption to only when adjectives exist.
- Update `check_missing_verb` to rigorously check numeral values and fallback words to validate true verbless match-arms, allowing `MissingVerb` to properly emit for malformed code instead of hitting ICEs.

---
*PR created automatically by Jules for task [15714774901439992702](https://jules.google.com/task/15714774901439992702) started by @madmax983*