### PR TITLE
🪒 Razor: Flatten Object-Oriented Visitors

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,13 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** `GnomonVisitor` in `src/tools/gnomon.rs` used an object-oriented visitor pattern for simple AST traversal.
+**Cut:** Flattened the object into a pure procedural function `calculate_max_depth` passing mutable references to `max_depth` state.
+**Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** `AuditorVisitor` in `src/tools/auditor.rs` used an object-oriented visitor pattern for stateful AST traversal.
+**Cut:** Flattened the object into pure procedural functions `audit_statement` and `audit_expr` passing mutable state hash maps.
+**Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.

--- a/do_refactor_auditor.py
+++ b/do_refactor_auditor.py
@@ -1,0 +1,228 @@
+import re
+
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+new_fn = """pub fn audit_statement(
+    stmt: &AnalyzedStatement,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match stmt {
+        AnalyzedStatement::Binding { name, value, mutable } => {
+            usage_count.insert(name.clone(), 0);
+            mutation_count.insert(name.clone(), 0);
+            if *mutable {
+                mutable_vars.insert(name.clone());
+            }
+            audit_expr(value, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedStatement::Assignment { name, value } => {
+            if let Some(count) = mutation_count.get_mut(name) {
+                *count += 1;
+            }
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
+            }
+            audit_expr(value, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedStatement::Print(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Expression(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Query(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::If { condition, then_body, else_body } => {
+            audit_expr(condition, usage_count, mutation_count, mutable_vars);
+            for s in then_body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    audit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::While { condition, body } => {
+            audit_expr(condition, usage_count, mutation_count, mutable_vars);
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::For { variable, iterator, body } => {
+            usage_count.insert(variable.clone(), 0);
+            audit_expr(iterator, usage_count, mutation_count, mutable_vars);
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Match { scrutinee, arms } => {
+            audit_expr(scrutinee, usage_count, mutation_count, mutable_vars);
+            for (expr, stmts) in arms {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+                for s in stmts {
+                    audit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { params, body, .. } => {
+            for (param_name, _) in params {
+                usage_count.insert(param_name.clone(), 0);
+            }
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Return { value } => {
+            if let Some(v) = value {
+                audit_expr(v, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Break
+        | AnalyzedStatement::Continue
+        | AnalyzedStatement::TypeDefinition { .. }
+        | AnalyzedStatement::TraitDefinition { .. }
+        | AnalyzedStatement::TraitImplementation { .. } => {}
+    }
+}
+
+pub fn audit_expr(
+    expr: &AnalyzedExpr,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match &expr.expr {
+        AnalyzedExprKind::Variable(name) => {
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
+            }
+        }
+        AnalyzedExprKind::BinOp { left, right, .. } => {
+            audit_expr(left, usage_count, mutation_count, mutable_vars);
+            audit_expr(right, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::UnaryOp { operand, .. } => {
+            audit_expr(operand, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::StructInstantiation { args, .. } => {
+            for arg in args {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::PropertyAccess { owner, .. } => {
+            audit_expr(owner, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::MethodCall { receiver, args, .. } => {
+            audit_expr(receiver, usage_count, mutation_count, mutable_vars);
+            for arg in args {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::FunctionCall { args, .. } | AnalyzedExprKind::VerbCall { args, .. } => {
+            for arg in args {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::ArrayLiteral(exprs) => {
+            for arg in exprs {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::IndexAccess { array, index } => {
+            audit_expr(array, usage_count, mutation_count, mutable_vars);
+            audit_expr(index, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::Lambda { body, .. } => {
+            audit_expr(body, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::Some(inner)
+        | AnalyzedExprKind::Ok(inner)
+        | AnalyzedExprKind::Err(inner)
+        | AnalyzedExprKind::Unwrap(inner)
+        | AnalyzedExprKind::Try(inner) => audit_expr(inner, usage_count, mutation_count, mutable_vars),
+        AnalyzedExprKind::Assert { condition } => {
+            audit_expr(condition, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::AssertEq { left, right } => {
+            audit_expr(left, usage_count, mutation_count, mutable_vars);
+            audit_expr(right, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::Range { start, end, .. } => {
+            audit_expr(start, usage_count, mutation_count, mutable_vars);
+            audit_expr(end, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::NumberLiteral(_)
+        | AnalyzedExprKind::StringLiteral(_)
+        | AnalyzedExprKind::BooleanLiteral(_)
+        | AnalyzedExprKind::None
+        | AnalyzedExprKind::CollectionNew { .. } => {}
+    }
+}
+"""
+
+start_str = "struct AuditorVisitor {"
+end_str = "        }\n    }\n}\n"
+
+start_idx = content.find(start_str)
+end_idx = content.find(end_str, start_idx) + len(end_str)
+
+if start_idx != -1 and end_idx != -1:
+    content = content[:start_idx] + new_fn + content[end_idx:]
+
+content = content.replace(
+"""    let mut visitor = AuditorVisitor::new();
+    for stmt in &program.statements {
+        visitor.visit_statement(stmt);
+    }""",
+"""    let mut usage_count = FxHashMap::default();
+    let mut mutation_count = FxHashMap::default();
+    let mut mutable_vars = FxHashSet::default();
+    for stmt in &program.statements {
+        audit_statement(stmt, &mut usage_count, &mut mutation_count, &mut mutable_vars);
+    }"""
+)
+
+content = content.replace(
+"""    for (var, count) in &visitor.usage_count {""",
+"""    for (var, count) in &usage_count {"""
+)
+content = content.replace(
+"""    for (var, count) in &visitor.mutation_count {""",
+"""    for (var, count) in &mutation_count {"""
+)
+content = content.replace(
+"""            && visitor.mutable_vars.contains(var)
+            && visitor.usage_count.get(var).unwrap_or(&0) > &0""",
+"""            && mutable_vars.contains(var)
+            && usage_count.get(var).unwrap_or(&0) > &0"""
+)
+
+# Test replacements
+test_setup = """        let mut usage_count = FxHashMap::default();
+        let mut mutation_count = FxHashMap::default();
+        let mut mutable_vars = FxHashSet::default();"""
+
+content = content.replace("        let mut visitor = AuditorVisitor::new();\n", test_setup + "\n")
+content = content.replace("visitor.visit_statement(&stmt);", "audit_statement(&stmt, &mut usage_count, &mut mutation_count, &mut mutable_vars);")
+content = content.replace("visitor.visit_statement(&s);", "audit_statement(&s, &mut usage_count, &mut mutation_count, &mut mutable_vars);")
+content = content.replace("visitor.visit_statement(s);", "audit_statement(s, &mut usage_count, &mut mutation_count, &mut mutable_vars);")
+content = content.replace("visitor.visit_expr(&expr);", "audit_expr(&expr, &mut usage_count, &mut mutation_count, &mut mutable_vars);")
+
+with open('src/tools/auditor.rs', 'w') as f:
+    f.write(content)

--- a/fix_auditor.py
+++ b/fix_auditor.py
@@ -1,0 +1,35 @@
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+# To fix this `clippy::only_used_in_recursion` warning, we can just allow it on `audit_expr` since this is part of a mutually recursive visiting pattern and it's cleaner to pass all state along even if one function only uses it to pass it back to another, or in this case, to itself.
+# Oh actually, `audit_expr` never calls `audit_statement`! It only calls `audit_expr`.
+# And since it only calls `audit_expr`, and `audit_expr` never uses `mutation_count` or `mutable_vars` directly, they are truly "only used in recursion". We can just drop them from `audit_expr`!
+# Let's see: `audit_expr` takes: expr, usage_count, mutation_count, mutable_vars.
+# Let's remove `mutation_count` and `mutable_vars` from `audit_expr` completely.
+
+content = content.replace("""pub fn audit_expr(
+    expr: &AnalyzedExpr,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+)""", """pub fn audit_expr(
+    expr: &AnalyzedExpr,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+)""")
+
+import re
+content = re.sub(
+    r'audit_expr\(([^,]+),\s*usage_count,\s*mutation_count,\s*mutable_vars\)',
+    r'audit_expr(\1, usage_count)',
+    content
+)
+
+# Also need to update the signature in `audit_statement` calls
+content = re.sub(
+    r'audit_expr\(([^,]+),\s*&mut\s*usage_count,\s*&mut\s*mutation_count,\s*&mut\s*mutable_vars\)',
+    r'audit_expr(\1, &mut usage_count)',
+    content
+)
+
+with open('src/tools/auditor.rs', 'w') as f:
+    f.write(content)

--- a/fix_auditor2.py
+++ b/fix_auditor2.py
@@ -1,0 +1,21 @@
+import re
+
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+# Fix test type inference
+content = content.replace(
+    "let mut mutation_count = FxHashMap::default();",
+    "let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();"
+)
+content = content.replace(
+    "let mut mutable_vars = FxHashSet::default();",
+    "let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();"
+)
+content = content.replace(
+    "let mut usage_count = FxHashMap::default();",
+    "let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();"
+)
+
+with open('src/tools/auditor.rs', 'w') as f:
+    f.write(content)

--- a/fix_auditor3.py
+++ b/fix_auditor3.py
@@ -1,0 +1,11 @@
+import re
+
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+# I removed mutation_count and mutable_vars from audit_expr, but I left them in the tests!
+# We just need to remove them from the test setup entirely if they aren't used.
+content = content.replace("        let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();\n        let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();\n", "")
+
+with open('src/tools/auditor.rs', 'w') as f:
+    f.write(content)

--- a/fix_auditor4.py
+++ b/fix_auditor4.py
@@ -1,0 +1,17 @@
+import re
+
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+# I removed them from tests but test_auditor_visitor_coverage_statements calls audit_statement which STILL needs them!
+# So we must put them back in the tests, but prefix them with underscore OR just not remove them from audit_statement, but they are used in audit_statement so it's fine.
+
+content = content.replace("let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();\n",
+                          "let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();\n        let mut mutation_count = FxHashMap::default();\n        let mut mutable_vars = FxHashSet::default();\n")
+
+# test_auditor_visitor_coverage_expressions calls audit_expr which ONLY needs usage_count now.
+content = content.replace("audit_expr(&expr, &mut usage_count, &mut mutation_count, &mut mutable_vars);", "audit_expr(&expr, &mut usage_count);")
+
+
+with open('src/tools/auditor.rs', 'w') as f:
+    f.write(content)

--- a/fix_auditor5.py
+++ b/fix_auditor5.py
@@ -1,0 +1,25 @@
+import re
+
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+content = content.replace("let mut mutation_count = FxHashMap::default();", "let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();")
+content = content.replace("let mut mutable_vars = FxHashSet::default();", "let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();")
+
+# Now handle the test `test_auditor_visitor_coverage_expressions` where these variables are unused.
+# They are declared but never used in `test_auditor_visitor_coverage_expressions` because we removed them from `audit_expr` call.
+# Let's just remove them from `test_auditor_visitor_coverage_expressions` specifically.
+# It's at the start of that function:
+str_to_replace = """    fn test_auditor_visitor_coverage_expressions() {
+        let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+        let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+        let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();"""
+
+new_str = """    fn test_auditor_visitor_coverage_expressions() {
+        let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();"""
+
+content = content.replace(str_to_replace, new_str)
+
+
+with open('src/tools/auditor.rs', 'w') as f:
+    f.write(content)

--- a/fix_auditor6.py
+++ b/fix_auditor6.py
@@ -1,0 +1,19 @@
+import re
+
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+# I accidentally duplicated variable declarations during the replacement.
+content = content.replace(
+"""    let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+        let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+        let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();
+    let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+    let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();""",
+"""    let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+    let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+    let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();"""
+)
+
+with open('src/tools/auditor.rs', 'w') as f:
+    f.write(content)

--- a/refactor_auditor.py
+++ b/refactor_auditor.py
@@ -1,0 +1,222 @@
+import re
+import subprocess
+
+subprocess.run(['git', 'checkout', 'src/tools/auditor.rs'])
+
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+new_fn = """pub fn audit_statement(
+    stmt: &AnalyzedStatement,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match stmt {
+        AnalyzedStatement::Binding { name, value, mutable } => {
+            usage_count.insert(name.clone(), 0);
+            mutation_count.insert(name.clone(), 0);
+            if *mutable {
+                mutable_vars.insert(name.clone());
+            }
+            audit_expr(value, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedStatement::Assignment { name, value } => {
+            if let Some(count) = mutation_count.get_mut(name) {
+                *count += 1;
+            }
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
+            }
+            audit_expr(value, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedStatement::Print(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Expression(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Query(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::If { condition, then_body, else_body } => {
+            audit_expr(condition, usage_count, mutation_count, mutable_vars);
+            for s in then_body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    audit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::While { condition, body } => {
+            audit_expr(condition, usage_count, mutation_count, mutable_vars);
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::For { variable, iterator, body } => {
+            usage_count.insert(variable.clone(), 0);
+            audit_expr(iterator, usage_count, mutation_count, mutable_vars);
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Match { scrutinee, arms } => {
+            audit_expr(scrutinee, usage_count, mutation_count, mutable_vars);
+            for (expr, stmts) in arms {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+                for s in stmts {
+                    audit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { params, body, .. } => {
+            for (param_name, _) in params {
+                usage_count.insert(param_name.clone(), 0);
+            }
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Return { value } => {
+            if let Some(v) = value {
+                audit_expr(v, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Break
+        | AnalyzedStatement::Continue
+        | AnalyzedStatement::TypeDefinition { .. }
+        | AnalyzedStatement::TraitDefinition { .. }
+        | AnalyzedStatement::TraitImplementation { .. } => {}
+    }
+}
+
+pub fn audit_expr(
+    expr: &AnalyzedExpr,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match &expr.expr {
+        AnalyzedExprKind::Variable(name) => {
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
+            }
+        }
+        AnalyzedExprKind::BinOp { left, right, .. } => {
+            audit_expr(left, usage_count, mutation_count, mutable_vars);
+            audit_expr(right, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::UnaryOp { operand, .. } => {
+            audit_expr(operand, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::StructInstantiation { args, .. } => {
+            for arg in args {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::PropertyAccess { owner, .. } => {
+            audit_expr(owner, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::MethodCall { receiver, args, .. } => {
+            audit_expr(receiver, usage_count, mutation_count, mutable_vars);
+            for arg in args {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::FunctionCall { args, .. } | AnalyzedExprKind::VerbCall { args, .. } => {
+            for arg in args {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::ArrayLiteral(exprs) => {
+            for arg in exprs {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::IndexAccess { array, index } => {
+            audit_expr(array, usage_count, mutation_count, mutable_vars);
+            audit_expr(index, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::Lambda { body, .. } => {
+            audit_expr(body, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::Some(inner)
+        | AnalyzedExprKind::Ok(inner)
+        | AnalyzedExprKind::Err(inner)
+        | AnalyzedExprKind::Unwrap(inner)
+        | AnalyzedExprKind::Try(inner) => audit_expr(inner, usage_count, mutation_count, mutable_vars),
+        AnalyzedExprKind::Assert { condition } => {
+            audit_expr(condition, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::AssertEq { left, right } => {
+            audit_expr(left, usage_count, mutation_count, mutable_vars);
+            audit_expr(right, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::Range { start, end, .. } => {
+            audit_expr(start, usage_count, mutation_count, mutable_vars);
+            audit_expr(end, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::NumberLiteral(_)
+        | AnalyzedExprKind::StringLiteral(_)
+        | AnalyzedExprKind::BooleanLiteral(_)
+        | AnalyzedExprKind::None
+        | AnalyzedExprKind::CollectionNew { .. } => {}
+    }
+}
+"""
+
+start_str = "struct AuditorVisitor {"
+end_str = "        }\n    }\n}\n"
+
+start_idx = content.find(start_str)
+end_idx = content.find(end_str, start_idx) + len(end_str)
+
+if start_idx != -1 and end_idx != -1:
+    content = content[:start_idx] + new_fn + content[end_idx:]
+
+# Update run_auditor
+content = content.replace(
+"""    let mut visitor = AuditorVisitor::new();
+    for stmt in &program.statements {
+        visitor.visit_statement(stmt);
+    }""",
+"""    let mut usage_count = FxHashMap::default();
+    let mut mutation_count = FxHashMap::default();
+    let mut mutable_vars = FxHashSet::default();
+    for stmt in &program.statements {
+        audit_statement(stmt, &mut usage_count, &mut mutation_count, &mut mutable_vars);
+    }"""
+)
+
+content = content.replace("visitor.usage_count", "usage_count")
+content = content.replace("visitor.mutation_count", "mutation_count")
+content = content.replace("visitor.mutable_vars", "mutable_vars")
+
+# Fix tests
+content = content.replace("let mut visitor = AuditorVisitor::new();", "let mut usage_count = FxHashMap::default();\n        let mut mutation_count = FxHashMap::default();\n        let mut mutable_vars = FxHashSet::default();")
+content = content.replace("visitor.visit_statement(", "audit_statement(")
+content = content.replace("visitor.visit_expr(&expr);", "audit_expr(&expr, &mut usage_count, &mut mutation_count, &mut mutable_vars);")
+
+content = re.sub(
+    r'audit_statement\((.*?)\);',
+    r'audit_statement(\1, &mut usage_count, &mut mutation_count, &mut mutable_vars);',
+    content
+)
+
+
+with open('src/tools/auditor.rs', 'w') as f:
+    f.write(content)

--- a/refactor_auditor2.py
+++ b/refactor_auditor2.py
@@ -1,0 +1,222 @@
+import subprocess
+subprocess.run(['git', 'checkout', 'src/tools/auditor.rs'])
+
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+new_fn = """pub fn audit_statement(
+    stmt: &AnalyzedStatement,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match stmt {
+        AnalyzedStatement::Binding { name, value, mutable } => {
+            usage_count.insert(name.clone(), 0);
+            mutation_count.insert(name.clone(), 0);
+            if *mutable {
+                mutable_vars.insert(name.clone());
+            }
+            audit_expr(value, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedStatement::Assignment { name, value } => {
+            if let Some(count) = mutation_count.get_mut(name) {
+                *count += 1;
+            }
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
+            }
+            audit_expr(value, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedStatement::Print(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Expression(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Query(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::If { condition, then_body, else_body } => {
+            audit_expr(condition, usage_count, mutation_count, mutable_vars);
+            for s in then_body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    audit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::While { condition, body } => {
+            audit_expr(condition, usage_count, mutation_count, mutable_vars);
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::For { variable, iterator, body } => {
+            usage_count.insert(variable.clone(), 0);
+            audit_expr(iterator, usage_count, mutation_count, mutable_vars);
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Match { scrutinee, arms } => {
+            audit_expr(scrutinee, usage_count, mutation_count, mutable_vars);
+            for (expr, stmts) in arms {
+                audit_expr(expr, usage_count, mutation_count, mutable_vars);
+                for s in stmts {
+                    audit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { params, body, .. } => {
+            for (param_name, _) in params {
+                usage_count.insert(param_name.clone(), 0);
+            }
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Return { value } => {
+            if let Some(v) = value {
+                audit_expr(v, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Break
+        | AnalyzedStatement::Continue
+        | AnalyzedStatement::TypeDefinition { .. }
+        | AnalyzedStatement::TraitDefinition { .. }
+        | AnalyzedStatement::TraitImplementation { .. } => {}
+    }
+}
+
+pub fn audit_expr(
+    expr: &AnalyzedExpr,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match &expr.expr {
+        AnalyzedExprKind::Variable(name) => {
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
+            }
+        }
+        AnalyzedExprKind::BinOp { left, right, .. } => {
+            audit_expr(left, usage_count, mutation_count, mutable_vars);
+            audit_expr(right, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::UnaryOp { operand, .. } => {
+            audit_expr(operand, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::StructInstantiation { args, .. } => {
+            for arg in args {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::PropertyAccess { owner, .. } => {
+            audit_expr(owner, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::MethodCall { receiver, args, .. } => {
+            audit_expr(receiver, usage_count, mutation_count, mutable_vars);
+            for arg in args {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::FunctionCall { args, .. } | AnalyzedExprKind::VerbCall { args, .. } => {
+            for arg in args {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::ArrayLiteral(exprs) => {
+            for arg in exprs {
+                audit_expr(arg, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedExprKind::IndexAccess { array, index } => {
+            audit_expr(array, usage_count, mutation_count, mutable_vars);
+            audit_expr(index, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::Lambda { body, .. } => {
+            audit_expr(body, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::Some(inner)
+        | AnalyzedExprKind::Ok(inner)
+        | AnalyzedExprKind::Err(inner)
+        | AnalyzedExprKind::Unwrap(inner)
+        | AnalyzedExprKind::Try(inner) => audit_expr(inner, usage_count, mutation_count, mutable_vars),
+        AnalyzedExprKind::Assert { condition } => {
+            audit_expr(condition, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::AssertEq { left, right } => {
+            audit_expr(left, usage_count, mutation_count, mutable_vars);
+            audit_expr(right, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::Range { start, end, .. } => {
+            audit_expr(start, usage_count, mutation_count, mutable_vars);
+            audit_expr(end, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::NumberLiteral(_)
+        | AnalyzedExprKind::StringLiteral(_)
+        | AnalyzedExprKind::BooleanLiteral(_)
+        | AnalyzedExprKind::None
+        | AnalyzedExprKind::CollectionNew { .. } => {}
+    }
+}
+"""
+
+start_str = "struct AuditorVisitor {"
+end_str = "        }\n    }\n}\n"
+
+start_idx = content.find(start_str)
+end_idx = content.find(end_str, start_idx) + len(end_str)
+
+if start_idx != -1 and end_idx != -1:
+    content = content[:start_idx] + new_fn + content[end_idx:]
+
+content = content.replace(
+"""    let mut visitor = AuditorVisitor::new();
+    for stmt in &program.statements {
+        visitor.visit_statement(stmt);
+    }""",
+"""    let mut usage_count = FxHashMap::default();
+    let mut mutation_count = FxHashMap::default();
+    let mut mutable_vars = FxHashSet::default();
+    for stmt in &program.statements {
+        audit_statement(stmt, &mut usage_count, &mut mutation_count, &mut mutable_vars);
+    }"""
+)
+
+content = content.replace("visitor.usage_count", "usage_count")
+content = content.replace("visitor.mutation_count", "mutation_count")
+content = content.replace("visitor.mutable_vars", "mutable_vars")
+
+
+import re
+# Fix tests specifically
+# Find all occurrences of let mut visitor = AuditorVisitor::new(); in tests
+content = content.replace(
+    "let mut visitor = AuditorVisitor::new();",
+    "let mut usage_count = FxHashMap::default();\n        let mut mutation_count = FxHashMap::default();\n        let mut mutable_vars = FxHashSet::default();"
+)
+content = content.replace("visitor.visit_statement(&stmt);", "audit_statement(&stmt, &mut usage_count, &mut mutation_count, &mut mutable_vars);")
+content = content.replace("visitor.visit_statement(&s);", "audit_statement(&s, &mut usage_count, &mut mutation_count, &mut mutable_vars);")
+content = content.replace("visitor.visit_statement(s);", "audit_statement(s, &mut usage_count, &mut mutation_count, &mut mutable_vars);")
+
+content = content.replace("visitor.visit_expr(&expr);", "audit_expr(&expr, &mut usage_count, &mut mutation_count, &mut mutable_vars);")
+
+
+with open('src/tools/auditor.rs', 'w') as f:
+    f.write(content)

--- a/refactor_auditor3.py
+++ b/refactor_auditor3.py
@@ -1,0 +1,12 @@
+import re
+
+with open('src/tools/auditor.rs', 'r') as f:
+    content = f.read()
+
+start_str = "struct AuditorVisitor {"
+end_str = "        }\n    }\n}\n"
+
+start_idx = content.find(start_str)
+end_idx = content.find(end_str, start_idx) + len(end_str)
+print("Found start:", start_idx != -1)
+print("Found end:", end_idx != -1)

--- a/refactor_gnomon.py
+++ b/refactor_gnomon.py
@@ -1,0 +1,167 @@
+import re
+import subprocess
+
+subprocess.run(['git', 'checkout', 'src/tools/gnomon.rs'])
+
+with open('src/tools/gnomon.rs', 'r') as f:
+    content = f.read()
+
+# Replace GnomonVisitor struct and impl
+new_fn = """/// Recursively visits a statement and updates loop depth metrics.
+///
+/// Increases depth when entering `While` or `For` loops, and explores
+/// inner statements in branches (`If`, `Match`, functions).
+pub fn calculate_max_depth(stmt: &AnalyzedStatement, current_depth: usize, max_depth: &mut usize) {
+    match stmt {
+        AnalyzedStatement::While { body, .. } => {
+            let next_depth = current_depth + 1;
+            if next_depth > *max_depth {
+                *max_depth = next_depth;
+            }
+            for s in body {
+                calculate_max_depth(s, next_depth, max_depth);
+            }
+        }
+        AnalyzedStatement::For { body, .. } => {
+            let next_depth = current_depth + 1;
+            if next_depth > *max_depth {
+                *max_depth = next_depth;
+            }
+            for s in body {
+                calculate_max_depth(s, next_depth, max_depth);
+            }
+        }
+        AnalyzedStatement::If {
+            then_body,
+            else_body,
+            ..
+        } => {
+            for s in then_body {
+                calculate_max_depth(s, current_depth, max_depth);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    calculate_max_depth(s, current_depth, max_depth);
+                }
+            }
+        }
+        AnalyzedStatement::Match { arms, .. } => {
+            for (_, stmts) in arms {
+                for s in stmts {
+                    calculate_max_depth(s, current_depth, max_depth);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { body, .. } => {
+            for s in body {
+                calculate_max_depth(s, current_depth, max_depth);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                calculate_max_depth(s, current_depth, max_depth);
+            }
+        }
+        _ => {}
+    }
+}"""
+
+start_str = """/// A visitor that traverses the Abstract Syntax Tree to calculate loop depth.
+///
+/// Just as a gnomon casts a shadow to indicate time, this visitor casts a shadow
+/// over the structure of a program to estimate its execution time complexity.
+/// It tracks the maximum nesting depth of `while` and `for` loops.
+#[derive(Default)]
+pub struct GnomonVisitor {
+    /// The current nesting depth of loops during traversal.
+    pub current_depth: usize,
+    /// The maximum nesting depth encountered so far.
+    pub max_depth: usize,
+}
+
+impl GnomonVisitor {
+    /// Creates a new `GnomonVisitor` starting at depth 0.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Recursively visits a statement and updates loop depth metrics.
+    ///
+    /// Increases depth when entering `While` or `For` loops, and explores
+    /// inner statements in branches (`If`, `Match`, functions).
+    pub fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
+        match stmt {
+            AnalyzedStatement::While { body, .. } => {
+                self.current_depth += 1;
+                if self.current_depth > self.max_depth {
+                    self.max_depth = self.current_depth;
+                }
+                for s in body {
+                    self.visit_statement(s);
+                }
+                self.current_depth -= 1;
+            }
+            AnalyzedStatement::For { body, .. } => {
+                self.current_depth += 1;
+                if self.current_depth > self.max_depth {
+                    self.max_depth = self.current_depth;
+                }
+                for s in body {
+                    self.visit_statement(s);
+                }
+                self.current_depth -= 1;
+            }
+            AnalyzedStatement::If {
+                then_body,
+                else_body,
+                ..
+            } => {
+                for s in then_body {
+                    self.visit_statement(s);
+                }
+                if let Some(else_stmts) = else_body {
+                    for s in else_stmts {
+                        self.visit_statement(s);
+                    }
+                }
+            }
+            AnalyzedStatement::Match { arms, .. } => {
+                for (_, stmts) in arms {
+                    for s in stmts {
+                        self.visit_statement(s);
+                    }
+                }
+            }
+            AnalyzedStatement::FunctionDef { body, .. } => {
+                for s in body {
+                    self.visit_statement(s);
+                }
+            }
+            AnalyzedStatement::TestDeclaration { body, .. } => {
+                for s in body {
+                    self.visit_statement(s);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+"""
+
+content = content.replace(start_str, new_fn + "\n")
+
+# Update run_gnomon usage
+content = content.replace("    let mut visitor = GnomonVisitor::new();", "    let mut max_depth = 0;")
+content = content.replace("visitor.visit_statement(stmt);", "calculate_max_depth(stmt, 0, &mut max_depth);")
+content = content.replace("visitor.max_depth", "max_depth")
+
+# Update test usages
+content = content.replace("let mut visitor = GnomonVisitor::new();", "let mut max_depth = 0;")
+content = content.replace("visitor.visit_statement(&stmt);", "calculate_max_depth(&stmt, 0, &mut max_depth);")
+content = content.replace("visitor.visit_statement(&outer_loop);", "calculate_max_depth(&outer_loop, 0, &mut max_depth);")
+
+# Ensure doc comment in run_gnomon matches the change
+content = content.replace("using the [`GnomonVisitor`].", "using the `calculate_max_depth` function.")
+
+with open('src/tools/gnomon.rs', 'w') as f:
+    f.write(content)

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -76,9 +76,16 @@ pub fn run_auditor(input: &Path) -> Result<()> {
 
     status.success();
 
-    let mut visitor = AuditorVisitor::new();
+    let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+    let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+    let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();
     for stmt in &program.statements {
-        visitor.visit_statement(stmt);
+        audit_statement(
+            stmt,
+            &mut usage_count,
+            &mut mutation_count,
+            &mut mutable_vars,
+        );
     }
 
     let mut issues = 0;
@@ -101,7 +108,7 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         Cell::new("Message").add_attribute(Attribute::Bold),
     ]);
 
-    for (var, count) in &visitor.usage_count {
+    for (var, count) in &usage_count {
         if *count == 0 {
             table.add_row(vec![
                 Cell::new("⚠️ Unused Variable").fg(Color::Yellow),
@@ -112,11 +119,8 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         }
     }
 
-    for (var, count) in &visitor.mutation_count {
-        if *count == 0
-            && visitor.mutable_vars.contains(var)
-            && visitor.usage_count.get(var).unwrap_or(&0) > &0
-        {
+    for (var, count) in &mutation_count {
+        if *count == 0 && mutable_vars.contains(var) && usage_count.get(var).unwrap_or(&0) > &0 {
             table.add_row(vec![
                 Cell::new("💡 Unnecessary Mutation").fg(Color::Blue),
                 Cell::new(var),
@@ -140,218 +144,174 @@ pub fn run_auditor(input: &Path) -> Result<()> {
     Ok(())
 }
 
-struct AuditorVisitor {
-    /// ⚡ Bolt Optimization: Uses `FxHashMap` instead of the standard `HashMap`
-    /// to reduce cryptographic hashing overhead for small string keys (`SmolStr`).
-    usage_count: FxHashMap<SmolStr, usize>,
-    mutation_count: FxHashMap<SmolStr, usize>,
-    mutable_vars: FxHashSet<SmolStr>,
+pub fn audit_statement(
+    stmt: &AnalyzedStatement,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match stmt {
+        AnalyzedStatement::Binding {
+            name,
+            value,
+            mutable,
+        } => {
+            usage_count.insert(name.clone(), 0);
+            mutation_count.insert(name.clone(), 0);
+            if *mutable {
+                mutable_vars.insert(name.clone());
+            }
+            audit_expr(value, usage_count);
+        }
+        AnalyzedStatement::Assignment { name, value } => {
+            if let Some(count) = mutation_count.get_mut(name) {
+                *count += 1;
+            }
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
+            }
+            audit_expr(value, usage_count);
+        }
+        AnalyzedStatement::Print(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count);
+            }
+        }
+        AnalyzedStatement::Expression(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count);
+            }
+        }
+        AnalyzedStatement::Query(exprs) => {
+            for expr in exprs {
+                audit_expr(expr, usage_count);
+            }
+        }
+        AnalyzedStatement::If {
+            condition,
+            then_body,
+            else_body,
+        } => {
+            audit_expr(condition, usage_count);
+            for s in then_body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    audit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::While { condition, body } => {
+            audit_expr(condition, usage_count);
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::For {
+            variable,
+            iterator,
+            body,
+        } => {
+            usage_count.insert(variable.clone(), 0);
+            audit_expr(iterator, usage_count);
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Match { scrutinee, arms } => {
+            audit_expr(scrutinee, usage_count);
+            for (expr, stmts) in arms {
+                audit_expr(expr, usage_count);
+                for s in stmts {
+                    audit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { params, body, .. } => {
+            for (param_name, _) in params {
+                usage_count.insert(param_name.clone(), 0);
+            }
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Return { value } => {
+            if let Some(v) = value {
+                audit_expr(v, usage_count);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                audit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Break
+        | AnalyzedStatement::Continue
+        | AnalyzedStatement::TypeDefinition { .. }
+        | AnalyzedStatement::TraitDefinition { .. }
+        | AnalyzedStatement::TraitImplementation { .. } => {}
+    }
 }
 
-impl AuditorVisitor {
-    fn new() -> Self {
-        Self {
-            usage_count: FxHashMap::default(),
-            mutation_count: FxHashMap::default(),
-            mutable_vars: FxHashSet::default(),
-        }
-    }
-
-    fn visit_if_statement(
-        &mut self,
-        condition: &AnalyzedExpr,
-        then_body: &[AnalyzedStatement],
-        else_body: &Option<Vec<AnalyzedStatement>>,
-    ) {
-        self.visit_expr(condition);
-        for s in then_body {
-            self.visit_statement(s);
-        }
-        if let Some(else_stmts) = else_body {
-            for s in else_stmts {
-                self.visit_statement(s);
+pub fn audit_expr(expr: &AnalyzedExpr, usage_count: &mut FxHashMap<SmolStr, usize>) {
+    match &expr.expr {
+        AnalyzedExprKind::Variable(name) => {
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
             }
         }
-    }
-
-    fn visit_while_loop(&mut self, condition: &AnalyzedExpr, body: &[AnalyzedStatement]) {
-        self.visit_expr(condition);
-        for s in body {
-            self.visit_statement(s);
+        AnalyzedExprKind::BinOp { left, right, .. } => {
+            audit_expr(left, usage_count);
+            audit_expr(right, usage_count);
         }
-    }
-
-    fn visit_for_loop(
-        &mut self,
-        variable: &smol_str::SmolStr,
-        iterator: &AnalyzedExpr,
-        body: &[AnalyzedStatement],
-    ) {
-        self.usage_count.insert(variable.clone(), 0);
-        self.visit_expr(iterator);
-        for s in body {
-            self.visit_statement(s);
-        }
-    }
-
-    fn visit_match_statement(
-        &mut self,
-        scrutinee: &AnalyzedExpr,
-        arms: &[(AnalyzedExpr, Vec<AnalyzedStatement>)],
-    ) {
-        self.visit_expr(scrutinee);
-        for (expr, stmts) in arms {
-            self.visit_expr(expr);
-            for s in stmts {
-                self.visit_statement(s);
+        AnalyzedExprKind::UnaryOp { operand, .. } => audit_expr(operand, usage_count),
+        AnalyzedExprKind::StructInstantiation { args, .. } => {
+            for arg in args {
+                audit_expr(arg, usage_count);
             }
         }
-    }
-
-    fn visit_function_def(
-        &mut self,
-        params: &[(smol_str::SmolStr, Option<crate::semantic::GlossaType>)],
-        body: &[AnalyzedStatement],
-    ) {
-        for (param_name, _) in params {
-            self.usage_count.insert(param_name.clone(), 0);
+        AnalyzedExprKind::PropertyAccess { owner, .. } => audit_expr(owner, usage_count),
+        AnalyzedExprKind::MethodCall { receiver, args, .. } => {
+            audit_expr(receiver, usage_count);
+            for arg in args {
+                audit_expr(arg, usage_count);
+            }
         }
-        for s in body {
-            self.visit_statement(s);
+        AnalyzedExprKind::FunctionCall { args, .. } | AnalyzedExprKind::VerbCall { args, .. } => {
+            for arg in args {
+                audit_expr(arg, usage_count);
+            }
         }
-    }
-
-    fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
-        match stmt {
-            AnalyzedStatement::Binding {
-                name,
-                value,
-                mutable,
-            } => {
-                self.usage_count.insert(name.clone(), 0);
-                self.mutation_count.insert(name.clone(), 0);
-                if *mutable {
-                    self.mutable_vars.insert(name.clone());
-                }
-                self.visit_expr(value);
+        AnalyzedExprKind::ArrayLiteral(exprs) => {
+            for arg in exprs {
+                audit_expr(arg, usage_count);
             }
-            AnalyzedStatement::Assignment { name, value } => {
-                if let Some(count) = self.mutation_count.get_mut(name) {
-                    *count += 1;
-                }
-                if let Some(count) = self.usage_count.get_mut(name) {
-                    *count += 1;
-                }
-                self.visit_expr(value);
-            }
-            AnalyzedStatement::Print(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::Expression(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::Query(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::If {
-                condition,
-                then_body,
-                else_body,
-            } => {
-                self.visit_if_statement(condition, then_body, else_body);
-            }
-            AnalyzedStatement::While { condition, body } => {
-                self.visit_while_loop(condition, body);
-            }
-            AnalyzedStatement::For {
-                variable,
-                iterator,
-                body,
-            } => {
-                self.visit_for_loop(variable, iterator, body);
-            }
-            AnalyzedStatement::Match { scrutinee, arms } => {
-                self.visit_match_statement(scrutinee, arms);
-            }
-            AnalyzedStatement::FunctionDef { params, body, .. } => {
-                self.visit_function_def(params, body);
-            }
-            AnalyzedStatement::Return { value } => {
-                if let Some(v) = value {
-                    self.visit_expr(v);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::Break
-            | AnalyzedStatement::Continue
-            | AnalyzedStatement::TypeDefinition { .. }
-            | AnalyzedStatement::TraitDefinition { .. }
-            | AnalyzedStatement::TraitImplementation { .. } => {}
         }
-    }
-
-    fn visit_exprs(&mut self, exprs: &[AnalyzedExpr]) {
-        for expr in exprs {
-            self.visit_expr(expr);
+        AnalyzedExprKind::IndexAccess { array, index } => {
+            audit_expr(array, usage_count);
+            audit_expr(index, usage_count);
         }
-    }
-
-    fn visit_expr(&mut self, expr: &AnalyzedExpr) {
-        match &expr.expr {
-            AnalyzedExprKind::Variable(name) => {
-                if let Some(count) = self.usage_count.get_mut(name) {
-                    *count += 1;
-                }
-            }
-            AnalyzedExprKind::BinOp { left, right, .. } => {
-                self.visit_expr(left);
-                self.visit_expr(right);
-            }
-            AnalyzedExprKind::UnaryOp { operand, .. } => self.visit_expr(operand),
-            AnalyzedExprKind::StructInstantiation { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::PropertyAccess { owner, .. } => self.visit_expr(owner),
-            AnalyzedExprKind::MethodCall { receiver, args, .. } => {
-                self.visit_expr(receiver);
-                self.visit_exprs(args);
-            }
-            AnalyzedExprKind::FunctionCall { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::VerbCall { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::ArrayLiteral(exprs) => self.visit_exprs(exprs),
-            AnalyzedExprKind::IndexAccess { array, index } => {
-                self.visit_expr(array);
-                self.visit_expr(index);
-            }
-            AnalyzedExprKind::Lambda { body, .. } => self.visit_expr(body),
-            AnalyzedExprKind::Some(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Ok(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Err(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Unwrap(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Try(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Assert { condition } => self.visit_expr(condition),
-            AnalyzedExprKind::AssertEq { left, right } => {
-                self.visit_expr(left);
-                self.visit_expr(right);
-            }
-            AnalyzedExprKind::Range { start, end, .. } => {
-                self.visit_expr(start);
-                self.visit_expr(end);
-            }
-            AnalyzedExprKind::NumberLiteral(_)
-            | AnalyzedExprKind::StringLiteral(_)
-            | AnalyzedExprKind::BooleanLiteral(_)
-            | AnalyzedExprKind::None
-            | AnalyzedExprKind::CollectionNew { .. } => {}
+        AnalyzedExprKind::Lambda { body, .. } => audit_expr(body, usage_count),
+        AnalyzedExprKind::Some(inner)
+        | AnalyzedExprKind::Ok(inner)
+        | AnalyzedExprKind::Err(inner)
+        | AnalyzedExprKind::Unwrap(inner)
+        | AnalyzedExprKind::Try(inner) => audit_expr(inner, usage_count),
+        AnalyzedExprKind::Assert { condition } => audit_expr(condition, usage_count),
+        AnalyzedExprKind::AssertEq { left, right } => {
+            audit_expr(left, usage_count);
+            audit_expr(right, usage_count);
         }
+        AnalyzedExprKind::Range { start, end, .. } => {
+            audit_expr(start, usage_count);
+            audit_expr(end, usage_count);
+        }
+        AnalyzedExprKind::NumberLiteral(_)
+        | AnalyzedExprKind::StringLiteral(_)
+        | AnalyzedExprKind::BooleanLiteral(_)
+        | AnalyzedExprKind::None
+        | AnalyzedExprKind::CollectionNew { .. } => {}
     }
 }
 
@@ -395,7 +355,9 @@ mod tests {
 
     #[test]
     fn test_auditor_visitor_coverage_statements() {
-        let mut visitor = AuditorVisitor::new();
+        let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+        let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+        let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();
 
         let statements = vec![
             AnalyzedStatement::Binding {
@@ -503,13 +465,18 @@ mod tests {
         ];
 
         for stmt in statements {
-            visitor.visit_statement(&stmt);
+            audit_statement(
+                &stmt,
+                &mut usage_count,
+                &mut mutation_count,
+                &mut mutable_vars,
+            );
         }
     }
 
     #[test]
     fn test_auditor_visitor_coverage_expressions() {
-        let mut visitor = AuditorVisitor::new();
+        let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
 
         let exprs = vec![
             AnalyzedExprKind::Variable("x".into()),
@@ -605,7 +572,7 @@ mod tests {
                 expr: kind,
                 glossa_type: crate::semantic::GlossaType::Boolean,
             };
-            visitor.visit_expr(&expr);
+            audit_expr(&expr, &mut usage_count);
         }
     }
 

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -17,91 +17,69 @@ use crossterm::style::Stylize;
 use miette::Result;
 use std::path::Path;
 
-/// A visitor that traverses the Abstract Syntax Tree to calculate loop depth.
+/// Recursively visits a statement and updates loop depth metrics.
 ///
-/// Just as a gnomon casts a shadow to indicate time, this visitor casts a shadow
-/// over the structure of a program to estimate its execution time complexity.
-/// It tracks the maximum nesting depth of `while` and `for` loops.
-#[derive(Default)]
-pub struct GnomonVisitor {
-    /// The current nesting depth of loops during traversal.
-    pub current_depth: usize,
-    /// The maximum nesting depth encountered so far.
-    pub max_depth: usize,
-}
-
-impl GnomonVisitor {
-    /// Creates a new `GnomonVisitor` starting at depth 0.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Recursively visits a statement and updates loop depth metrics.
-    ///
-    /// Increases depth when entering `While` or `For` loops, and explores
-    /// inner statements in branches (`If`, `Match`, functions).
-    pub fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
-        match stmt {
-            AnalyzedStatement::While { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
+/// Increases depth when entering `While` or `For` loops, and explores
+/// inner statements in branches (`If`, `Match`, functions).
+pub fn calculate_max_depth(stmt: &AnalyzedStatement, current_depth: usize, max_depth: &mut usize) {
+    match stmt {
+        AnalyzedStatement::While { body, .. } => {
+            let next_depth = current_depth + 1;
+            if next_depth > *max_depth {
+                *max_depth = next_depth;
             }
-            AnalyzedStatement::For { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
+            for s in body {
+                calculate_max_depth(s, next_depth, max_depth);
             }
-            AnalyzedStatement::If {
-                then_body,
-                else_body,
-                ..
-            } => {
-                for s in then_body {
-                    self.visit_statement(s);
-                }
-                if let Some(else_stmts) = else_body {
-                    for s in else_stmts {
-                        self.visit_statement(s);
-                    }
-                }
-            }
-            AnalyzedStatement::Match { arms, .. } => {
-                for (_, stmts) in arms {
-                    for s in stmts {
-                        self.visit_statement(s);
-                    }
-                }
-            }
-            AnalyzedStatement::FunctionDef { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            _ => {}
         }
+        AnalyzedStatement::For { body, .. } => {
+            let next_depth = current_depth + 1;
+            if next_depth > *max_depth {
+                *max_depth = next_depth;
+            }
+            for s in body {
+                calculate_max_depth(s, next_depth, max_depth);
+            }
+        }
+        AnalyzedStatement::If {
+            then_body,
+            else_body,
+            ..
+        } => {
+            for s in then_body {
+                calculate_max_depth(s, current_depth, max_depth);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    calculate_max_depth(s, current_depth, max_depth);
+                }
+            }
+        }
+        AnalyzedStatement::Match { arms, .. } => {
+            for (_, stmts) in arms {
+                for s in stmts {
+                    calculate_max_depth(s, current_depth, max_depth);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { body, .. } => {
+            for s in body {
+                calculate_max_depth(s, current_depth, max_depth);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                calculate_max_depth(s, current_depth, max_depth);
+            }
+        }
+        _ => {}
     }
 }
 
 /// Analyzes a ΓΛΩΣΣΑ source file and estimates its Big-O time complexity.
 ///
 /// This function coordinates the parsing, semantic analysis, and AST traversal
-/// using the [`GnomonVisitor`]. The result is presented to the user in a
+/// using the `calculate_max_depth` function. The result is presented to the user in a
 /// stylized terminal table.
 ///
 /// # Errors
@@ -146,9 +124,9 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
 
     status.success();
 
-    let mut visitor = GnomonVisitor::new();
+    let mut max_depth = 0;
     for stmt in &program.statements {
-        visitor.visit_statement(stmt);
+        calculate_max_depth(stmt, 0, &mut max_depth);
     }
 
     println!();
@@ -170,23 +148,23 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
         Cell::new("Value").add_attribute(Attribute::Bold),
     ]);
 
-    let complexity = if visitor.max_depth == 0 {
+    let complexity = if max_depth == 0 {
         "O(1)".to_string()
-    } else if visitor.max_depth == 1 {
+    } else if max_depth == 1 {
         "O(N)".to_string()
     } else {
-        format!("O(N^{})", visitor.max_depth)
+        format!("O(N^{})", max_depth)
     };
 
     table.add_row(vec![
         Cell::new("Max Loop Depth"),
-        Cell::new(visitor.max_depth.to_string()),
+        Cell::new(max_depth.to_string()),
     ]);
     table.add_row(vec![
         Cell::new("Estimated Big-O"),
-        Cell::new(complexity).fg(if visitor.max_depth > 2 {
+        Cell::new(complexity).fg(if max_depth > 2 {
             Color::Red
-        } else if visitor.max_depth == 2 {
+        } else if max_depth == 2 {
             Color::Yellow
         } else {
             Color::Green
@@ -214,30 +192,30 @@ mod tests {
 
     #[test]
     fn test_gnomon_while_loop() {
-        let mut visitor = GnomonVisitor::new();
+        let mut max_depth = 0;
         let stmt = AnalyzedStatement::While {
             condition: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        calculate_max_depth(&stmt, 0, &mut max_depth);
+        assert_eq!(max_depth, 1);
     }
 
     #[test]
     fn test_gnomon_for_loop() {
-        let mut visitor = GnomonVisitor::new();
+        let mut max_depth = 0;
         let stmt = AnalyzedStatement::For {
             variable: SmolStr::new("x"),
             iterator: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        calculate_max_depth(&stmt, 0, &mut max_depth);
+        assert_eq!(max_depth, 1);
     }
 
     #[test]
     fn test_gnomon_nested_loops() {
-        let mut visitor = GnomonVisitor::new();
+        let mut max_depth = 0;
         let inner_loop = AnalyzedStatement::For {
             variable: SmolStr::new("y"),
             iterator: dummy_expr(),
@@ -247,7 +225,7 @@ mod tests {
             condition: dummy_expr(),
             body: vec![inner_loop],
         };
-        visitor.visit_statement(&outer_loop);
-        assert_eq!(visitor.max_depth, 2);
+        calculate_max_depth(&outer_loop, 0, &mut max_depth);
+        assert_eq!(max_depth, 2);
     }
 }

--- a/test.py
+++ b/test.py
@@ -1,0 +1,4 @@
+import re
+with open('src/tools/gnomon.rs', 'r') as f:
+    content = f.read()
+print("GnomonVisitor" in content)


### PR DESCRIPTION
## [Reduction]
**Bloat:** `GnomonVisitor` in `src/tools/gnomon.rs` and `AuditorVisitor` in `src/tools/auditor.rs` used stateful object-oriented builder/visitor patterns for AST traversal, requiring manual struct instantiation and method calls.
**Cut:** Flattened both visitor structs into pure procedural functions (`calculate_max_depth`, `audit_statement`, and `audit_expr`), passing state down the recursion tree via mutable references.
**Saved:** Replaced localized object-oriented abstractions with simpler, standard procedural Rust functions. Eliminated boilerplate struct and `impl` definitions.

---
*PR created automatically by Jules for task [2886079274567237058](https://jules.google.com/task/2886079274567237058) started by @madmax983*