### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -146,7 +146,6 @@ struct StatementContext {
     is_multiple_nominatives: bool,
     is_array: bool,
     has_delimiter: bool,
-    is_match_arm: bool,
 }
 pub(crate) mod model;
 pub use model::*;
@@ -650,10 +649,6 @@ impl Assembler {
                 is_multiple_nominatives: !self.state.nominatives.is_empty(),
                 is_array: !self.state.arrays.is_empty(),
                 has_delimiter: self.state.has_delimiter_preposition,
-                is_match_arm: !self.state.adjectives.is_empty()
-                    || (self.state.subject.is_some()
-                        && self.state.object.is_none()
-                        && self.state.literals.is_empty()),
             };
             self.check_missing_verb(&ctx)?;
         }
@@ -664,8 +659,6 @@ impl Assembler {
             if !self.state.nominatives.is_empty()
                 && self.state.operators.is_empty()
                 && !crate::morphology::lexicon::is_binding_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_print_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_find_verb(&verb.lemma)
             {
                 return Err(AssemblyError::DoubleSubject);
             }
@@ -716,17 +709,6 @@ impl Assembler {
             && self.state.subject.is_none()
             && self.state.object.is_none()
         {
-            return Ok(());
-        }
-        if ctx.is_match_arm
-            && self.state.object.is_none()
-            && self.state.nominatives.is_empty()
-            && self.state.adjectives.is_empty()
-            && let Some(subject) = self.state.subject.as_ref()
-        {
-            if subject.lemma == "ανθρωπος" {
-                return Err(AssemblyError::MissingVerb);
-            }
             return Ok(());
         }
         Err(AssemblyError::MissingVerb)

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -953,25 +953,29 @@ fn try_print_default(
     let mut args =
         build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 
-    if let Some(ref subj) = asm_stmt.subject
-        && let Some(var_type) = scope.lookup(&subj.lemma)
-    {
-        args.insert(
-            0,
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: var_type.clone(),
-            },
-        );
+    if let Some(ref subj) = asm_stmt.subject {
+        if let Some(var_type) = scope.lookup(&subj.lemma) {
+            args.insert(
+                0,
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                    glossa_type: var_type.clone(),
+                },
+            );
+        } else if crate::morphology::lexicon::numeral_value(&subj.lemma).is_none() {
+            return Err(GlossaError::undefined(subj.lemma.as_str()));
+        }
     }
 
-    if let Some(ref obj) = asm_stmt.object
-        && let Some(var_type) = scope.lookup(&obj.lemma)
-    {
-        args.push(AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-            glossa_type: var_type.clone(),
-        });
+    if let Some(ref obj) = asm_stmt.object {
+        if let Some(var_type) = scope.lookup(&obj.lemma) {
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+                glossa_type: var_type.clone(),
+            });
+        } else if crate::morphology::lexicon::numeral_value(&obj.lemma).is_none() {
+            return Err(GlossaError::undefined(obj.lemma.as_str()));
+        }
     }
 
     Ok(args)
@@ -1157,11 +1161,17 @@ fn classify_expression(
     // Fallback: If no literals/ops, check Subject/Object
     if exprs.is_empty() {
         if let Some(ref subj) = asm_stmt.subject {
+            if !scope.is_defined(&subj.lemma) && crate::morphology::lexicon::numeral_value(&subj.lemma).is_none() {
+                return Err(GlossaError::undefined(subj.lemma.as_str()));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
             });
         } else if let Some(ref obj) = asm_stmt.object {
+            if !scope.is_defined(&obj.lemma) && crate::morphology::lexicon::numeral_value(&obj.lemma).is_none() {
+                return Err(GlossaError::undefined(obj.lemma.as_str()));
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
@@ -1555,6 +1565,41 @@ fn extract_object_fallback(
     )))
 }
 
+
+fn extract_subject_fallback(
+    asm_stmt: &AssembledStatement,
+    scope: &Scope,
+) -> Result<Option<(AnalyzedExpr, GlossaType)>, GlossaError> {
+    let Some(ref subj) = asm_stmt.subject else {
+        return Ok(None);
+    };
+
+    let subj_lemma = &subj.lemma;
+
+    // Check if it's a numeral word
+    if let Some(value) = crate::morphology::lexicon::numeral_value(subj_lemma) {
+        return Ok(Some((
+            AnalyzedExpr {
+                expr: AnalyzedExprKind::NumberLiteral(value),
+                glossa_type: GlossaType::Number,
+            },
+            GlossaType::Number,
+        )));
+    }
+
+    if !scope.is_defined(subj_lemma) {
+        return Err(GlossaError::undefined(subj_lemma.as_str()));
+    }
+
+    Ok(Some((
+        AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+            glossa_type: GlossaType::Unknown,
+        },
+        GlossaType::Unknown,
+    )))
+}
+
 /// Extract value from assembled statement
 ///
 /// This function looks at the fields of the [`AssembledStatement`] and tries
@@ -1668,6 +1713,9 @@ pub fn extract_value(
         return Ok(res);
     }
     if let Some(res) = extract_object_fallback(asm_stmt, scope)? {
+        return Ok(res);
+    }
+    if let Some(res) = extract_subject_fallback(asm_stmt, scope)? {
         return Ok(res);
     }
 

--- a/tests/havoc_issue_echo.rs
+++ b/tests/havoc_issue_echo.rs
@@ -1,42 +1,29 @@
 #![allow(missing_docs)]
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
+use glossa::errors::GlossaError;
+use glossa::errors::AssemblyError;
 
 #[test]
 fn test_double_subject_should_pass_havoc_constraint() {
     let source = "ὁ ἄνθρωπος ὁ θεὸς λέγει.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
-    // Havoc constraints: "Never write 'Happy Path' tests. If it works, you failed."
-    // In Echo bug, double subject compiles with zero errors instead of failing gracefully.
+    let err = analyze_program(&ast).unwrap_err();
+    assert!(matches!(err, GlossaError::AssemblyError(AssemblyError::DoubleSubject)));
 }
 
 #[test]
 fn test_undefined_variable_evaluates_to_zero_silently() {
-    let source = "ἄγνωστος λέγε."; // 'unknown say' -> undefined variable
+    let source = "ἄγνωστος λέγε.";
     let ast = parse(source).unwrap();
-    let prog = analyze_program(&ast).unwrap();
-
-    // The previous implementation was completely ignoring undefined variables and producing an empty print.
-    // Let's assert it generates an empty print instead of crashing.
-    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0]
-        && expressions.is_empty()
-    {
-        // It silently became empty/zero!
-        return;
-    }
-    panic!(
-        "Did not evaluate to empty/zero silently! It got {:?}",
-        prog.statements[0]
-    );
+    let err = analyze_program(&ast).unwrap_err();
+    assert!(matches!(err, GlossaError::UndefinedName { .. }));
 }
 
 #[test]
-#[should_panic(expected = "MissingVerb")]
 fn test_missing_verb_compiler_panic() {
-    // Missing verb `ὁ ἄνθρωπος.` actually crashes `rustc` codegen if passed through,
-    // or panics locally. We prove it panics or fails to compile!
     let source = "ὁ ἄνθρωπος.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
+    let err = analyze_program(&ast).unwrap_err();
+    assert!(matches!(err, GlossaError::AssemblyError(AssemblyError::MissingVerb)));
 }

--- a/tests/havoc_repro.rs
+++ b/tests/havoc_repro.rs
@@ -22,7 +22,7 @@ proptest! {
         ", val);
 
         let ast = parse(&source).unwrap();
-        let analyzed = analyze_program(&ast).unwrap();
+        let analyzed = analyze_program(&ast).unwrap_or_else(|_| panic!("Bug detected! Expected return {}, got 0", val));
         let rust_code = generate_rust(&analyzed);
 
         // If the code returns 0, it means the bug is triggered (since val >= 1).


### PR DESCRIPTION
Fix semantic compiler errors that were not correctly triggering as described in the README (`Διπλοῦν ὑποκείμενον`, `Ῥῆμα οὐχ εὑρέθη`, etc.) due to exceptions that swallowed them, or silent fallbacks to 0 in variable name lookups.

📖 Chapter: Assembly Parsing Fixes
💡 Insight: Fixed missing verb, double subject, and undefined variable errors not correctly triggering.
🧪 Example: Cleaned up tests in `havoc_issue_echo.rs` and `havoc_repro.rs` to expect proper errors.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [7682676870968732258](https://jules.google.com/task/7682676870968732258) started by @madmax983*