### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-05-06 - The CLI Tools "Ghost" Examples
+**Confusion:** The public entry point functions for the tools in `src/tools/` (like `run_alchemist`, `run_map`, etc.) were missing `## Examples` doc-tests, making them "Black Boxes" to programmatic users. However, many of these functions write directly to stdout or read from stdin, which causes `cargo test` doc-tests to hang or spam output.
+**Clarification:** Added `///` doc comments with `## Examples` sections to all tool entry point functions. Used the ````rust,no_run` attribute on the code blocks for functions that perform interactive I/O or require actual files to exist, satisfying the requirement for executable examples without breaking the test suite.

--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -18,6 +18,23 @@ use std::fmt::Write;
 use std::path::Path;
 
 /// Run the Alchemist tool on a file
+///
+/// This function acts as the programmatic entry point for transpiling a ΓΛΩΣΣΑ
+/// file into a Python script. It handles reading the file, performing semantic analysis,
+/// and outputting the transpiled code to stdout. It exists to provide an alternative
+/// execution environment for ΓΛΩΣΣΑ logic.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::alchemist::run_alchemist;
+/// use std::path::Path;
+///
+/// let input = Path::new("script.γλ");
+/// if let Err(e) = run_alchemist(&input) {
+///     eprintln!("Transpilation failed: {}", e);
+/// }
+/// ```
 pub fn run_alchemist(input: &Path) -> miette::Result<()> {
     let source = crate::tools::runner::load_source(input)?;
 
@@ -60,6 +77,25 @@ pub fn run_alchemist(input: &Path) -> miette::Result<()> {
 }
 
 /// Transpile an AnalyzedProgram to Python source code
+///
+/// This function is the core transpilation engine of the Alchemist. It traverses
+/// the semantically analyzed abstract syntax tree and generates equivalent Python
+/// syntax, proving that ΓΛΩΣΣΑ's semantics can map to dynamic languages.
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::parser::parse;
+/// use glossa::semantic::analyze_program;
+/// use glossa::tools::alchemist::transpile_to_python;
+///
+/// let source = "ξ 5 ἔστω.";
+/// let ast = parse(source).unwrap();
+/// let program = analyze_program(&ast).unwrap();
+///
+/// let python_code = transpile_to_python(&program);
+/// assert!(python_code.contains("x = 5"));
+/// ```
 pub fn transpile_to_python(program: &AnalyzedProgram) -> String {
     let mut out = String::new();
     out.push_str("from typing import Any\n");

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -43,7 +43,22 @@ use std::path::Path;
 
 /// Run the Cartographer tool on a file
 ///
-/// Reads the source file, parses it, and prints the architectural map to stdout.
+/// This function acts as the programmatic entry point for the "Cartographer" tool.
+/// It parses and analyzes the provided ΓΛΩΣΣΑ file, and prints the architectural
+/// map (a Mermaid.js class diagram) to stdout. It exists to provide a high-level
+/// overview of the module structures and interfaces in a codebase.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::cartographer::run_map;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// if let Err(e) = run_map(&input) {
+///     eprintln!("Cartographer failed: {}", e);
+/// }
+/// ```
 pub fn run_map(input: &Path) -> Result<()> {
     let source = crate::tools::runner::load_source(input)?;
 
@@ -109,6 +124,26 @@ pub fn run_map(input: &Path) -> Result<()> {
 }
 
 /// Generate a Mermaid class diagram from an analyzed program
+///
+/// This function is the core string-generation engine for the Cartographer.
+/// It iterates over all defined types (Structs) and traits (Interfaces) within
+/// the parsed scope, and formats them according to Mermaid class diagram syntax.
+///
+/// ## Examples
+///
+/// ```rust
+/// use glossa::parser::parse;
+/// use glossa::semantic::analyze_program;
+/// use glossa::tools::cartographer::generate_map;
+///
+/// let source = "εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. }.";
+/// let ast = parse(source).unwrap();
+/// let program = analyze_program(&ast).unwrap();
+///
+/// let mermaid_code = generate_map(&program);
+/// assert!(mermaid_code.contains("class Χρήστης"));
+/// assert!(mermaid_code.contains("+ὄνομα: String"));
+/// ```
 pub fn generate_map(program: &AnalyzedProgram) -> String {
     let mut map = String::from("classDiagram\n");
 

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -11,6 +11,20 @@ use crossterm::style::Stylize;
 use miette::Result;
 
 /// Run the catalog explorer
+///
+/// This function acts as the programmatic entry point for the "Catalog" tool,
+/// which enumerates and visually prints all known words in the compiler's built-in lexicon.
+/// It exists to help users explore the core vocabulary of ΓΛΩΣΣΑ by their parts of speech.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::catalog::run_catalog;
+///
+/// if let Err(e) = run_catalog() {
+///     eprintln!("Failed to run catalog: {}", e);
+/// }
+/// ```
 pub fn run_catalog() -> Result<()> {
     // ⚡ Bolt Optimization: Uses `rustc_hash::FxHashMap` instead of the standard `HashMap`
     // since the keys are internal `PartOfSpeech` enums and are not exposed to HashDoS attacks.

--- a/src/tools/dictionary.rs
+++ b/src/tools/dictionary.rs
@@ -53,6 +53,21 @@ use crate::morphology::{analyze_all, lexicon};
 use crate::text::normalize_greek;
 
 /// Lookup a word in the dictionary
+///
+/// This function acts as the programmatic entry point for the "Lexicon" tool,
+/// looking up a provided Ancient Greek word using both the static internal lexicon
+/// and dynamic morphological analysis. It exists to provide interactive debugging
+/// of the compiler's morphological phase.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::dictionary::lookup_word;
+///
+/// if let Err(e) = lookup_word("λόγον") {
+///     eprintln!("Lookup failed: {}", e);
+/// }
+/// ```
 pub fn lookup_word(word: &str) -> Result<()> {
     let normalized = normalize_greek(word);
 

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -18,6 +18,23 @@ use std::fmt::Write;
 use std::path::Path;
 
 /// Runs the Haruspex tool to generate a Graphviz DOT representation of the AST.
+///
+/// This function acts as the programmatic entry point for the "Haruspex" tool.
+/// It parses and analyzes the provided ΓΛΩΣΣΑ file, traversing its abstract syntax tree
+/// to generate a Graphviz DOT file. It exists so that developers can visually
+/// debug the semantic nesting and structure of complex expressions.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::haruspex::run_haruspex;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// if let Err(e) = run_haruspex(&input) {
+///     eprintln!("Haruspex failed: {}", e);
+/// }
+/// ```
 pub fn run_haruspex(input: &Path) -> Result<()> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -22,6 +22,23 @@ use crossterm::style::Stylize;
 use std::path::Path;
 
 /// Run the Labyrinth tool on a file
+///
+/// This function acts as the programmatic entry point for the "Labyrinth" tool.
+/// It parses and analyzes the provided ΓΛΩΣΣΑ file, constructing a Mermaid flowchart
+/// diagram to represent the program's control flow logic, and prints it to stdout.
+/// It exists to provide a clear, visual representation of execution paths.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::labyrinth::run_labyrinth;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// if let Err(e) = run_labyrinth(&input) {
+///     eprintln!("Labyrinth failed: {}", e);
+/// }
+/// ```
 pub fn run_labyrinth(input: &Path) -> miette::Result<()> {
     let source = crate::tools::runner::load_source(input)?;
     let mut buffer = Vec::new();

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -107,8 +107,20 @@ const LESSONS: &[Lesson] = &[
 
 /// Start the interactive Mentor session
 ///
-/// This function enters a loop where it presents lessons to the user and waits
-/// for them to type code that satisfies the lesson's requirements.
+/// This function acts as the programmatic entry point for the "Mentor" tool.
+/// It enters an interactive loop where it presents lessons to the user via stdout
+/// and waits for them to type code via stdin that satisfies the lesson's requirements.
+/// It exists to provide an interactive educational experience for learning ΓΛΩΣΣΑ.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::mentor::run_mentor;
+///
+/// if let Err(e) = run_mentor() {
+///     eprintln!("Mentor session failed: {}", e);
+/// }
+/// ```
 pub fn run_mentor() -> Result<()> {
     let stdin = std::io::stdin();
     let mut stdout = std::io::stdout();

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -36,7 +36,23 @@ use std::path::Path;
 
 /// Run the Mosaic tool on a file
 ///
-/// Reads the source file, parses it, and prints the semantic assembly table to stdout.
+/// This function acts as the programmatic entry point for the "Mosaic" tool.
+/// It reads the provided ΓΛΩΣΣΑ file, parses its contents, and constructs a
+/// colorful table visualizing how the compiler's morphological assembler maps
+/// individual words into syntactic slots (Subject, Verb, Object, etc.). It exists
+/// to demystify the assembler and help users understand free word order semantics.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::mosaic::run_mosaic;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// if let Err(e) = run_mosaic(&input) {
+///     eprintln!("Mosaic failed: {}", e);
+/// }
+/// ```
 pub fn run_mosaic(input_path: &Path) -> Result<()> {
     let source = crate::tools::runner::load_source(input_path)?;
 

--- a/src/tools/weave.rs
+++ b/src/tools/weave.rs
@@ -21,7 +21,23 @@ use std::path::Path;
 
 /// Run the Weave tool on a file
 ///
-/// Reads the source file, compiles it, generates the mosaic, and writes out a Markdown file.
+/// This function acts as the programmatic entry point for the "Weave" tool.
+/// It reads the source file, parses its AST, computes the semantic assembly logic
+/// via `run_mosaic_inner`, generates the Rust transpilation via `generate_rust_file`,
+/// and weaves all three (source, mosaic, generated code) into a Markdown file. It exists
+/// to automatically produce 'Rosetta Stone' style educational documents from raw code.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::weave::run_weave;
+/// use std::path::Path;
+///
+/// let input = Path::new("main.γλ");
+/// if let Err(e) = run_weave(&input) {
+///     eprintln!("Weave failed: {}", e);
+/// }
+/// ```
 pub fn run_weave(input: &Path) -> Result<()> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));


### PR DESCRIPTION
📖 Chapter: `src/tools/` sub-commands
🔦 Insight: The public entry point functions for the tools in `src/tools/` (like `run_alchemist`, `run_map`, etc.) were missing `## Examples` doc-tests, making them "Black Boxes" to programmatic users. Added `///` doc comments with `## Examples` sections and context explaining *why* they exist.
🧪 Example: Added executable and `no_run` doc-tests demonstrating how to invoke tools programmatically.
🖼️ Preview: Documentation is now visible and compiled.

---
*PR created automatically by Jules for task [10153112637676818083](https://jules.google.com/task/10153112637676818083) started by @madmax983*