### PR TITLE
🗣️ Echo: Fix silent and panic semantic error cases

### DIFF
--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -664,7 +664,8 @@ impl Assembler {
             if !self.state.nominatives.is_empty()
                 && self.state.operators.is_empty()
                 && !crate::morphology::lexicon::is_binding_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_print_verb(&verb.lemma)
+                && (!crate::morphology::lexicon::is_print_verb(&verb.lemma)
+                    || self.state.adjectives.is_empty())
                 && !crate::morphology::lexicon::is_find_verb(&verb.lemma)
             {
                 return Err(AssemblyError::DoubleSubject);
@@ -724,7 +725,9 @@ impl Assembler {
             && self.state.adjectives.is_empty()
             && let Some(subject) = self.state.subject.as_ref()
         {
-            if subject.lemma == "ανθρωπος" {
+            if crate::morphology::lexicon::is_find_verb(&subject.lemma)
+                || subject.lemma == "ανθρωπος"
+            {
                 return Err(AssemblyError::MissingVerb);
             }
             return Ok(());

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -380,6 +380,17 @@ fn classify_subjunctive_comparison(
     Ok(Some(AnalyzedStatement::Expression(vec![comparison])))
 }
 
+/// Helper: Check if a name is a known field of any struct defined in the current scope
+fn is_known_field(name: &str, scope: &Scope) -> bool {
+    scope.types().any(|(_, t)| {
+        if let GlossaType::Struct { fields, .. } = t {
+            fields.iter().any(|(f_name, _)| f_name == name)
+        } else {
+            false
+        }
+    })
+}
+
 /// Helper: Resolve the target variable name and the effective assembled statement for binding
 ///
 /// ⚡ Bolt Optimization: Returns a `std::borrow::Cow<'_, AssembledStatement>` instead of
@@ -953,24 +964,34 @@ fn try_print_default(
     let mut args =
         build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 
-    if let Some(ref subj) = asm_stmt.subject
-        && let Some(var_type) = scope.lookup(&subj.lemma)
-    {
+    if let Some(ref subj) = asm_stmt.subject {
+        if !scope.is_defined(&subj.lemma) && !is_known_field(&subj.lemma, scope) {
+            return Err(GlossaError::undefined(&*subj.lemma));
+        }
+        let var_type = scope
+            .lookup(&subj.lemma)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown);
         args.insert(
             0,
             AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: var_type.clone(),
+                glossa_type: var_type,
             },
         );
     }
 
-    if let Some(ref obj) = asm_stmt.object
-        && let Some(var_type) = scope.lookup(&obj.lemma)
-    {
+    if let Some(ref obj) = asm_stmt.object {
+        if !scope.is_defined(&obj.lemma) && !is_known_field(&obj.lemma, scope) {
+            return Err(GlossaError::undefined(&*obj.lemma));
+        }
+        let var_type = scope
+            .lookup(&obj.lemma)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown);
         args.push(AnalyzedExpr {
             expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-            glossa_type: var_type.clone(),
+            glossa_type: var_type,
         });
     }
 
@@ -1157,14 +1178,26 @@ fn classify_expression(
     // Fallback: If no literals/ops, check Subject/Object
     if exprs.is_empty() {
         if let Some(ref subj) = asm_stmt.subject {
+            if !scope.is_defined(&subj.lemma) && !is_known_field(&subj.lemma, scope) {
+                return Err(GlossaError::undefined(&*subj.lemma));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: GlossaType::Unknown,
+                glossa_type: scope
+                    .lookup(&subj.lemma)
+                    .cloned()
+                    .unwrap_or(GlossaType::Unknown),
             });
         } else if let Some(ref obj) = asm_stmt.object {
+            if !scope.is_defined(&obj.lemma) && !is_known_field(&obj.lemma, scope) {
+                return Err(GlossaError::undefined(&*obj.lemma));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                glossa_type: GlossaType::Unknown,
+                glossa_type: scope
+                    .lookup(&obj.lemma)
+                    .cloned()
+                    .unwrap_or(GlossaType::Unknown),
             });
         }
     }
@@ -1542,16 +1575,20 @@ fn extract_object_fallback(
         )));
     }
 
-    if !scope.is_defined(obj_lemma) {
+    if !scope.is_defined(obj_lemma) && !is_known_field(obj_lemma, scope) {
         return Err(GlossaError::undefined(obj_lemma.as_str()));
     }
 
+    let glossa_type = scope
+        .lookup(obj_lemma)
+        .cloned()
+        .unwrap_or(GlossaType::Unknown);
     Ok(Some((
         AnalyzedExpr {
             expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-            glossa_type: GlossaType::Unknown,
+            glossa_type: glossa_type.clone(),
         },
-        GlossaType::Unknown,
+        glossa_type,
     )))
 }
 

--- a/tests/havoc_issue_echo.rs
+++ b/tests/havoc_issue_echo.rs
@@ -3,6 +3,7 @@ use glossa::parser::parse;
 use glossa::semantic::analyze_program;
 
 #[test]
+#[should_panic(expected = "DoubleSubject")]
 fn test_double_subject_should_pass_havoc_constraint() {
     let source = "ὁ ἄνθρωπος ὁ θεὸς λέγει.";
     let ast = parse(source).unwrap();
@@ -12,23 +13,11 @@ fn test_double_subject_should_pass_havoc_constraint() {
 }
 
 #[test]
+#[should_panic(expected = "UndefinedName")]
 fn test_undefined_variable_evaluates_to_zero_silently() {
     let source = "ἄγνωστος λέγε."; // 'unknown say' -> undefined variable
     let ast = parse(source).unwrap();
-    let prog = analyze_program(&ast).unwrap();
-
-    // The previous implementation was completely ignoring undefined variables and producing an empty print.
-    // Let's assert it generates an empty print instead of crashing.
-    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0]
-        && expressions.is_empty()
-    {
-        // It silently became empty/zero!
-        return;
-    }
-    panic!(
-        "Did not evaluate to empty/zero silently! It got {:?}",
-        prog.statements[0]
-    );
+    let _ = analyze_program(&ast).unwrap();
 }
 
 #[test]

--- a/tests/word_order_tests.rs
+++ b/tests/word_order_tests.rs
@@ -72,7 +72,7 @@ fn test_article_disambiguation_context() {
     // ὁ ἄνθρωπος should be recognized as masculine nominative singular
     // τὸν λόγον should be recognized as masculine accusative singular
     // These don't produce Rust code yet, but they should parse without error
-    let ast = parse("ὁ ἄνθρωπος λέγει.").expect("Should parse");
+    let ast = parse("ἄνθρωπος πέντε ἔστω. ὁ ἄνθρωπος λέγει.").expect("Should parse");
     let _analyzed = analyze_program(&ast).expect("Should analyze");
 }
 


### PR DESCRIPTION
🤦 **The Confusion:**
Undefined variables compiled silently, missing verbs caused ICE panics, and double subjects bypassed checks.

🕵️ **The Reality:**
Missing verb validation was bypassed for simple subjects in `is_match_arm`, causing codegen to receive bad Rust code. Print verbs universally bypassed `DoubleSubject` checks. Undefined variable lookups defaulted to `Unknown` instead of returning errors.

💡 **The Fix:**
Added checks to return `UndefinedName` explicitly, restricted `DoubleSubject` bypass to match arms with adjectives, and scoped `is_match_arm` to properly validate missing verbs.

**Testing:** Passed all `cargo test` and `clippy` checks.

---
*PR created automatically by Jules for task [17533287215730824299](https://jules.google.com/task/17533287215730824299) started by @madmax983*