### PR TITLE
🪒 Razor: Ignore unused variable in Commands::Gnomon

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** Unused variables warning in `src/main.rs` due to the `input` field in `Commands::Gnomon` being ignored when the `nova` feature is disabled.
+**Cut:** Prefixed the `input` variable with an underscore (`_input`) in the match arm to explicitly mark it as unused and suppress the warning without hiding other potential issues.
+**Saved:** Suppressed 1 compiler warning.

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,9 +178,9 @@ fn main() -> Result<()> {
             );
         }
 
-        Some(Commands::Gnomon { input }) => {
+        Some(Commands::Gnomon { input: _input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::gnomon::run_gnomon(&input)?;
+            glossa::tools::gnomon::run_gnomon(&_input)?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(


### PR DESCRIPTION
🪒 **Razor:** Essentialist Refactoring

### Reduction
**Bloat:** Unused variables warning in `src/main.rs` due to the `input` field in `Commands::Gnomon` being ignored when the `nova` feature is disabled.
**Cut:** Ignored the unused variable warning by changing the variable name to `_input` in the match arm for `Commands::Gnomon`. This is the standard Rust idiom to suppress this specific warning cleanly without disabling the warning globally for the block.
**Saved:** Suppressed 1 compiler warning.

---
*PR created automatically by Jules for task [18319193176114091640](https://jules.google.com/task/18319193176114091640) started by @madmax983*