### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module.
🔦 Insight: The `use std::fmt::Write;` statement was incorrectly placed between the `///` documentation block and the `to_rust_type` function signature. This caused the rustdoc to attach to the `use` statement instead of the public function, triggering a missing documentation warning and hiding the function's docs. The statement has been moved above the doc block.
🧪 Example: Verified via `RUSTDOCFLAGS="-W missing_docs" cargo doc --no-deps`. The warning is resolved and all executable doctests compile.
🖼️ Preview: `to_rust_type` now appears correctly with examples in the HTML docs.

---
*PR created automatically by Jules for task [12622293916021648134](https://jules.google.com/task/12622293916021648134) started by @madmax983*