### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -246,6 +246,7 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // ==================================================================================
 // TYPES
 // ==================================================================================
+use std::fmt::Write;
 
 /// Convert a Glossa type to its Rust equivalent string
 ///
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,11 +178,12 @@ fn main() -> Result<()> {
             );
         }
 
+        #[cfg(feature = "nova")]
         Some(Commands::Gnomon { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::gnomon::run_gnomon(&input)?;
-
-            #[cfg(not(feature = "nova"))]
+        }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Gnomon { .. }) => {
             miette::bail!(
                 "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
             );


### PR DESCRIPTION
📖 Chapter: Fixed missing documentation for `to_rust_type` in `src/codegen.rs` and resolved an unused variable warning in `src/main.rs`.
🔦 Insight: The `use std::fmt::Write;` statement in `src/codegen.rs` was placed between the doc comment and the `pub fn to_rust_type` function, causing the docs to attach to the `use` statement instead. Moved the `use` statement up to properly attach the docs. Also, modified the `Commands::Gnomon` match arm in `src/main.rs` to ignore the `input` field when the `nova` feature is disabled, resolving an unused variable warning and ensuring `cargo clippy` passes strictly.
🧪 Example: Run `cargo doc --no-deps` to verify the `to_rust_type` function is fully documented. Run `cargo clippy --all-targets --all-features -- -D warnings` to verify zero warnings.
🖼️ Preview: Documentation for `to_rust_type` now appears correctly, and all lints pass strictly.

---
*PR created automatically by Jules for task [9048376866772964739](https://jules.google.com/task/9048376866772964739) started by @madmax983*