### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-05-18 - Detached Documentation
+**Confusion:** The documentation for `to_rust_type` in `src/codegen.rs` was not being rendered in `cargo doc` despite a full rustdoc block being present right above it. `cargo doc` complained about missing documentation on the function.
+**Clarification:** I moved an intervening `use std::fmt::Write;` statement that was placed directly between the documentation block and the `to_rust_type` function signature. Rustdoc always attaches documentation to the item immediately following the comment, so the `use` statement was effectively "stealing" the documentation, leaving the public function undocumented. I hoisted the import above the block to fix it.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -246,6 +246,7 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // ==================================================================================
 // TYPES
 // ==================================================================================
+use std::fmt::Write;
 
 /// Convert a Glossa type to its Rust equivalent string
 ///
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module
🔦 Insight: Fixed detached documentation for `to_rust_type` by moving the `use` import above the doc comment block, resolving missing docs warning.
🧪 Example: Executable doctest is now correctly associated with the function.
🖼️ Preview: (None)

---
*PR created automatically by Jules for task [9000008463041565215](https://jules.google.com/task/9000008463041565215) started by @madmax983*