### PR TITLE
⚡ Bolt: Optimize String allocation in tester.rs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+## Optimize String allocation in tester.rs
+**Learning:** When capturing raw standard error or failure outputs line by line in testing tools, using `String::new()` forces the string to undergo multiple heap reallocations as it expands. `String::with_capacity()` can eliminate these intermediate allocations. Even for unpredictable sizes like panic stack traces, estimating a small but reasonable capacity (e.g., 1024 bytes) prevents early micro-allocations, and when an upper bound is exactly known (e.g., `raw_stderr.len()`), it provides an exact O(1) allocation.
+**Action:** Always prefer `String::with_capacity()` when aggregating string parts inside a loop, especially in critical paths or output parsers.

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -141,7 +141,8 @@ fn parse_failure_name(line: &str) -> Option<String> {
 }
 
 fn capture_failure_message(lines: &mut std::iter::Peekable<std::str::Lines>) -> String {
-    let mut message = String::new();
+    // ⚡ Bolt Optimization: Pre-allocate reasonable capacity for panic messages to avoid intermediate heap reallocations.
+    let mut message = String::with_capacity(1024);
     while let Some(current) = lines.peek() {
         let trimmed = current.trim();
         if (trimmed.starts_with("----") && trimmed.ends_with("stdout ----"))
@@ -225,7 +226,8 @@ fn compile_test_harness(temp_path: &Path, exe_path: &Path, status: Status) -> Re
     if !rustc_output.status.success() {
         let raw_stderr = String::from_utf8_lossy(&rustc_output.stderr);
 
-        let mut clean_stderr = String::new();
+        // ⚡ Bolt Optimization: Pre-allocate exact required capacity to avoid multiple heap reallocations.
+        let mut clean_stderr = String::with_capacity(raw_stderr.len());
         let mut prev_empty = false;
         for line in raw_stderr.lines() {
             // Skip file location lines


### PR DESCRIPTION
💡 What: Replaced `String::new()` with `String::with_capacity()` in `tester.rs` for `clean_stderr` and `message` collection.
🎯 Why: Aggregating lines of strings (especially large compiler output or test stack traces) into an empty string forces multiple hidden heap reallocations. 
📊 Impact: Eliminates multiple heap reallocations when formatting Rustc error outputs or test failure stack traces, improving the memory profile of test extraction.
🔬 Measurement: Run `cargo test tools::tester` and observe correct processing with optimized allocation.

---
*PR created automatically by Jules for task [9568870518548927608](https://jules.google.com/task/9568870518548927608) started by @madmax983*