### PR TITLE
🎻 Bard: Fix missing docs on to_rust_type

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -273,8 +273,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();
@@ -282,6 +280,7 @@ pub fn to_rust_type(ty: &GlossaType) -> String {
 }
 
 fn write_rust_type(ty: &GlossaType, out: &mut String) -> std::fmt::Result {
+    use std::fmt::Write;
     match ty {
         GlossaType::Number => write!(out, "i64"),
         GlossaType::String => write!(out, "String"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 #![deny(unsafe_code)]
 //! ΓΛΩΣΣΑ (GLOSSA) - A compiler where Ancient Greek morphology encodes programming semantics
 //!


### PR DESCRIPTION
📖 Chapter: `src/codegen.rs`
🔦 Insight: A `use` statement between a doc comment and a function attaches the documentation to the import instead of the function, leaving the function undocumented.
🧪 Example: Moved `use std::fmt::Write;` into `write_rust_type`, which restored the `## Examples` block for `to_rust_type`.
🖼️ Preview: Documentation is now visible on `to_rust_type`.

---
*PR created automatically by Jules for task [12624268632857934207](https://jules.google.com/task/12624268632857934207) started by @madmax983*