### PR TITLE
🎨 Mosaic: UI Polish for Haruspex

### DIFF
--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -13,8 +13,11 @@
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
+use comfy_table::{Attribute, Cell, Color, Table, presets};
+use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Runs the Haruspex tool to generate a Graphviz DOT representation of the AST.
@@ -46,7 +49,38 @@ pub fn run_haruspex(input: &Path) -> Result<()> {
     let mut generator = DotGenerator::new();
     let dot = generator.generate(&program);
 
-    println!("{}", dot);
+    if std::io::stdout().is_terminal() {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   H A R U S P E X".bold().cyan());
+        println!("   {}", "Abstract Syntax Tree Visualization".italic().dim());
+        println!();
+
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
+
+        table.set_header(vec![
+            Cell::new("Graphviz DOT Code")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+        ]);
+
+        let formatted_dot = format!("```dot\n{}\n```", dot.trim());
+        table.add_row(vec![Cell::new(formatted_dot)]);
+
+        println!("{table}");
+        println!();
+        println!("   {}", "📋 Usage Instructions:".bold().underlined());
+        println!("   1. Copy the code block above.");
+        println!(
+            "   2. Paste it into {}",
+            "https://dreampuf.github.io/GraphvizOnline"
+                .cyan()
+                .underlined()
+        );
+        println!();
+    } else {
+        println!("{}", dot);
+    }
     Ok(())
 }
 

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -744,6 +744,15 @@ mod tests {
     }
 
     #[test]
+    fn test_run_haruspex_success() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let valid_file = temp_dir.path().join("valid.γλ");
+        std::fs::write(&valid_file, "ὁ χρόνος φεύγει.").unwrap();
+        let result = run_haruspex(&valid_file);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_dot_generator_coverage() {
         let scope = Scope::new();
 


### PR DESCRIPTION
🖌️ **Before:** The Haruspex tool dumped unformatted, raw Graphviz DOT strings directly to standard output, making it difficult to read and offering no user guidance.
✨ **After:** Haruspex now renders a stylized dashboard using `comfy-table` and `crossterm` when run in an interactive terminal. It provides clear instructions for the user and safely wraps the output. The raw DOT output is preserved when output is piped.
🖼️ **Visuals:** Added cyan and dim styling, a full UTF-8 table box around the DOT code, and instructions pointing to GraphvizOnline.

---
*PR created automatically by Jules for task [13007533597595637498](https://jules.google.com/task/13007533597595637498) started by @madmax983*