### PR TITLE
🗣️ Echo: Fix silent compiler failure for undefined variables and double subjects

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,1 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+Everything is perfectly staged! I am ready to submit!

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -664,7 +664,8 @@ impl Assembler {
             if !self.state.nominatives.is_empty()
                 && self.state.operators.is_empty()
                 && !crate::morphology::lexicon::is_binding_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_print_verb(&verb.lemma)
+                && (!crate::morphology::lexicon::is_print_verb(&verb.lemma)
+                    || self.state.adjectives.is_empty())
                 && !crate::morphology::lexicon::is_find_verb(&verb.lemma)
             {
                 return Err(AssemblyError::DoubleSubject);

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -49,6 +49,17 @@ use crate::semantic::resolver::Scope;
 use crate::semantic::types::GlossaType;
 use crate::semantic::{Constituent, Literal};
 
+fn is_known_field(lemma: &str, scope: &Scope) -> bool {
+    for (_, ty) in scope.types() {
+        if let GlossaType::Struct { fields, .. } = ty
+            && fields.iter().any(|(name, _)| name == lemma)
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Convert an AssembledStatement to an AnalyzedStatement
 ///
 /// This is the main entry point for lowering the "Assembled" semantic model (slot-based)
@@ -367,9 +378,12 @@ fn classify_subjunctive_comparison(
             glossa_type: var_type.clone(),
         }
     } else {
+        if subject.lemma != "self" && subject.lemma != "τω" && subject.lemma != "τῷ" && !is_known_field(&subject.lemma, scope) {
+            return Err(GlossaError::undefined(subject.lemma.as_str()));
+        }
         AnalyzedExpr {
-            expr: AnalyzedExprKind::BooleanLiteral(false),
-            glossa_type: GlossaType::Boolean,
+            expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
+            glossa_type: GlossaType::Unknown,
         }
     };
 
@@ -953,24 +967,28 @@ fn try_print_default(
     let mut args =
         build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 
-    if let Some(ref subj) = asm_stmt.subject
-        && let Some(var_type) = scope.lookup(&subj.lemma)
-    {
+    if let Some(ref subj) = asm_stmt.subject {
+        if !scope.is_defined(&subj.lemma) && subj.lemma != "self" && subj.lemma != "τω" && subj.lemma != "τῷ" && !is_known_field(&subj.lemma, scope) {
+            return Err(GlossaError::undefined(subj.lemma.as_str()));
+        }
+        let var_type = scope.lookup(&subj.lemma).unwrap_or(&GlossaType::Unknown).clone();
         args.insert(
             0,
             AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: var_type.clone(),
+                glossa_type: var_type,
             },
         );
     }
 
-    if let Some(ref obj) = asm_stmt.object
-        && let Some(var_type) = scope.lookup(&obj.lemma)
-    {
+    if let Some(ref obj) = asm_stmt.object {
+        if !scope.is_defined(&obj.lemma) && obj.lemma != "self" && obj.lemma != "τω" && obj.lemma != "τῷ" && !is_known_field(&obj.lemma, scope) {
+            return Err(GlossaError::undefined(obj.lemma.as_str()));
+        }
+        let var_type = scope.lookup(&obj.lemma).unwrap_or(&GlossaType::Unknown).clone();
         args.push(AnalyzedExpr {
             expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-            glossa_type: var_type.clone(),
+            glossa_type: var_type,
         });
     }
 
@@ -1128,24 +1146,39 @@ fn classify_expression(
     if !asm_stmt.operators.is_empty() && asm_stmt.literals.len() < 2 {
         let op = asm_stmt.operators[0];
 
-        let left = asm_stmt.subject.as_ref().map(|subj| AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-            glossa_type: GlossaType::Unknown,
-        });
+        let left = if let Some(ref subj) = asm_stmt.subject {
+            if !scope.is_defined(&subj.lemma) && subj.lemma != "self" && subj.lemma != "τω" && subj.lemma != "τῷ" && !is_known_field(&subj.lemma, scope) {
+                return Err(GlossaError::undefined(subj.lemma.as_str()));
+            }
+            Some(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                glossa_type: GlossaType::Unknown,
+            })
+        } else {
+            None
+        };
 
         // Try to get right operand from exprs (literal) or object or nominatives
         let right = if let Some(lit_expr) = exprs.first() {
             Some(lit_expr.clone())
         } else if let Some(ref obj) = asm_stmt.object {
+            if !scope.is_defined(&obj.lemma) && obj.lemma != "self" && obj.lemma != "τω" && obj.lemma != "τῷ" && !is_known_field(&obj.lemma, scope) {
+                return Err(GlossaError::undefined(obj.lemma.as_str()));
+            }
             Some(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
             })
-        } else {
-            asm_stmt.nominatives.first().map(|nom| AnalyzedExpr {
+        } else if let Some(nom) = asm_stmt.nominatives.first() {
+            if !scope.is_defined(&nom.lemma) && nom.lemma != "self" && nom.lemma != "τω" && nom.lemma != "τῷ" && !is_known_field(&nom.lemma, scope) {
+                return Err(GlossaError::undefined(nom.lemma.as_str()));
+            }
+            Some(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(nom.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
             })
+        } else {
+            None
         };
 
         if let (Some(l), Some(r)) = (left, right) {
@@ -1157,11 +1190,17 @@ fn classify_expression(
     // Fallback: If no literals/ops, check Subject/Object
     if exprs.is_empty() {
         if let Some(ref subj) = asm_stmt.subject {
+            if !scope.is_defined(&subj.lemma) && subj.lemma != "self" && subj.lemma != "τω" && subj.lemma != "τῷ" && !is_known_field(&subj.lemma, scope) {
+                return Err(GlossaError::undefined(subj.lemma.as_str()));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
             });
         } else if let Some(ref obj) = asm_stmt.object {
+            if !scope.is_defined(&obj.lemma) && obj.lemma != "self" && obj.lemma != "τω" && obj.lemma != "τῷ" && !is_known_field(&obj.lemma, scope) {
+                return Err(GlossaError::undefined(obj.lemma.as_str()));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
@@ -1542,7 +1581,7 @@ fn extract_object_fallback(
         )));
     }
 
-    if !scope.is_defined(obj_lemma) {
+    if !scope.is_defined(obj_lemma) && !is_known_field(obj_lemma, scope) {
         return Err(GlossaError::undefined(obj_lemma.as_str()));
     }
 

--- a/tests/control_flow_tests.rs
+++ b/tests/control_flow_tests.rs
@@ -176,7 +176,7 @@ fn test_match_wildcard() {
 #[test]
 fn test_break() {
     // παῦε means "stop" - translates to break
-    let source = "ἀπὸ μηδενὸς μέχρι δέκα, εἰ ι πέντε μεῖζον ᾖ, παῦε.";
+    let source = "ι μηδέν ἔστω. ἀπὸ μηδενὸς μέχρι δέκα, εἰ ι πέντε μεῖζον ᾖ, παῦε.";
     let output = compile_to_rust(source);
 
     eprintln!("Generated output:\n{}", output);
@@ -186,7 +186,7 @@ fn test_break() {
 #[test]
 fn test_continue() {
     // συνέχιζε means "continue" - translates to continue
-    let source = "ἀπὸ μηδενὸς μέχρι δέκα, εἰ ι τρία ἔλαττον ᾖ, συνέχιζε.";
+    let source = "ι μηδέν ἔστω. ἀπὸ μηδενὸς μέχρι δέκα, εἰ ι τρία ἔλαττον ᾖ, συνέχιζε.";
     let output = compile_to_rust(source);
 
     assert!(output.contains("continue"), "Expected continue statement");

--- a/tests/havoc_issue_echo.rs
+++ b/tests/havoc_issue_echo.rs
@@ -1,41 +1,28 @@
 #![allow(missing_docs)]
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
+use glossa::errors::GlossaError;
+use glossa::errors::AssemblyError;
 
 #[test]
 fn test_double_subject_should_pass_havoc_constraint() {
     let source = "ὁ ἄνθρωπος ὁ θεὸς λέγει.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
-    // Havoc constraints: "Never write 'Happy Path' tests. If it works, you failed."
-    // In Echo bug, double subject compiles with zero errors instead of failing gracefully.
+    let err = analyze_program(&ast).unwrap_err();
+    assert!(matches!(err, GlossaError::AssemblyError(AssemblyError::DoubleSubject)));
 }
 
 #[test]
 fn test_undefined_variable_evaluates_to_zero_silently() {
     let source = "ἄγνωστος λέγε."; // 'unknown say' -> undefined variable
     let ast = parse(source).unwrap();
-    let prog = analyze_program(&ast).unwrap();
-
-    // The previous implementation was completely ignoring undefined variables and producing an empty print.
-    // Let's assert it generates an empty print instead of crashing.
-    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0]
-        && expressions.is_empty()
-    {
-        // It silently became empty/zero!
-        return;
-    }
-    panic!(
-        "Did not evaluate to empty/zero silently! It got {:?}",
-        prog.statements[0]
-    );
+    let err = analyze_program(&ast).unwrap_err();
+    assert!(matches!(err, GlossaError::UndefinedName { .. }));
 }
 
 #[test]
 #[should_panic(expected = "MissingVerb")]
 fn test_missing_verb_compiler_panic() {
-    // Missing verb `ὁ ἄνθρωπος.` actually crashes `rustc` codegen if passed through,
-    // or panics locally. We prove it panics or fails to compile!
     let source = "ὁ ἄνθρωπος.";
     let ast = parse(source).unwrap();
     let _ = analyze_program(&ast).unwrap();

--- a/tests/word_order_tests.rs
+++ b/tests/word_order_tests.rs
@@ -72,7 +72,7 @@ fn test_article_disambiguation_context() {
     // ὁ ἄνθρωπος should be recognized as masculine nominative singular
     // τὸν λόγον should be recognized as masculine accusative singular
     // These don't produce Rust code yet, but they should parse without error
-    let ast = parse("ὁ ἄνθρωπος λέγει.").expect("Should parse");
+    let ast = parse("ἄνθρωπος «foo» ἔστω. ὁ ἄνθρωπος λέγει.").expect("Should parse");
     let _analyzed = analyze_program(&ast).expect("Should analyze");
 }
 


### PR DESCRIPTION
🗣️ Echo: Fix silent compiler failure for undefined variables and double subjects

🤦 **The Confusion:** Tried to run `αγνωστος λέγε.` or pass double subjects to print verbs, but the compiler just silently continued or generated invalid Rust code without returning `Οὐκ οἶδα τὸ ὄνομα` or `Διπλοῦν ὑποκείμενον`.
🕵️ **The Reality:** The Semantic conversion fallback routines evaluating expressions blindly assigned `Unknown` defaults, and the `DoubleSubject` checks universally exempted print verbs entirely regardless of structure.
💡 **The Fix:** Explicitly throw `UndefinedName` explicitly when unverified variables appear, ensuring variables match scope dictionary keys or defined struct fields (`is_known_field`) to not disrupt parsed trait properties (`selfου`). Adjust `is_print_verb` check to trigger `DoubleSubject` when extra adjectives are not present.

---
*PR created automatically by Jules for task [15429010667232477293](https://jules.google.com/task/15429010667232477293) started by @madmax983*