### PR TITLE
👺 Havoc: Semantic Drop Stack Overflow Vulnerability

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,13 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. **Understand the Havoc Persona Goal:** Identify a weak point in the Glossa compiler that leads to a crash, panic, race condition, or deadlock, and write a failing "wreckage" test that detonates this weakness. Do *not* fix the bug. Submit the PR with the failing test.
+2. **Current Finding:** `AnalyzedExpr` is a recursive enum (`AnalyzedExprKind::BinOp { left: Box<AnalyzedExpr>, ... }`). When a deeply nested `AnalyzedExpr` goes out of scope, the Rust compiler implicitly drops it, which walks the tree recursively. This causes a stack overflow (`SIGABRT`) on the main thread!
+3. **Execution Plan:**
+   - I have already verified the stack overflow using `tests/havoc_semantic_drop.rs`.
+   - The test must fail `cargo test` because it detonates. (Wait, if `cargo test` fails, the test suite is broken. Let me double check: the memory snippet says: "When writing 'wreckage' tests for the Havoc persona to demonstrate system fragility (e.g., stack overflows), the tests must detonate directly within the main thread (causing cargo test to fail) rather than mitigating or asserting the crash via a spawned subprocess." This explicitly confirms the test *must* crash the runner!)
+   - Ensure the required persona log entry is made? The prompt says "Create a PR (or Issue) with: Title: 👺 Havoc: [TITLE]". No mention of updating journal.
+   - Run `pre_commit_instructions` since the pre-commit step is strictly required. Wait, as Havoc I shouldn't fix anything, just submit the failing test.
+   - I will submit the PR!
+
+Plan steps:
+1. Save `tests/havoc_semantic_drop.rs`.
+2. Ensure pre-commit instructions are followed.
+3. Submit the change using `request_code_review` (wait, the prompt says "The correct tool to submit code changes and open a PR is `request_code_review`. Do not use non-existent tools like `submit` in the execution plan.").

--- a/tests/havoc_semantic_drop.rs
+++ b/tests/havoc_semantic_drop.rs
@@ -1,0 +1,24 @@
+#![allow(missing_docs)]
+use glossa::morphology::BinaryOp;
+use glossa::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
+
+#[test]
+fn test_havoc_semantic_drop_overflow() {
+    let mut expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(1),
+        glossa_type: GlossaType::Number,
+    };
+    for _ in 0..100000 {
+        expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::BinOp {
+                left: Box::new(expr),
+                op: BinaryOp::Add,
+                right: Box::new(AnalyzedExpr {
+                    expr: AnalyzedExprKind::NumberLiteral(1),
+                    glossa_type: GlossaType::Number,
+                }),
+            },
+            glossa_type: GlossaType::Number,
+        };
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Deeply nested `AnalyzedExpr` AST elements created during compilation (e.g. from 100k depth BinOp operations) cause a stack overflow when being implicitly dropped by Rust because the type (`AnalyzedExpr`) uses an auto-derived or default recursive `Drop` implementation without stack growth mitigation.
📉 **The Stack Trace:**
```
thread 'test_havoc_semantic_drop_overflow' has overflowed its stack
fatal runtime error: stack overflow, aborting
```
🧪 **Reproduction:** Run `cargo test --test havoc_semantic_drop`.
😈 **Comment:** You assumed tree structures would always fit comfortably in the call stack during drop. You were wrong.

---
*PR created automatically by Jules for task [11941326910697902725](https://jules.google.com/task/11941326910697902725) started by @madmax983*