### PR TITLE
⚒️ Forge: Refactor parse_match_pattern duplication

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+
+**Refactoring `parse_match_pattern` Duplication**
+**Learning:** Found an anti-pattern in `src/semantic/control_flow.rs` where identical logic for parsing wildcard ("αλλο"), numerals, and variables from a Greek word was fully duplicated in two branches of `parse_match_pattern` (one for raw `Word` inputs and one unwrapping `Word` from a `Phrase`).
+**Action:** Extracted the 30+ line shared logic into a single `parse_word_pattern` helper function to enforce DRY principles without altering behavior.

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -532,6 +532,41 @@ fn parse_return_expression(clause: &Clause, scope: &Scope) -> Result<AnalyzedExp
 }
 
 /// Parse a match pattern expression
+fn parse_word_pattern(w: &crate::ast::Word, scope: &Scope) -> Result<AnalyzedExpr, GlossaError> {
+    let normalized = &w.normalized;
+
+    // Check for wildcard (ἄλλο)
+    if normalized == "αλλο" {
+        return Ok(AnalyzedExpr {
+            expr: AnalyzedExprKind::BooleanLiteral(true),
+            glossa_type: GlossaType::Boolean,
+        });
+    }
+
+    // Check for numeral
+    if let Some(val) = lexicon::numeral_value(normalized) {
+        return Ok(AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(val),
+            glossa_type: GlossaType::Number,
+        });
+    }
+
+    // Otherwise, treat as variable reference
+    let var_type = scope
+        .lookup(normalized)
+        .cloned()
+        .unwrap_or(GlossaType::Unknown);
+
+    if var_type == GlossaType::Unknown && !scope.is_function(normalized) {
+        return Err(GlossaError::undefined(normalized.clone()));
+    }
+
+    Ok(AnalyzedExpr {
+        expr: AnalyzedExprKind::Variable(normalized.clone()),
+        glossa_type: var_type,
+    })
+}
+
 fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, GlossaError> {
     // Pattern is typically: value ᾖ
     if let Expr::Phrase(terms) = expr {
@@ -541,68 +576,10 @@ fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, G
 
         // Get first word (the pattern value)
         if let Expr::Word(w) = &terms[0] {
-            let normalized = &w.normalized;
-
-            // Check if it's ἄλλο (wildcard)
-            if normalized == "αλλο" {
-                return Ok(AnalyzedExpr {
-                    expr: AnalyzedExprKind::BooleanLiteral(true),
-                    glossa_type: GlossaType::Boolean,
-                });
-            }
-
-            // Check if it's a numeral
-            if let Some(val) = lexicon::numeral_value(normalized) {
-                return Ok(AnalyzedExpr {
-                    expr: AnalyzedExprKind::NumberLiteral(val),
-                    glossa_type: GlossaType::Number,
-                });
-            }
-
-            // Otherwise, treat as variable reference
-            let var_type = scope
-                .lookup(normalized)
-                .cloned()
-                .unwrap_or(GlossaType::Unknown);
-            if var_type == GlossaType::Unknown && !scope.is_function(normalized) {
-                return Err(GlossaError::undefined(normalized.clone()));
-            }
-            return Ok(AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(normalized.clone()),
-                glossa_type: var_type,
-            });
+            return parse_word_pattern(w, scope);
         }
     } else if let Expr::Word(w) = expr {
-        let normalized = &w.normalized;
-
-        // Check for wildcard
-        if normalized == "αλλο" {
-            return Ok(AnalyzedExpr {
-                expr: AnalyzedExprKind::BooleanLiteral(true),
-                glossa_type: GlossaType::Boolean,
-            });
-        }
-
-        // Check for numeral
-        if let Some(val) = lexicon::numeral_value(normalized) {
-            return Ok(AnalyzedExpr {
-                expr: AnalyzedExprKind::NumberLiteral(val),
-                glossa_type: GlossaType::Number,
-            });
-        }
-
-        let var_type = scope
-            .lookup(normalized)
-            .cloned()
-            .unwrap_or(GlossaType::Unknown);
-        if var_type == GlossaType::Unknown && !scope.is_function(normalized) {
-            return Err(GlossaError::undefined(normalized.clone()));
-        }
-
-        return Ok(AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(normalized.clone()),
-            glossa_type: var_type,
-        });
+        return parse_word_pattern(w, scope);
     }
 
     Err(GlossaError::semantic("Invalid match pattern"))


### PR DESCRIPTION
🚮 Smell: Large blocks of duplicated logic existed inside `parse_match_pattern` in `src/semantic/control_flow.rs`, where handling for Greek word primitives (wildcard checks for "αλλο", numeral value extraction, and unknown variable/function definition resolution) was copy-pasted across both the `Expr::Phrase` unpacking branch and the direct `Expr::Word` branch.
✨ Solution: Extracted the 30-line shared matching block into a dedicated `parse_word_pattern` helper function and replaced the duplicated branches with calls to the new helper.
🧼 Benefit: Greatly reduces cognitive load, eliminates the copy-paste technical debt (DRY), and flattens the match conditional structure inside `parse_match_pattern`.
🛡️ Verification: Tests passed (`cargo test` suite run successfully). No logic changed (zero behavior change). Format and linting rules applied successfully.

---
*PR created automatically by Jules for task [15924044531539212636](https://jules.google.com/task/15924044531539212636) started by @madmax983*