### PR TITLE
⚡ Bolt: Optimize lemma allocation in declension analysis

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**Optimize lemma allocation in declension analysis
+**Learning:** Modern Rust (1.62+) is often good at optimizing `format!` for simple concatenations, but manually allocating a String with `String::with_capacity` and using `push_str` guarantees we bypass the formatting macro machinery overhead entirely.
+**Action:** Use manual String allocation and push for highly-executed hot paths (like morphology analysis) instead of `format!`.

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -234,7 +234,11 @@ pub fn analyze_noun_all_into(word: &str, analyses: &mut Vec<MorphAnalysis>) {
             {
                 Cow::Owned(word.to_string())
             } else {
-                Cow::Owned(format!("{}{}", stem, decl.nom_ending))
+                // ⚡ Bolt Optimization: Use `String::with_capacity` and `push_str` instead of `format!` to avoid macro overhead.
+                let mut s = String::with_capacity(stem.len() + decl.nom_ending.len());
+                s.push_str(stem);
+                s.push_str(decl.nom_ending);
+                Cow::Owned(s)
             };
 
             analyses.push(MorphAnalysis {


### PR DESCRIPTION
💡 What: Replaced `format!` with `String::with_capacity` and `push_str` when constructing noun lemmas.
🎯 Why: `format!` has unnecessary overhead for simple string concatenation. This occurs in `analyze_noun_all_into`, which is a hot path executed for almost every word during semantic analysis.
📊 Impact: Reduces CPU overhead and avoids formatting machinery for string concatenation in the morphology engine.
🔬 Measurement: Verify tests pass with `cargo test`.

---
*PR created automatically by Jules for task [6607806975915462381](https://jules.google.com/task/6607806975915462381) started by @madmax983*