### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,7 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+
+**Testing clean_panic_message logic**
+**Learning:** Found coverage gaps in `src/tools/tester.rs` for `clean_panic_message`, specifically the logic stripping out Thread IDs. Writing tests for logic parsing dynamically formatted logs like rustc error streams helps guarantee formatting safeguards works correctly.
+**Action:** Wrote an isolated unit test `test_clean_panic_message` that explicitly inputs mocked rustc test failure messages containing PID representations and verifying the fallback conditions do not trigger false-positive panics.

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -703,6 +703,34 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
     }
 
     #[test]
+    fn test_clean_panic_message() {
+        // Test ignoring irrelevant lines
+        assert_eq!(clean_panic_message("just a normal line"), None);
+        assert_eq!(clean_panic_message("panicked at src/main.rs"), None);
+
+        // Test missing "panicked at"
+        assert_eq!(clean_panic_message("thread 'main' failed"), None);
+
+        // Test normal panic without thread PID
+        assert_eq!(
+            clean_panic_message("thread 'main' panicked at 'error', src/main.rs:1:1"),
+            Some("thread 'main' panicked".to_string())
+        );
+
+        // Test panic with thread PID to ensure `.replace_range()` indexing logic works perfectly
+        assert_eq!(
+            clean_panic_message("thread 'main' (1234) panicked at 'error', src/main.rs:1:1"),
+            Some("thread 'main' panicked".to_string())
+        );
+
+        // Edge case: empty PID
+        assert_eq!(
+            clean_panic_message("thread 'main' () panicked at 'error', src/main.rs:1:1"),
+            Some("thread 'main' panicked".to_string())
+        );
+    }
+
+    #[test]
     fn test_parse_test_output_edge_cases() {
         struct TestCase {
             name: &'static str,


### PR DESCRIPTION
🎯 Target: `clean_panic_message` in `src/tools/tester.rs`
💣 Risk: Edge cases in PID string manipulation with `.replace_range()` could panic if index parsing logic is flawed or the fallback `thread '...'` matcher misses.
🧪 Strategy: Added specific edge cases representing typical mock compiler outputs:
1. Normal lines that should be ignored
2. Panic messages without thread identification 
3. Panics with populated thread PIDs 
4. Edge cases like empty PIDs
🔭 Verification: `cargo test --lib -- test_clean_panic_message`

---
*PR created automatically by Jules for task [4513829105754947317](https://jules.google.com/task/4513829105754947317) started by @madmax983*