### PR TITLE
🔒 Warden: Fix unbounded read_line DoS in REPL and Mentor

### DIFF
--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -127,7 +127,9 @@ fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Resu
             output.flush().into_diagnostic()?;
 
             let mut line = String::new();
-            let bytes = input.read_line(&mut line).into_diagnostic()?;
+            let bytes = std::io::Read::take(input.by_ref(), 50_000)
+                .read_line(&mut line)
+                .into_diagnostic()?;
 
             if bytes == 0 {
                 return Ok(()); // EOF
@@ -155,7 +157,8 @@ fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Resu
                             .into_diagnostic()?;
                         writeln!(output, "{}", "Press Enter to continue...".dim())
                             .into_diagnostic()?;
-                        let _ = input.read_line(&mut String::new());
+                        let _ = std::io::Read::take(input.by_ref(), 50_000)
+                            .read_line(&mut String::new());
                         break; // Next lesson
                     } else {
                         writeln!(

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -73,7 +73,9 @@ fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result
         let _ = output.flush();
 
         let mut line = String::new();
-        let bytes = input.read_line(&mut line).into_diagnostic()?;
+        let bytes = std::io::Read::take(input.by_ref(), 50_000)
+            .read_line(&mut line)
+            .into_diagnostic()?;
 
         // Handle EOF
         if bytes == 0 {


### PR DESCRIPTION
🦠 Threat: Memory exhaustion via unbounded read_line.\n🛡️ Defense: Capped input streams using take(LIMIT).\n💥 Severity: High.\n🧪 Verification: Tested locally and ran test suite.

---
*PR created automatically by Jules for task [11069711549198797794](https://jules.google.com/task/11069711549198797794) started by @madmax983*