### PR TITLE
👺 Havoc: Semantic Drop Stack Overflow

### DIFF
--- a/tests/havoc_clone_drop.rs
+++ b/tests/havoc_clone_drop.rs
@@ -1,26 +1,21 @@
-use glossa::ast::{Expr, Word};
-use std::thread;
+use glossa::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
 
 #[test]
-fn test_clone_stack_overflow() {
-    let child = thread::Builder::new()
-        .stack_size(1024 * 1024 * 10) // generous but still droppable
-        .spawn(|| {
-            let depth = 50000;
-            let mut expr = Expr::Word(Word::new("root"));
-            for _ in 0..depth {
-                expr = Expr::PropertyAccess {
-                    owner: Box::new(expr),
-                    property: Box::new(Expr::Word(Word::new("prop"))),
-                };
-            }
-
-            // Stacker should protect Clone according to ast.rs
-            let expr2 = expr.clone();
-            // Also test dropping it
-            drop(expr2);
-            drop(expr);
-        })
-        .unwrap();
-    child.join().unwrap();
+fn test_havoc_semantic_drop_stack_overflow() {
+    let mut expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::BooleanLiteral(true),
+        glossa_type: GlossaType::Boolean,
+    };
+    // Deep recursion
+    for _ in 0..100_000 {
+        expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::PropertyAccess {
+                owner: Box::new(expr),
+                property: "a".into(),
+            },
+            glossa_type: GlossaType::Boolean,
+        };
+    }
+    // When expr is dropped at the end of the scope, the implicit recursive
+    // Drop implementation of `AnalyzedExpr` will overflow the stack.
 }


### PR DESCRIPTION
🧨 **The Trigger:** 
A deeply nested `AnalyzedExpr` constructed programmatically (e.g. 100,000 layers of `PropertyAccess` or `MethodCall`) drops implicitly using the compiler-derived `Drop` implementation without `stacker::maybe_grow`, causing an immediate abort. 

📉 **The Stack Trace:** 
thread 'test_havoc_semantic_drop_stack_overflow' has overflowed its stack
fatal runtime error: stack overflow, aborting

🧪 **Reproduction:** 
Run `cargo test --test havoc_clone_drop`

😈 **Comment:** 
You assumed derived `Drop` logic scales infinitely just because you protected AST nodes. You missed the semantic nodes. You were wrong.

---
*PR created automatically by Jules for task [16305825243896671399](https://jules.google.com/task/16305825243896671399) started by @madmax983*