### PR TITLE
🗺️ Atlas: Encapsulate semantic::assembly module behind pub(crate)

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -20,3 +20,18 @@
 **Tangle:** Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`, breaking encapsulation by exposing internal implementation details to the public API.
 **Blueprint:** Modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these modules with `pub(crate) mod`.
 **Stability:** Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains.
+
+## [Encapsulating Assembly Module]
+**Tangle:** The `assembly` module under `src/semantic` was exposed as `pub mod`, violating the boundary and exposing the underlying Assembler directly, but should be encapsulated behind `pub(crate) mod` according to standard encapsulation rules. The main facade, `src/semantic/mod.rs` re-exports what is needed via `pub use assembly::Assembler;` and `pub use assembly::{AssembledStatement, ...};`, so the module itself should be private.
+**Blueprint:** Modified `src/semantic/mod.rs` to restrict `assembly` module with `pub(crate) mod`.
+**Stability:** Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains.
+
+## [Encapsulating Tools Submodules]
+**Tangle:** The `src/tools/` submodules were reverted from `pub(crate) mod` back to `pub mod` because integration tests within the `tests/` directory require them.
+**Blueprint:** Tools modules are accessed across multiple integration tests, so maintaining them as `pub mod` is necessary given Rust's module visibility rules for external `tests/` directory. We will not change this unless we move tests internally to the modules.
+**Stability:** No change needed at this time.
+
+## [No Further Structural Changes Needed]
+**Tangle:** None. The repository structure is highly cohesive, well-separated, and adheres to low-coupling directives.
+**Blueprint:** Concluded the structural review.
+**Stability:** The system is sound.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,6 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. **Run Tests:**
+   - Run tests using `cargo test --all-targets --all-features` to ensure my changes have not broken existing functionality.
+2. **Pre-commit Steps:**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+3. **Submit PR:**
+   - Once verified, I will submit the PR to encapsulate the `semantic::assembly` module and record my findings about `src/tools` and the overall structure in `.jules/atlas.md`.

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -34,7 +34,7 @@
 pub(crate) mod analyzer;
 #[cfg(test)]
 mod assembler_tests;
-pub mod assembly;
+pub(crate) mod assembly;
 #[cfg(test)]
 mod classification_tests;
 pub(crate) mod control_flow;


### PR DESCRIPTION
🕸️ Tangle: The `assembly` module under `src/semantic` was unnecessarily exposed as `pub mod`, violating the boundary and exposing the internal `Assembler` directly instead of relying solely on re-exports.

📐 Blueprint: Modified `src/semantic/mod.rs` to restrict the `assembly` module with `pub(crate) mod`. Re-exports correctly handle the required public APIs.

🧱 Stability: Improved encapsulation and achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains.

🔭 Verification: Built successfully and all tests pass with strict separation enforced. Tested `src/tools/` submodules and retained them as `pub mod` since external integration tests explicitly rely on them.

---
*PR created automatically by Jules for task [12317759959663896605](https://jules.google.com/task/12317759959663896605) started by @madmax983*