### PR TITLE
🎻 Bard: Documentation completeness for parser and semantic tests

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-03-24 - The Missing Test Stories
+**Confusion:** Many `#[cfg(test)]` modules in the codebase (like `src/semantic/conversion_tests.rs` or `src/semantic/assembler_tests.rs`) did not have `//!` module-level documentation, treating them as afterthoughts.
+**Clarification:** Even test modules should have a high-level summary that explains what core behavior they verify. Added `//!` to all major test files in `src/semantic/` to adhere to "every module tells a story", ensuring the documentation accurately reflects the module's testing goals (e.g., "The Assembly Line" or "The Shield Wall").

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -31,6 +31,25 @@ pub(crate) fn build_expression(pair: Pair<'_, Rule>) -> Result<Expr, ParseError>
     }
 }
 
+/// Extracts a single grammatical unit (`Expr`) from a parsed term.
+///
+/// A "term" in ΓΛΩΣΣΑ's grammar is the smallest distinct part of speech before they
+/// are assembled into phrases. This function maps PEG `term` rules (like blocks, array
+/// literals, variable lookups, and basic literals) into their corresponding AST `Expr` types.
+///
+/// ## Examples
+///
+/// ```text
+/// use crate::parser::grammar::{GlossaParser, Rule};
+/// use pest::Parser;
+///
+/// // Parse a simple number literal as a term
+/// let mut pairs = GlossaParser::parse(Rule::term, "42").unwrap();
+/// let term_pair = pairs.next().unwrap();
+///
+/// let expr = build_term(term_pair).unwrap();
+/// assert!(matches!(expr, crate::ast::Expr::NumberLiteral(42)));
+/// ```
 pub(crate) fn build_term(pair: Pair<'_, Rule>) -> Result<Expr, ParseError> {
     let inner = pair.into_inner().next().ok_or(ParseError::EmptyTerm)?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -89,6 +89,26 @@ fn parse_source(source: &str) -> Result<Program, ParseError> {
     Ok(Program { statements })
 }
 
+/// Extracts a higher-level AST `Statement` from a PEG statement pair.
+///
+/// Statements represent the major structural boundaries of a ΓΛΩΣΣΑ program. They can be
+/// structural definitions (like traits or types), logic tests, or standard declarative
+/// sentences (`Statement::Regular`). This function acts as the primary dispatch router,
+/// inspecting the initial rule of the statement and delegating to specialized builders.
+///
+/// ## Examples
+///
+/// ```text
+/// use crate::parser::grammar::{GlossaParser, Rule};
+/// use pest::Parser;
+///
+/// // Parse an entire statement "ξ πέντε ἔστω." (Let x be 5)
+/// let mut pairs = GlossaParser::parse(Rule::statement, "ξ πέντε ἔστω.").unwrap();
+/// let statement_pair = pairs.next().unwrap();
+///
+/// let stmt = build_statement(statement_pair).unwrap();
+/// assert!(matches!(stmt, crate::ast::Statement::Regular { .. }));
+/// ```
 pub(crate) fn build_statement(pair: Pair<'_, Rule>) -> Result<Statement, ParseError> {
     let mut pairs = pair.into_inner();
     let first = pairs

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -7,6 +7,27 @@ use crate::parser::expressions::build_expression;
 use crate::parser::grammar::Rule;
 use pest::iterators::Pair;
 
+/// Constructs a `Statement::Regular` from a parsed `clause_list` PEG pair.
+///
+/// This function acts as the bridge between the raw grammar token stream and the structured
+/// Abstract Syntax Tree for standard declarative sentences. It extracts individual grammatical
+/// clauses and parses any trailing punctuation markers (like query `?` or propagate `;`)
+/// to determine the statement's control flow behavior.
+///
+/// ## Examples
+///
+/// ```text
+/// use crate::parser::grammar::{GlossaParser, Rule};
+/// use pest::Parser;
+///
+/// // Parse "ξ πέντε ἔστω." (Let x be 5)
+/// let mut pairs = GlossaParser::parse(Rule::statement, "ξ πέντε ἔστω.").unwrap();
+/// let statement_pair = pairs.next().unwrap();
+/// let mut inner_pairs = statement_pair.into_inner();
+///
+/// let clause_list = inner_pairs.next().unwrap();
+/// let stmt = build_regular_statement(clause_list, inner_pairs).unwrap();
+/// ```
 pub(crate) fn build_regular_statement(
     clause_list_pair: Pair<'_, Rule>,
     mut statement_pairs: pest::iterators::Pairs<'_, Rule>,

--- a/src/semantic/assembler_tests.rs
+++ b/src/semantic/assembler_tests.rs
@@ -1,3 +1,10 @@
+//! The Assembly Line (Δοκιμασία τῆς Συναρμολογήσεως)
+//!
+//! This module verifies the behavior of the `Assembler`, the core component that
+//! consumes stream of morphologically analyzed words and categorizes them into their
+//! proper syntactical slots (Subjects, Objects, Verbs, Modifiers) based on their
+//! grammatical case rather than their position.
+
 use crate::ast::{Expr, Word};
 use crate::morphology::{Case, Gender, MorphAnalysis, Number, PartOfSpeech, Person, analyze};
 use crate::semantic::AssemblyError;

--- a/src/semantic/classification_tests.rs
+++ b/src/semantic/classification_tests.rs
@@ -1,3 +1,10 @@
+//! The Classification Chamber (Δοκιμασία τῆς Ταξινομήσεως)
+//!
+//! This module verifies the algorithm that decides the overarching intent of a sentence.
+//! Once the assembler builds a bag of words (Subject, Object, Verb), `classify_assembled_statement`
+//! examines the contents to decide if the statement is a Variable Binding, an Assignment,
+//! a Function Call, or a Loop.
+
 use super::conversion::classify_assembled_statement;
 use crate::ast::Expr;
 use crate::morphology::Case;

--- a/src/semantic/control_flow_coverage_tests.rs
+++ b/src/semantic/control_flow_coverage_tests.rs
@@ -1,3 +1,9 @@
+//! The Paths of Execution (Δοκιμασία τῆς Ῥοῆς)
+//!
+//! This module verifies the semantic analysis of control flow statements
+//! (If, While, For, Match). It ensures that loops properly manage their iteration variables
+//! and that conditional branches deduce correct boolean logic.
+
 use crate::ast::{Clause, Expr, Statement, Word};
 use crate::semantic::Scope;
 use crate::semantic::analyze_statement;

--- a/src/semantic/conversion_tests.rs
+++ b/src/semantic/conversion_tests.rs
@@ -1,3 +1,10 @@
+//! The Conversion Crucible (Δοκιμασία τῆς Μετατροπῆς)
+//!
+//! This module verifies the transformation of intermediate `AssembledStatement` objects
+//! into fully typed `AnalyzedStatement` structures. It tests that the compiler correctly
+//! deduces semantic meaning (like bindings, assignments, and expressions) from
+//! syntactically valid but structurally loose assembled sentences.
+
 use super::conversion::{convert_assembled_to_analyzed, extract_value};
 use crate::ast::Expr;
 use crate::morphology::lexicon::BinaryOp;

--- a/src/semantic/property_access_tests.rs
+++ b/src/semantic/property_access_tests.rs
@@ -1,3 +1,10 @@
+//! The Property Proving Grounds (Δοκιμασία τῆς Ἰδιοκτησίας)
+//!
+//! This module verifies the assembler's handling of property accesses via the
+//! genitive case (e.g. `χρήστου ὄνομα` -> `user.name`). It ensures that properties
+//! inherit the grammatical case of their owners, allowing them to function correctly
+//! as subjects or objects in the wider sentence.
+
 use crate::ast::Expr;
 use crate::semantic::expressions::feed_expr_to_assembler_with_context;
 use crate::semantic::{Assembler, DisambiguationContext};

--- a/src/semantic/recursion_safety_tests.rs
+++ b/src/semantic/recursion_safety_tests.rs
@@ -1,3 +1,10 @@
+//! The Shield Wall (Ἀσπίς) against Stack Overflows
+//!
+//! This module verifies the memory safety of the semantic analyzer. Compilers are
+//! notoriously prone to stack overflows when parsing deeply nested structures (like
+//! `((((1))))`). These tests ensure that the AST-to-IR lowering phase respects
+//! strict depth bounds and correctly drops large trees without crashing the process.
+
 use crate::ast::{Expr, Word};
 use crate::limits::MAX_AST_DEPTH;
 use crate::semantic::expressions::feed_expr_to_assembler_with_context;

--- a/src/semantic/sentry_conversion_tests.rs
+++ b/src/semantic/sentry_conversion_tests.rs
@@ -1,3 +1,9 @@
+//! The Edge Case Defenses (Δοκιμασία τῆς Φρουρᾶς)
+//!
+//! This module acts as the "Sentry", guarding against edge cases in the semantic
+//! conversion layer. It tests how `extract_value` handles unexpected overlaps
+//! (like multiple object/literal combinations) to ensure robustness.
+
 use super::conversion::{convert_assembled_to_analyzed, extract_value};
 use crate::morphology::lexicon::BinaryOp;
 use crate::morphology::{Case, Mood, Number, Person, Tense};


### PR DESCRIPTION
Ensured documentation completeness by adding missing `pub` and `pub(crate)` function docs in the parser, and `//!` module documentation in the semantic test modules.

---
*PR created automatically by Jules for task [8113699262434593162](https://jules.google.com/task/8113699262434593162) started by @madmax983*