### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/022-haruspex-tool.md
+++ b/docs/adr/022-haruspex-tool.md
@@ -1,0 +1,24 @@
+# 22. Add Haruspex to Developer Experience Tools
+
+Date: 2026-05-10
+Status: Proposed
+
+## Context
+
+The ΓΛΩΣΣΑ compiler includes the "Haruspex" (ὁ Ἱεροσκόπος) tool (`src/tools/haruspex.rs`).
+While the Cartographer maps architecture and the Labyrinth traces control flow, the Haruspex allows compiler developers to inspect the raw semantic tree structure.
+It translates the semantic AST (`AnalyzedProgram`) of a ΓΛΩΣΣΑ program into a DOT graph for visualization with Graphviz.
+
+This tool exists but has not been documented with an Architecture Decision Record or in the architecture diagrams, which violates the Codex principles of Architectural Transparency.
+
+## Decision
+
+We formally recognize the **Haruspex** tool as a component within the "Developer Experience (Nova)" container (`src/tools/`).
+
+Haruspex is defined as the Graphviz AST Visualizer that takes an `AnalyzedProgram` from the Semantic Analyzer and generates a DOT graph. It will be integrated into the architecture diagram (`docs/architecture.md`) alongside other Nova tools.
+
+## Consequences
+
+*   **Positive:** The internal structure of the `AnalyzedProgram` can be easily inspected, allowing compiler developers to see exactly how expressions are nested and typed.
+*   **Positive:** Architectural Clarity: The role and existence of the Haruspex tool are explicitly documented and mapped, eliminating implicit decisions.
+*   **Negative:** As a recognized tool, Haruspex must be maintained to keep pace with changes to the semantic model (`AnalyzedProgram`), to ensure it can correctly traverse and emit the DOT graph for all expressions and statements.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,7 @@ C4Container
         Container(catalog, "The Catalog", "src/tools/catalog.rs", "Lexicon Explorer (CLI)")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
         Container(dictionary, "The Lexicon", "src/tools/dictionary.rs", "The Source of Truth for Words (Dictionary)")
+        Container(haruspex, "Haruspex", "src/tools/haruspex.rs", "Graphviz AST Visualizer")
         Container(highlight, "Highlighter", "src/tools/highlight.rs", "Semantic syntax highlighting")
         Container(interpreter, "Interpreter", "src/tools/interpreter.rs", "In-memory tree-walk simulator")
         Container(labyrinth, "Labyrinth", "src/tools/labyrinth.rs", "Visualizes the control flow graph as a Mermaid flowchart")
@@ -74,6 +75,8 @@ C4Container
     Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, papyrus, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
+    Rel(semantic, haruspex, "Analyzed Program")
+
 
     Rel(morphology, dictionary, "Lexicon Data")
     Rel(morphology, catalog, "Lexicon Data")


### PR DESCRIPTION
🧠 **Decision:** Recorded the creation of the Haruspex (Graphviz AST Visualizer) tool.
🗺️ **Visuals:** Updated C4 Container diagram to show the Haruspex tool inside the Developer Experience (Nova) block.
🔗 **Link:** See `docs/adr/022-haruspex-tool.md`.

---
*PR created automatically by Jules for task [7663998846858188001](https://jules.google.com/task/7663998846858188001) started by @madmax983*