### PR TITLE
⚡ Bolt: Use `Vec::with_capacity` in morphology analyzers

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -525,8 +525,10 @@ where
 /// For example, "-ε" could be:
 /// - 2nd person singular present imperative (λέγε!)
 /// - 3rd person singular aorist indicative (ἔλυσε)
+///
+/// Uses `Vec::with_capacity(8)` to prevent intermediate heap re-allocations on hot paths.
 pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    let mut analyses = Vec::with_capacity(8);
     analyze_verb_all_into(word, &mut analyses);
     analyses
 }
@@ -882,6 +884,16 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_analyze_verb_all_capacity() {
+        let analyses = analyze_verb_all("testcapacity");
+        assert!(
+            analyses.capacity() >= 8,
+            "Expected analyze_verb_all to pre-allocate vector capacity to at least 8 to prevent intermediate heap re-allocations on hot paths, found {}",
+            analyses.capacity()
+        );
     }
 
     #[test]

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -203,8 +203,10 @@ where
 /// - Vocative singular (O sea!)
 ///
 /// The caller should use syntactic context to pick the right one.
+///
+/// Uses `Vec::with_capacity(8)` to prevent intermediate heap re-allocations on hot paths.
 pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    let mut analyses = Vec::with_capacity(8);
     analyze_noun_all_into(word, &mut analyses);
     analyses
 }
@@ -560,6 +562,16 @@ mod tests {
         assert_eq!(get_stem("λογος", Declension::Second), "λογ");
         assert_eq!(get_stem("τιμη", Declension::First), "τιμ");
         assert_eq!(get_stem("ονομα", Declension::Third), "ονο");
+    }
+
+    #[test]
+    fn test_analyze_noun_all_capacity() {
+        let analyses = analyze_noun_all("testcapacity");
+        assert!(
+            analyses.capacity() >= 8,
+            "Expected analyze_noun_all to pre-allocate vector capacity to at least 8 to prevent intermediate heap re-allocations on hot paths, found {}",
+            analyses.capacity()
+        );
     }
 
     #[test]


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(8)` in `analyze_noun_all` and `analyze_verb_all` in `src/morphology/declension.rs` and `src/morphology/conjugation.rs`. Added tests to verify the pre-allocation and `///` doc comments explaining the optimization.
🎯 Why: To prevent intermediate heap re-allocations on hot paths.
📊 Impact: Reduces heap allocs when analyzing nouns and verbs, improving overall parsing performance.
🔬 Measurement: Added tests `test_analyze_noun_all_capacity` and `test_analyze_verb_all_capacity` which verify that the vectors returned by these functions are pre-allocated to at least capacity 8.

---
*PR created automatically by Jules for task [13042452139934002361](https://jules.google.com/task/13042452139934002361) started by @madmax983*