### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,8 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+
+## 2026-05-19 - The Missing Docs Dilemma
+
+**Confusion:** `cargo doc` with `missing_docs` denied returned an error where `to_rust_type` missed a doc comment. However, reading `src/codegen.rs` showed that a doc comment with doctests was present.
+**Clarification:** I discovered an intervening `use std::fmt::Write;` between the doc block and the `to_rust_type` declaration. This caused `cargo doc` to associate the doc block with the `use` statement rather than the function. Moving the `use` statement to the top of the file attached the doc comment properly.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -102,6 +102,7 @@ use crate::semantic::{
 use crate::text::normalize_greek;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
+use std::fmt::Write;
 // ==================================================================================
 // UTILS
 // ==================================================================================
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The missing docs in `to_rust_type`.
🔦 Insight: Moving an intervening `use std::fmt::Write;` allowed the existing doc block to correctly attach to `to_rust_type`.
🧪 Example: Verified via `cargo doc` with `missing_docs` denied.
🖼️ Preview: The `to_rust_type` function now properly displays its rich documentation and doctests in the generated HTML.

---
*PR created automatically by Jules for task [8364774624152522064](https://jules.google.com/task/8364774624152522064) started by @madmax983*