### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2024-05-29 - Fixed Documentation For to_rust_type
+**Confusion:** The `to_rust_type` function in `src/codegen.rs` appeared undocumented in the output, even though it had a full, valid docstring attached to it in the code.
+**Clarification:** I realized that there was a `use std::fmt::Write;` import placed precisely between the documentation block and the `pub fn to_rust_type` signature. This caused the rustdoc engine to associate the docstring with the `use` statement instead of the function! I hoisted the import to the top of the file, which instantly fixed the issue without breaking existing formatting.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -95,6 +95,8 @@
 #![allow(clippy::needless_doctest_main)]
 
 use crate::morphology::lexicon::{BinaryOp, UnaryOp};
+use std::fmt::Write;
+
 use crate::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedMethod, AnalyzedProgram, AnalyzedStatement,
     CaptureMode, GlossaType,
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: Fixed broken documentation for `to_rust_type`.
🔦 Insight: Removed an intermediate `use` statement between the doc string and function signature for `to_rust_type` which was causing the function to appear undocumented. The `use` statement was safely hoisted to the module's top imports.
🧪 Example: Documented the finding in `.jules/bard.md`.

---
*PR created automatically by Jules for task [7895287842318501877](https://jules.google.com/task/7895287842318501877) started by @madmax983*