### PR TITLE
🎨 Mosaic: UI Polish for test command empty state

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -41,7 +41,7 @@
 
 use crate::codegen::generate_rust_file;
 use crate::tools::ui::Status;
-use comfy_table::{Attribute, Cell, CellAlignment, Color, Table, presets};
+use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
 use std::fs;
@@ -340,20 +340,11 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         }
         println!("{table}");
     } else {
-        let mut empty_table = Table::new();
-        empty_table.load_preset(presets::UTF8_FULL);
-        empty_table.set_header(vec![
-            Cell::new("Status")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Yellow),
-        ]);
-        empty_table.add_row(vec![
-            Cell::new("No tests found.")
-                .fg(Color::DarkGrey)
-                .add_attribute(Attribute::Italic)
-                .set_alignment(CellAlignment::Center),
-        ]);
-        println!("{empty_table}");
+        println!(
+            "  {} {}",
+            "∅".yellow(),
+            "Οὐδεμία δοκιμασία εὑρέθη (No tests found)".dim()
+        );
     }
 
     // If there were failures, try to extract and print them nicely


### PR DESCRIPTION
🎨 Mosaic: UI Polish for test command empty state

🖌️ **Before:** When running `glossa test` on a file with no tests, the output was a full ASCII table with a "Status" header and a "No tests found." row, which was bulky and unnecessary.

✨ **After:** The empty state is now a sleek, low-profile inline message: `∅ Οὐδεμία δοκιμασία εὑρέθη (No tests found)`.

🖼️ **Visuals:** The "∅" is styled yellow, and the message is dimmed, pushing debug/empty information into the background and maintaining a cleaner visual hierarchy. Unused UI dependencies were also cleaned up.

---
*PR created automatically by Jules for task [2331344229443753452](https://jules.google.com/task/2331344229443753452) started by @madmax983*