### PR TITLE
👺 Havoc: Broken Pipe Panic in REPL

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/tests/havoc_repl_empty.rs
+++ b/tests/havoc_repl_empty.rs
@@ -1,7 +1,37 @@
-use glossa::tools::repl::run_repl;
+#![allow(missing_docs)]
+use std::env;
+use std::io::Write;
+use std::process::{Command, Stdio};
 
-// test wrapper for REPL crash
+/// 👺 Havoc: Broken Pipe Panic in REPL
+///
+/// If a user runs the REPL and pipes the output to a program that closes
+/// its stdin early (e.g., `head -n 0`), the REPL's `println!` will trigger
+/// a Rust standard panic ("failed printing to stdout: Broken pipe").
 #[test]
 fn havoc_repl_empty_panic_wrapper() {
-    let _ = run_repl;
+    let exe = env!("CARGO_BIN_EXE_glossa");
+
+    let mut child = Command::new(exe)
+        .arg("repl")
+        .stdout(Stdio::piped())
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn glossa repl");
+
+    // Close stdout immediately to cause a broken pipe for the child
+    drop(child.stdout.take());
+
+    // Send an input to the REPL to trigger it to print something and hit the broken pipe
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all("1 λέγε.\n".as_bytes());
+    }
+
+    let status = child.wait().expect("Failed to wait for child process");
+
+    // The REPL should panic (which means exit code != 0) due to broken pipe.
+    assert!(
+        !status.success(),
+        "Subprocess should have crashed due to broken pipe panic!"
+    );
 }


### PR DESCRIPTION
This PR fulfills the 'Havoc' persona directive to prove the system is fragile by delivering a failing reproducer. The Glossa REPL (`glossa repl`) does not suppress Broken Pipe errors on `stdout` when the output stream is closed early (e.g. `glossa repl | head -n 0`).

This commits a test `tests/havoc_repl_empty.rs` that spawns the `glossa repl` binary, immediately closes `stdout`, and asserts that the REPL crashes with an unhandled Rust panic (`failed printing to stdout: Broken pipe`).

🧨 **The Trigger:** Running the REPL and immediately closing the `stdout` pipe.
📉 **The Stack Trace:** `thread 'main' panicked at library/std/src/io/stdio.rs:failed printing to stdout: Broken pipe (os error 32)`
🧪 **Reproduction:** `cargo test --test havoc_repl_empty`
😈 **Comment:** "You thought stdout was infinite. You were wrong."

---
*PR created automatically by Jules for task [15864276391603284303](https://jules.google.com/task/15864276391603284303) started by @madmax983*