### PR TITLE
🪒 Razor: Fix unused variable warning in Gnomon command

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** `unused_variables` warning for `input` in `Commands::Gnomon` match arm when compiled without `--all-features`.
+**Cut:** Renamed `input` to `_input` in the match arm pattern to silence the warning without using `#[allow(unused_variables)]`.
+**Saved:** Suppressed a compiler warning gracefully, maintaining `#[deny(warnings)]` compliance and codebase cleanliness.

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,9 +178,9 @@ fn main() -> Result<()> {
             );
         }
 
-        Some(Commands::Gnomon { input }) => {
+        Some(Commands::Gnomon { input: _input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::gnomon::run_gnomon(&input)?;
+            glossa::tools::gnomon::run_gnomon(&_input)?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(


### PR DESCRIPTION
🪒 **Razor:** Essentialist Refactoring

### Reduction
**Bloat:** `unused_variables` warning for `input` in `Commands::Gnomon` match arm when compiled without `--all-features`.
**Cut:** Renamed `input` to `_input` in the match arm pattern to silence the warning without using `#[allow(unused_variables)]`.
**Saved:** Suppressed a compiler warning gracefully, maintaining `#[deny(warnings)]` compliance and codebase cleanliness.

---
*PR created automatically by Jules for task [7999268543007201641](https://jules.google.com/task/7999268543007201641) started by @madmax983*