### PR TITLE
🎨 Mosaic: UI Polish for Tool Output

### DIFF
--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -15,6 +15,7 @@ use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedS
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Run the Alchemist tool on a file
@@ -36,25 +37,29 @@ pub fn run_alchemist(input: &Path) -> miette::Result<()> {
 
     status.success();
 
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   A L C H E M I S T".bold().cyan());
-    println!("   {}", "Python Transpilation Result".italic().dim());
-    println!();
+    if std::io::stdout().is_terminal() {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   A L C H E M I S T".bold().cyan());
+        println!("   {}", "Python Transpilation Result".italic().dim());
+        println!();
 
-    let mut table = Table::new();
-    table.load_preset(presets::UTF8_FULL);
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
 
-    table.set_header(vec![
-        Cell::new("Python Source Code")
-            .add_attribute(Attribute::Bold)
-            .fg(Color::Cyan),
-    ]);
+        table.set_header(vec![
+            Cell::new("Python Source Code")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+        ]);
 
-    let formatted_code = format!("```python\n{}\n```", python_code.trim());
-    table.add_row(vec![Cell::new(formatted_code)]);
+        let formatted_code = format!("```python\n{}\n```", python_code.trim());
+        table.add_row(vec![Cell::new(formatted_code)]);
 
-    println!("{table}");
-    println!();
+        println!("{table}");
+        println!();
+    } else {
+        println!("{}", python_code.trim());
+    }
 
     Ok(())
 }

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -15,6 +15,7 @@ use comfy_table::presets::UTF8_FULL;
 use comfy_table::{Attribute, Cell, Color, Table};
 use crossterm::style::Stylize;
 use miette::Result;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// A visitor that traverses the Abstract Syntax Tree to calculate loop depth.
@@ -151,25 +152,6 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
         visitor.visit_statement(stmt);
     }
 
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   G N O M O N".cyan().bold());
-    println!(
-        "   {}",
-        format!("Complexity Estimate for {}", input.display())
-            .italic()
-            .dim()
-    );
-    println!();
-
-    let mut table = Table::new();
-    table.load_preset(UTF8_FULL);
-    table.set_header(vec![
-        Cell::new("Metric")
-            .add_attribute(Attribute::Bold)
-            .fg(Color::Cyan),
-        Cell::new("Value").add_attribute(Attribute::Bold),
-    ]);
-
     let complexity = if visitor.max_depth == 0 {
         "O(1)".to_string()
     } else if visitor.max_depth == 1 {
@@ -178,23 +160,47 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
         format!("O(N^{})", visitor.max_depth)
     };
 
-    table.add_row(vec![
-        Cell::new("Max Loop Depth"),
-        Cell::new(visitor.max_depth.to_string()),
-    ]);
-    table.add_row(vec![
-        Cell::new("Estimated Big-O"),
-        Cell::new(complexity).fg(if visitor.max_depth > 2 {
-            Color::Red
-        } else if visitor.max_depth == 2 {
-            Color::Yellow
-        } else {
-            Color::Green
-        }),
-    ]);
+    if std::io::stdout().is_terminal() {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   G N O M O N".cyan().bold());
+        println!(
+            "   {}",
+            format!("Complexity Estimate for {}", input.display())
+                .italic()
+                .dim()
+        );
+        println!();
 
-    println!("{table}");
-    println!();
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
+        table.set_header(vec![
+            Cell::new("Metric")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+            Cell::new("Value").add_attribute(Attribute::Bold),
+        ]);
+
+        table.add_row(vec![
+            Cell::new("Max Loop Depth"),
+            Cell::new(visitor.max_depth.to_string()),
+        ]);
+        table.add_row(vec![
+            Cell::new("Estimated Big-O"),
+            Cell::new(complexity).fg(if visitor.max_depth > 2 {
+                Color::Red
+            } else if visitor.max_depth == 2 {
+                Color::Yellow
+            } else {
+                Color::Green
+            }),
+        ]);
+
+        println!("{table}");
+        println!();
+    } else {
+        println!("Max Loop Depth: {}", visitor.max_depth);
+        println!("Estimated Big-O: {}", complexity);
+    }
 
     Ok(())
 }

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -19,20 +19,26 @@ use crate::semantic::{AnalyzedProgram, AnalyzedStatement};
 use crate::tools::ui::Status;
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Run the Labyrinth tool on a file
 pub fn run_labyrinth(input: &Path) -> miette::Result<()> {
     let source = crate::tools::runner::load_source(input)?;
     let mut buffer = Vec::new();
-    run_labyrinth_inner(&source, &mut buffer)?;
+    let is_tty = std::io::stdout().is_terminal();
+    run_labyrinth_inner(&source, &mut buffer, is_tty)?;
     let output = String::from_utf8(buffer).expect("comfy-table outputs valid UTF-8");
     print!("{}", output);
     Ok(())
 }
 
 /// Internal implementation of Labyrinth logic for testing
-pub fn run_labyrinth_inner<W: std::io::Write>(source: &str, writer: &mut W) -> miette::Result<()> {
+pub fn run_labyrinth_inner<W: std::io::Write>(
+    source: &str,
+    writer: &mut W,
+    is_tty: bool,
+) -> miette::Result<()> {
     use miette::IntoDiagnostic;
     let status = Status::start_with_symbol("Λαβύρινθος (Control Flow Graph)", "🔀");
 
@@ -47,58 +53,62 @@ pub fn run_labyrinth_inner<W: std::io::Write>(source: &str, writer: &mut W) -> m
     let cfg = generate_cfg(&program);
     status.success();
 
-    writeln!(writer).into_diagnostic()?;
-    writeln!(
-        writer,
-        "   {}",
-        "Γ Λ Ω Σ Σ Α   L A B Y R I N T H".bold().cyan()
-    )
-    .into_diagnostic()?;
-    writeln!(writer, "   {}", "Control Flow Graph".italic().dim()).into_diagnostic()?;
-    writeln!(writer).into_diagnostic()?;
-
-    let mut table = Table::new();
-    table.load_preset(presets::UTF8_FULL);
-
-    if program.statements.is_empty() {
-        table.set_header(vec![
-            Cell::new("Status")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Yellow),
-        ]);
-        table.add_row(vec![
-            Cell::new("No control flow structures found.")
-                .fg(Color::DarkGrey)
-                .add_attribute(Attribute::Italic),
-        ]);
-        writeln!(writer, "{table}").into_diagnostic()?;
-        writeln!(writer).into_diagnostic()?;
-    } else {
-        table.set_header(vec![
-            Cell::new("Mermaid.js Diagram")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Cyan),
-        ]);
-
-        let formatted_cfg = format!("```mermaid\n{}\n```", cfg.trim());
-        table.add_row(vec![Cell::new(formatted_cfg)]);
-
-        writeln!(writer, "{table}").into_diagnostic()?;
+    if is_tty {
         writeln!(writer).into_diagnostic()?;
         writeln!(
             writer,
             "   {}",
-            "📋 Usage Instructions:".bold().underlined()
+            "Γ Λ Ω Σ Σ Α   L A B Y R I N T H".bold().cyan()
         )
         .into_diagnostic()?;
-        writeln!(writer, "   1. Copy the code block above.").into_diagnostic()?;
-        writeln!(
-            writer,
-            "   2. Paste it into {}",
-            "https://mermaid.live".cyan().underlined()
-        )
-        .into_diagnostic()?;
+        writeln!(writer, "   {}", "Control Flow Graph".italic().dim()).into_diagnostic()?;
         writeln!(writer).into_diagnostic()?;
+
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
+
+        if program.statements.is_empty() {
+            table.set_header(vec![
+                Cell::new("Status")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Yellow),
+            ]);
+            table.add_row(vec![
+                Cell::new("No control flow structures found.")
+                    .fg(Color::DarkGrey)
+                    .add_attribute(Attribute::Italic),
+            ]);
+            writeln!(writer, "{table}").into_diagnostic()?;
+            writeln!(writer).into_diagnostic()?;
+        } else {
+            table.set_header(vec![
+                Cell::new("Mermaid.js Diagram")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Cyan),
+            ]);
+
+            let formatted_cfg = format!("```mermaid\n{}\n```", cfg.trim());
+            table.add_row(vec![Cell::new(formatted_cfg)]);
+
+            writeln!(writer, "{table}").into_diagnostic()?;
+            writeln!(writer).into_diagnostic()?;
+            writeln!(
+                writer,
+                "   {}",
+                "📋 Usage Instructions:".bold().underlined()
+            )
+            .into_diagnostic()?;
+            writeln!(writer, "   1. Copy the code block above.").into_diagnostic()?;
+            writeln!(
+                writer,
+                "   2. Paste it into {}",
+                "https://mermaid.live".cyan().underlined()
+            )
+            .into_diagnostic()?;
+            writeln!(writer).into_diagnostic()?;
+        }
+    } else {
+        writeln!(writer, "{}", cfg.trim()).into_diagnostic()?;
     }
 
     Ok(())

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -32,6 +32,7 @@ use comfy_table::presets::UTF8_FULL;
 use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Run the Mosaic tool on a file
@@ -52,11 +53,15 @@ pub fn run_mosaic(input_path: &Path) -> Result<()> {
 
     status.success();
 
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   M O S A I C".bold().cyan());
-    println!("   {}", "Semantic Sentence Structure".italic().dim());
-    println!();
-    println!("{}", output);
+    if std::io::stdout().is_terminal() {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   M O S A I C".bold().cyan());
+        println!("   {}", "Semantic Sentence Structure".italic().dim());
+        println!();
+        println!("{}", output);
+    } else {
+        println!("{}", output);
+    }
 
     Ok(())
 }

--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -23,6 +23,7 @@ use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Runs the Papyrus tool to generate SQL schemas from Glossa types.
@@ -89,25 +90,29 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
         }
     }
 
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   P A P Y R U S".bold().cyan());
-    println!("   {}", "SQL Schema".italic().dim());
-    println!();
+    if std::io::stdout().is_terminal() {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   P A P Y R U S".bold().cyan());
+        println!("   {}", "SQL Schema".italic().dim());
+        println!();
 
-    let mut table = Table::new();
-    table.load_preset(presets::UTF8_FULL);
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
 
-    table.set_header(vec![
-        Cell::new("SQL Schema")
-            .add_attribute(Attribute::Bold)
-            .fg(Color::Cyan),
-    ]);
+        table.set_header(vec![
+            Cell::new("SQL Schema")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+        ]);
 
-    let formatted_code = format!("```sql\n{}\n```", output.trim());
-    table.add_row(vec![Cell::new(formatted_code)]);
+        let formatted_code = format!("```sql\n{}\n```", output.trim());
+        table.add_row(vec![Cell::new(formatted_code)]);
 
-    println!("{table}");
-    println!();
+        println!("{table}");
+        println!();
+    } else {
+        println!("{}", output.trim());
+    }
 
     Ok(())
 }

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -29,10 +29,12 @@ use crate::tools::highlight::highlight;
 use crate::tools::narrator::tell_tale;
 use crate::tools::report::{CompilationReport, GlossaReport, ProgramStats};
 use crate::tools::ui::Status;
+use comfy_table::presets::UTF8_FULL;
+use comfy_table::{Attribute, Cell, Color, Table};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
 use std::fs;
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 use std::path::Path;
 use std::process::{Command, Stdio};
 
@@ -336,24 +338,23 @@ fn invoke_rustc(cached_rs: &Path, cached_exe: &Path) -> Result<()> {
     if !rustc_output.status.success() {
         let stderr = String::from_utf8_lossy(&rustc_output.stderr);
 
-        // Format the error nicely
-        let error_msg = format!(
-            "\n{}\n{}\n{}\n",
-            "╔══════════════════════════════════════════════════════════════╗".red(),
-            "║  INTERNAL COMPILER ERROR (Codegen Failed)                    ║"
-                .red()
-                .bold(),
-            "╚══════════════════════════════════════════════════════════════╝".red()
-        );
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL);
+        table.set_header(vec![
+            Cell::new("INTERNAL COMPILER ERROR (Codegen Failed)")
+                .bg(Color::DarkRed)
+                .fg(Color::White)
+                .add_attribute(Attribute::Bold),
+        ]);
 
-        let help_msg = format!(
-            "{}\n{}",
-            "This indicates a bug in the Glossa compiler's code generation.",
-            "Please report this issue with the following details:"
-        )
-        .yellow();
+        table.add_row(vec![
+            Cell::new("This indicates a bug in the Glossa compiler's code generation.\nPlease report this issue with the following details:")
+                .fg(Color::Yellow),
+        ]);
 
-        return Err(miette::miette!("{}\n{}\n\n{}", error_msg, help_msg, stderr));
+        table.add_row(vec![Cell::new(stderr).fg(Color::Red)]);
+
+        return Err(miette::miette!("\n{}\n", table));
     }
 
     Ok(())
@@ -452,7 +453,20 @@ pub fn report_file(input: &Path) -> Result<()> {
     let report = GlossaReport::new(&analyzed, filename);
 
     status.success();
-    println!("{}", report);
+
+    if std::io::stdout().is_terminal() {
+        println!("{}", report);
+    } else {
+        let stats = ProgramStats::new(&analyzed);
+        println!("File: {}", input.display());
+        println!("Statements: {}", stats.statement_count);
+        println!("Expressions: {}", stats.expression_count);
+        println!("Bindings: {}", stats.binding_count);
+        println!("Functions: {}", stats.function_count);
+        println!("Types: {}", stats.type_count);
+        println!("Loops: {}", stats.loop_count);
+        println!("Max Depth: {}", stats.max_depth);
+    }
 
     Ok(())
 }

--- a/tests/labyrinth_coverage.rs
+++ b/tests/labyrinth_coverage.rs
@@ -8,7 +8,7 @@ fn test_run_labyrinth_comfy_table_output() {
     let source = "ξ 10 ἔστω.\n";
     let mut buffer = Vec::new();
 
-    let result = run_labyrinth_inner(source, &mut buffer);
+    let result = run_labyrinth_inner(source, &mut buffer, true);
     assert!(result.is_ok());
 
     let output = String::from_utf8(buffer).unwrap();
@@ -26,7 +26,7 @@ fn test_run_labyrinth_empty_output() {
     let source = "";
     let mut buffer = Vec::new();
 
-    let result = run_labyrinth_inner(source, &mut buffer);
+    let result = run_labyrinth_inner(source, &mut buffer, true);
     assert!(result.is_ok());
 
     let output = String::from_utf8(buffer).unwrap();


### PR DESCRIPTION
🖌️ **Before:**
The "INTERNAL COMPILER ERROR (Codegen Failed)" was printed with raw ASCII art hardcoded strings. If a user piped tools like `alchemist`, `papyrus`, `gnomon`, `mosaic`, or `report` into a file using standard terminal bash pipes (`> file`), the UI dashboard artifacts (headers, colors, comfy_table boxes) polluted the actual raw data making programmatic pipelines messy.

✨ **After:**
The ICE is gracefully wrapped utilizing `comfy_table` with proper error styling matching the rest of the ecosystem. The CLI tools are now equipped with `is_terminal()` conditional flags on standard output.

🖼️ **Visuals:**
When run in a console, users see full, colored dashboards. When output is sent through a pipe (`cargo run -- papyrus test.γλ > schema.sql`), the target receives only pure SQL, pure Python, pure Mermaid flowcharts, etc.

---
*PR created automatically by Jules for task [12750302061189251580](https://jules.google.com/task/12750302061189251580) started by @madmax983*