### PR TITLE
🎨 Mosaic: UI Polish for Haruspex

### DIFF
--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -47,7 +47,12 @@ pub fn run_haruspex(input: &Path) -> Result<()> {
 
     let dot = generate_dot(&program);
 
-    if std::io::stdout().is_terminal() {
+    print_dashboard(&dot, std::io::stdout().is_terminal());
+    Ok(())
+}
+
+fn print_dashboard(dot: &str, is_tty: bool) {
+    if is_tty {
         println!();
         println!("   {}", "Γ Λ Ω Σ Σ Α   H A R U S P E X".cyan().bold());
         println!(
@@ -78,7 +83,6 @@ pub fn run_haruspex(input: &Path) -> Result<()> {
     } else {
         println!("{}", dot);
     }
-    Ok(())
 }
 
 fn generate_dot(program: &AnalyzedProgram) -> String {
@@ -822,6 +826,30 @@ fn visit_lambda_expr(
 mod tests {
     use super::*;
     use crate::semantic::{GlossaType, Scope};
+
+    #[test]
+    fn test_print_dashboard_tty() {
+        // Just verify it doesn't panic
+        print_dashboard(
+            "digraph AST { node_0 [label=\"Program\"]; node_0 -> node_1; }",
+            true,
+        );
+    }
+
+    #[test]
+    fn test_print_dashboard_no_tty() {
+        print_dashboard("digraph AST { node_0 [label=\"Program\"]; }", false);
+    }
+
+    #[test]
+    fn test_run_haruspex_success() {
+        // Need to test the actual success path
+        let temp_dir = tempfile::tempdir().unwrap();
+        let valid_file = temp_dir.path().join("valid.γλ");
+        std::fs::write(&valid_file, "εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. }.").unwrap();
+        let result = run_haruspex(&valid_file);
+        assert!(result.is_ok());
+    }
 
     #[test]
     fn test_haruspex_errors() {

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -13,8 +13,10 @@
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
+use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Runs the Haruspex tool to generate a Graphviz DOT representation of the AST.
@@ -45,7 +47,37 @@ pub fn run_haruspex(input: &Path) -> Result<()> {
 
     let dot = generate_dot(&program);
 
-    println!("{}", dot);
+    if std::io::stdout().is_terminal() {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   H A R U S P E X".cyan().bold());
+        println!(
+            "   {}",
+            "AST Graphviz DOT Representation Generated".italic().dim()
+        );
+        println!();
+
+        let actual_nodes = dot.lines().filter(|l| l.contains("[label=")).count();
+        let edges = dot.matches("->").count();
+
+        println!("   {} {}", "Nodes:".bold(), actual_nodes.to_string().cyan());
+        println!("   {} {}", "Edges:".bold(), edges.to_string().cyan());
+        println!();
+        println!(
+            "   {}",
+            "To view the graph, pipe this command to a file or tool:".dim()
+        );
+        println!(
+            "   {}",
+            "cargo run --features nova --bin glossa -- haruspex <file> > ast.dot".dim()
+        );
+        println!(
+            "   {}",
+            "cargo run --features nova --bin glossa -- haruspex <file> | dot -Tpng > ast.png".dim()
+        );
+        println!();
+    } else {
+        println!("{}", dot);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
* 🖌️ **Before:** `haruspex` dumped raw `dot` syntax text output onto the user's terminal upon running, looking messy and ugly.
* ✨ **After:** `haruspex` detects whether standard out is attached to a TTY device. If so, it prints a beautiful formatted dashboard showing the number of nodes and edges computed in the DOT file, along with instructions on how to pipe the command for viewing/saving. If not, it falls back to raw DOT string output. This perfectly maintains the "Golden Path" for programmatic piping and file redirection.
* 🖼️ **Visuals:** Added `Γ Λ Ω Σ Σ Α   H A R U S P E X` stylized header, dimension summary, and interactive instructions utilizing `crossterm` colored syntax similar to other CLI dashboard tools (`gnomon`, `scholar`).

---
*PR created automatically by Jules for task [8482276045167344968](https://jules.google.com/task/8482276045167344968) started by @madmax983*