### PR TITLE
🎨 Mosaic: UI Polish for Semantic Type Errors

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,75 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. Modify `src/semantic/conversion.rs` using `run_in_bash_session` to add type validation in `classify_insert`, `classify_push`, and `classify_pop`.
+   - The implementation was already verified during exploration.
+   - Execute the following exact command:
+```bash
+cat << 'EOF' > fix.patch
+--- src/semantic/conversion.rs	2024-05-31 15:45:00.000000000 +0000
++++ src/semantic/conversion.rs	2024-05-31 16:00:00.000000000 +0000
+@@ -578,11 +578,21 @@
+         return Ok(None);
+     };
+
++    let subj_name = &subject.normalized;
++    let subj_type = scope
++        .lookup(subj_name)
++        .cloned()
++        .unwrap_or(GlossaType::Unknown);
++
++    if matches!(subj_type, GlossaType::Number | GlossaType::String | GlossaType::Boolean) {
++        return Err(GlossaError::semantic(format!(
++            "Τὸ «{}» ἔστιν {}, οὐχὶ συλλογή. Οὐ δύναται ἕλκειν.",
++            subj_name, subj_type.to_greek()
++        )));
++    }
++
+     let receiver = AnalyzedExpr {
+-        expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
+-        glossa_type: scope
+-            .lookup(&subject.lemma)
+-            .cloned()
+-            .unwrap_or(GlossaType::Unknown),
++        expr: AnalyzedExprKind::Variable(subj_name.clone()),
++        glossa_type: subj_type.clone(),
+     };
+
+@@ -604,11 +614,21 @@
+         return Ok(None);
+     };
+
++    let subj_name = &subject.normalized;
++    let subj_type = scope
++        .lookup(subj_name)
++        .cloned()
++        .unwrap_or(GlossaType::Unknown);
++
++    if matches!(subj_type, GlossaType::Number | GlossaType::String | GlossaType::Boolean) {
++        return Err(GlossaError::semantic(format!(
++            "Τὸ «{}» ἔστιν {}, οὐχὶ συλλογή. Οὐ δύναται ὠθεῖν.",
++            subj_name, subj_type.to_greek()
++        )));
++    }
++
+     let receiver = AnalyzedExpr {
+-        expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
+-        glossa_type: scope
+-            .lookup(&subject.lemma)
+-            .cloned()
+-            .unwrap_or(GlossaType::Unknown),
++        expr: AnalyzedExprKind::Variable(subj_name.clone()),
++        glossa_type: subj_type.clone(),
+     };
+
+@@ -662,6 +682,13 @@
+         .cloned()
+         .unwrap_or(GlossaType::Unknown);
+
++    if matches!(subj_type, GlossaType::Number | GlossaType::String | GlossaType::Boolean) {
++        return Err(GlossaError::semantic(format!(
++            "Τὸ «{}» ἔστιν {}, οὐχὶ συλλογή. Οὐ δύναται τιθέναι.",
++            subj_name, subj_type.to_greek()
++        )));
++    }
++
+     let receiver = AnalyzedExpr {
+         expr: AnalyzedExprKind::Variable(subj_name.clone()),
+         glossa_type: subj_type.clone(),

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -574,12 +574,26 @@ fn classify_pop(
         return Ok(None);
     };
 
+    let subj_name = &subject.normalized;
+    let subj_type = scope
+        .lookup(subj_name)
+        .cloned()
+        .unwrap_or(GlossaType::Unknown);
+
+    if matches!(
+        subj_type,
+        GlossaType::Number | GlossaType::String | GlossaType::Boolean
+    ) {
+        return Err(GlossaError::semantic(format!(
+            "Τὸ «{}» ἔστιν {}, οὐχὶ συλλογή. Οὐ δύναται ἕλκειν.",
+            subj_name,
+            subj_type.to_greek()
+        )));
+    }
+
     let receiver = AnalyzedExpr {
-        expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
-        glossa_type: scope
-            .lookup(&subject.lemma)
-            .cloned()
-            .unwrap_or(GlossaType::Unknown),
+        expr: AnalyzedExprKind::Variable(subj_name.clone()),
+        glossa_type: subj_type.clone(),
     };
 
     let method_call = AnalyzedExpr {
@@ -607,12 +621,26 @@ fn classify_push(
         return Ok(None);
     };
 
+    let subj_name = &subject.normalized;
+    let subj_type = scope
+        .lookup(subj_name)
+        .cloned()
+        .unwrap_or(GlossaType::Unknown);
+
+    if matches!(
+        subj_type,
+        GlossaType::Number | GlossaType::String | GlossaType::Boolean
+    ) {
+        return Err(GlossaError::semantic(format!(
+            "Τὸ «{}» ἔστιν {}, οὐχὶ συλλογή. Οὐ δύναται ὠθεῖν.",
+            subj_name,
+            subj_type.to_greek()
+        )));
+    }
+
     let receiver = AnalyzedExpr {
-        expr: AnalyzedExprKind::Variable(subject.lemma.clone()),
-        glossa_type: scope
-            .lookup(&subject.lemma)
-            .cloned()
-            .unwrap_or(GlossaType::Unknown),
+        expr: AnalyzedExprKind::Variable(subj_name.clone()),
+        glossa_type: subj_type.clone(),
     };
 
     let arg = if let Some(lit) = asm_stmt.literals.first() {
@@ -662,6 +690,17 @@ fn classify_insert(
         .lookup(subj_name)
         .cloned()
         .unwrap_or(GlossaType::Unknown);
+
+    if matches!(
+        subj_type,
+        GlossaType::Number | GlossaType::String | GlossaType::Boolean
+    ) {
+        return Err(GlossaError::semantic(format!(
+            "Τὸ «{}» ἔστιν {}, οὐχὶ συλλογή. Οὐ δύναται τιθέναι.",
+            subj_name,
+            subj_type.to_greek()
+        )));
+    }
 
     let receiver = AnalyzedExpr {
         expr: AnalyzedExprKind::Variable(subj_name.clone()),


### PR DESCRIPTION
🖌️ **Before:** Type mismatch during collection operations (like inserting into a number) bypassed semantic validation and caused an ugly internal rustc E0599 panic to be displayed to the user.
✨ **After:** Semantic validation now catches collection operations on primitive types and emits a beautiful, localized GlossaError during the compilation phase, shielding the user from internal compiler errors.
🖼️ **Visuals:** The user now sees a clean 'Σφάλμα σημασίας: ...' error instead of a giant red rustc panic block.

---
*PR created automatically by Jules for task [13866505670302968348](https://jules.google.com/task/13866505670302968348) started by @madmax983*