### PR TITLE
⚡ Bolt: Pre-allocate morphology vectors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -178,11 +178,12 @@ fn main() -> Result<()> {
             );
         }
 
+        #[cfg(feature = "nova")]
         Some(Commands::Gnomon { input }) => {
-            #[cfg(feature = "nova")]
             glossa::tools::gnomon::run_gnomon(&input)?;
-
-            #[cfg(not(feature = "nova"))]
+        }
+        #[cfg(not(feature = "nova"))]
+        Some(Commands::Gnomon { .. }) => {
             miette::bail!(
                 "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
             );

--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -526,7 +526,7 @@ where
 /// - 2nd person singular present imperative (λέγε!)
 /// - 3rd person singular aorist indicative (ἔλυσε)
 pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    let mut analyses = Vec::with_capacity(8);
     analyze_verb_all_into(word, &mut analyses);
     analyses
 }
@@ -567,7 +567,7 @@ fn try_analyze_infinitive(
 /// ## Examples
 ///
 /// ```text
-/// let mut analyses = Vec::new();
+/// let mut analyses = Vec::with_capacity(8);
 /// // Append all analyses of "γράφω" into our vector
 /// analyze_verb_all_into("γραφω", &mut analyses);
 /// assert!(!analyses.is_empty());

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -204,7 +204,7 @@ where
 ///
 /// The caller should use syntactic context to pick the right one.
 pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    let mut analyses = Vec::with_capacity(8);
     analyze_noun_all_into(word, &mut analyses);
     analyses
 }


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(8)` in `analyze_verb_all` and `analyze_noun_all`.
🎯 Why: These functions were repeatedly pushing morphological analyses to vectors that grew dynamically, causing unnecessary heap reallocations on a critical hot path.
📊 Impact: Reduces intermediate heap allocations for word analysis. Also resolves a lingering unused variable warning on the CLI interface.
🔬 Measurement: Run `cargo test` and `cargo bench` if available. Also validated via `cargo clippy`.

---
*PR created automatically by Jules for task [943043314271612714](https://jules.google.com/task/943043314271612714) started by @madmax983*