### PR TITLE
🪒 Razor: Flatten TestCase abstractions in test tables

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** `TestCase` struct in test tables in `src/tools/tester.rs` and `src/morphology/declension.rs`.
+**Cut:** Replaced the custom `TestCase` struct with simple tuples to flatten abstractions and enforce KISS principle.
+**Saved:** Reduced cognitive load and boilerplate for data-driven testing.

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -640,120 +640,104 @@ mod tests {
     #[test]
     fn test_decline_table() {
         // Table-driven test for decline() covering multiple declensions and cases
-        struct TestCase {
-            stem: &'static str,
-            declension: Declension,
-            gender: Gender,
-            case: Case,
-            number: Number,
-            expected: &'static str,
-            description: &'static str,
-        }
-
         let cases = vec![
             // First Declension - Eta type (stem ending in consonant other than rho)
-            TestCase {
-                stem: "τιμ",
-                declension: Declension::First,
-                gender: Gender::Feminine,
-                case: Case::Nominative,
-                number: Number::Singular,
-                expected: "τιμη",
-                description: "First Declension Eta Nominative Singular",
-            },
-            TestCase {
-                stem: "τιμ",
-                declension: Declension::First,
-                gender: Gender::Feminine,
-                case: Case::Genitive,
-                number: Number::Singular,
-                expected: "τιμης",
-                description: "First Declension Eta Genitive Singular",
-            },
+            (
+                "τιμ",
+                Declension::First,
+                Gender::Feminine,
+                Case::Nominative,
+                Number::Singular,
+                "τιμη",
+                "First Declension Eta Nominative Singular",
+            ),
+            (
+                "τιμ",
+                Declension::First,
+                Gender::Feminine,
+                Case::Genitive,
+                Number::Singular,
+                "τιμης",
+                "First Declension Eta Genitive Singular",
+            ),
             // First Declension - Alpha type (stem ending in rho)
-            TestCase {
-                stem: "χωρ",
-                declension: Declension::First,
-                gender: Gender::Feminine,
-                case: Case::Nominative,
-                number: Number::Singular,
-                expected: "χωρα",
-                description: "First Declension Alpha (rho) Nominative Singular",
-            },
-            TestCase {
-                stem: "χωρ",
-                declension: Declension::First,
-                gender: Gender::Feminine,
-                case: Case::Genitive,
-                number: Number::Singular,
-                expected: "χωρας",
-                description: "First Declension Alpha (rho) Genitive Singular",
-            },
+            (
+                "χωρ",
+                Declension::First,
+                Gender::Feminine,
+                Case::Nominative,
+                Number::Singular,
+                "χωρα",
+                "First Declension Alpha (rho) Nominative Singular",
+            ),
+            (
+                "χωρ",
+                Declension::First,
+                Gender::Feminine,
+                Case::Genitive,
+                Number::Singular,
+                "χωρας",
+                "First Declension Alpha (rho) Genitive Singular",
+            ),
             // First Declension - Alpha type (stem ending in iota)
-            TestCase {
-                stem: "οικι",
-                declension: Declension::First,
-                gender: Gender::Feminine,
-                case: Case::Genitive,
-                number: Number::Singular,
-                expected: "οικιας",
-                description: "First Declension Alpha (iota) Genitive Singular",
-            },
+            (
+                "οικι",
+                Declension::First,
+                Gender::Feminine,
+                Case::Genitive,
+                Number::Singular,
+                "οικιας",
+                "First Declension Alpha (iota) Genitive Singular",
+            ),
             // First Declension - Alpha type (stem ending in epsilon)
             // e.g. γενεά -> γενε
-            TestCase {
-                stem: "γενε",
-                declension: Declension::First,
-                gender: Gender::Feminine,
-                case: Case::Genitive,
-                number: Number::Singular,
-                expected: "γενεας",
-                description: "First Declension Alpha (epsilon) Genitive Singular",
-            },
+            (
+                "γενε",
+                Declension::First,
+                Gender::Feminine,
+                Case::Genitive,
+                Number::Singular,
+                "γενεας",
+                "First Declension Alpha (epsilon) Genitive Singular",
+            ),
             // Second Declension - Masculine
-            TestCase {
-                stem: "λογ",
-                declension: Declension::Second,
-                gender: Gender::Masculine,
-                case: Case::Accusative,
-                number: Number::Plural,
-                expected: "λογους",
-                description: "Second Declension Masculine Accusative Plural",
-            },
+            (
+                "λογ",
+                Declension::Second,
+                Gender::Masculine,
+                Case::Accusative,
+                Number::Plural,
+                "λογους",
+                "Second Declension Masculine Accusative Plural",
+            ),
             // Second Declension - Neuter
-            TestCase {
-                stem: "δωρ",
-                declension: Declension::Second,
-                gender: Gender::Neuter,
-                case: Case::Nominative,
-                number: Number::Plural,
-                expected: "δωρα",
-                description: "Second Declension Neuter Nominative Plural",
-            },
+            (
+                "δωρ",
+                Declension::Second,
+                Gender::Neuter,
+                Case::Nominative,
+                Number::Plural,
+                "δωρα",
+                "Second Declension Neuter Nominative Plural",
+            ),
             // Third Declension - Neuter (-μα type)
-            TestCase {
-                stem: "σω", // σῶμα -> σώματος
-                declension: Declension::Third,
-                gender: Gender::Neuter,
-                case: Case::Genitive,
-                number: Number::Singular,
-                expected: "σωματος",
-                description: "Third Declension Neuter Genitive Singular",
-            },
+            (
+                "σω", // σῶμα -> σώματος
+                Declension::Third,
+                Gender::Neuter,
+                Case::Genitive,
+                Number::Singular,
+                "σωματος",
+                "Third Declension Neuter Genitive Singular",
+            ),
         ];
 
-        for test in cases {
-            let result = decline(
-                test.stem,
-                test.declension,
-                test.gender,
-                test.case,
-                test.number,
-            );
+        for (stem, declension, gender, case, number, expected, description) in cases {
+            let result = decline(stem, declension, gender, case, number);
             assert_eq!(
-                result, test.expected,
+                result, expected,
                 "Failed test: {}. Stem: {}, Decl: {:?}, Gender: {:?}, Case: {:?}, Num: {:?}",
-                test.description, test.stem, test.declension, test.gender, test.case, test.number
+                description, stem, declension, gender, case, number
             );
         }
     }

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -624,26 +624,20 @@ failures:
 
     #[test]
     fn test_extract_failures_edge_cases() {
-        struct TestCase {
-            name: &'static str,
-            input: &'static str,
-            expected_count: usize,
-        }
-
         let test_cases = vec![
-            TestCase {
-                name: "No failures block",
-                input: "
+            (
+                "No failures block",
+                "
 running 1 test
 test my_test ... FAILED
 
 test result: FAILED...
 ",
-                expected_count: 0,
-            },
-            TestCase {
-                name: "Malformed stdout block",
-                input: "
+                0,
+            ),
+            (
+                "Malformed stdout block",
+                "
 failures:
 
 ---- my_test_without_end_block
@@ -652,21 +646,21 @@ Error message here
 failures:
     my_test_without_end_block
 ",
-                expected_count: 0,
-            },
-            TestCase {
-                name: "Missing end of test details block",
-                input: "
+                0,
+            ),
+            (
+                "Missing end of test details block",
+                "
 failures:
 
 ---- my_test_missing_end stdout ----
 Error message here
 ",
-                expected_count: 1,
-            },
-            TestCase {
-                name: "Missing next test block",
-                input: "
+                1,
+            ),
+            (
+                "Missing next test block",
+                "
 failures:
 
 ---- my_test_next stdout ----
@@ -674,11 +668,11 @@ Error 1
 ---- my_test_next_missing stdout ----
 Error 2
 ",
-                expected_count: 2,
-            },
-            TestCase {
-                name: "Thread panicked internal rust string stripped",
-                input: "
+                2,
+            ),
+            (
+                "Thread panicked internal rust string stripped",
+                "
 failures:
 
 ---- test_panicked stdout ----
@@ -687,68 +681,40 @@ thread 'test_panicked' panicked at 'internal panic message', src/lib.rs:1:1
    1: core::panicking::panic_fmt
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ",
-                expected_count: 1, // It should still capture the failure but strip some internal messages
-            },
+                1, // It should still capture the failure but strip some internal messages
+            ),
         ];
 
-        for case in test_cases {
-            let failures = extract_failures(case.input);
-            assert_eq!(
-                failures.len(),
-                case.expected_count,
-                "Failed case: {}",
-                case.name
-            );
+        for (name, input, expected_count) in test_cases {
+            let failures = extract_failures(input);
+            assert_eq!(failures.len(), expected_count, "Failed case: {}", name);
         }
     }
 
     #[test]
     fn test_parse_test_output_edge_cases() {
-        struct TestCase {
-            name: &'static str,
-            input: &'static str,
-            expected_count: usize,
-        }
-
         let test_cases = vec![
-            TestCase {
-                name: "Empty parts (less than 4)",
-                input: "
+            (
+                "Empty parts (less than 4)",
+                "
 running 1 test
 test ... ok
 ",
-                expected_count: 0,
-            },
-            TestCase {
-                name: "Missing test prefix",
-                input: "my_test ... ok",
-                expected_count: 0,
-            },
-            TestCase {
-                name: "Unknown status",
-                input: "test my_test ... WEIRD_STATUS",
-                expected_count: 0,
-            },
-            TestCase {
-                name: "Just test prefix",
-                input: "test ",
-                expected_count: 0,
-            },
-            TestCase {
-                name: "Extraneous info but valid format",
-                input: "test my_test has extra words before ... ok",
-                expected_count: 1,
-            },
+                0,
+            ),
+            ("Missing test prefix", "my_test ... ok", 0),
+            ("Unknown status", "test my_test ... WEIRD_STATUS", 0),
+            ("Just test prefix", "test ", 0),
+            (
+                "Extraneous info but valid format",
+                "test my_test has extra words before ... ok",
+                1,
+            ),
         ];
 
-        for case in test_cases {
-            let results = parse_test_output(case.input);
-            assert_eq!(
-                results.len(),
-                case.expected_count,
-                "Failed case: {}",
-                case.name
-            );
+        for (name, input, expected_count) in test_cases {
+            let results = parse_test_output(input);
+            assert_eq!(results.len(), expected_count, "Failed case: {}", name);
         }
     }
 }


### PR DESCRIPTION
## [Reduction]
**Bloat:** `TestCase` struct in test tables in `src/tools/tester.rs` and `src/morphology/declension.rs`. Also a minor unused variable warning in `src/main.rs`.
**Cut:** Replaced the custom `TestCase` struct with simple tuples to flatten abstractions and enforce KISS principle. Explicitly ignored the variable in `main.rs`.
**Saved:** Reduced cognitive load and boilerplate for data-driven testing, and resolved a clippy warning.

---
*PR created automatically by Jules for task [2228343964081770750](https://jules.google.com/task/2228343964081770750) started by @madmax983*