### PR TITLE
🌟 Nova: The Architect (JSON Schema Exporter)

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -52,3 +52,7 @@
 **Concept:** A CLI tool (`glossa gnomon`) that estimates the Big-O time complexity of a ΓΛΩΣΣΑ program by statically analyzing loop depth in the semantic AST.
 **Fate:** Proposed
 **Lesson:** Statically analyzing the semantic AST provides an easy and dependency-free way to estimate program complexity. The `AnalyzedStatement` enum variants effectively map the control flow (like `While` and `For` loops). Building a visitor pattern over these structures allows powerful tooling with minimal effort.
+## 🌟 The Architect (ὁ Ἀρχιτέκτων)
+**Concept:** A JSON Schema generator (`glossa architect`) that transpiles Glossa structs (`εἶδος`) directly to JSON Schema objects.
+**Fate:** Proposed
+**Lesson:** Treating Glossa as a Data Definition Language bridges ancient syntax with modern JSON validation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,18 @@ fn main() -> Result<()> {
             }
         }
 
+        Some(Commands::Architect { input: _input }) => {
+            #[cfg(feature = "nova")]
+            glossa::tools::architect::run_architect(&_input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                miette::bail!(
+                    "The 'architect' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
+        }
+
         Some(Commands::Repl) | None => {
             run_repl()?;
         }

--- a/src/tools/architect.rs
+++ b/src/tools/architect.rs
@@ -129,3 +129,26 @@ mod tests {
         );
     }
 }
+
+    #[test]
+    fn test_glossa_type_to_json_schema_complex() {
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::List(Box::new(GlossaType::Number))),
+            "\"type\": \"array\", \"items\": { \"type\": \"integer\" }"
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Set(Box::new(GlossaType::String))),
+            "\"type\": \"array\", \"uniqueItems\": true, \"items\": { \"type\": \"string\" }"
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Map(
+                Box::new(GlossaType::String),
+                Box::new(GlossaType::Number)
+            )),
+            "\"type\": \"object\""
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Option(Box::new(GlossaType::Boolean))),
+            "\"type\": \"boolean\""
+        );
+    }

--- a/src/tools/architect.rs
+++ b/src/tools/architect.rs
@@ -1,0 +1,131 @@
+//! The Architect (ὁ Ἀρχιτέκτων) - JSON Schema Generator
+//!
+//! This module implements the "Architect" tool, which inspects type definitions
+//! (`εἶδος`) within a ΓΛΩΣΣΑ program and translates them into JSON Schema.
+
+use crate::semantic::{AnalyzedStatement, GlossaType};
+use crate::tools::runner::load_source;
+use miette::Result;
+use std::fmt::Write;
+use std::path::Path;
+
+pub fn run_architect(input: &Path) -> Result<()> {
+    if !input.exists() {
+        return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
+    }
+
+    println!("📐 Ἀρχιτέκτων (Generating JSON Schema)...");
+
+    let source = match load_source(input) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Σφάλμα ἀρχείου (File Error)");
+            return Err(e);
+        }
+    };
+
+    let program = match crate::tools::runner::analyze_source(&source) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Σφάλμα ἀναλύσεως (Analysis Error)");
+            return Err(e);
+        }
+    };
+
+    let mut schemas = Vec::new();
+
+    for stmt in &program.statements {
+        if let AnalyzedStatement::TypeDefinition { name, fields } = stmt {
+            let mut output = String::new();
+            let _ = writeln!(output, "{{");
+            let _ = writeln!(
+                output,
+                "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
+            );
+            let _ = writeln!(output, "  \"title\": \"{}\",", name);
+            let _ = writeln!(output, "  \"type\": \"object\",");
+            let _ = writeln!(output, "  \"properties\": {{");
+            for (i, (field_name, field_type)) in fields.iter().enumerate() {
+                let json_type = glossa_type_to_json_schema(field_type);
+                let comma = if i < fields.len() - 1 { "," } else { "" };
+                let _ = writeln!(
+                    output,
+                    "    \"{}\": {{ {} }}{}",
+                    field_name, json_type, comma
+                );
+            }
+            let _ = writeln!(output, "  }},");
+
+            let required_fields: Vec<String> = fields
+                .iter()
+                .filter(|(_, t)| !matches!(t, GlossaType::Option(_)))
+                .map(|(n, _)| format!("\"{}\"", n))
+                .collect();
+
+            if !required_fields.is_empty() {
+                let _ = writeln!(output, "  \"required\": [{}]", required_fields.join(", "));
+            } else {
+                let _ = writeln!(output, "  \"required\": []");
+            }
+            let _ = writeln!(output, "}}");
+            schemas.push(output);
+        }
+    }
+
+    println!();
+    println!("Γ Λ Ω Σ Σ Α   A R C H I T E C T");
+    println!("JSON Schema");
+    println!();
+
+    for schema in schemas {
+        println!("```json");
+        println!("{}", schema.trim());
+        println!("```\n");
+    }
+
+    Ok(())
+}
+
+fn glossa_type_to_json_schema(g_type: &GlossaType) -> String {
+    match g_type {
+        GlossaType::Number => "\"type\": \"integer\"".to_string(),
+        GlossaType::String => "\"type\": \"string\"".to_string(),
+        GlossaType::Boolean => "\"type\": \"boolean\"".to_string(),
+        GlossaType::List(inner) => format!(
+            "\"type\": \"array\", \"items\": {{ {} }}",
+            glossa_type_to_json_schema(inner)
+        ),
+        GlossaType::Set(inner) => format!(
+            "\"type\": \"array\", \"uniqueItems\": true, \"items\": {{ {} }}",
+            glossa_type_to_json_schema(inner)
+        ),
+        GlossaType::Map(_, _) => "\"type\": \"object\"".to_string(),
+        GlossaType::Option(inner) => glossa_type_to_json_schema(inner),
+        _ => "\"type\": \"object\"".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_glossa_type_to_json_schema() {
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Number),
+            "\"type\": \"integer\""
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::String),
+            "\"type\": \"string\""
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Boolean),
+            "\"type\": \"boolean\""
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Unknown),
+            "\"type\": \"object\""
+        );
+    }
+}

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -218,4 +218,10 @@ pub enum Commands {
         /// Input file (.γλ)
         input: PathBuf,
     },
+
+    /// Generate JSON Schema from type definitions (Requires "nova" feature)
+    Architect {
+        /// Input file (.γλ)
+        input: PathBuf,
+    },
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -82,3 +82,6 @@ pub mod tester;
 pub(crate) mod ui;
 #[cfg(feature = "nova")]
 pub mod weave;
+
+#[cfg(feature = "nova")]
+pub mod architect;

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -281,3 +281,43 @@ fn test_run_scholar_syntax_error() {
 }
 
 // removed test_run_tests_rustc_error because of environment variable pollution causing intermittent failures in parallel execution and it being redundant to runner tests
+
+#[test]
+fn test_run_architect_success() {
+    let mut temp_file = Builder::new()
+        .suffix(".γλ")
+        .tempfile()
+        .expect("Failed to create temp file");
+
+    let source = "εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. ἡλικία ἀριθμοῦ. }. ξ 5 ἔστω.";
+    write!(temp_file, "{}", source).expect("Failed to write to temp file");
+
+    let result = glossa::tools::architect::run_architect(temp_file.path());
+    assert!(result.is_ok(), "Architect failed: {:?}", result.err());
+}
+
+#[test]
+fn test_run_architect_file_not_found() {
+    let path = PathBuf::from("non_existent_file.gl");
+    let result = glossa::tools::architect::run_architect(&path);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Ἀρχεῖον οὐχ εὑρέθη")
+    );
+}
+
+#[test]
+fn test_run_architect_syntax_error() {
+    let mut temp_file = Builder::new()
+        .suffix(".γλ")
+        .tempfile()
+        .expect("Failed to create temp file");
+
+    write!(temp_file, "invalid syntax").expect("Failed to write");
+
+    let result = glossa::tools::architect::run_architect(temp_file.path());
+    assert!(result.is_err());
+}


### PR DESCRIPTION
💡 **The Spark:** I noticed we treat Glossa Structs (`εἶδος`) as internal types, but we don't have a way to export them for external system validation.
🚀 **The Feature:** Implemented `glossa architect` which parses type definitions and automatically generates standard JSON Schema output.
🔮 **The Potential:** Could be used to validate JSON payloads across systems, using Glossa as a universal Data Definition Language.
⚠️ **Risk:** Low. Isolated in `src/tools/architect.rs` and behind the `nova` feature flag.

---
*PR created automatically by Jules for task [15175459285002857916](https://jules.google.com/task/15175459285002857916) started by @madmax983*