### PR TITLE
🎨 Mosaic: UI Polish for Papyrus and Haruspex

### DIFF
--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -16,7 +16,6 @@ use crate::tools::ui::Status;
 use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
-use std::io::IsTerminal;
 use std::path::Path;
 
 /// Runs the Haruspex tool to generate a Graphviz DOT representation of the AST.
@@ -46,43 +45,42 @@ pub fn run_haruspex(input: &Path) -> Result<()> {
     status.success();
 
     let dot = generate_dot(&program);
+    let out_path = input.with_extension("dot");
 
-    print_dashboard(&dot, std::io::stdout().is_terminal());
+    if let Err(e) = std::fs::write(&out_path, &dot) {
+        return Err(miette::miette!("Σφάλμα ἐγγραφῆς (Write Error): {}", e));
+    }
+
+    print_dashboard(&dot, &out_path);
     Ok(())
 }
 
-fn print_dashboard(dot: &str, is_tty: bool) {
-    if is_tty {
-        println!();
-        println!("   {}", "Γ Λ Ω Σ Σ Α   H A R U S P E X".cyan().bold());
-        println!(
-            "   {}",
-            "AST Graphviz DOT Representation Generated".italic().dim()
-        );
-        println!();
+fn print_dashboard(dot: &str, out_path: &Path) {
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   H A R U S P E X".cyan().bold());
+    println!(
+        "   {}",
+        "AST Graphviz DOT Representation Generated".italic().dim()
+    );
+    println!();
 
-        let actual_nodes = dot.lines().filter(|l| l.contains("[label=")).count();
-        let edges = dot.matches("->").count();
+    let actual_nodes = dot.lines().filter(|l| l.contains("[label=")).count();
+    let edges = dot.matches("->").count();
 
-        println!("   {} {}", "Nodes:".bold(), actual_nodes.to_string().cyan());
-        println!("   {} {}", "Edges:".bold(), edges.to_string().cyan());
-        println!();
-        println!(
-            "   {}",
-            "To view the graph, pipe this command to a file or tool:".dim()
-        );
-        println!(
-            "   {}",
-            "cargo run --features nova --bin glossa -- haruspex <file> > ast.dot".dim()
-        );
-        println!(
-            "   {}",
-            "cargo run --features nova --bin glossa -- haruspex <file> | dot -Tpng > ast.png".dim()
-        );
-        println!();
-    } else {
-        println!("{}", dot);
-    }
+    println!("   {} {}", "Nodes:".bold(), actual_nodes.to_string().cyan());
+    println!("   {} {}", "Edges:".bold(), edges.to_string().cyan());
+    println!();
+
+    let display_path = out_path.display().to_string();
+    println!("   {} {}", "Saved to:".bold(), display_path.as_str().dim());
+
+    println!();
+    println!("   {}", "To view the graph, run:".dim());
+    println!(
+        "   {}",
+        format!("dot -Tpng {} > ast.png", display_path).dim()
+    );
+    println!();
 }
 
 fn generate_dot(program: &AnalyzedProgram) -> String {
@@ -828,17 +826,13 @@ mod tests {
     use crate::semantic::{GlossaType, Scope};
 
     #[test]
-    fn test_print_dashboard_tty() {
+    fn test_print_dashboard() {
         // Just verify it doesn't panic
+        let p = std::path::Path::new("dummy.dot");
         print_dashboard(
             "digraph AST { node_0 [label=\"Program\"]; node_0 -> node_1; }",
-            true,
+            p,
         );
-    }
-
-    #[test]
-    fn test_print_dashboard_no_tty() {
-        print_dashboard("digraph AST { node_0 [label=\"Program\"]; }", false);
     }
 
     #[test]

--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -89,6 +89,11 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
         }
     }
 
+    let out_path = input.with_extension("sql");
+    if let Err(e) = std::fs::write(&out_path, &output) {
+        return Err(miette::miette!("Σφάλμα ἐγγραφῆς (Write Error): {}", e));
+    }
+
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   P A P Y R U S".bold().cyan());
     println!("   {}", "SQL Schema".italic().dim());
@@ -103,8 +108,9 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
             .fg(Color::Cyan),
     ]);
 
-    let formatted_code = format!("```sql\n{}\n```", output.trim());
-    table.add_row(vec![Cell::new(formatted_code)]);
+    let display_path = out_path.display().to_string();
+    let saved_msg = format!("Saved to {}", display_path.dim());
+    table.add_row(vec![Cell::new(saved_msg)]);
 
     println!("{table}");
     println!();


### PR DESCRIPTION
🖌️ **Before:** The Haruspex and Papyrus commands dumped raw Graphviz DOT code or raw SQL code directly to standard output, making the terminal difficult to read and acting more like a log file than a clean dashboard tool.

✨ **After:** Haruspex and Papyrus now save their raw outputs to `.dot` and `.sql` files respectively alongside the input file. 

🖼️ **Visuals:** The terminal output now only shows clean summary tables and formatted messages (e.g., node/edge counts, file save paths) to maintain a strong visual hierarchy and a dashboard-like appearance, adhering strictly to the Mosaic philosophy of not dumping raw text.

---
*PR created automatically by Jules for task [11171058574385587959](https://jules.google.com/task/11171058574385587959) started by @madmax983*