### PR TITLE
👺 Havoc: Semantic Clone Stack Overflow

### DIFF
--- a/tests/havoc_semantic_panic.rs
+++ b/tests/havoc_semantic_panic.rs
@@ -1,0 +1,41 @@
+#![allow(missing_docs)]
+use glossa::morphology::BinaryOp;
+use glossa::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
+
+/// 👺 Havoc: True Stack Overflow in AnalyzedExpr Clone and Drop
+///
+/// This test explicitly bypasses the test suite's subprocess mitigation
+/// by detonating directly within the main thread, proving that the semantic
+/// AST (`AnalyzedExpr` and `AnalyzedStatement`) is exposed to stack overflows
+/// via the derived `#[derive(Clone)]` and implicit `Drop`.
+#[test]
+fn havoc_semantic_panic() {
+    let depth = 50_000;
+    let mut expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(1),
+        glossa_type: GlossaType::Number,
+    };
+    for _ in 0..depth {
+        expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::BinOp {
+                left: Box::new(expr),
+                op: BinaryOp::Add,
+                right: Box::new(AnalyzedExpr {
+                    expr: AnalyzedExprKind::NumberLiteral(1),
+                    glossa_type: GlossaType::Number,
+                }),
+            },
+            glossa_type: GlossaType::Number,
+        };
+    }
+
+    // 💥 DETONATE
+    println!("Cloning deep expression (depth {})...", depth);
+    let expr2 = expr.clone();
+
+    println!("Dropping cloned expression...");
+    drop(expr2);
+
+    println!("Dropping original expression...");
+    drop(expr);
+}


### PR DESCRIPTION
🧨 **The Trigger:**
Deeply nested semantic AST `AnalyzedExpr` nodes exceeding stack limits when `clone()` is implicitly invoked.

📉 **The Stack Trace:**
```
thread 'havoc_semantic_panic' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

🧪 **Reproduction:**
Run `RUST_MIN_STACK=33554432 cargo test --test havoc_semantic_panic`

😈 **Comment:**
Warden meticulously secured `Drop`, `Clone`, and `PartialEq` using `stacker::maybe_grow` on the parser's AST (`Expr`), but left the Semantic AST (`AnalyzedExpr` and `AnalyzedStatement`) completely exposed to stack overflows via the derived `#[derive(Clone)]` and implicit `Drop`. If I can crash it, I win.

---
*PR created automatically by Jules for task [18136601964095468019](https://jules.google.com/task/18136601964095468019) started by @madmax983*