### PR TITLE
⚡ Bolt: Pre-allocate morphology analyzer vectors

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -526,7 +526,8 @@ where
 /// - 2nd person singular present imperative (λέγε!)
 /// - 3rd person singular aorist indicative (ἔλυσε)
 pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector to prevent intermediate heap re-allocations on hot paths.
+    let mut analyses = Vec::with_capacity(8);
     analyze_verb_all_into(word, &mut analyses);
     analyses
 }

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -204,7 +204,8 @@ where
 ///
 /// The caller should use syntactic context to pick the right one.
 pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector to prevent intermediate heap re-allocations on hot paths.
+    let mut analyses = Vec::with_capacity(8);
     analyze_noun_all_into(word, &mut analyses);
     analyses
 }


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(8)` in `analyze_noun_all` (declension.rs) and `analyze_verb_all` (conjugation.rs).

🎯 Why: Morphology analysis functions (`analyze_noun_all`, `analyze_verb_all`) are extremely hot paths during parsing. They were initializing `Vec::new()` which has 0 capacity, causing immediate and repeated heap re-allocations as multiple morphological analyses are pushed into the vector.

📊 Impact: Reduces intermediate heap allocations for every single noun and verb parsed by the compiler. A capacity of 8 safely covers the vast majority of ambiguous morphological matches without triggering re-allocation.

🔬 Measurement: Run `cargo bench` (if available) or observe reduced allocator pressure during large file compilation. Tested functionality using standard `cargo test` suite.

---
*PR created automatically by Jules for task [17554635441329778263](https://jules.google.com/task/17554635441329778263) started by @madmax983*