### PR TITLE
🗺️ Atlas: Encapsulate Internal Modules

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -1,4 +1,4 @@
-## [Splitting The Blob: Assembler]
+**[Splitting The Blob: Assembler]
 **Tangle:** `src/semantic/assembly.rs` was a monolithic file (~2000 lines) mixing DTOs (`AssembledStatement`, `Constituent`) with complex assembly logic (`Assembler`) and tests.
 **Blueprint:**
 1. Created `src/semantic/assembly/` module.
@@ -7,7 +7,7 @@
 4. Updated dependent modules to import from `crate::semantic::assembly`.
 **Stability:** Improves separation of concerns (Data vs Logic) and reduces file size.
 
-## [Splitting The Blob: Assembly]
+**[Splitting The Blob: Assembly]
 **Tangle:** `src/semantic/assembly.rs` was a monolithic file (~2000 lines) mixing DTOs (`AssembledStatement`, `Constituent`) with complex assembly logic (`Assembler`) and tests.
 **Blueprint:**
 1. Created `src/semantic/assembly/` module.
@@ -16,7 +16,7 @@
 4. Updated dependent modules to import from `crate::semantic::assembly`.
 **Stability:** Improves separation of concerns (Data vs Logic) and reduces file size.
 
-## [Encapsulating Internal Modules]
+**[Encapsulating Internal Modules]
 **Tangle:** Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`, breaking encapsulation by exposing internal implementation details to the public API.
-**Blueprint:** Modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these modules with `pub(crate) mod`.
+**Blueprint:** Modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these modules with `pub(crate) mod`. Fixed unused variable warnings and export issues that arose from the change.
 **Stability:** Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub mod semantic;
 pub mod text;
 pub mod tools;
 
-pub use tools::highlight;
+pub use tools::highlight::highlight;
 
 pub use ast::Program;
 pub use codegen::generate_rust;

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,9 +178,9 @@ fn main() -> Result<()> {
             );
         }
 
-        Some(Commands::Gnomon { input }) => {
+        Some(Commands::Gnomon { input: _input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::gnomon::run_gnomon(&input)?;
+            glossa::tools::gnomon::run_gnomon(&_input)?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -24,7 +24,7 @@
 //! # Usage
 //!
 //! ```rust
-//! use glossa::highlight::highlight;
+//! use glossa::highlight;
 //!
 //! let source = "ὁ ἄνθρωπος τὸν λόγον λέγει.";
 //! let highlighted = highlight(source).unwrap();


### PR DESCRIPTION
🕸️ Tangle: Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`, breaking encapsulation by exposing internal implementation details to the public API. Unused variables warnings existed in `src/main.rs`.
📐 Blueprint: Modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these modules with `pub(crate) mod`. Fixed unused variable warnings by using underscore prefixed variable name `_input`. Changed use in `src/lib.rs` and `src/tools/highlight.rs` for `glossa::highlight` appropriately.
🧱 Stability: Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains. Warnings removed.
🔭 Verification: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all` completed successfully.

---
*PR created automatically by Jules for task [3237797253443881684](https://jules.google.com/task/3237797253443881684) started by @madmax983*