### PR TITLE
⚒️ Forge: Refactor `to_rust_type` to eliminate recursive allocations

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,4 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+**Refactored `to_rust_type`**\n**Learning:** Found a performance smell where `to_rust_type` recursively allocated `String`s using `format!`.\n**Action:** Extracted the logic into a recursive helper `write_rust_type` that writes directly into a mutable `String` buffer using `std::fmt::Write`.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -273,30 +273,63 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-pub fn to_rust_type(ty: &GlossaType) -> String {
+use std::fmt::Write;
+
+fn write_rust_type(ty: &GlossaType, buf: &mut String) -> std::fmt::Result {
     match ty {
-        GlossaType::Number => "i64".to_string(),
-        GlossaType::String => "String".to_string(),
-        GlossaType::Boolean => "bool".to_string(),
-        GlossaType::List(inner) => format!("Vec<{}>", to_rust_type(inner)),
-        GlossaType::Set(inner) => format!("HashSet<{}>", to_rust_type(inner)),
+        GlossaType::Number => buf.write_str("i64"),
+        GlossaType::String => buf.write_str("String"),
+        GlossaType::Boolean => buf.write_str("bool"),
+        GlossaType::List(inner) => {
+            buf.write_str("Vec<")?;
+            write_rust_type(inner, buf)?;
+            buf.write_str(">")
+        }
+        GlossaType::Set(inner) => {
+            buf.write_str("HashSet<")?;
+            write_rust_type(inner, buf)?;
+            buf.write_str(">")
+        }
         GlossaType::Map(key, value) => {
-            format!("HashMap<{}, {}>", to_rust_type(key), to_rust_type(value))
+            buf.write_str("HashMap<")?;
+            write_rust_type(key, buf)?;
+            buf.write_str(", ")?;
+            write_rust_type(value, buf)?;
+            buf.write_str(">")
         }
-        GlossaType::Option(inner) => format!("Option<{}>", to_rust_type(inner)),
+        GlossaType::Option(inner) => {
+            buf.write_str("Option<")?;
+            write_rust_type(inner, buf)?;
+            buf.write_str(">")
+        }
         GlossaType::Result(ok, err) => {
-            format!("Result<{}, {}>", to_rust_type(ok), to_rust_type(err))
+            buf.write_str("Result<")?;
+            write_rust_type(ok, buf)?;
+            buf.write_str(", ")?;
+            write_rust_type(err, buf)?;
+            buf.write_str(">")
         }
-        GlossaType::Unit => "()".to_string(),
-        GlossaType::Struct { name, .. } => Sanitizer {
-            name,
-            capitalize: true,
+        GlossaType::Unit => buf.write_str("()"),
+        GlossaType::Struct { name, .. } => {
+            write!(
+                buf,
+                "{}",
+                Sanitizer {
+                    name,
+                    capitalize: true
+                }
+            )
         }
-        .to_string(),
         // TODO: Better representation for function types if they appear in type signatures
-        GlossaType::Function { .. } => "fn".to_string(),
-        GlossaType::Unknown => "_".to_string(),
+        GlossaType::Function { .. } => buf.write_str("fn"),
+        GlossaType::Unknown => buf.write_str("_"),
     }
+}
+
+pub fn to_rust_type(ty: &GlossaType) -> String {
+    let mut buf = String::with_capacity(32);
+    write_rust_type(ty, &mut buf).expect("writing to String buffer failed");
+    buf
 }
 
 /// Generates the Rust token stream for a given `GlossaType`.


### PR DESCRIPTION
🚮 **Smell**: `to_rust_type` in `src/codegen.rs` recursively used `format!` to construct nested Rust types (like `Vec<Vec<i64>>`), causing multiple unnecessary temporary `String` heap allocations.
✨ **Solution**: Extracted the logic into a recursive helper `write_rust_type` that accepts a mutable `&mut String` buffer, using `std::fmt::Write` to append strings directly.
🧼 **Benefit**: Eliminates intermediate heap allocations, drastically improving performance and memory efficiency during type stringification, aligning with zero-cost abstraction idioms.
🛡️ **Verification**: `cargo clippy`, `cargo test`, and `cargo fmt` passed perfectly. No runtime logic was changed. All tests testing formatting pass.

---
*PR created automatically by Jules for task [17740868387554741812](https://jules.google.com/task/17740868387554741812) started by @madmax983*