### PR TITLE
🪒 Razor: Flatten conditional compilation in main.rs CLI commands

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** Conditionally compiled commands in `src/main.rs` used variable binding and `{ let _ = input; ... }` to silence unused variable warnings, making code hard to read.
+**Cut:** Conditionally compiled the entire match arms, using structural wildcard `{ .. }` for negative feature fallbacks to implicitly ignore inputs.
+**Saved:** Reduced syntactic noise and boilerplate code handling feature flags.

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,13 @@ fn main() -> Result<()> {
             run_file(&input)?;
         }
 
+        #[cfg(feature = "nova")]
         Some(Commands::Mentor) => {
-            #[cfg(feature = "nova")]
             glossa::tools::mentor::run_mentor()?;
+        }
 
-            #[cfg(not(feature = "nova"))]
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mentor) => {
             miette::bail!(
                 "The 'mentor' command is experimental. Recompile glossa with '--features nova' to enable it."
             );
@@ -64,141 +66,136 @@ fn main() -> Result<()> {
             glossa::tools::tester::run_tests(&input)?;
         }
 
+        #[cfg(feature = "nova")]
         Some(Commands::Mosaic { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::mosaic::run_mosaic(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'mosaic' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Mosaic { .. }) => {
+            miette::bail!(
+                "The 'mosaic' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
+        }
+
+        #[cfg(feature = "nova")]
         Some(Commands::Map { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::cartographer::run_map(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'map' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Map { .. }) => {
+            miette::bail!(
+                "The 'map' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
+        }
+
+        #[cfg(feature = "nova")]
         Some(Commands::Labyrinth { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::labyrinth::run_labyrinth(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'labyrinth' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Labyrinth { .. }) => {
+            miette::bail!(
+                "The 'labyrinth' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
+        }
+
+        #[cfg(feature = "nova")]
         Some(Commands::Weave { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::weave::run_weave(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'weave' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Weave { .. }) => {
+            miette::bail!(
+                "The 'weave' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
+        }
+
+        #[cfg(feature = "nova")]
         Some(Commands::Alchemist { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::alchemist::run_alchemist(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'alchemist' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Alchemist { .. }) => {
+            miette::bail!(
+                "The 'alchemist' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
+        }
+
+        #[cfg(feature = "nova")]
         Some(Commands::Papyrus { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::papyrus::run_papyrus(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'papyrus' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Papyrus { .. }) => {
+            miette::bail!(
+                "The 'papyrus' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
+        }
+
+        #[cfg(feature = "nova")]
         Some(Commands::Haruspex { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::haruspex::run_haruspex(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'haruspex' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
         }
 
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Haruspex { .. }) => {
+            miette::bail!(
+                "The 'haruspex' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
+        }
+
+        #[cfg(feature = "nova")]
         Some(Commands::Audit { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::auditor::run_auditor(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'audit' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
         }
 
-        Some(Commands::Catalog) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::catalog::run_catalog()?;
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Audit { .. }) => {
+            miette::bail!(
+                "The 'audit' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
+        }
 
-            #[cfg(not(feature = "nova"))]
+        #[cfg(feature = "nova")]
+        Some(Commands::Catalog) => {
+            glossa::tools::catalog::run_catalog()?;
+        }
+
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Catalog) => {
             miette::bail!(
                 "The 'catalog' command is experimental. Recompile glossa with '--features nova' to enable it."
             );
         }
 
+        #[cfg(feature = "nova")]
         Some(Commands::Gnomon { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::gnomon::run_gnomon(&input)?;
+        }
 
-            #[cfg(not(feature = "nova"))]
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Gnomon { .. }) => {
             miette::bail!(
                 "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
             );
         }
 
+        #[cfg(feature = "nova")]
         Some(Commands::Scholar { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::scholar::run_scholar(&input)?;
+        }
 
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'scholar' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Scholar { .. }) => {
+            miette::bail!(
+                "The 'scholar' command is experimental. Recompile glossa with '--features nova' to enable it."
+            );
         }
 
         Some(Commands::Repl) | None => {


### PR DESCRIPTION
## [Reduction]
**Bloat:** Conditionally compiled commands in `src/main.rs` used variable binding and `{ let _ = input; ... }` to silence unused variable warnings, making code hard to read.
**Cut:** Conditionally compiled the entire match arms, using structural wildcard `{ .. }` for negative feature fallbacks to implicitly ignore inputs.
**Saved:** Reduced syntactic noise and boilerplate code handling feature flags.

---
*PR created automatically by Jules for task [6975985156197999907](https://jules.google.com/task/6975985156197999907) started by @madmax983*