### PR TITLE
🔒 Warden: Fix Unbounded Read DoS in REPL and Mentor

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -131,3 +131,7 @@ Signed,
 **2026-04-30 - [Infinite Stream DoS Vulnerability in File Loading]
 **Threat:** The `load_source` function in `src/tools/runner.rs` relied on `fs::metadata().len()` to enforce the `MAX_FILE_SIZE` limit. However, special device files like `/dev/zero` report a length of 0 while producing an infinite stream of bytes when read. Reading these files with `fs::read_to_string` causes a thread hang or Out-Of-Memory (OOM) Denial-of-Service condition.
 **Defense:** Added an explicit `metadata.is_file()` check in `check_file_size` to guarantee that the input path points to a regular file and explicitly reject non-regular file types like directories and device streams. Updated `tests/havoc_dos.rs` and `test_load_source_directory_error` to assert the "Not a valid file" error and pass cleanly without timeouts.
+
+**2023-11-20 - [Unbounded File Read DoS in REPL and Mentor Tools]**
+**Threat:** The `run_repl_inner` and `run_mentor_inner` loops used `input.read_line()` without upper bounds. An attacker or anomalous input stream (e.g. `/dev/zero`) lacking newlines could cause the application to endlessly buffer characters, exhausting memory and resulting in a Denial of Service.
+**Defense:** Added `Read` import and bounded the stream reads using `input.by_ref().take(LIMIT)`. The REPL is capped at `MAX_REPL_SOURCE_LEN as u64` and the Mentor is capped at 50,000 bytes.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,18 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. **Fix Memory Exhaustion DoS in REPL (`src/tools/repl.rs`)**
+   - Use `run_in_bash_session` to run `sed` and replace the unbounded `input.read_line(&mut line)` with a capped read `input.by_ref().take(MAX_REPL_SOURCE_LEN as u64).read_line(&mut line)` inside `run_repl_inner` to prevent memory exhaustion on infinite input streams without newlines.
+2. **Fix Memory Exhaustion DoS in Mentor (`src/tools/mentor.rs`)**
+   - Use `run_in_bash_session` to run `sed` and replace the unbounded `input.read_line(&mut line)` calls (two instances) with a capped read using `.take(50000)` inside `run_mentor_inner` to prevent memory exhaustion.
+3. **Verify the fixes**
+   - Run the integration test `tests/repl_dos.rs` via `run_in_bash_session` using `cargo test --test repl_dos`.
+   - Run `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` via `run_in_bash_session` to ensure no regressions or warnings are introduced.
+4. **Log the security discovery in Warden's journal**
+   - Use `run_in_bash_session` to append a new entry to `.jules/warden.md` detailing the unbounded `read_line` vulnerability and the application of capped readers.
+5. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+6. **Submit PR**
+   - Use `request_code_review` to submit the PR with the required Sentry/Warden format:
+     - Title: `🔒 Warden: [Fix Unbounded Read DoS in REPL and Mentor]`
+     - Description with:
+       * 🦠 Threat: The `read_line` function was used on potentially infinite input streams (without newlines), causing memory exhaustion (DoS).
+       * 🛡️ Defense: Applied bounded reading via `.by_ref().take(LIMIT)` to cap maximum memory usage per input line.
+       * 💥 Severity: Medium/High (Local Denial of Service).
+       * 🧪 Verification: Validated with `tests/repl_dos.rs` simulating an infinite `read` stream without newlines.

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -18,7 +18,7 @@ use crate::semantic::{AnalyzedProgram, AnalyzedStatement, GlossaType};
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
-use std::io::{BufRead, Write};
+use std::io::{BufRead, Read, Write};
 
 /// A self-contained chapter in the interactive ΓΛΩΣΣΑ tutorial.
 ///
@@ -127,7 +127,11 @@ fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Resu
             output.flush().into_diagnostic()?;
 
             let mut line = String::new();
-            let bytes = input.read_line(&mut line).into_diagnostic()?;
+            let bytes = input
+                .by_ref()
+                .take(50000)
+                .read_line(&mut line)
+                .into_diagnostic()?;
 
             if bytes == 0 {
                 return Ok(()); // EOF
@@ -155,7 +159,7 @@ fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Resu
                             .into_diagnostic()?;
                         writeln!(output, "{}", "Press Enter to continue...".dim())
                             .into_diagnostic()?;
-                        let _ = input.read_line(&mut String::new());
+                        let _ = input.by_ref().take(50000).read_line(&mut String::new());
                         break; // Next lesson
                     } else {
                         writeln!(

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -26,7 +26,7 @@
 use comfy_table::{Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
-use std::io::{BufRead, Write};
+use std::io::{BufRead, Read, Write};
 
 use crate::codegen::generate_statement_code;
 use crate::errors::GlossaError;
@@ -73,7 +73,11 @@ fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result
         let _ = output.flush();
 
         let mut line = String::new();
-        let bytes = input.read_line(&mut line).into_diagnostic()?;
+        let bytes = input
+            .by_ref()
+            .take(MAX_REPL_SOURCE_LEN as u64)
+            .read_line(&mut line)
+            .into_diagnostic()?;
 
         // Handle EOF
         if bytes == 0 {


### PR DESCRIPTION
🦠 Threat: The `read_line` function was used on potentially infinite input streams (without newlines), causing memory exhaustion (DoS).
🛡️ Defense: Applied bounded reading via `.by_ref().take(LIMIT)` to cap maximum memory usage per input line.
💥 Severity: Medium/High (Local Denial of Service).
🧪 Verification: Validated with `tests/repl_dos.rs` simulating an infinite `read` stream without newlines.

---
*PR created automatically by Jules for task [4313561636524772273](https://jules.google.com/task/4313561636524772273) started by @madmax983*