### PR TITLE
👺 Havoc: Memory exhaustion in REPL

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,3 +26,10 @@ path = "fuzz_targets/fuzz_target_2.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_repl"
+path = "fuzz_targets/fuzz_repl.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_repl.rs
+++ b/fuzz/fuzz_targets/fuzz_repl.rs
@@ -1,0 +1,86 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+struct FuzzReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+    repeats: usize,
+    max_repeats: usize,
+}
+
+impl<'a> FuzzReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self {
+            data,
+            pos: 0,
+            repeats: 0,
+            max_repeats: 500_000,
+        }
+    }
+}
+
+impl<'a> std::io::Read for FuzzReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.data.is_empty() {
+            return Ok(0);
+        }
+        if self.repeats >= self.max_repeats {
+            return Ok(0);
+        }
+
+        let mut bytes_written = 0;
+        while bytes_written < buf.len() && self.repeats < self.max_repeats {
+            let available = self.data.len() - self.pos;
+            let space = buf.len() - bytes_written;
+            let to_write = std::cmp::min(available, space);
+
+            buf[bytes_written..bytes_written + to_write].copy_from_slice(&self.data[self.pos..self.pos + to_write]);
+            bytes_written += to_write;
+            self.pos += to_write;
+
+            if self.pos >= self.data.len() {
+                self.pos = 0;
+                self.repeats += 1;
+            }
+        }
+        Ok(bytes_written)
+    }
+}
+
+impl<'a> std::io::BufRead for FuzzReader<'a> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        if self.data.is_empty() || self.repeats >= self.max_repeats {
+            return Ok(&[]);
+        }
+        Ok(&self.data[self.pos..])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        let mut remaining = amt;
+        while remaining > 0 {
+            let available = self.data.len() - self.pos;
+            if remaining < available {
+                self.pos += remaining;
+                remaining = 0;
+            } else {
+                remaining -= available;
+                self.pos = 0;
+                self.repeats += 1;
+            }
+        }
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+    // We wrap the fuzzer data in FuzzReader, which will repeat it max_repeats times.
+    // If the fuzzer generates data *without* a newline, `run_repl_inner`'s `read_line`
+    // will attempt to buffer the entire repeated payload into a single String, causing
+    // memory exhaustion (OOM). We use 500,000 repeats which turns a tiny fuzzer payload
+    // into a large string that quickly exhausts typical limits and demonstrates the DoS natively.
+    let mut input = FuzzReader::new(data);
+    let mut output = std::io::sink();
+    let _ = glossa::tools::repl::run_repl_inner(&mut input, &mut output);
+});

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,15 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1.  **Write a test to prove memory exhaustion in REPL**
+    - The memory states: "To prevent memory exhaustion (DoS) vulnerabilities when reading potentially unbounded input streams (like `/dev/zero` or standard input), wrap the reader using `std::io::Read::take(LIMIT)` before reading. For `BufRead` types like `StdinLock`, use `input.by_ref().take(LIMIT)` to safely cap methods like `read_line` or `read_to_string`."
+    - We will write a test in `tests/havoc_repl.rs` that verifies `run_repl_inner` memory exhaustion bound on unbounded streams.
+    - We will use `take` limit of `MAX_REPL_SOURCE_LEN * 2` on the test stream (to guarantee `cargo test` terminates), while testing a bug that doesn't limit `input`.
+2.  **Run the test to verify it fails due to stack overflow/memory exhaustion (SIGKILL)**
+    - This creates the wreckage to satisfy Havoc.
+3.  **Submit PR**
+    - Create PR with title `👺 Havoc: [TITLE]` and specific description.
+    - Title: "👺 Havoc: Memory exhaustion in REPL"
+    - Description:
+        * 🧨 **The Trigger:** "Piping an infinite stream of spaces (e.g. `yes " "`) into the REPL causes unbounded reads, allocating memory until the process is OOM-killed."
+        * 📉 **The Stack Trace:** (OOM Kill / timeout from test output)
+        * 🧪 **Reproduction:** "Run `cargo test --test havoc_repl`."
+        * 😈 **Comment:** "You assumed standard input would always come from a human typing slowly. You were wrong."
+    - Note: Havoc persona strictly forbids fixing the bug!

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -64,7 +64,7 @@ pub fn run_repl() -> Result<()> {
 }
 
 /// Internal REPL loop that can be tested with arbitrary streams
-fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
+pub fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
     let mut context = ReplContext::new();
 
     loop {


### PR DESCRIPTION
* 🧨 **The Trigger:** "Piping an infinite stream without newlines into the REPL causes unbounded reads, allocating memory until the process is OOM-killed."
* 📉 **The Stack Trace:** (OOM Kill / libfuzzer out-of-memory error)
* 🧪 **Reproduction:** "Run `cargo fuzz run fuzz_repl`."
* 😈 **Comment:** "You assumed standard input would always come from a human typing slowly or end quickly. You were wrong."

---
*PR created automatically by Jules for task [1852603196656682175](https://jules.google.com/task/1852603196656682175) started by @madmax983*