### PR TITLE
⚡ Bolt: Optimize FxHashSet<String> to FxHashSet<&str> in cartographer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**Avoid String Allocation via &str in HashSets**
+**Learning:** Extracting string-like wrappers like `SmolStr` or `String` from AST node structures (like `GlossaType`) directly into a `FxHashSet<String>` incurs an unnecessary heap allocation (via `.to_string()`). Using `FxHashSet<&str>` alongside `.as_str()` and querying via references eliminates this cost.
+**Action:** When filtering and collecting unique names for validation or tracking dependency structures, bind to their string references (`&str`) within `FxHashSet<&str>` rather than owning new heap Strings, as long as lifetimes permit.

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -190,12 +190,14 @@ fn format_dependencies(
     dependencies: FxHashSet<(String, String)>,
 ) {
     use std::fmt::Write;
-    let defined_types: FxHashSet<String> = program
+    // ⚡ Bolt Optimization: Uses `FxHashSet<&str>` to prevent allocating a new `String`
+    // for every defined struct name in the program.
+    let defined_types: FxHashSet<&str> = program
         .scope
         .types()
         .filter_map(|(_, ty)| {
             if let GlossaType::Struct { name, .. } = ty {
-                Some(name.to_string())
+                Some(name.as_str())
             } else {
                 None
             }
@@ -206,7 +208,7 @@ fn format_dependencies(
     sorted_deps.sort();
 
     for (source, target) in sorted_deps {
-        if defined_types.contains(&target) {
+        if defined_types.contains(target.as_str()) {
             let _ = writeln!(map, "    {} --> {}", source, target);
         }
     }


### PR DESCRIPTION
💡 **What:** Swapped an intermediate `FxHashSet<String>` for an `FxHashSet<&str>` in `src/tools/cartographer.rs`.
🎯 **Why:** Previously, tracking defined struct types allocated a new `String` on the heap via `.to_string()` for every struct parsed in the program. Extracting `.as_str()` from the `SmolStr` node references avoids these redundant O(n) allocations completely since the strings already exist.
📊 **Impact:** Reduces heap allocations by $N$ (where $N$ is the number of user-defined structs in the AST) during the `glossa cartographer` tool execution, eliminating unneeded `String` copies.
🔭 **Measurement:** Verified with `cargo clippy --all-targets` and `cargo test --lib tools::cartographer`.

---
*PR created automatically by Jules for task [2078426621049698908](https://jules.google.com/task/2078426621049698908) started by @madmax983*