### PR TITLE
🎨 Mosaic: UI Polish for CLI piping (Cartographer, Papyrus, Alchemist)

### DIFF
--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -15,6 +15,7 @@ use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedS
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Run the Alchemist tool on a file
@@ -35,6 +36,11 @@ pub fn run_alchemist(input: &Path) -> miette::Result<()> {
     let python_code = transpile_to_python(&program);
 
     status.success();
+
+    if !std::io::stdout().is_terminal() {
+        println!("{}", python_code.trim());
+        return Ok(());
+    }
 
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   A L C H E M I S T".bold().cyan());

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -39,6 +39,7 @@ use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 use rustc_hash::FxHashSet;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Run the Cartographer tool on a file
@@ -60,6 +61,11 @@ pub fn run_map(input: &Path) -> Result<()> {
     let map = generate_map(&program);
 
     status.success();
+
+    if !std::io::stdout().is_terminal() {
+        println!("{}", map.trim());
+        return Ok(());
+    }
 
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   M A P".bold().cyan());

--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -23,6 +23,7 @@ use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Runs the Papyrus tool to generate SQL schemas from Glossa types.
@@ -87,6 +88,11 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
             }
             output.push_str(");\n\n");
         }
+    }
+
+    if !std::io::stdout().is_terminal() {
+        println!("{}", output.trim());
+        return Ok(());
     }
 
     println!();


### PR DESCRIPTION
🖌️ **Before:** The tools `alchemist`, `papyrus`, and `map` (cartographer) always outputted stylized `comfy_table` dashboards with ANSI colors. If a user piped the output into a file or another command (e.g., `glossa map file.γλ > map.mmd`), the raw data would be polluted with box-drawing characters and escape codes, ruining scriptability and the UNIX pipeline.

✨ **After:** The standard "Golden Path" for piping has been preserved. The tools now verify if the standard output is connected to a TTY (`std::io::stdout().is_terminal()`). If it's a pipe/redirect, they seamlessly print only the pure generated text (Mermaid.js code, SQL schema, or Python script) and exit early. The stylized UI dashboard is reserved strictly for interactive terminal use.

🖼️ **Visuals:** Piped output is perfectly clean and machine-readable, while the terminal dashboard remains beautiful.

---
*PR created automatically by Jules for task [4842323551996294622](https://jules.google.com/task/4842323551996294622) started by @madmax983*