### PR TITLE
🎨 Mosaic: UI Polish for Code Exporters

### DIFF
--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -15,6 +15,7 @@ use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedS
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Run the Alchemist tool on a file
@@ -36,25 +37,31 @@ pub fn run_alchemist(input: &Path) -> miette::Result<()> {
 
     status.success();
 
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   A L C H E M I S T".bold().cyan());
-    println!("   {}", "Python Transpilation Result".italic().dim());
-    println!();
+    let is_tty = std::io::stdout().is_terminal();
 
-    let mut table = Table::new();
-    table.load_preset(presets::UTF8_FULL);
+    if is_tty {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   A L C H E M I S T".bold().cyan());
+        println!("   {}", "Python Transpilation Result".italic().dim());
+        println!();
 
-    table.set_header(vec![
-        Cell::new("Python Source Code")
-            .add_attribute(Attribute::Bold)
-            .fg(Color::Cyan),
-    ]);
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
 
-    let formatted_code = format!("```python\n{}\n```", python_code.trim());
-    table.add_row(vec![Cell::new(formatted_code)]);
+        table.set_header(vec![
+            Cell::new("Python Source Code")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+        ]);
 
-    println!("{table}");
-    println!();
+        let formatted_code = format!("```python\n{}\n```", python_code.trim());
+        table.add_row(vec![Cell::new(formatted_code)]);
+
+        println!("{table}");
+        println!();
+    } else {
+        println!("{}", python_code.trim());
+    }
 
     Ok(())
 }

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -27,6 +27,7 @@ use crossterm::style::Stylize;
 use miette::Result;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smol_str::SmolStr;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Runs the Auditor tool on a given Glossa source file.
@@ -83,15 +84,19 @@ pub fn run_auditor(input: &Path) -> Result<()> {
 
     let mut issues = 0;
 
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   A U D I T O R".cyan().bold());
-    println!(
-        "   {}",
-        format!("Audit Report for {}", input.display())
-            .italic()
-            .dim()
-    );
-    println!();
+    let is_tty = std::io::stdout().is_terminal();
+
+    if is_tty {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   A U D I T O R".cyan().bold());
+        println!(
+            "   {}",
+            format!("Audit Report for {}", input.display())
+                .italic()
+                .dim()
+        );
+        println!();
+    }
 
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
@@ -101,6 +106,8 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         Cell::new("Message").add_attribute(Attribute::Bold),
     ]);
 
+    let mut raw_output = String::new();
+
     for (var, count) in &visitor.usage_count {
         if *count == 0 {
             table.add_row(vec![
@@ -108,6 +115,12 @@ pub fn run_auditor(input: &Path) -> Result<()> {
                 Cell::new(var),
                 Cell::new("Declared but never used"),
             ]);
+            if !is_tty {
+                raw_output.push_str(&format!(
+                    "Unused Variable\t{}\tDeclared but never used\n",
+                    var
+                ));
+            }
             issues += 1;
         }
     }
@@ -122,19 +135,31 @@ pub fn run_auditor(input: &Path) -> Result<()> {
                 Cell::new(var),
                 Cell::new("Declared mutable ('μετά') but never changed"),
             ]);
+            if !is_tty {
+                raw_output.push_str(&format!(
+                    "Unnecessary Mutation\t{}\tDeclared mutable ('μετά') but never changed\n",
+                    var
+                ));
+            }
             issues += 1;
         }
     }
 
-    if issues == 0 {
-        println!(
-            "   {}",
-            "✨ No issues found. The code is pure.".green().bold()
-        );
-        println!();
+    if is_tty {
+        if issues == 0 {
+            println!(
+                "   {}",
+                "✨ No issues found. The code is pure.".green().bold()
+            );
+            println!();
+        } else {
+            println!("{table}");
+            println!("\n   Total issues found: {}", issues);
+        }
     } else {
-        println!("{table}");
-        println!("\n   Total issues found: {}", issues);
+        if issues > 0 {
+            print!("{}", raw_output);
+        }
     }
 
     Ok(())

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -39,6 +39,7 @@ use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 use rustc_hash::FxHashSet;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Run the Cartographer tool on a file
@@ -61,48 +62,56 @@ pub fn run_map(input: &Path) -> Result<()> {
 
     status.success();
 
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   M A P".bold().cyan());
-    println!("   {}", "Architectural Blueprint".italic().dim());
-    println!();
+    let is_tty = std::io::stdout().is_terminal();
 
-    let mut table = Table::new();
-    table.load_preset(presets::UTF8_FULL);
-
-    if map.trim() == "classDiagram" {
-        table.set_header(vec![
-            Cell::new("Status")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Yellow),
-        ]);
-        table.add_row(vec![
-            Cell::new("No architectural structures (Structs) found.")
-                .fg(Color::DarkGrey)
-                .add_attribute(Attribute::Italic),
-        ]);
-        println!("{table}");
+    if is_tty {
         println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   M A P".bold().cyan());
+        println!("   {}", "Architectural Blueprint".italic().dim());
+        println!();
+
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
+
+        if map.trim() == "classDiagram" {
+            table.set_header(vec![
+                Cell::new("Status")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Yellow),
+            ]);
+            table.add_row(vec![
+                Cell::new("No architectural structures (Structs) found.")
+                    .fg(Color::DarkGrey)
+                    .add_attribute(Attribute::Italic),
+            ]);
+            println!("{table}");
+            println!();
+        } else {
+            table.set_header(vec![
+                Cell::new("Mermaid.js Diagram")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Cyan),
+            ]);
+
+            // Wrap in markdown code block for easy copying
+            let formatted_map = format!("```mermaid\n{}\n```", map.trim());
+
+            table.add_row(vec![Cell::new(formatted_map)]);
+
+            println!("{table}");
+            println!();
+            println!("   {}", "📋 Usage Instructions:".bold().underlined());
+            println!("   1. Copy the code block above.");
+            println!(
+                "   2. Paste it into {}",
+                "https://mermaid.live".cyan().underlined()
+            );
+            println!();
+        }
     } else {
-        table.set_header(vec![
-            Cell::new("Mermaid.js Diagram")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Cyan),
-        ]);
-
-        // Wrap in markdown code block for easy copying
-        let formatted_map = format!("```mermaid\n{}\n```", map.trim());
-
-        table.add_row(vec![Cell::new(formatted_map)]);
-
-        println!("{table}");
-        println!();
-        println!("   {}", "📋 Usage Instructions:".bold().underlined());
-        println!("   1. Copy the code block above.");
-        println!(
-            "   2. Paste it into {}",
-            "https://mermaid.live".cyan().underlined()
-        );
-        println!();
+        if map.trim() != "classDiagram" {
+            println!("{}", map.trim());
+        }
     }
 
     Ok(())

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -37,26 +37,33 @@ use std::path::Path;
 /// Run the Mosaic tool on a file
 ///
 /// Reads the source file, parses it, and prints the semantic assembly table to stdout.
+use std::io::IsTerminal;
 pub fn run_mosaic(input_path: &Path) -> Result<()> {
     let source = crate::tools::runner::load_source(input_path)?;
 
     let status = Status::start_with_symbol("Ψηφιδωτόν (Mosaic)", "🧩");
 
+    let is_tty = std::io::stdout().is_terminal();
+
     // Create a buffer for the table
     let mut buffer = Vec::new();
-    if let Err(e) = run_mosaic_inner(&source, &mut buffer) {
+    if let Err(e) = run_mosaic_inner(&source, &mut buffer, is_tty) {
         status.error("Σφάλμα (Error)");
         return Err(e);
     }
-    let output = String::from_utf8(buffer).expect("comfy-table outputs valid UTF-8");
+    let output = String::from_utf8(buffer).expect("outputs valid UTF-8");
 
     status.success();
 
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   M O S A I C".bold().cyan());
-    println!("   {}", "Semantic Sentence Structure".italic().dim());
-    println!();
-    println!("{}", output);
+    if is_tty {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   M O S A I C".bold().cyan());
+        println!("   {}", "Semantic Sentence Structure".italic().dim());
+        println!();
+        println!("{}", output);
+    } else {
+        print!("{}", output);
+    }
 
     Ok(())
 }
@@ -64,31 +71,43 @@ pub fn run_mosaic(input_path: &Path) -> Result<()> {
 /// Internal implementation of Mosaic logic
 ///
 /// Separated for testing purposes (allows injecting a writer).
-pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Result<()> {
+pub fn run_mosaic_inner<W: std::io::Write>(
+    source: &str,
+    writer: &mut W,
+    is_tty: bool,
+) -> Result<()> {
     let program = parse(source)?;
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_header(vec![
-            Cell::new("Line").add_attribute(Attribute::Bold),
-            Cell::new("Subject (Nom)")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Cyan),
-            Cell::new("Verb (Action)")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Yellow),
-            Cell::new("Object (Acc)")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Green),
-            Cell::new("Indirect (Dat)")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Magenta),
-            Cell::new("Other")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::DarkGrey),
-        ]);
+    if is_tty {
+        table
+            .load_preset(UTF8_FULL)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_header(vec![
+                Cell::new("Line").add_attribute(Attribute::Bold),
+                Cell::new("Subject (Nom)")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Cyan),
+                Cell::new("Verb (Action)")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Yellow),
+                Cell::new("Object (Acc)")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Green),
+                Cell::new("Indirect (Dat)")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::Magenta),
+                Cell::new("Other")
+                    .add_attribute(Attribute::Bold)
+                    .fg(Color::DarkGrey),
+            ]);
+    } else {
+        writeln!(
+            writer,
+            "Line\tSubject (Nom)\tVerb (Action)\tObject (Acc)\tIndirect (Dat)\tOther"
+        )
+        .into_diagnostic()?;
+    }
 
     for (i, stmt) in program.statements.iter().enumerate() {
         // Only assemble regular statements (others like TypeDef don't go through Assembler in the same way)
@@ -96,17 +115,56 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
         if let crate::ast::Statement::Regular { .. } = stmt {
             match assemble_statement(stmt) {
                 Ok(assembled) => {
-                    add_row(&mut table, i + 1, &assembled);
+                    if is_tty {
+                        add_row(&mut table, i + 1, &assembled);
+                    } else {
+                        let full_subject = format_subject(&assembled).replace("\n", " ");
+                        let verb = assembled
+                            .verb
+                            .as_ref()
+                            .map(|v| v.original.to_string())
+                            .unwrap_or_default()
+                            .replace("\n", " ");
+                        let object = assembled
+                            .object
+                            .as_ref()
+                            .map(fmt_constituent)
+                            .unwrap_or_default()
+                            .replace("\n", " ");
+                        let indirect = assembled
+                            .indirect
+                            .as_ref()
+                            .map(fmt_constituent)
+                            .unwrap_or_default()
+                            .replace("\n", " ");
+                        let other = format_other_column(&assembled).replace("\n", " ");
+
+                        writeln!(
+                            writer,
+                            "{}\t{}\t{}\t{}\t{}\t{}",
+                            i + 1,
+                            full_subject,
+                            verb,
+                            object,
+                            indirect,
+                            other
+                        )
+                        .into_diagnostic()?;
+                    }
                 }
                 Err(e) => {
-                    table.add_row(vec![
-                        Cell::new(i + 1),
-                        Cell::new(format!("Error: {}", e)).fg(Color::Red),
-                        Cell::new(""),
-                        Cell::new(""),
-                        Cell::new(""),
-                        Cell::new(""),
-                    ]);
+                    if is_tty {
+                        table.add_row(vec![
+                            Cell::new(i + 1),
+                            Cell::new(format!("Error: {}", e)).fg(Color::Red),
+                            Cell::new(""),
+                            Cell::new(""),
+                            Cell::new(""),
+                            Cell::new(""),
+                        ]);
+                    } else {
+                        writeln!(writer, "{}\tError: {}\t\t\t\t", i + 1, e).into_diagnostic()?;
+                    }
                 }
             }
         } else {
@@ -118,20 +176,26 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
                 crate::ast::Statement::TestDeclaration(_) => "Test Declaration",
                 _ => "Unknown",
             };
-            table.add_row(vec![
-                Cell::new(i + 1),
-                Cell::new(type_name)
-                    .fg(Color::Blue)
-                    .add_attribute(Attribute::Italic),
-                Cell::new(""),
-                Cell::new(""),
-                Cell::new(""),
-                Cell::new(""),
-            ]);
+            if is_tty {
+                table.add_row(vec![
+                    Cell::new(i + 1),
+                    Cell::new(type_name)
+                        .fg(Color::Blue)
+                        .add_attribute(Attribute::Italic),
+                    Cell::new(""),
+                    Cell::new(""),
+                    Cell::new(""),
+                    Cell::new(""),
+                ]);
+            } else {
+                writeln!(writer, "{}\t{}\t\t\t\t", i + 1, type_name).into_diagnostic()?;
+            }
         }
     }
 
-    writeln!(writer, "{}", table).into_diagnostic()?;
+    if is_tty {
+        writeln!(writer, "{}", table).into_diagnostic()?;
+    }
     Ok(())
 }
 
@@ -380,7 +444,7 @@ mod tests {
     fn test_mosaic_output() {
         let source = "ὁ ἄνθρωπος τὸν λόγον λέγει.";
         let mut buffer = Vec::new();
-        run_mosaic_inner(source, &mut buffer).unwrap();
+        run_mosaic_inner(source, &mut buffer, true).unwrap();
         let output = String::from_utf8(buffer).unwrap();
 
         assert!(output.contains("ἄνθρωπος")); // Subject
@@ -392,7 +456,7 @@ mod tests {
     fn test_mosaic_non_regular() {
         let source = "εἶδος Χ ὁρίζειν { x ἀριθμοῦ. }.";
         let mut buffer = Vec::new();
-        run_mosaic_inner(source, &mut buffer).unwrap();
+        run_mosaic_inner(source, &mut buffer, true).unwrap();
         let output = String::from_utf8(buffer).unwrap();
 
         assert!(output.contains("Type Definition"));
@@ -416,7 +480,7 @@ mod tests {
             τέλος.
         ";
         let mut buffer = Vec::new();
-        run_mosaic_inner(source, &mut buffer).unwrap();
+        run_mosaic_inner(source, &mut buffer, true).unwrap();
         let output = String::from_utf8(buffer).unwrap();
 
         // Assert we hit the commas for multiple adjectives, genitives, and participles
@@ -495,7 +559,7 @@ mod tests {
         // Let's create an invalid assembled statement error inside `run_mosaic_inner`
         let source = "πέντε πέντε ἔστω."; // Left side of assignment must be a word.
         let mut buffer = Vec::new();
-        let _ = run_mosaic_inner(source, &mut buffer);
+        let _ = run_mosaic_inner(source, &mut buffer, true);
         let output = String::from_utf8(buffer).unwrap();
 
         if output.contains("Error: ") {

--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -23,6 +23,7 @@ use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Runs the Papyrus tool to generate SQL schemas from Glossa types.
@@ -89,25 +90,31 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
         }
     }
 
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   P A P Y R U S".bold().cyan());
-    println!("   {}", "SQL Schema".italic().dim());
-    println!();
+    let is_tty = std::io::stdout().is_terminal();
 
-    let mut table = Table::new();
-    table.load_preset(presets::UTF8_FULL);
+    if is_tty {
+        println!();
+        println!("   {}", "Γ Λ Ω Σ Σ Α   P A P Y R U S".bold().cyan());
+        println!("   {}", "SQL Schema".italic().dim());
+        println!();
 
-    table.set_header(vec![
-        Cell::new("SQL Schema")
-            .add_attribute(Attribute::Bold)
-            .fg(Color::Cyan),
-    ]);
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
 
-    let formatted_code = format!("```sql\n{}\n```", output.trim());
-    table.add_row(vec![Cell::new(formatted_code)]);
+        table.set_header(vec![
+            Cell::new("SQL Schema")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+        ]);
 
-    println!("{table}");
-    println!();
+        let formatted_code = format!("```sql\n{}\n```", output.trim());
+        table.add_row(vec![Cell::new(formatted_code)]);
+
+        println!("{table}");
+        println!();
+    } else {
+        println!("{}", output.trim());
+    }
 
     Ok(())
 }

--- a/src/tools/weave.rs
+++ b/src/tools/weave.rs
@@ -51,7 +51,7 @@ pub fn run_weave(input: &Path) -> Result<()> {
 
     // 3. Generate Mosaic Table
     let mut mosaic_buffer = Vec::new();
-    if let Err(e) = run_mosaic_inner(&source, &mut mosaic_buffer) {
+    if let Err(e) = run_mosaic_inner(&source, &mut mosaic_buffer, true) {
         status.error("Σφάλμα (Error)");
         return Err(e);
     }

--- a/tests/mosaic_coverage.rs
+++ b/tests/mosaic_coverage.rs
@@ -28,7 +28,7 @@ fn test_mosaic_comprehensive_coverage() {
     ";
 
     let mut buffer = Vec::new();
-    match run_mosaic_inner(source, &mut buffer) {
+    match run_mosaic_inner(source, &mut buffer, true) {
         Ok(_) => {}
         Err(e) => panic!("Mosaic failed: {:?}", e),
     }


### PR DESCRIPTION
🖌️ **Before:** The commands output tables no matter the output stream making pipe/scripts difficult as they have ANSI color codes and unicode drawing characters inside it. 
✨ **After:** Detects if stdout is a TTY and only formats using `comfy_table` in terminal contexts, reverting to clear string/csv formatting in non-terminal scenarios.
🖼️ **Visuals:** Commands look the same in terminal, but cleanly pipeline via things like `cargo run mosaic examples/hello.γλ | grep ...`

---
*PR created automatically by Jules for task [18008794389967192442](https://jules.google.com/task/18008794389967192442) started by @madmax983*