### PR TITLE
⚡ Bolt: Optimize to_rust_type with mutable String buffer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 **[Optimizing AST Node Cloning with `std::mem::replace`]**
 **Learning:** During iterative AST tree building (e.g., when wrapping an expression in successive `MethodCall`s like `.iter().map().filter().collect()`), the previous expression `current_expr` had to be passed into the new node. Because it's stored in a `Box`, using `Box::new(current_expr.clone())` causes an expensive deep clone of the entire recursive AST structure for each method in the chain. However, since the old node is entirely moved into the new node (and we overwrite `current_expr` immediately after), we can use `std::mem::replace(&mut current_expr, AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unknown })` to safely extract the old tree without a single allocation, effectively a zero-cost transfer of ownership.
 **Action:** Use `std::mem::replace` to avoid deep cloning of AST nodes when building recursive or iterative tree structures in place.
+
+**[Optimizing Recursive String Construction]**
+**Learning:** Using `format!` in recursive functions (like AST or type serialization) forces an unnecessary heap allocation at every level of depth. Instead, passing a pre-allocated mutable `String` buffer and using `std::fmt::Write` with the `write!` macro can reduce allocations to roughly O(1).
+**Action:** Replace recursive string concatenations and formats with a single mutable buffer passed by reference when traversing structures.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -273,29 +273,65 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
+/// Generates the Rust type string for a given `GlossaType`.
+///
+/// **Optimization:** To avoid recursive heap allocations via `format!` calls on deeply nested types
+/// (like `Vec<HashMap<String, Result<i64, bool>>>`), we pass a mutable pre-allocated `String`
+/// buffer down the recursive calls and build the string in place.
 pub fn to_rust_type(ty: &GlossaType) -> String {
+    let mut out = String::with_capacity(32);
+    // Ignore the error as writing to a String cannot fail
+    let _ = write_rust_type(ty, &mut out);
+    out
+}
+
+fn write_rust_type(ty: &GlossaType, out: &mut String) -> std::fmt::Result {
+    use std::fmt::Write;
     match ty {
-        GlossaType::Number => "i64".to_string(),
-        GlossaType::String => "String".to_string(),
-        GlossaType::Boolean => "bool".to_string(),
-        GlossaType::List(inner) => format!("Vec<{}>", to_rust_type(inner)),
-        GlossaType::Set(inner) => format!("HashSet<{}>", to_rust_type(inner)),
+        GlossaType::Number => write!(out, "i64"),
+        GlossaType::String => write!(out, "String"),
+        GlossaType::Boolean => write!(out, "bool"),
+        GlossaType::List(inner) => {
+            write!(out, "Vec<")?;
+            write_rust_type(inner, out)?;
+            write!(out, ">")
+        }
+        GlossaType::Set(inner) => {
+            write!(out, "HashSet<")?;
+            write_rust_type(inner, out)?;
+            write!(out, ">")
+        }
         GlossaType::Map(key, value) => {
-            format!("HashMap<{}, {}>", to_rust_type(key), to_rust_type(value))
+            write!(out, "HashMap<")?;
+            write_rust_type(key, out)?;
+            write!(out, ", ")?;
+            write_rust_type(value, out)?;
+            write!(out, ">")
         }
-        GlossaType::Option(inner) => format!("Option<{}>", to_rust_type(inner)),
+        GlossaType::Option(inner) => {
+            write!(out, "Option<")?;
+            write_rust_type(inner, out)?;
+            write!(out, ">")
+        }
         GlossaType::Result(ok, err) => {
-            format!("Result<{}, {}>", to_rust_type(ok), to_rust_type(err))
+            write!(out, "Result<")?;
+            write_rust_type(ok, out)?;
+            write!(out, ", ")?;
+            write_rust_type(err, out)?;
+            write!(out, ">")
         }
-        GlossaType::Unit => "()".to_string(),
-        GlossaType::Struct { name, .. } => Sanitizer {
-            name,
-            capitalize: true,
-        }
-        .to_string(),
+        GlossaType::Unit => write!(out, "()"),
+        GlossaType::Struct { name, .. } => write!(
+            out,
+            "{}",
+            Sanitizer {
+                name,
+                capitalize: true,
+            }
+        ),
         // TODO: Better representation for function types if they appear in type signatures
-        GlossaType::Function { .. } => "fn".to_string(),
-        GlossaType::Unknown => "_".to_string(),
+        GlossaType::Function { .. } => write!(out, "fn"),
+        GlossaType::Unknown => write!(out, "_"),
     }
 }
 

--- a/test_bolt.rs
+++ b/test_bolt.rs
@@ -1,0 +1,13 @@
+use glossa::semantic::GlossaType;
+use glossa::codegen::to_rust_type;
+
+fn main() {
+    let mut ty = GlossaType::Number;
+    for _ in 0..1000 {
+        ty = GlossaType::List(Box::new(ty));
+    }
+    let start = std::time::Instant::now();
+    let res = to_rust_type(&ty);
+    println!("Elapsed: {:?}", start.elapsed());
+    assert!(res.starts_with("Vec<"));
+}


### PR DESCRIPTION
💡 What: Replaced recursive string allocations in `to_rust_type` with a single pre-allocated mutable `String` buffer and the `std::fmt::Write` macro.
🎯 Why: `format!` inside recursive AST/type traversal creates temporary string objects on the heap for every level of depth, which is very inefficient for nested collections like `Vec<Result<i64, String>>`.
📊 Impact: Reduces string allocations for complex nested types from O(N) to roughly O(1).
🔭 Measurement: Run `cargo test` and verify that the tests in `codegen_optimizations.rs` and `repro_codegen_perf.rs` pass, or inspect binary heap behavior if tracking allocs.

---
*PR created automatically by Jules for task [6215345436216710207](https://jules.google.com/task/6215345436216710207) started by @madmax983*