### PR TITLE
🪒 Razor: Flatten HashMap optimization

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,7 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+## [Reduction]
+**Bloat:** Unnecessary `FxHashMap` and `FxHashSet` optimization
+**Cut:** Replaced with standard `HashMap` and `HashSet` from `std::collections`. The `rustc_hash` crate provides a performance improvement when cryptographic security (DoS prevention) is unnecessary, however, replacing the standard map with it throughout tools creates excessive complexity unless there is a verified hot path.
+**Saved:** Simplified the dependency graph and reduced code cleverness.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,6 @@ dependencies = [
  "proc-macro2",
  "proptest",
  "quote",
- "rustc-hash",
  "sha2",
  "smol_str",
  "stacker",
@@ -940,12 +939,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "4", features = ["derive"] }
 quote = "1"
 proc-macro2 = "1"
 smol_str = "0.3"
-rustc-hash = "2"
 comfy-table = "7.2.2"
 sha2 = "0.10"
 hex = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,9 +178,9 @@ fn main() -> Result<()> {
             );
         }
 
-        Some(Commands::Gnomon { input }) => {
+        Some(Commands::Gnomon { input: _input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::gnomon::run_gnomon(&input)?;
+            glossa::tools::gnomon::run_gnomon(&_input)?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(

--- a/src/morphology/lexicon.rs
+++ b/src/morphology/lexicon.rs
@@ -56,8 +56,8 @@
 use crate::morphology::models::{
     Case, Gender, Mood, MorphAnalysis, Number, PartOfSpeech, Person, Tense, Voice,
 };
-use rustc_hash::FxHashMap;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
 /// A lexicon entry with full morphological information
@@ -133,8 +133,8 @@ impl LexiconEntry {
 }
 
 /// The built-in lexicon
-static LEXICON: LazyLock<FxHashMap<&'static str, LexiconEntry>> = LazyLock::new(|| {
-    let mut m = FxHashMap::default();
+static LEXICON: LazyLock<HashMap<&'static str, LexiconEntry>> = LazyLock::new(|| {
+    let mut m = HashMap::default();
 
     // =========================================================================
     // Built-in verbs

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -8,7 +8,7 @@
 //!
 //! The resolver uses a stack-based lexical environment:
 //! * **[`Scope`]**: The entire environment, containing a stack of [`ScopeLevel`]s.
-//! * **[`ScopeLevel`]**: A single dictionary (using `FxHashMap` for speed) mapping names to [`Binding`]s.
+//! * **[`ScopeLevel`]**: A single dictionary (using `HashMap` for speed) mapping names to [`Binding`]s.
 //! * **`ScopeGuard`**: An RAII (Resource Acquisition Is Initialization) guard returned by `Scope::enter_scope`.
 //!   When the guard goes out of scope, it automatically drops the deepest `ScopeLevel`.
 //!
@@ -33,22 +33,20 @@
 //! ```
 
 use crate::semantic::GlossaType;
-use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
+use std::collections::HashMap;
 
 /// A scope level containing symbol bindings
 #[derive(Debug, Clone, Default)]
 struct ScopeLevel {
     /// Variables defined in this scope.
-    /// ⚡ Bolt Optimization: Uses `FxHashMap` instead of the standard `HashMap`
-    /// to avoid cryptographic hashing overhead for fast, deterministic lookups of interned strings.
-    variables: FxHashMap<SmolStr, Binding>,
+    variables: HashMap<SmolStr, Binding>,
     /// Functions defined in this scope.
-    functions: FxHashMap<SmolStr, FunctionSignature>,
+    functions: HashMap<SmolStr, FunctionSignature>,
     /// Types defined in this scope.
-    types: FxHashMap<SmolStr, GlossaType>,
+    types: HashMap<SmolStr, GlossaType>,
     /// Traits defined in this scope.
-    traits: FxHashMap<SmolStr, crate::semantic::model::TraitDef>,
+    traits: HashMap<SmolStr, crate::semantic::model::TraitDef>,
     /// Trait implementations in this scope
     trait_impls: Vec<crate::semantic::model::TraitImpl>,
 }

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -25,8 +25,8 @@ use comfy_table::presets::UTF8_FULL;
 use comfy_table::{Attribute, Cell, Color, Table};
 use crossterm::style::Stylize;
 use miette::Result;
-use rustc_hash::{FxHashMap, FxHashSet};
 use smol_str::SmolStr;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 /// Runs the Auditor tool on a given Glossa source file.
@@ -141,19 +141,17 @@ pub fn run_auditor(input: &Path) -> Result<()> {
 }
 
 struct AuditorVisitor {
-    /// ⚡ Bolt Optimization: Uses `FxHashMap` instead of the standard `HashMap`
-    /// to reduce cryptographic hashing overhead for small string keys (`SmolStr`).
-    usage_count: FxHashMap<SmolStr, usize>,
-    mutation_count: FxHashMap<SmolStr, usize>,
-    mutable_vars: FxHashSet<SmolStr>,
+    usage_count: HashMap<SmolStr, usize>,
+    mutation_count: HashMap<SmolStr, usize>,
+    mutable_vars: HashSet<SmolStr>,
 }
 
 impl AuditorVisitor {
     fn new() -> Self {
         Self {
-            usage_count: FxHashMap::default(),
-            mutation_count: FxHashMap::default(),
-            mutable_vars: FxHashSet::default(),
+            usage_count: HashMap::default(),
+            mutation_count: HashMap::default(),
+            mutable_vars: HashSet::default(),
         }
     }
 

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -38,7 +38,7 @@ use crate::tools::ui::Status;
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 use std::path::Path;
 
 /// Run the Cartographer tool on a file
@@ -112,11 +112,7 @@ pub fn run_map(input: &Path) -> Result<()> {
 pub fn generate_map(program: &AnalyzedProgram) -> String {
     let mut map = String::from("classDiagram\n");
 
-    // ⚡ Bolt Optimization: Swapped `HashSet` for `FxHashSet` for performance.
-    // Standard `HashSet` uses SipHash, which is cryptographically secure but slower.
-    // For internal tracking of predictable short type names in the cartographer,
-    // where HashDoS isn't a concern, `FxHashSet` avoids unnecessary hashing overhead.
-    let mut dependencies = FxHashSet::default();
+    let mut dependencies = HashSet::default();
 
     format_structs(&mut map, program, &mut dependencies);
     format_traits(&mut map, program);
@@ -129,7 +125,7 @@ pub fn generate_map(program: &AnalyzedProgram) -> String {
 fn format_structs(
     map: &mut String,
     program: &AnalyzedProgram,
-    dependencies: &mut FxHashSet<(String, String)>,
+    dependencies: &mut HashSet<(String, String)>,
 ) {
     use std::fmt::Write;
     let mut types: Vec<_> = program.scope.types().collect();
@@ -187,10 +183,10 @@ fn format_traits(map: &mut String, program: &AnalyzedProgram) {
 fn format_dependencies(
     map: &mut String,
     program: &AnalyzedProgram,
-    dependencies: FxHashSet<(String, String)>,
+    dependencies: HashSet<(String, String)>,
 ) {
     use std::fmt::Write;
-    let defined_types: FxHashSet<String> = program
+    let defined_types: HashSet<String> = program
         .scope
         .types()
         .filter_map(|(_, ty)| {

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -12,12 +12,10 @@ use miette::Result;
 
 /// Run the catalog explorer
 pub fn run_catalog() -> Result<()> {
-    // ⚡ Bolt Optimization: Uses `rustc_hash::FxHashMap` instead of the standard `HashMap`
-    // since the keys are internal `PartOfSpeech` enums and are not exposed to HashDoS attacks.
-    let mut entries_by_pos: rustc_hash::FxHashMap<
+    let mut entries_by_pos: std::collections::HashMap<
         PartOfSpeech,
         Vec<(&str, &crate::morphology::lexicon::LexiconEntry)>,
-    > = rustc_hash::FxHashMap::default();
+    > = std::collections::HashMap::default();
 
     for (word, entry) in crate::morphology::lexicon::entries() {
         entries_by_pos

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -16,7 +16,7 @@
 
 use crate::morphology::lexicon::{BinaryOp, UnaryOp};
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use std::fmt;
 
 /// The fundamental unit of data in the Simulator's runtime environment.
@@ -142,8 +142,8 @@ pub enum EvalError {
 /// ```
 pub struct Interpreter {
     // Stack of scopes. For now, just one global scope for simplicity.
-    // In a real implementation, this would be `Vec<FxHashMap<String, Value>>`.
-    env: Vec<FxHashMap<String, Value>>,
+    // In a real implementation, this would be `Vec<HashMap<String, Value>>`.
+    env: Vec<HashMap<String, Value>>,
 
     // Output buffer for capturing print statements (useful for testing/WASM)
     output: Vec<String>,
@@ -170,7 +170,7 @@ impl Interpreter {
     /// ```
     pub fn new() -> Self {
         Self {
-            env: vec![FxHashMap::default()],
+            env: vec![HashMap::default()],
             output: Vec::new(),
         }
     }


### PR DESCRIPTION
🪒 **Razor:** Essentialist Refactoring

### Reduction
**Bloat:** Unnecessary `FxHashMap` and `FxHashSet` optimization via the `rustc-hash` dependency.
**Cut:** Replaced with standard `HashMap` and `HashSet` from `std::collections` across multiple tools (`auditor`, `cartographer`, `catalog`, `interpreter`) and core modules (`lexicon`, `resolver`). The `rustc-hash` dependency was removed from `Cargo.toml`.
**Saved:** Simplified the dependency graph and reduced code cleverness.

---
*PR created automatically by Jules for task [14812638900245077588](https://jules.google.com/task/14812638900245077588) started by @madmax983*