### PR TITLE
👺 Havoc: Unbounded Memory Exhaustion in REPL & Mentor

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,3 +26,10 @@ path = "fuzz_targets/fuzz_target_2.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_repl"
+path = "fuzz_targets/fuzz_repl.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_repl.rs
+++ b/fuzz/fuzz_targets/fuzz_repl.rs
@@ -1,0 +1,39 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use std::io::{BufRead, Read, BufReader};
+use glossa::tools::repl::run_repl_inner;
+use std::thread;
+
+struct EndlessStream<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> Read for EndlessStream<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.data.is_empty() {
+            return Ok(0);
+        }
+        for b in buf.iter_mut() {
+            *b = self.data[0];
+        }
+        Ok(buf.len())
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() || data[0] == b'\n' {
+        return;
+    }
+
+    // Create an endless stream that repeats the first byte of `data`
+    let stream = EndlessStream { data };
+
+    // Bounded externally for the fuzzer so we don't literally OOM the fuzzer process
+    // But large enough to crash or timeout if there's no bound inside the REPL
+    // Let's take 2MB. If the REPL unbounded-reads, it will consume all 2MB in one read_line.
+    let mut bounded_input = BufReader::new(stream.take(2_000_000));
+
+    let mut output = Vec::new();
+    let _ = run_repl_inner(&mut bounded_input, &mut output);
+});

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -115,7 +115,7 @@ pub fn run_mentor() -> Result<()> {
     run_mentor_inner(&mut stdin.lock(), &mut stdout)
 }
 
-fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
+pub fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
     print_banner(output)?;
 
     for (i, lesson) in LESSONS.iter().enumerate() {

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -64,7 +64,7 @@ pub fn run_repl() -> Result<()> {
 }
 
 /// Internal REPL loop that can be tested with arbitrary streams
-fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
+pub fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
     let mut context = ReplContext::new();
 
     loop {

--- a/tests/test_chaos_exhaustion.rs
+++ b/tests/test_chaos_exhaustion.rs
@@ -1,0 +1,68 @@
+#[cfg(feature = "nova")]
+use glossa::tools::mentor::run_mentor_inner;
+use glossa::tools::repl::run_repl_inner;
+use std::io::{BufReader, Read};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+struct EndlessStream {
+    count: Arc<Mutex<usize>>,
+}
+
+impl Read for EndlessStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        for b in buf.iter_mut() {
+            *b = b'A'; // No newline
+        }
+        let mut c = self.count.lock().unwrap();
+        *c += buf.len();
+        Ok(buf.len())
+    }
+}
+
+#[test]
+fn test_repl_exhaustion_exploit() {
+    let count = Arc::new(Mutex::new(0));
+    let stream = EndlessStream {
+        count: count.clone(),
+    };
+
+    let handle = thread::spawn(move || {
+        let mut bounded = BufReader::new(stream.take(1_000_000));
+        let mut output = Vec::new();
+        let _ = run_repl_inner(&mut bounded, &mut output);
+    });
+
+    handle.join().unwrap();
+    let final_count = *count.lock().unwrap();
+
+    assert!(
+        final_count < 100_000,
+        "REPL is vulnerable to memory exhaustion. It read {} bytes without returning!",
+        final_count
+    );
+}
+
+#[cfg(feature = "nova")]
+#[test]
+fn test_mentor_exhaustion_exploit() {
+    let count = Arc::new(Mutex::new(0));
+    let stream = EndlessStream {
+        count: count.clone(),
+    };
+
+    let handle = thread::spawn(move || {
+        let mut bounded = BufReader::new(stream.take(1_000_000));
+        let mut output = Vec::new();
+        let _ = run_mentor_inner(&mut bounded, &mut output);
+    });
+
+    handle.join().unwrap();
+    let final_count = *count.lock().unwrap();
+
+    assert!(
+        final_count < 100_000,
+        "Mentor is vulnerable to memory exhaustion. It read {} bytes without returning!",
+        final_count
+    );
+}


### PR DESCRIPTION
🧨 **The Trigger:** Input stream lacking a newline character (e.g. piping `/dev/zero`) causes `run_repl_inner` and `run_mentor_inner` to read indefinitely, resulting in memory exhaustion.
📉 **The Stack Trace:**
thread 'test_repl_exhaustion_exploit' panicked at tests/test_chaos_exhaustion.rs:37:5:
REPL is vulnerable to memory exhaustion. It read 1000000 bytes without returning!
thread 'test_mentor_exhaustion_exploit' panicked at tests/test_chaos_exhaustion.rs:55:5:
Mentor is vulnerable to memory exhaustion. It read 1000000 bytes without returning!
🧪 **Reproduction:** Run `cargo test --test test_chaos_exhaustion --all-features`.
😈 **Comment:** You assumed the buffer would never be larger than RAM. You were wrong.

---
*PR created automatically by Jules for task [7888924089069022505](https://jules.google.com/task/7888924089069022505) started by @madmax983*