### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/022-split-lexicon-and-conversion.md
+++ b/docs/adr/022-split-lexicon-and-conversion.md
@@ -1,0 +1,18 @@
+# 22. Split Lexicon and Conversion
+
+Date: 2026-05-11
+Status: Proposed
+
+## Context
+
+The files `src/morphology/lexicon.rs` and `src/semantic/conversion.rs` had grown significantly large, exhibiting the "Blob" anti-pattern. A significant portion of this size was due to extensive inline tests. This massive file size was hurting cohesion, navigating the codebase, and developer experience.
+
+## Decision
+
+We converted both `src/morphology/lexicon.rs` and `src/semantic/conversion.rs` into directory modules (`src/morphology/lexicon/mod.rs` and `src/semantic/conversion/mod.rs`) and extracted their respective tests into new `tests.rs` sub-modules.
+
+## Consequences
+
+- File size for the core logic modules is significantly reduced.
+- Code navigation and readability are improved by cleanly separating test code from core logic.
+- We have introduced new module boundary declarations and imports, but this trade-off is worthwhile for the organizational benefits.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@ C4Component
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
         Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
         Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
-        Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
+        Component(conversion, "Conversion", "src/semantic/conversion/mod.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")
         Component(types, "Type System", "src/semantic/types.rs", "GlossaType definitions and utilities")


### PR DESCRIPTION
🧠 **Decision:** Recorded the refactoring of `lexicon.rs` and `conversion.rs` into submodules (`lexicon/mod.rs` and `conversion/mod.rs`) to break up "The Blob" and separate tests from core logic.
🗺️ **Visuals:** Updated the C4 Component diagram in `docs/architecture.md` to show the new boundary and path for `src/semantic/conversion/mod.rs`.
🔗 **Link:** See `docs/adr/022-split-lexicon-and-conversion.md`.

---
*PR created automatically by Jules for task [4185071329492072108](https://jules.google.com/task/4185071329492072108) started by @madmax983*