### PR TITLE
👺 Havoc: Semantic Fuzzing & AnalyzedExpr Clone/Drop Stack Overflow

### DIFF
--- a/HAVOC_PR.md
+++ b/HAVOC_PR.md
@@ -1,0 +1,17 @@
+# 👺 Havoc: Semantic Fuzzing & AnalyzedExpr Clone/Drop Stack Overflow
+
+🧨 **The Trigger:**
+Passing a deeply recursive string into the Codegen phase or dropping/cloning heavily nested `AnalyzedExpr` nodes bypasses the strict recursion bounds built into the initial AST parser. `fuzz_target_codegen` quickly triggered an out-of-memory or stack overflow crash when `AnalyzedExpr` attempted to tear down the recursively constructed semantic structures without `stacker::maybe_grow` protecting the drop.
+
+📉 **The Stack Trace:**
+```text
+thread 'test_havoc_analyzedexpr_drop' has overflowed its stack
+fatal runtime error: stack overflow, aborting
+```
+
+🧪 **Reproduction:**
+- **Fuzzing:** Run `cargo +nightly fuzz run fuzz_target_codegen -- -max_total_time=10`
+- **Tests:** Run `cargo test --test havoc_clone_drop`
+
+😈 **Comment:**
+Warden put armor on the parser AST but left the semantic models naked and exposed to implicit recursive drops. Never leave `Clone` or `Drop` naked on recursive trees. I have added `fuzz_target_codegen` to hammer the parser-to-codegen pipeline, and `havoc_clone_drop.rs` safely proves the crash without stalling `cargo test`.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,3 +26,10 @@ path = "fuzz_targets/fuzz_target_2.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_target_codegen"
+path = "fuzz_targets/fuzz_target_codegen.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_target_codegen.rs
+++ b/fuzz/fuzz_targets/fuzz_target_codegen.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        if let Ok(ast) = glossa::parser::parse(s) {
+            if let Ok(program) = glossa::semantic::analyze_program(&ast) {
+                let _ = glossa::codegen::generate_rust(&program);
+            }
+        }
+    }
+});

--- a/tests/havoc_clone_drop.rs
+++ b/tests/havoc_clone_drop.rs
@@ -24,3 +24,57 @@ fn test_clone_stack_overflow() {
         .unwrap();
     child.join().unwrap();
 }
+
+use glossa::morphology::BinaryOp;
+use glossa::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
+use std::env;
+use std::process::Command;
+
+/// 👺 Havoc: AnalyzedExpr Drop Stack Overflow
+///
+/// Ensures we can crash the process with a deep `AnalyzedExpr` drop.
+#[test]
+fn test_havoc_analyzedexpr_drop() {
+    if env::var("HAVOC_DETONATE_SEMANTIC_OVERFLOW").is_ok() {
+        let depth = 50_000;
+        let mut expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(1),
+            glossa_type: GlossaType::Number,
+        };
+        for _ in 0..depth {
+            expr = AnalyzedExpr {
+                expr: AnalyzedExprKind::BinOp {
+                    left: Box::new(expr),
+                    op: BinaryOp::Add,
+                    right: Box::new(AnalyzedExpr {
+                        expr: AnalyzedExprKind::NumberLiteral(1),
+                        glossa_type: GlossaType::Number,
+                    }),
+                },
+                glossa_type: GlossaType::Number,
+            };
+        }
+
+        // 💥 Detonate
+        println!("Dropping cloned expression...");
+        drop(expr);
+
+        println!("Survived and mitigated!");
+        std::process::exit(0);
+    }
+
+    // Spawn a subprocess to run this exact test.
+    let exe = env::current_exe().expect("Failed to get current executable");
+
+    let status = Command::new(exe)
+        .env("HAVOC_DETONATE_SEMANTIC_OVERFLOW", "1")
+        .arg("--nocapture")
+        .arg("test_havoc_analyzedexpr_drop")
+        .status()
+        .expect("Failed to spawn subprocess");
+
+    assert!(
+        !status.success(),
+        "Subprocess should have crashed due to stack overflow!"
+    );
+}


### PR DESCRIPTION
👺 Havoc: Semantic Fuzzing & AnalyzedExpr Clone/Drop Stack Overflow

🧨 The Trigger:
Passing a deeply recursive string into the Codegen phase or dropping/cloning heavily nested AnalyzedExpr nodes bypasses the strict recursion bounds built into the initial AST parser. fuzz_target_codegen quickly triggered an out-of-memory or stack overflow crash when AnalyzedExpr attempted to tear down the recursively constructed semantic structures without stacker::maybe_grow protecting the drop.

📉 The Stack Trace:
thread 'test_havoc_analyzedexpr_drop' has overflowed its stack
fatal runtime error: stack overflow, aborting

🧪 Reproduction:
Fuzzing: Run cargo +nightly fuzz run fuzz_target_codegen -- -max_total_time=10
Tests: Run cargo test --test havoc_clone_drop

😈 Comment:
Warden put armor on the parser AST but left the semantic models naked and exposed to implicit recursive drops. Never leave Clone or Drop naked on recursive trees. I have added fuzz_target_codegen to hammer the parser-to-codegen pipeline, and havoc_clone_drop.rs safely proves the crash without stalling cargo test.

---
*PR created automatically by Jules for task [11947260387337557094](https://jules.google.com/task/11947260387337557094) started by @madmax983*