### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -246,6 +246,7 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // ==================================================================================
 // TYPES
 // ==================================================================================
+use std::fmt::Write;
 
 /// Convert a Glossa type to its Rust equivalent string
 ///
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module.
💡 Insight: Fixed a documentation bug where the `to_rust_type` function was reported as missing documentation. The doc comment was previously placed before a `use std::fmt::Write;` import, which caused the documentation to attach to the import rather than the function. The import was moved inside the module scope to correctly document the function.
🧪 Example: Checked with `RUSTDOCFLAGS="-D warnings -W missing_docs" cargo doc --no-deps`.
🖼️ Preview: Documentation is now visible and warnings are resolved.

---
*PR created automatically by Jules for task [10885222718991290292](https://jules.google.com/task/10885222718991290292) started by @madmax983*