### PR TITLE
👺 Havoc: Semantic AST Deep Drop Stack Overflow

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/tests/havoc_semantic_overflow.rs
+++ b/tests/havoc_semantic_overflow.rs
@@ -1,0 +1,28 @@
+use glossa::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
+
+#[test]
+#[ignore]
+fn test_havoc_semantic_overflow() {
+    let mut expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(1),
+        glossa_type: GlossaType::Number,
+    };
+
+    // Deeply nest the expression to trigger a stack overflow upon drop
+    for _ in 0..1_000_000 {
+        expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::BinOp {
+                left: Box::new(expr),
+                op: glossa::morphology::BinaryOp::Add,
+                right: Box::new(AnalyzedExpr {
+                    expr: AnalyzedExprKind::NumberLiteral(1),
+                    glossa_type: GlossaType::Number,
+                }),
+            },
+            glossa_type: GlossaType::Number,
+        };
+    }
+
+    // Attempt to drop the deeply nested expression, which will stack overflow
+    drop(expr);
+}


### PR DESCRIPTION
🧨 **The Trigger:** Deeply nested `AnalyzedExpr` nodes lack `stacker::maybe_grow` on their `Drop` implementation.
📉 **The Stack Trace:** 
```
thread 'test_havoc_semantic_overflow' has overflowed its stack
fatal runtime error: stack overflow, aborting
```
🧪 **Reproduction:** Run `cargo test --test havoc_semantic_overflow -- --ignored`.
😈 **Comment:** You assumed AST recursion limits in the parser would protect you, but you forgot that users can manually build semantic ASTs in macros or tests, or the codegen phase can clone/drop them implicitly. You were wrong.

---
*PR created automatically by Jules for task [7331270823827830030](https://jules.google.com/task/7331270823827830030) started by @madmax983*