### PR TITLE
🛡️ Sentry: semantic error guard coverage

### DIFF
--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -1406,4 +1406,73 @@ mod tests {
         let expr = Expr::Word(Word::new("εαν"));
         assert!(check_conditional_start(&expr));
     }
+
+    #[test]
+    fn test_parse_for_range_empty_clause_sentry() {
+        let mut scope = Scope::new();
+        let stmt = Statement::Regular {
+            clauses: vec![
+                Clause { expressions: vec![] },
+                Clause { expressions: vec![Expr::NumberLiteral(1)] },
+            ],
+            is_query: false,
+            is_propagate: false,
+        };
+        let result = parse_for_range_loop(&stmt, &mut scope);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Empty range clause in for loop"));
+    }
+
+    #[test]
+    fn test_parse_for_range_not_phrase_sentry() {
+        let mut scope = Scope::new();
+        let stmt = Statement::Regular {
+            clauses: vec![
+                Clause { expressions: vec![Expr::NumberLiteral(1)] },
+                Clause { expressions: vec![Expr::NumberLiteral(1)] },
+            ],
+            is_query: false,
+            is_propagate: false,
+        };
+        let result = parse_for_range_loop(&stmt, &mut scope);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Expected phrase in for range"));
+    }
+
+    #[test]
+    fn test_parse_while_loop_missing_body_sentry() {
+        let mut scope = Scope::new();
+        let stmt = Statement::Regular {
+            clauses: vec![
+                Clause { expressions: vec![Expr::Phrase(vec![
+                    Expr::Word(Word::new("εως")),
+                    Expr::NumberLiteral(1),
+                ])] },
+            ],
+            is_query: false,
+            is_propagate: false,
+        };
+        let result = parse_while_loop(&stmt, &mut scope);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("While loop needs at least 2 clauses: condition and body"));
+    }
+
+    #[test]
+    fn test_parse_conditional_empty_then_body_sentry() {
+        let mut scope = Scope::new();
+        let stmt = Statement::Regular {
+            clauses: vec![
+                Clause { expressions: vec![Expr::Phrase(vec![
+                    Expr::Word(Word::new("εαν")),
+                    Expr::NumberLiteral(1),
+                ])] },
+                Clause { expressions: vec![] }, // Empty then body
+            ],
+            is_query: false,
+            is_propagate: false,
+        };
+        let result = parse_conditional(&stmt, &mut scope, 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Empty then-body in conditional"));
+    }
 }

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -1450,4 +1450,12 @@ mod regression_tests {
             err
         );
     }
+
+    #[test]
+    fn test_analyze_literal_error_sentry() {
+        let expr = Expr::Word(crate::ast::Word::new("not_a_literal"));
+        let result = super::analyze_literal(&expr);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Not a literal expression"));
+    }
 }


### PR DESCRIPTION
🎯 Target: `src/semantic/control_flow.rs` and `src/semantic/expressions.rs`
💣 Risk: Undocumented and unreachable panic/error guards in AST semantic evaluation could break if grammar rules are relaxed or mutated in code generation pipelines.
🧪 Strategy: Constructed invalid AST nodes manually via `Statement::Regular` and `Expr::Word` directly in embedded `#[cfg(test)] mod tests` to hit deep semantic validation fallback branches. Renamed to descriptive Sentry-specific naming conventions.
🔬 Verification: `cargo test --lib semantic::control_flow semantic::expressions`

---
*PR created automatically by Jules for task [9088335385269845898](https://jules.google.com/task/9088335385269845898) started by @madmax983*