### PR TITLE
🗣️ Echo: Free word order examples in Philosophy docs are broken

### DIFF
--- a/echo_issue.md
+++ b/echo_issue.md
@@ -1,0 +1,10 @@
+# 🗣️ Echo: Free word order examples in Philosophy docs are broken
+
+🤦 **The Confusion:**
+I read the documentation in `docs/reference/1-Philosophy.md` about free word order, copied the examples (like `χρήστης δεδομένα γράφει.`), and tried to run them. The compiler exploded with a massive "INTERNAL COMPILER ERROR (Codegen Failed)" and `error[E0425]: cannot find value ... in this scope`.
+
+🕵️ **The Reality:**
+Turns out the examples use variables (`χρήστης`, `δεδομένα`) that were never defined anywhere in the code snippet.
+
+💡 **The Fix:**
+Please fix the docs! Either add the variable initializations to the code snippets so they actually run. If I copy-paste the example and it doesn't compile, I am leaving.


### PR DESCRIPTION
Reported an issue with the free word order examples in `docs/reference/1-Philosophy.md` failing to compile. The examples use undefined variables, which causes an ICE (Codegen Failed). This PR adds `echo_issue.md` containing the DX audit findings as per the Echo persona directives.

---
*PR created automatically by Jules for task [14191509821294473834](https://jules.google.com/task/14191509821294473834) started by @madmax983*