### PR TITLE
🗺️ Atlas: Encapsulate assembly module

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,3 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. **Change module boundary in `src/semantic/mod.rs`**: Change `pub mod assembly` to `pub(crate) mod assembly`. This encapsulates the internal assembler implementation while making it available throughout the crate, effectively hiding it from the public API and satisfying the "Atlas" boundary goals.
+2. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+3. **Report the findings and completion**: The architecture is sound overall. No circular dependencies exist. However, the change restricts `assembly` to `pub(crate)` improving the internal structure to follow the rules from `.jules/atlas.md`. Provide a formatted PR message.

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -160,7 +160,7 @@ pub use model::*;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::semantic::assembly::Assembler;
+/// use glossa::semantic::Assembler;
 /// let mut asm = Assembler::new();
 /// // Then feed analysis and finalise statement
 /// ```

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -16,7 +16,7 @@ use crate::ast::{Expr, Statement};
 use crate::errors::GlossaError;
 use crate::limits::MAX_AST_DEPTH;
 use crate::morphology::{self, DisambiguationContext, analyze_article, disambiguate, resolve_best};
-use crate::semantic::assembly::Assembler;
+use crate::semantic::Assembler;
 use crate::semantic::assembly::Literal;
 use crate::semantic::model::{AnalyzedExpr, AnalyzedExprKind};
 use crate::semantic::resolver::Scope;

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -34,7 +34,7 @@
 pub(crate) mod analyzer;
 #[cfg(test)]
 mod assembler_tests;
-pub mod assembly;
+pub(crate) mod assembly;
 #[cfg(test)]
 mod classification_tests;
 pub(crate) mod control_flow;


### PR DESCRIPTION
🕸️ Tangle: The `src/semantic/assembly/` module was exposed as `pub mod` in `src/semantic/mod.rs`, breaking encapsulation by exposing internal implementation details to the public API.
📐 Blueprint: Restricted the `assembly` module in `src/semantic/mod.rs` with `pub(crate) mod`.
🧱 Stability: Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains.
🔬 Verification: Builds successfully, strict separation enforced.

---
*PR created automatically by Jules for task [10126985443141488821](https://jules.google.com/task/10126985443141488821) started by @madmax983*