### PR TITLE
🎨 Mosaic: UI Polish for Haruspex

### DIFF
--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -13,6 +13,8 @@
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
+use comfy_table::{presets, Attribute, Cell, Color, Table};
+use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
 use std::path::Path;
@@ -46,7 +48,54 @@ pub fn run_haruspex(input: &Path) -> Result<()> {
     let mut generator = DotGenerator::new();
     let dot = generator.generate(&program);
 
-    println!("{}", dot);
+    println!();
+    println!(
+        "   {}",
+        "Γ Λ Ω Σ Σ Α   H A R U S P E X".bold().cyan()
+    );
+    println!("   {}", "Semantic AST Graphviz DOT".italic().dim());
+    println!();
+
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL);
+
+    if program.statements.is_empty() {
+        table.set_header(vec![
+            Cell::new("Status")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Yellow),
+        ]);
+        table.add_row(vec![
+            Cell::new("No AST structures found.")
+                .fg(Color::DarkGrey)
+                .add_attribute(Attribute::Italic),
+        ]);
+        println!("{table}");
+        println!();
+    } else {
+        table.set_header(vec![
+            Cell::new("Graphviz DOT Graph")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+        ]);
+
+        let formatted_dot = format!("```dot\n{}\n```", dot.trim());
+        table.add_row(vec![Cell::new(formatted_dot)]);
+
+        println!("{table}");
+        println!();
+        println!(
+            "   {}",
+            "📋 Usage Instructions:".bold().underlined()
+        );
+        println!("   1. Copy the code block above.");
+        println!(
+            "   2. Paste it into {}",
+            "https://dreampuf.github.io/GraphvizOnline/".cyan().underlined()
+        );
+        println!();
+    }
+
     Ok(())
 }
 

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -13,10 +13,11 @@
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
-use comfy_table::{presets, Attribute, Cell, Color, Table};
+use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Runs the Haruspex tool to generate a Graphviz DOT representation of the AST.
@@ -48,52 +49,54 @@ pub fn run_haruspex(input: &Path) -> Result<()> {
     let mut generator = DotGenerator::new();
     let dot = generator.generate(&program);
 
-    println!();
-    println!(
-        "   {}",
-        "Γ Λ Ω Σ Σ Α   H A R U S P E X".bold().cyan()
-    );
-    println!("   {}", "Semantic AST Graphviz DOT".italic().dim());
-    println!();
-
-    let mut table = Table::new();
-    table.load_preset(presets::UTF8_FULL);
-
-    if program.statements.is_empty() {
-        table.set_header(vec![
-            Cell::new("Status")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Yellow),
-        ]);
-        table.add_row(vec![
-            Cell::new("No AST structures found.")
-                .fg(Color::DarkGrey)
-                .add_attribute(Attribute::Italic),
-        ]);
-        println!("{table}");
-        println!();
+    if !std::io::stdout().is_terminal() {
+        // Golden Path: If we are being piped, output the raw DOT.
+        println!("{}", dot);
     } else {
-        table.set_header(vec![
-            Cell::new("Graphviz DOT Graph")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Cyan),
-        ]);
-
-        let formatted_dot = format!("```dot\n{}\n```", dot.trim());
-        table.add_row(vec![Cell::new(formatted_dot)]);
-
-        println!("{table}");
+        // UI Mode: Display the styled dashboard.
         println!();
-        println!(
-            "   {}",
-            "📋 Usage Instructions:".bold().underlined()
-        );
-        println!("   1. Copy the code block above.");
-        println!(
-            "   2. Paste it into {}",
-            "https://dreampuf.github.io/GraphvizOnline/".cyan().underlined()
-        );
+        println!("   {}", "Γ Λ Ω Σ Σ Α   H A R U S P E X".bold().cyan());
+        println!("   {}", "Semantic AST Graphviz DOT".italic().dim());
         println!();
+
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
+
+        if program.statements.is_empty() {
+            table.set_header(vec![
+                Cell::new("Status")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Yellow),
+            ]);
+            table.add_row(vec![
+                Cell::new("No AST structures found.")
+                    .fg(Color::DarkGrey)
+                    .add_attribute(Attribute::Italic),
+            ]);
+            println!("{table}");
+            println!();
+        } else {
+            table.set_header(vec![
+                Cell::new("Graphviz DOT Graph")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Cyan),
+            ]);
+
+            let formatted_dot = format!("```dot\n{}\n```", dot.trim());
+            table.add_row(vec![Cell::new(formatted_dot)]);
+
+            println!("{table}");
+            println!();
+            println!("   {}", "📋 Usage Instructions:".bold().underlined());
+            println!("   1. Copy the code block above.");
+            println!(
+                "   2. Paste it into {}",
+                "https://dreampuf.github.io/GraphvizOnline/"
+                    .cyan()
+                    .underlined()
+            );
+            println!();
+        }
     }
 
     Ok(())

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -759,6 +759,21 @@ mod tests {
     }
 
     #[test]
+    fn test_run_haruspex_success() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let valid_file = temp_dir.path().join("valid.γλ");
+        std::fs::write(&valid_file, "ξ 10 ἔστω.").unwrap();
+        let result = run_haruspex(&valid_file);
+        assert!(result.is_ok());
+
+        // Also test empty program to cover the "empty statements" branch
+        let empty_file = temp_dir.path().join("empty.γλ");
+        std::fs::write(&empty_file, "").unwrap();
+        let result = run_haruspex(&empty_file);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_dot_generator_coverage() {
         let scope = Scope::new();
 


### PR DESCRIPTION
🖌️ **Before:** The `haruspex` tool dumped raw Graphviz DOT data directly to the user's console via `println!("{}", dot)`. This violated the UI philosophy of not outputting raw machine-readable data directly.

✨ **After:** The `haruspex` tool now wraps the Graphviz DOT data in a nicely styled `comfy_table`. It includes bold/colored headers indicating what the content is, and provides explicit instructions on how to use it by directing the user to a web visualizer (`https://dreampuf.github.io/GraphvizOnline/`).

🖼️ **Visuals:** The output now features a cyan title (`Γ Λ Ω Σ Σ Α   H A R U S P E X`), followed by a framed table containing the raw dot output labeled "Graphviz DOT Graph", and usage instructions at the bottom.

---
*PR created automatically by Jules for task [7286415384047638691](https://jules.google.com/task/7286415384047638691) started by @madmax983*