### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,6 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+**Testing AST Edge Cases in Parser & Semantic Modules**
+**Learning:** Some private helper functions and "catch-all" match arm logic in Pest parsers or semantic conversion layers are inherently difficult or impossible to test via integration tests parsing complete code blocks due to strict grammar boundaries.
+**Action:** When trying to increase coverage for semantic logic or internal parser rules, construct and instantiate the intermediate models (e.g. `AssembledStatement`) directly within a module-level `#[cfg(test)]` block. This bypasses structural grammar restrictions and allows testing fallback branches (e.g. "empty/missing" properties) explicitly.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -46,7 +46,6 @@ use crate::semantic::assembly::AssembledStatement;
 use crate::semantic::model::{AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement};
 use crate::semantic::resolver::Scope;
 
-use crate::semantic::types::GlossaType;
 use crate::semantic::{Constituent, Literal};
 
 /// Convert an AssembledStatement to an AnalyzedStatement
@@ -2879,5 +2878,78 @@ mod tests {
         } else {
             panic!("Expected Unwrap expr");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests_sentry_conversion_extract {
+    use super::*;
+    use crate::semantic::resolver::Scope;
+    use crate::semantic::assembly::model::{AssembledStatement, Constituent};
+    use smol_str::SmolStr;
+
+    #[test]
+    fn test_extract_value_empty_fallback() {
+        let asm_stmt = AssembledStatement::default();
+        let scope = Scope::new();
+        let result = extract_value(&asm_stmt, &scope);
+        assert!(result.is_ok());
+        let (val, _ty) = result.unwrap();
+        assert!(matches!(val.expr, AnalyzedExprKind::NumberLiteral(0)));
+    }
+
+    #[test]
+    fn test_extract_unwrap_none() {
+        let asm_stmt = AssembledStatement::default();
+        let scope = Scope::new();
+        let result = extract_unwrap(&asm_stmt, &scope);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_extract_object_fallback_none() {
+        let asm_stmt = AssembledStatement::default();
+        let scope = Scope::new();
+        let result = extract_object_fallback(&asm_stmt, &scope);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_extract_enum_from_nominatives_none() {
+        let asm_stmt = AssembledStatement::default();
+        let scope = Scope::new();
+        let result = extract_enum_from_nominatives(&asm_stmt, &scope);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_try_print_property_access_some() {
+        let mut asm_stmt = AssembledStatement::default();
+        asm_stmt.property_accesses.push(("owner".into(), "len".into()));
+        let mut scope = Scope::new();
+        let result = try_print_property_access(&asm_stmt, &mut scope);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_extract_value_nominative_fallback() {
+        let mut asm_stmt = AssembledStatement { operators: vec![crate::morphology::lexicon::BinaryOp::Add], ..Default::default() };
+        let nominative = Constituent {
+            lemma: SmolStr::new("right_var").to_string().into(),
+            original: SmolStr::new("right_var").to_string().into(),
+            normalized: SmolStr::new("right_var").to_string().into(),
+            case: crate::morphology::Case::Nominative,
+            number: Some(crate::morphology::Number::Singular),
+            gender: Some(crate::morphology::Gender::Masculine),
+            person: None,
+        };
+        asm_stmt.nominatives = vec![nominative];
+
+        let scope = Scope::new();
+        let value_result = extract_value(&asm_stmt, &scope);
+        assert!(value_result.is_ok());
     }
 }

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -45,6 +45,7 @@ use crate::morphology::{self};
 use crate::semantic::assembly::AssembledStatement;
 use crate::semantic::model::{AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement};
 use crate::semantic::resolver::Scope;
+use crate::semantic::types::GlossaType;
 
 use crate::semantic::{Constituent, Literal};
 
@@ -2884,8 +2885,9 @@ mod tests {
 #[cfg(test)]
 mod tests_sentry_conversion_extract {
     use super::*;
+    use crate::semantic::assembly::AssembledStatement;
+    use crate::semantic::Constituent;
     use crate::semantic::resolver::Scope;
-    use crate::semantic::assembly::model::{AssembledStatement, Constituent};
     use smol_str::SmolStr;
 
     #[test]
@@ -2928,7 +2930,9 @@ mod tests_sentry_conversion_extract {
     #[test]
     fn test_try_print_property_access_some() {
         let mut asm_stmt = AssembledStatement::default();
-        asm_stmt.property_accesses.push(("owner".into(), "len".into()));
+        asm_stmt
+            .property_accesses
+            .push(("owner".into(), "len".into()));
         let mut scope = Scope::new();
         let result = try_print_property_access(&asm_stmt, &mut scope);
         assert!(result.is_some());
@@ -2936,11 +2940,14 @@ mod tests_sentry_conversion_extract {
 
     #[test]
     fn test_extract_value_nominative_fallback() {
-        let mut asm_stmt = AssembledStatement { operators: vec![crate::morphology::lexicon::BinaryOp::Add], ..Default::default() };
+        let mut asm_stmt = AssembledStatement {
+            operators: vec![crate::morphology::lexicon::BinaryOp::Add],
+            ..Default::default()
+        };
         let nominative = Constituent {
-            lemma: SmolStr::new("right_var").to_string().into(),
-            original: SmolStr::new("right_var").to_string().into(),
-            normalized: SmolStr::new("right_var").to_string().into(),
+            lemma: SmolStr::new("right_var"),
+            original: SmolStr::new("right_var"),
+            normalized: SmolStr::new("right_var"),
             case: crate::morphology::Case::Nominative,
             number: Some(crate::morphology::Number::Singular),
             gender: Some(crate::morphology::Gender::Masculine),


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `src/semantic/conversion.rs` (`extract_value`, `try_print_property_access`, `extract_unwrap`, `extract_object_fallback`)
💣 Risk: Edge cases and fallbacks handling missing or empty properties within `AssembledStatement` were untested, relying on implicit default returns or unwrap calls without verification.
🧪 Strategy: Wrote targeted unit tests inside a private `#[cfg(test)] mod tests` block, manually instantiating `AssembledStatement`s with empty or minimal fields to bypass parser grammar strictness and explicitly trigger all defensive fallback branches.
🔬 Verification: `cargo test --lib semantic::conversion::tests_sentry_conversion_extract` and `cargo llvm-cov`.

---
*PR created automatically by Jules for task [324997332438993921](https://jules.google.com/task/324997332438993921) started by @madmax983*