### PR TITLE
🪒 Razor: Fix unused variable in Gnomon fallback

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,7 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+## [Reduction]
+**Bloat:** Unused `input` variable warning in conditionally compiled CLI arm (`Commands::Gnomon`).
+**Cut:** Ignored the bound variable with `let _ = input;` in the `#[cfg(not(feature = "nova"))]` block to satisfy the compiler without changing functionality.
+**Saved:** Removed 1 compiler warning (0 cognitive load).

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {


### PR DESCRIPTION
🪒 **Razor:** Fixed an unused variable compiler warning in `src/main.rs`.

**Bloat:** The `input` variable in `Commands::Gnomon` was ignored when the `nova` feature is not enabled, which violated the `-D warnings` constraint.
**Cut:** Added `let _ = input;` in the fallback block.
**Saved:** Cleaned up 1 compiler warning.

Passed `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt`.

---
*PR created automatically by Jules for task [6329353223281830997](https://jules.google.com/task/6329353223281830997) started by @madmax983*