### PR TITLE
🪒 Razor: fix unused variable warning in Commands::Gnomon

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,7 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+## [Reduction]
+**Bloat:** Unused variable warning `input` in `Commands::Gnomon` enum variant in `src/main.rs`.
+**Cut:** Ignored the unused variable with `let _ = input;`.
+**Saved:** Suppressed a compiler warning without changing any logic or breaking dependencies.

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {


### PR DESCRIPTION
## [Reduction]
**Bloat:** Unused variable warning for `input` in the `Commands::Gnomon` variant when the `nova` feature is not enabled.
**Cut:** Prevented the `unused_variables` warning by adding `let _ = input;` in the `#[cfg(not(feature = "nova"))]` block.
**Saved:** Clean build, removing a distracting compiler warning without needing to alter data structures needed by the disabled feature.

---
*PR created automatically by Jules for task [15447239515782976580](https://jules.google.com/task/15447239515782976580) started by @madmax983*