### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -131,3 +131,7 @@ Signed,
 **2026-04-30 - [Infinite Stream DoS Vulnerability in File Loading]
 **Threat:** The `load_source` function in `src/tools/runner.rs` relied on `fs::metadata().len()` to enforce the `MAX_FILE_SIZE` limit. However, special device files like `/dev/zero` report a length of 0 while producing an infinite stream of bytes when read. Reading these files with `fs::read_to_string` causes a thread hang or Out-Of-Memory (OOM) Denial-of-Service condition.
 **Defense:** Added an explicit `metadata.is_file()` check in `check_file_size` to guarantee that the input path points to a regular file and explicitly reject non-regular file types like directories and device streams. Updated `tests/havoc_dos.rs` and `test_load_source_directory_error` to assert the "Not a valid file" error and pass cleanly without timeouts.
+
+**2026-06-01 - [Unbounded REPL and Mentor Read_Line DoS]**
+**Threat:** The interactive prompts in `src/tools/repl.rs` and `src/tools/mentor.rs` used `read_line` on unbounded `BufRead` streams. This allowed a memory exhaustion DoS attack if fed an infinite stream of characters without a newline (e.g. from `/dev/zero`).
+**Defense:** Replaced the unbounded reads with capped readers using `.take(LIMIT)` wrapping the `BufRead` stream, explicitly preventing lines larger than `MAX_REPL_SOURCE_LEN` from continuously allocating memory.

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -115,7 +115,7 @@ pub fn run_mentor() -> Result<()> {
     run_mentor_inner(&mut stdin.lock(), &mut stdout)
 }
 
-fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
+pub fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
     print_banner(output)?;
 
     for (i, lesson) in LESSONS.iter().enumerate() {
@@ -127,7 +127,13 @@ fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Resu
             output.flush().into_diagnostic()?;
 
             let mut line = String::new();
-            let bytes = input.read_line(&mut line).into_diagnostic()?;
+            let mut input_take = std::io::Read::take(&mut *input, 50_000 + 1);
+            let bytes = input_take.read_line(&mut line).into_diagnostic()?;
+            if bytes > 50_000 {
+                return Err(miette::miette!(
+                    "Input line exceeded maximum allowed length"
+                ));
+            }
 
             if bytes == 0 {
                 return Ok(()); // EOF
@@ -155,7 +161,8 @@ fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Resu
                             .into_diagnostic()?;
                         writeln!(output, "{}", "Press Enter to continue...".dim())
                             .into_diagnostic()?;
-                        let _ = input.read_line(&mut String::new());
+                        let mut input_take = std::io::Read::take(&mut *input, 50_000 + 1);
+                        let _ = input_take.read_line(&mut String::new());
                         break; // Next lesson
                     } else {
                         writeln!(

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -64,7 +64,7 @@ pub fn run_repl() -> Result<()> {
 }
 
 /// Internal REPL loop that can be tested with arbitrary streams
-fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
+pub fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
     let mut context = ReplContext::new();
 
     loop {
@@ -73,7 +73,13 @@ fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result
         let _ = output.flush();
 
         let mut line = String::new();
-        let bytes = input.read_line(&mut line).into_diagnostic()?;
+        let mut input_take = std::io::Read::take(&mut *input, MAX_REPL_SOURCE_LEN as u64 + 1);
+        let bytes = input_take.read_line(&mut line).into_diagnostic()?;
+        if bytes > MAX_REPL_SOURCE_LEN {
+            return Err(miette::miette!(
+                "Input line exceeded maximum allowed length"
+            ));
+        }
 
         // Handle EOF
         if bytes == 0 {

--- a/tests/warden_mentor_dos.rs
+++ b/tests/warden_mentor_dos.rs
@@ -1,0 +1,44 @@
+#![allow(missing_docs)]
+use std::io::{BufReader, Read};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+struct InfiniteA;
+
+impl Read for InfiniteA {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        for b in buf.iter_mut() {
+            *b = b'A'; // No newline
+        }
+        Ok(buf.len())
+    }
+}
+
+#[test]
+fn test_mentor_dos_unbounded_readline() {
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        let mut input = BufReader::new(InfiniteA);
+        let mut output = Vec::new();
+
+        // This will hang and consume memory until OOM if not capped
+        let _ = glossa::tools::mentor::run_mentor_inner(&mut input, &mut output);
+        let _ = tx.send(());
+    });
+
+    match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(_) => {
+            // Finished!
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!(
+                "Test timed out! run_mentor_inner hung on infinite line, confirming DoS vulnerability."
+            );
+        }
+        Err(_) => {
+            panic!("Thread disconnected unexpectedly");
+        }
+    }
+}

--- a/tests/warden_mentor_dos.rs
+++ b/tests/warden_mentor_dos.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nova")]
 #![allow(missing_docs)]
 use std::io::{BufReader, Read};
 use std::sync::mpsc;
@@ -41,4 +42,15 @@ fn test_mentor_dos_unbounded_readline() {
             panic!("Thread disconnected unexpectedly");
         }
     }
+}
+
+#[test]
+fn test_mentor_dos_second_prompt() {
+    let mut data = String::from("ξ 10 ἔστω.\n");
+    data.push_str(&"A".repeat(50_005));
+
+    let mut input = std::io::Cursor::new(data);
+    let mut output = Vec::new();
+
+    let _ = glossa::tools::mentor::run_mentor_inner(&mut input, &mut output);
 }

--- a/tests/warden_repl_dos.rs
+++ b/tests/warden_repl_dos.rs
@@ -1,0 +1,45 @@
+#![allow(missing_docs)]
+
+use std::io::{BufReader, Read};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+struct InfiniteA;
+
+impl Read for InfiniteA {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        for b in buf.iter_mut() {
+            *b = b'A'; // No newline
+        }
+        Ok(buf.len())
+    }
+}
+
+#[test]
+fn test_repl_dos_unbounded_readline() {
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        let mut input = BufReader::new(InfiniteA);
+        let mut output = Vec::new();
+
+        // This will hang and consume memory until OOM if not capped
+        let _ = glossa::tools::repl::run_repl_inner(&mut input, &mut output);
+        let _ = tx.send(());
+    });
+
+    match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(_) => {
+            // Finished!
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!(
+                "Test timed out! run_repl_inner hung on infinite line, confirming DoS vulnerability."
+            );
+        }
+        Err(_) => {
+            panic!("Thread disconnected unexpectedly");
+        }
+    }
+}


### PR DESCRIPTION
🦠 Threat: Unbounded `read_line` in REPL and Mentor loops allows memory exhaustion (DoS) when fed with infinite streams without newlines.
🛡️ Defense: Implemented capped readers using `.take(LIMIT)` on `BufRead` streams to strictly limit memory allocation per line.
💥 Severity: High - Remote or local denial of service via memory exhaustion.
🧪 Verification: Fuzz tests created `tests/warden_repl_dos.rs` and `tests/warden_mentor_dos.rs` verify memory limits.

---
*PR created automatically by Jules for task [15631386141839516061](https://jules.google.com/task/15631386141839516061) started by @madmax983*