### PR TITLE
🎨 Mosaic: UI Polish for Haruspex

### DIFF
--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -13,6 +13,7 @@
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
+use comfy_table::{Cell, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
@@ -80,6 +81,10 @@ fn print_dashboard(dot: &str, is_tty: bool) {
             "cargo run --features nova --bin glossa -- haruspex <file> | dot -Tpng > ast.png".dim()
         );
         println!();
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
+        table.add_row(vec![Cell::new(dot)]);
+        println!("{table}");
     } else {
         println!("{}", dot);
     }


### PR DESCRIPTION
🖌️ **Before:** The Haruspex tool dumped a raw DOT graph directly to the console when run in TTY mode, creating a giant text wall that looked more like a log file than a CLI dashboard.
✨ **After:** The raw DOT output is now nicely wrapped in a `comfy-table` "panel" when run in an interactive terminal, creating visual hierarchy. The `!is_tty` branch correctly remains untouched to preserve raw piped output for external Graphviz tools.
🖼️ **Visuals:** The DOT graph now displays neatly inside a bordered box under the tool header.

---
*PR created automatically by Jules for task [13405295584612537866](https://jules.google.com/task/13405295584612537866) started by @madmax983*