### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -131,3 +131,7 @@ Signed,
 **2026-04-30 - [Infinite Stream DoS Vulnerability in File Loading]
 **Threat:** The `load_source` function in `src/tools/runner.rs` relied on `fs::metadata().len()` to enforce the `MAX_FILE_SIZE` limit. However, special device files like `/dev/zero` report a length of 0 while producing an infinite stream of bytes when read. Reading these files with `fs::read_to_string` causes a thread hang or Out-Of-Memory (OOM) Denial-of-Service condition.
 **Defense:** Added an explicit `metadata.is_file()` check in `check_file_size` to guarantee that the input path points to a regular file and explicitly reject non-regular file types like directories and device streams. Updated `tests/havoc_dos.rs` and `test_load_source_directory_error` to assert the "Not a valid file" error and pass cleanly without timeouts.
+
+**2024-05-15 - [REPL Memory Exhaustion DoS]
+**Threat:** Calling `read_line` on unbounded inputs without capping allowed arbitrary memory allocation up to OOM, risking a Denial of Service via unbounded buffers (e.g. streaming /dev/zero without newlines into standard input for REPL and Mentor loops).
+**Defense:** Wrapped the input reader inside REPL and Mentor loops with `std::io::Read::take(LIMIT)` to forcefully cap the stream reader buffering before it exhausts process memory.

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -18,7 +18,7 @@ use crate::semantic::{AnalyzedProgram, AnalyzedStatement, GlossaType};
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
-use std::io::{BufRead, Write};
+use std::io::{BufRead, Read, Write};
 
 /// A self-contained chapter in the interactive ΓΛΩΣΣΑ tutorial.
 ///
@@ -127,7 +127,11 @@ fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Resu
             output.flush().into_diagnostic()?;
 
             let mut line = String::new();
-            let bytes = input.read_line(&mut line).into_diagnostic()?;
+            let bytes = input
+                .by_ref()
+                .take(50_000)
+                .read_line(&mut line)
+                .into_diagnostic()?;
 
             if bytes == 0 {
                 return Ok(()); // EOF
@@ -155,7 +159,7 @@ fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Resu
                             .into_diagnostic()?;
                         writeln!(output, "{}", "Press Enter to continue...".dim())
                             .into_diagnostic()?;
-                        let _ = input.read_line(&mut String::new());
+                        let _ = input.by_ref().take(50_000).read_line(&mut String::new());
                         break; // Next lesson
                     } else {
                         writeln!(

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -26,7 +26,7 @@
 use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
-use std::io::{BufRead, Write};
+use std::io::{BufRead, Read, Write};
 
 use crate::codegen::generate_statement_code;
 use crate::errors::GlossaError;
@@ -73,7 +73,11 @@ fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result
         let _ = output.flush();
 
         let mut line = String::new();
-        let bytes = input.read_line(&mut line).into_diagnostic()?;
+        let bytes = input
+            .by_ref()
+            .take(MAX_REPL_SOURCE_LEN as u64)
+            .read_line(&mut line)
+            .into_diagnostic()?;
 
         // Handle EOF
         if bytes == 0 {

--- a/tests/warden_repl_dos.rs
+++ b/tests/warden_repl_dos.rs
@@ -1,0 +1,38 @@
+use std::io::{BufRead, Read};
+
+// Provide a mock input that generates an unbounded line without newlines
+struct InfiniteLineReader;
+
+impl std::io::Read for InfiniteLineReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        for b in buf.iter_mut() {
+            *b = b'A'; // Just return infinite A's, no newline
+        }
+        Ok(buf.len())
+    }
+}
+
+impl std::io::BufRead for InfiniteLineReader {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        static BUF: [u8; 1024] = [b'A'; 1024];
+        Ok(&BUF)
+    }
+    fn consume(&mut self, _amt: usize) {}
+}
+
+#[test]
+fn test_repl_memory_exhaustion() {
+    let mut reader = InfiniteLineReader;
+    let mut reader = reader.by_ref().take(50_000);
+    let mut line = String::new();
+
+    // We simulate the fixed REPL doing:
+    // let bytes = input.by_ref().take(MAX_REPL_SOURCE_LEN as u64).read_line(&mut line).into_diagnostic()?;
+    // Since InfiniteLineReader has no newline, read_line will try to read until EOF or newline.
+    // take(50_000) limits it to 50,000 bytes, thus preventing the memory exhaustion DoS vulnerability.
+    let bytes = reader.read_line(&mut line).unwrap();
+
+    // Check that it only read up to the limit
+    assert_eq!(bytes, 50_000);
+    assert_eq!(line.len(), 50_000);
+}


### PR DESCRIPTION
🦠 Threat: The `run_repl_inner` and `run_mentor_inner` loops used `input.read_line(&mut line)` without bounds checking. An attacker could pipe an infinite stream of characters without newlines (e.g. from `/dev/zero`) into standard input, causing the process to allocate memory indefinitely until OOM, resulting in a Denial of Service.
🛡️ Defense: Wrapped the `BufRead` instances with `.by_ref().take(50_000)` inside the read loops. This ensures `read_line` will safely stop reading and return after 50,000 bytes, capping the buffer allocation.
💥 Severity: Critical - allows unauthenticated local DoS via standard input buffer exhaustion.
🧪 Verification: Added `tests/warden_repl_dos.rs` to verify that `read_line` correctly limits unbounded mocked streams.

---
*PR created automatically by Jules for task [2043220129641111745](https://jules.google.com/task/2043220129641111745) started by @madmax983*