### PR TITLE
🪕 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-05-18 - Missing tool docs
+**Confusion:** Many tools in `src/tools/` lacked `# Examples` and detailed descriptions for their `run_*` functions, triggering warnings or failing the Bard directive.
+**Clarification:** Added `# Examples` with `rust,no_run` to prevent execution of dummy paths while ensuring compilation, and removed throwaway scripts before review.

--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -18,6 +18,20 @@ use std::fmt::Write;
 use std::path::Path;
 
 /// Run the Alchemist tool on a file
+///
+/// Converts the Glossa program to Python and prints the transpiled code.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::alchemist::run_alchemist;
+/// use std::path::Path;
+///
+/// let input = Path::new("script.γλ");
+/// if let Err(e) = run_alchemist(&input) {
+///     eprintln!("Failed to transpile to Python: {}", e);
+/// }
+/// ```
 pub fn run_alchemist(input: &Path) -> miette::Result<()> {
     let source = crate::tools::runner::load_source(input)?;
 

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -44,6 +44,18 @@ use std::path::Path;
 /// Run the Cartographer tool on a file
 ///
 /// Reads the source file, parses it, and prints the architectural map to stdout.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::cartographer::run_map;
+/// use std::path::Path;
+///
+/// let input = Path::new("models.γλ");
+/// if let Err(e) = run_map(&input) {
+///     eprintln!("Failed to generate architectural map: {}", e);
+/// }
+/// ```
 pub fn run_map(input: &Path) -> Result<()> {
     let source = crate::tools::runner::load_source(input)?;
 

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -11,6 +11,20 @@ use crossterm::style::Stylize;
 use miette::Result;
 
 /// Run the catalog explorer
+///
+/// This function outputs a detailed breakdown of the internal compiler dictionary
+/// (the `lexicon`) to the terminal. It groups words by their part of speech and
+/// displays their meaning and mapping to Rust constructs.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::catalog::run_catalog;
+///
+/// if let Err(e) = run_catalog() {
+///     eprintln!("Failed to display the lexicon catalog: {}", e);
+/// }
+/// ```
 pub fn run_catalog() -> Result<()> {
     // ⚡ Bolt Optimization: Uses `rustc_hash::FxHashMap` instead of the standard `HashMap`
     // since the keys are internal `PartOfSpeech` enums and are not exposed to HashDoS attacks.

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -20,6 +20,21 @@ use std::io::IsTerminal;
 use std::path::Path;
 
 /// Runs the Haruspex tool to generate a Graphviz DOT representation of the AST.
+///
+/// This function reads the specified file, runs semantic analysis to construct the AST,
+/// and then prints the DOT format to stdout so it can be piped into Graphviz.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::haruspex::run_haruspex;
+/// use std::path::Path;
+///
+/// let input = Path::new("ast.γλ");
+/// if let Err(e) = run_haruspex(&input) {
+///     eprintln!("Failed to generate DOT graph: {}", e);
+/// }
+/// ```
 pub fn run_haruspex(input: &Path) -> Result<()> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -22,6 +22,21 @@ use crossterm::style::Stylize;
 use std::path::Path;
 
 /// Run the Labyrinth tool on a file
+///
+/// Reads the source file, compiles it, and prints the Mermaid.js flowchart
+/// to standard output.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::labyrinth::run_labyrinth;
+/// use std::path::Path;
+///
+/// let input = Path::new("maze.γλ");
+/// if let Err(e) = run_labyrinth(&input) {
+///     eprintln!("Failed to generate CFG map: {}", e);
+/// }
+/// ```
 pub fn run_labyrinth(input: &Path) -> miette::Result<()> {
     let source = crate::tools::runner::load_source(input)?;
     let mut buffer = Vec::new();

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -37,6 +37,18 @@ use std::path::Path;
 /// Run the Mosaic tool on a file
 ///
 /// Reads the source file, parses it, and prints the semantic assembly table to stdout.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::mosaic::run_mosaic;
+/// use std::path::Path;
+///
+/// let input = Path::new("sentence.γλ");
+/// if let Err(e) = run_mosaic(&input) {
+///     eprintln!("Failed to generate mosaic: {}", e);
+/// }
+/// ```
 pub fn run_mosaic(input_path: &Path) -> Result<()> {
     let source = crate::tools::runner::load_source(input_path)?;
 

--- a/src/tools/weave.rs
+++ b/src/tools/weave.rs
@@ -22,6 +22,18 @@ use std::path::Path;
 /// Run the Weave tool on a file
 ///
 /// Reads the source file, compiles it, generates the mosaic, and writes out a Markdown file.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::weave::run_weave;
+/// use std::path::Path;
+///
+/// let input = Path::new("module.γλ");
+/// if let Err(e) = run_weave(&input) {
+///     eprintln!("Failed to weave document: {}", e);
+/// }
+/// ```
 pub fn run_weave(input: &Path) -> Result<()> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));


### PR DESCRIPTION
📖 Chapter: The Missing Examples in the Toolset
🔦 Insight: The `run_*` functions in `src/tools/` lacked executable examples and descriptive context, violating the philosophy that undocumented code doesn't exist.
🧪 Example: Added 7 compilable (`no_run`) doctests for `run_alchemist`, `run_map`, `run_catalog`, `run_haruspex`, `run_labyrinth`, `run_mosaic`, and `run_weave`.
🖼️ Preview: (The updated documentation can be viewed via `cargo doc --open`).

---
*PR created automatically by Jules for task [8933611906572649398](https://jules.google.com/task/8933611906572649398) started by @madmax983*