### PR TITLE
⚡ Bolt: Use fmt::Write to avoid string allocations in labyrinth cfg generator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+**Use std::fmt::Write to avoid intermediate String allocations**
+**Learning:** Using `format!` in a loop to construct a large string creates many temporary, short-lived `String` heap allocations just to append them to a main buffer.
+**Action:** Replace `push_str(&format!(...))` with `writeln!(out, ...)` (importing `std::fmt::Write`) to write directly to the output buffer, bypassing the intermediate allocation step entirely.

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -19,6 +19,7 @@ use crate::semantic::{AnalyzedProgram, AnalyzedStatement};
 use crate::tools::ui::Status;
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
+use std::fmt::Write;
 use std::path::Path;
 
 /// Run the Labyrinth tool on a file
@@ -123,6 +124,9 @@ pub fn run_labyrinth_inner<W: std::io::Write>(source: &str, writer: &mut W) -> m
 /// let cfg = generate_cfg(&program);
 /// assert!(cfg.contains("graph TD"));
 /// ```
+///
+/// ⚡ Bolt Optimization: Uses `writeln!` instead of `format!` to avoid
+/// intermediate heap allocations when constructing the CFG.
 pub fn generate_cfg(program: &AnalyzedProgram) -> String {
     let mut nodes = Vec::new();
     let mut edges = Vec::new();
@@ -146,10 +150,10 @@ pub fn generate_cfg(program: &AnalyzedProgram) -> String {
 
     let mut out = String::from("graph TD\n");
     for node in nodes {
-        out.push_str(&format!("    {}\n", node));
+        let _ = writeln!(out, "    {}", node);
     }
     for edge in edges {
-        out.push_str(&format!("    {}\n", edge));
+        let _ = writeln!(out, "    {}", edge);
     }
     out
 }


### PR DESCRIPTION
💡 **What:** Replaced `out.push_str(&format!(...))` with `writeln!(out, ...)` in `src/tools/labyrinth.rs`.
🎯 **Why:** Using `format!` in a loop creates many short-lived intermediate `String` heap allocations just to append them to the main buffer. Using `fmt::Write` macros writes directly to the buffer.
📊 **Impact:** Removes `N + E` (number of nodes + edges) heap allocations per `generate_cfg` call.
🔬 **Measurement:** Verified with `cargo clippy` and `cargo test`.

---
*PR created automatically by Jules for task [8552451261265738337](https://jules.google.com/task/8552451261265738337) started by @madmax983*