### PR TITLE
⚒️ Forge: Flatten check_recursion_depth loop

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+
+**Flattening deeply nested loops**
+**Learning:** Parsing loops often suffer from deep nesting due to `if/else` handling state (like strings) wrapping a large `match` block.
+**Action:** Use guard clauses (`if state { ... continue; }`) at the top of the loop to handle specific states, allowing the main logic and `match` statements to remain un-indented and readable.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,15 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. **Refactor `src/parser/recursion.rs`:**
+   - I will modify `src/parser/recursion.rs` using `run_in_bash_session` to rewrite `check_recursion_depth`.
+   - The current `check_recursion_depth` function has deeply nested `if/else` and `match` blocks. It currently manually iterates `i` over byte length.
+   - I will extract logic into private helper functions (like `check_keywords` or similar) or simplify the loop with guard clauses, flattening the logic to improve readability. I will ensure no runtime behavior changes (especially the iteration over bytes with varying jump lengths).
+2. **Verify changes:**
+   - Run `cargo fmt --all`.
+   - Run `cargo clippy --all-targets --all-features -- -D warnings`.
+   - Run `cargo test` to ensure tests pass.
+3. **Log learning:**
+   - Log the refactoring insights to `.jules/forge.md` via `echo "..." >> .jules/forge.md`.
+4. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+5. **Submit Pull Request:**
+   - Use `request_code_review` or `submit` with the exact PR Title and Description.
+     - Title: `⚒️ Forge: Flatten check_recursion_depth`
+     - Description with `🚬 Smell:`, `✨ Solution:`, `🧱 Benefit:`, `🛡️ Verification:`.

--- a/src/parser/recursion.rs
+++ b/src/parser/recursion.rs
@@ -23,71 +23,73 @@ pub(crate) fn check_recursion_depth(source: &str) -> Result<(), ParseError> {
     // » is [0xC2, 0xBB]
     while i < bytes.len() {
         let b = bytes[i];
+
         if in_string {
             // Check for » [0xC2, 0xBB]
             if b == 0xC2 && i + 1 < bytes.len() && bytes[i + 1] == 0xBB {
                 in_string = false;
                 i += 2;
-            } else {
-                i += 1;
+                continue;
             }
-        } else {
-            // Check for keywords first if byte matches start of UTF-8 sequence
-            // δοκιμή (test): starts with \xCE\xB4 (δ)
-            // τέλος (end): starts with \xCF\x84 (τ)
+            i += 1;
+            continue;
+        }
 
-            // Check for "δοκιμή" or "δοκιμη" (test declaration start)
-            if b == 0xCE && (source[i..].starts_with("δοκιμή") || source[i..].starts_with("δοκιμη"))
-            {
+        // Check for keywords first if byte matches start of UTF-8 sequence
+        // δοκιμή (test): starts with \xCE\xB4 (δ)
+        // τέλος (end): starts with \xCF\x84 (τ)
+
+        // Check for "δοκιμή" or "δοκιμη" (test declaration start)
+        if b == 0xCE && (source[i..].starts_with("δοκιμή") || source[i..].starts_with("δοκιμη"))
+        {
+            depth += 1;
+            if depth > MAX_PARSE_DEPTH {
+                return Err(ParseError::RecursionLimitExceeded(MAX_PARSE_DEPTH));
+            }
+            // Both versions have length 12 bytes
+            i += "δοκιμή".len();
+            continue;
+        }
+
+        // Check for "τέλος" or "τελος" (test declaration end)
+        if b == 0xCF && (source[i..].starts_with("τέλος") || source[i..].starts_with("τελος"))
+        {
+            depth = depth.saturating_sub(1);
+            // Both versions have length 10 bytes
+            i += "τέλος".len();
+            continue;
+        }
+
+        match b {
+            // Check for « [0xC2, 0xAB]
+            0xC2 if i + 1 < bytes.len() && bytes[i + 1] == 0xAB => {
+                in_string = true;
+                i += 2;
+            }
+            b'(' | b'{' | b'[' => {
                 depth += 1;
                 if depth > MAX_PARSE_DEPTH {
                     return Err(ParseError::RecursionLimitExceeded(MAX_PARSE_DEPTH));
                 }
-                // Both versions have length 12 bytes
-                i += "δοκιμή".len();
-                continue;
+                i += 1;
             }
-
-            // Check for "τέλος" or "τελος" (test declaration end)
-            if b == 0xCF && (source[i..].starts_with("τέλος") || source[i..].starts_with("τελος"))
-            {
+            b')' | b'}' | b']' => {
                 depth = depth.saturating_sub(1);
-                // Both versions have length 10 bytes
-                i += "τέλος".len();
-                continue;
+                i += 1;
             }
-
-            match b {
-                // Check for « [0xC2, 0xAB]
-                0xC2 if i + 1 < bytes.len() && bytes[i + 1] == 0xAB => {
-                    in_string = true;
-                    i += 2;
-                }
-                b'(' | b'{' | b'[' => {
-                    depth += 1;
-                    if depth > MAX_PARSE_DEPTH {
-                        return Err(ParseError::RecursionLimitExceeded(MAX_PARSE_DEPTH));
-                    }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                // Skip comment
+                i += 2;
+                while i < bytes.len() {
+                    let c = bytes[i];
                     i += 1;
-                }
-                b')' | b'}' | b']' => {
-                    depth = depth.saturating_sub(1);
-                    i += 1;
-                }
-                b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
-                    // Skip comment
-                    i += 2;
-                    while i < bytes.len() {
-                        let c = bytes[i];
-                        i += 1;
-                        if c == b'\n' || c == b'\r' {
-                            break;
-                        }
+                    if c == b'\n' || c == b'\r' {
+                        break;
                     }
                 }
-                _ => {
-                    i += 1;
-                }
+            }
+            _ => {
+                i += 1;
             }
         }
     }


### PR DESCRIPTION
🚮 Smell: Deeply nested `if/else` enclosing a large `match` block in `check_recursion_depth` ("Pyramid of Doom").
✨ Solution: Re-structured the loop to use guard clauses (`continue`) for string handling and keyword detection, flattening the main match block to the top level of the loop.
🧼 Benefit: Reduces cognitive load and indentation, making the byte-level state machine easier to read and maintain.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [8944541441211443150](https://jules.google.com/task/8944541441211443150) started by @madmax983*