### PR TITLE
🪒 Razor: Flatten AuditorVisitor and GnomonVisitor into pure functions

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** `GnomonVisitor` in `src/tools/gnomon.rs` and `AuditorVisitor` in `src/tools/auditor.rs` used an object-oriented builder/visitor pattern for simple ast traversal.
+**Cut:** Flattened both struct objects into pure procedural functions passing simple state structs and avoiding unnecessary state tracking object bloat.
+**Saved:** Removed two OOP class implementations, turning them into simpler pure functions.

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -14,8 +14,8 @@
 //!
 //! The [`run_auditor`](crate::tools::auditor::run_auditor) function drives the analysis:
 //! 1. The code is parsed and semantically analyzed.
-//! 2. A custom visitor (`AuditorVisitor`) traverses every statement and expression in the AST.
-//! 3. The visitor tracks variable declarations, usages, and reassignments using HashMaps and HashSets.
+//! 2. A simple `visit_statement` function traverses every statement and expression in the AST.
+//! 3. The traversal tracks variable declarations, usages, and reassignments using HashMaps and HashSets.
 //! 4. After traversal, the findings are cross-referenced to produce a final report,
 //!    which is displayed in a stylized terminal table.
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement};
@@ -28,6 +28,159 @@ use miette::Result;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smol_str::SmolStr;
 use std::path::Path;
+
+struct AuditorState {
+    usage_count: FxHashMap<SmolStr, usize>,
+    mutation_count: FxHashMap<SmolStr, usize>,
+    mutable_vars: FxHashSet<SmolStr>,
+}
+
+fn visit_expr(expr: &AnalyzedExpr, state: &mut AuditorState) {
+    match &expr.expr {
+        AnalyzedExprKind::Variable(name) => {
+            if let Some(count) = state.usage_count.get_mut(name) {
+                *count += 1;
+            }
+        }
+        AnalyzedExprKind::BinOp { left, right, .. } => {
+            visit_expr(left, state);
+            visit_expr(right, state);
+        }
+        AnalyzedExprKind::UnaryOp { operand, .. } => visit_expr(operand, state),
+        AnalyzedExprKind::StructInstantiation { args, .. } => visit_exprs(args, state),
+        AnalyzedExprKind::PropertyAccess { owner, .. } => visit_expr(owner, state),
+        AnalyzedExprKind::MethodCall { receiver, args, .. } => {
+            visit_expr(receiver, state);
+            visit_exprs(args, state);
+        }
+        AnalyzedExprKind::FunctionCall { args, .. } => visit_exprs(args, state),
+        AnalyzedExprKind::VerbCall { args, .. } => visit_exprs(args, state),
+        AnalyzedExprKind::ArrayLiteral(exprs) => visit_exprs(exprs, state),
+        AnalyzedExprKind::IndexAccess { array, index } => {
+            visit_expr(array, state);
+            visit_expr(index, state);
+        }
+        AnalyzedExprKind::Lambda { body, .. } => visit_expr(body, state),
+        AnalyzedExprKind::Some(inner) => visit_expr(inner, state),
+        AnalyzedExprKind::Ok(inner) => visit_expr(inner, state),
+        AnalyzedExprKind::Err(inner) => visit_expr(inner, state),
+        AnalyzedExprKind::Unwrap(inner) => visit_expr(inner, state),
+        AnalyzedExprKind::Try(inner) => visit_expr(inner, state),
+        AnalyzedExprKind::Assert { condition } => visit_expr(condition, state),
+        AnalyzedExprKind::AssertEq { left, right } => {
+            visit_expr(left, state);
+            visit_expr(right, state);
+        }
+        AnalyzedExprKind::Range { start, end, .. } => {
+            visit_expr(start, state);
+            visit_expr(end, state);
+        }
+        AnalyzedExprKind::NumberLiteral(_)
+        | AnalyzedExprKind::StringLiteral(_)
+        | AnalyzedExprKind::BooleanLiteral(_)
+        | AnalyzedExprKind::None
+        | AnalyzedExprKind::CollectionNew { .. } => {}
+    }
+}
+
+fn visit_exprs(exprs: &[AnalyzedExpr], state: &mut AuditorState) {
+    for expr in exprs {
+        visit_expr(expr, state);
+    }
+}
+
+fn visit_statement(stmt: &AnalyzedStatement, state: &mut AuditorState) {
+    match stmt {
+        AnalyzedStatement::Binding {
+            name,
+            value,
+            mutable,
+        } => {
+            state.usage_count.insert(name.clone(), 0);
+            state.mutation_count.insert(name.clone(), 0);
+            if *mutable {
+                state.mutable_vars.insert(name.clone());
+            }
+            visit_expr(value, state);
+        }
+        AnalyzedStatement::Assignment { name, value } => {
+            if let Some(count) = state.mutation_count.get_mut(name) {
+                *count += 1;
+            }
+            if let Some(count) = state.usage_count.get_mut(name) {
+                *count += 1;
+            }
+            visit_expr(value, state);
+        }
+        AnalyzedStatement::Print(exprs) => visit_exprs(exprs, state),
+        AnalyzedStatement::Expression(exprs) => visit_exprs(exprs, state),
+        AnalyzedStatement::Query(exprs) => visit_exprs(exprs, state),
+        AnalyzedStatement::If {
+            condition,
+            then_body,
+            else_body,
+        } => {
+            visit_expr(condition, state);
+            for s in then_body {
+                visit_statement(s, state);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    visit_statement(s, state);
+                }
+            }
+        }
+        AnalyzedStatement::While { condition, body } => {
+            visit_expr(condition, state);
+            for s in body {
+                visit_statement(s, state);
+            }
+        }
+        AnalyzedStatement::For {
+            variable,
+            iterator,
+            body,
+        } => {
+            state.usage_count.insert(variable.clone(), 0);
+            visit_expr(iterator, state);
+            for s in body {
+                visit_statement(s, state);
+            }
+        }
+        AnalyzedStatement::Match { scrutinee, arms } => {
+            visit_expr(scrutinee, state);
+            for (expr, stmts) in arms {
+                visit_expr(expr, state);
+                for s in stmts {
+                    visit_statement(s, state);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { params, body, .. } => {
+            for (param_name, _) in params {
+                state.usage_count.insert(param_name.clone(), 0);
+            }
+            for s in body {
+                visit_statement(s, state);
+            }
+        }
+        AnalyzedStatement::Return { value } => {
+            if let Some(v) = value {
+                visit_expr(v, state);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                visit_statement(s, state);
+            }
+        }
+        AnalyzedStatement::Break
+        | AnalyzedStatement::Continue
+        | AnalyzedStatement::TypeDefinition { .. }
+        | AnalyzedStatement::TraitDefinition { .. }
+        | AnalyzedStatement::TraitImplementation { .. } => {}
+    }
+}
 
 /// Runs the Auditor tool on a given Glossa source file.
 ///
@@ -76,9 +229,13 @@ pub fn run_auditor(input: &Path) -> Result<()> {
 
     status.success();
 
-    let mut visitor = AuditorVisitor::new();
+    let mut state = AuditorState {
+        usage_count: FxHashMap::default(),
+        mutation_count: FxHashMap::default(),
+        mutable_vars: FxHashSet::default(),
+    };
     for stmt in &program.statements {
-        visitor.visit_statement(stmt);
+        visit_statement(stmt, &mut state);
     }
 
     let mut issues = 0;
@@ -101,7 +258,7 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         Cell::new("Message").add_attribute(Attribute::Bold),
     ]);
 
-    for (var, count) in &visitor.usage_count {
+    for (var, count) in &state.usage_count {
         if *count == 0 {
             table.add_row(vec![
                 Cell::new("⚠️ Unused Variable").fg(Color::Yellow),
@@ -112,10 +269,10 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         }
     }
 
-    for (var, count) in &visitor.mutation_count {
+    for (var, count) in &state.mutation_count {
         if *count == 0
-            && visitor.mutable_vars.contains(var)
-            && visitor.usage_count.get(var).unwrap_or(&0) > &0
+            && state.mutable_vars.contains(var)
+            && state.usage_count.get(var).unwrap_or(&0) > &0
         {
             table.add_row(vec![
                 Cell::new("💡 Unnecessary Mutation").fg(Color::Blue),
@@ -140,233 +297,19 @@ pub fn run_auditor(input: &Path) -> Result<()> {
     Ok(())
 }
 
-struct AuditorVisitor {
-    /// ⚡ Bolt Optimization: Uses `FxHashMap` instead of the standard `HashMap`
-    /// to reduce cryptographic hashing overhead for small string keys (`SmolStr`).
-    usage_count: FxHashMap<SmolStr, usize>,
-    mutation_count: FxHashMap<SmolStr, usize>,
-    mutable_vars: FxHashSet<SmolStr>,
-}
-
-impl AuditorVisitor {
-    fn new() -> Self {
-        Self {
-            usage_count: FxHashMap::default(),
-            mutation_count: FxHashMap::default(),
-            mutable_vars: FxHashSet::default(),
-        }
-    }
-
-    fn visit_if_statement(
-        &mut self,
-        condition: &AnalyzedExpr,
-        then_body: &[AnalyzedStatement],
-        else_body: &Option<Vec<AnalyzedStatement>>,
-    ) {
-        self.visit_expr(condition);
-        for s in then_body {
-            self.visit_statement(s);
-        }
-        if let Some(else_stmts) = else_body {
-            for s in else_stmts {
-                self.visit_statement(s);
-            }
-        }
-    }
-
-    fn visit_while_loop(&mut self, condition: &AnalyzedExpr, body: &[AnalyzedStatement]) {
-        self.visit_expr(condition);
-        for s in body {
-            self.visit_statement(s);
-        }
-    }
-
-    fn visit_for_loop(
-        &mut self,
-        variable: &smol_str::SmolStr,
-        iterator: &AnalyzedExpr,
-        body: &[AnalyzedStatement],
-    ) {
-        self.usage_count.insert(variable.clone(), 0);
-        self.visit_expr(iterator);
-        for s in body {
-            self.visit_statement(s);
-        }
-    }
-
-    fn visit_match_statement(
-        &mut self,
-        scrutinee: &AnalyzedExpr,
-        arms: &[(AnalyzedExpr, Vec<AnalyzedStatement>)],
-    ) {
-        self.visit_expr(scrutinee);
-        for (expr, stmts) in arms {
-            self.visit_expr(expr);
-            for s in stmts {
-                self.visit_statement(s);
-            }
-        }
-    }
-
-    fn visit_function_def(
-        &mut self,
-        params: &[(smol_str::SmolStr, Option<crate::semantic::GlossaType>)],
-        body: &[AnalyzedStatement],
-    ) {
-        for (param_name, _) in params {
-            self.usage_count.insert(param_name.clone(), 0);
-        }
-        for s in body {
-            self.visit_statement(s);
-        }
-    }
-
-    fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
-        match stmt {
-            AnalyzedStatement::Binding {
-                name,
-                value,
-                mutable,
-            } => {
-                self.usage_count.insert(name.clone(), 0);
-                self.mutation_count.insert(name.clone(), 0);
-                if *mutable {
-                    self.mutable_vars.insert(name.clone());
-                }
-                self.visit_expr(value);
-            }
-            AnalyzedStatement::Assignment { name, value } => {
-                if let Some(count) = self.mutation_count.get_mut(name) {
-                    *count += 1;
-                }
-                if let Some(count) = self.usage_count.get_mut(name) {
-                    *count += 1;
-                }
-                self.visit_expr(value);
-            }
-            AnalyzedStatement::Print(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::Expression(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::Query(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::If {
-                condition,
-                then_body,
-                else_body,
-            } => {
-                self.visit_if_statement(condition, then_body, else_body);
-            }
-            AnalyzedStatement::While { condition, body } => {
-                self.visit_while_loop(condition, body);
-            }
-            AnalyzedStatement::For {
-                variable,
-                iterator,
-                body,
-            } => {
-                self.visit_for_loop(variable, iterator, body);
-            }
-            AnalyzedStatement::Match { scrutinee, arms } => {
-                self.visit_match_statement(scrutinee, arms);
-            }
-            AnalyzedStatement::FunctionDef { params, body, .. } => {
-                self.visit_function_def(params, body);
-            }
-            AnalyzedStatement::Return { value } => {
-                if let Some(v) = value {
-                    self.visit_expr(v);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::Break
-            | AnalyzedStatement::Continue
-            | AnalyzedStatement::TypeDefinition { .. }
-            | AnalyzedStatement::TraitDefinition { .. }
-            | AnalyzedStatement::TraitImplementation { .. } => {}
-        }
-    }
-
-    fn visit_exprs(&mut self, exprs: &[AnalyzedExpr]) {
-        for expr in exprs {
-            self.visit_expr(expr);
-        }
-    }
-
-    fn visit_expr(&mut self, expr: &AnalyzedExpr) {
-        match &expr.expr {
-            AnalyzedExprKind::Variable(name) => {
-                if let Some(count) = self.usage_count.get_mut(name) {
-                    *count += 1;
-                }
-            }
-            AnalyzedExprKind::BinOp { left, right, .. } => {
-                self.visit_expr(left);
-                self.visit_expr(right);
-            }
-            AnalyzedExprKind::UnaryOp { operand, .. } => self.visit_expr(operand),
-            AnalyzedExprKind::StructInstantiation { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::PropertyAccess { owner, .. } => self.visit_expr(owner),
-            AnalyzedExprKind::MethodCall { receiver, args, .. } => {
-                self.visit_expr(receiver);
-                self.visit_exprs(args);
-            }
-            AnalyzedExprKind::FunctionCall { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::VerbCall { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::ArrayLiteral(exprs) => self.visit_exprs(exprs),
-            AnalyzedExprKind::IndexAccess { array, index } => {
-                self.visit_expr(array);
-                self.visit_expr(index);
-            }
-            AnalyzedExprKind::Lambda { body, .. } => self.visit_expr(body),
-            AnalyzedExprKind::Some(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Ok(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Err(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Unwrap(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Try(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Assert { condition } => self.visit_expr(condition),
-            AnalyzedExprKind::AssertEq { left, right } => {
-                self.visit_expr(left);
-                self.visit_expr(right);
-            }
-            AnalyzedExprKind::Range { start, end, .. } => {
-                self.visit_expr(start);
-                self.visit_expr(end);
-            }
-            AnalyzedExprKind::NumberLiteral(_)
-            | AnalyzedExprKind::StringLiteral(_)
-            | AnalyzedExprKind::BooleanLiteral(_)
-            | AnalyzedExprKind::None
-            | AnalyzedExprKind::CollectionNew { .. } => {}
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::semantic::{AnalyzedExpr, AnalyzedExprKind};
     use std::io::Write;
 
     #[test]
-    fn test_auditor_unused_var() {
+    fn test_auditor_unused_variable() {
         let dir = tempfile::tempdir().unwrap();
         let input_path = dir.path().join("unused.γλ");
         {
             let mut f = std::fs::File::create(&input_path).unwrap();
-            f.write_all("ξ 10 ἔστω.\n".as_bytes()).unwrap();
+            f.write_all("ξ 5 ἔστω.\n".as_bytes()).unwrap();
         }
 
         let result = run_auditor(&input_path);
@@ -379,7 +322,7 @@ mod tests {
         let input_path = dir.path().join("mut.γλ");
         {
             let mut f = std::fs::File::create(&input_path).unwrap();
-            f.write_all("μετά ξ 10 ἔστω. ξ λέγε.\n".as_bytes()).unwrap();
+            f.write_all("μετὰ ξ 5 ἔστω.\nξ λέγε.\n".as_bytes()).unwrap();
         }
 
         let result = run_auditor(&input_path);
@@ -394,8 +337,12 @@ mod tests {
     }
 
     #[test]
-    fn test_auditor_visitor_coverage_statements() {
-        let mut visitor = AuditorVisitor::new();
+    fn test_auditor_coverage_statements() {
+        let mut state = AuditorState {
+            usage_count: FxHashMap::default(),
+            mutation_count: FxHashMap::default(),
+            mutable_vars: FxHashSet::default(),
+        };
 
         let statements = vec![
             AnalyzedStatement::Binding {
@@ -503,13 +450,17 @@ mod tests {
         ];
 
         for stmt in statements {
-            visitor.visit_statement(&stmt);
+            visit_statement(&stmt, &mut state);
         }
     }
 
     #[test]
-    fn test_auditor_visitor_coverage_expressions() {
-        let mut visitor = AuditorVisitor::new();
+    fn test_auditor_coverage_expressions() {
+        let mut state = AuditorState {
+            usage_count: FxHashMap::default(),
+            mutation_count: FxHashMap::default(),
+            mutable_vars: FxHashSet::default(),
+        };
 
         let exprs = vec![
             AnalyzedExprKind::Variable("x".into()),
@@ -605,7 +556,7 @@ mod tests {
                 expr: kind,
                 glossa_type: crate::semantic::GlossaType::Boolean,
             };
-            visitor.visit_expr(&expr);
+            visit_expr(&expr, &mut state);
         }
     }
 

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -17,50 +17,21 @@ use crossterm::style::Stylize;
 use miette::Result;
 use std::path::Path;
 
-/// A visitor that traverses the Abstract Syntax Tree to calculate loop depth.
+/// Recursively calculates the maximum loop depth of a list of statements.
 ///
-/// Just as a gnomon casts a shadow to indicate time, this visitor casts a shadow
-/// over the structure of a program to estimate its execution time complexity.
-/// It tracks the maximum nesting depth of `while` and `for` loops.
-#[derive(Default)]
-pub struct GnomonVisitor {
-    /// The current nesting depth of loops during traversal.
-    pub current_depth: usize,
-    /// The maximum nesting depth encountered so far.
-    pub max_depth: usize,
-}
-
-impl GnomonVisitor {
-    /// Creates a new `GnomonVisitor` starting at depth 0.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Recursively visits a statement and updates loop depth metrics.
-    ///
-    /// Increases depth when entering `While` or `For` loops, and explores
-    /// inner statements in branches (`If`, `Match`, functions).
-    pub fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
+/// Increases depth when entering `While` or `For` loops, and explores
+/// inner statements in branches (`If`, `Match`, functions).
+pub fn calculate_max_depth(statements: &[AnalyzedStatement]) -> usize {
+    fn visit(stmt: &AnalyzedStatement, current_depth: usize, max_depth: &mut usize) {
         match stmt {
-            AnalyzedStatement::While { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
+            AnalyzedStatement::While { body, .. } | AnalyzedStatement::For { body, .. } => {
+                let next_depth = current_depth + 1;
+                if next_depth > *max_depth {
+                    *max_depth = next_depth;
                 }
                 for s in body {
-                    self.visit_statement(s);
+                    visit(s, next_depth, max_depth);
                 }
-                self.current_depth -= 1;
-            }
-            AnalyzedStatement::For { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
             }
             AnalyzedStatement::If {
                 then_body,
@@ -68,40 +39,42 @@ impl GnomonVisitor {
                 ..
             } => {
                 for s in then_body {
-                    self.visit_statement(s);
+                    visit(s, current_depth, max_depth);
                 }
                 if let Some(else_stmts) = else_body {
                     for s in else_stmts {
-                        self.visit_statement(s);
+                        visit(s, current_depth, max_depth);
                     }
                 }
             }
             AnalyzedStatement::Match { arms, .. } => {
                 for (_, stmts) in arms {
                     for s in stmts {
-                        self.visit_statement(s);
+                        visit(s, current_depth, max_depth);
                     }
                 }
             }
-            AnalyzedStatement::FunctionDef { body, .. } => {
+            AnalyzedStatement::FunctionDef { body, .. }
+            | AnalyzedStatement::TestDeclaration { body, .. } => {
                 for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
+                    visit(s, current_depth, max_depth);
                 }
             }
             _ => {}
         }
     }
+
+    let mut max = 0;
+    for stmt in statements {
+        visit(stmt, 0, &mut max);
+    }
+    max
 }
 
 /// Analyzes a ΓΛΩΣΣΑ source file and estimates its Big-O time complexity.
 ///
 /// This function coordinates the parsing, semantic analysis, and AST traversal
-/// using the [`GnomonVisitor`]. The result is presented to the user in a
+/// using a pure recursive function. The result is presented to the user in a
 /// stylized terminal table.
 ///
 /// # Errors
@@ -146,10 +119,7 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
 
     status.success();
 
-    let mut visitor = GnomonVisitor::new();
-    for stmt in &program.statements {
-        visitor.visit_statement(stmt);
-    }
+    let max_depth = calculate_max_depth(&program.statements);
 
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   G N O M O N".cyan().bold());
@@ -170,23 +140,23 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
         Cell::new("Value").add_attribute(Attribute::Bold),
     ]);
 
-    let complexity = if visitor.max_depth == 0 {
+    let complexity = if max_depth == 0 {
         "O(1)".to_string()
-    } else if visitor.max_depth == 1 {
+    } else if max_depth == 1 {
         "O(N)".to_string()
     } else {
-        format!("O(N^{})", visitor.max_depth)
+        format!("O(N^{})", max_depth)
     };
 
     table.add_row(vec![
         Cell::new("Max Loop Depth"),
-        Cell::new(visitor.max_depth.to_string()),
+        Cell::new(max_depth.to_string()),
     ]);
     table.add_row(vec![
         Cell::new("Estimated Big-O"),
-        Cell::new(complexity).fg(if visitor.max_depth > 2 {
+        Cell::new(complexity).fg(if max_depth > 2 {
             Color::Red
-        } else if visitor.max_depth == 2 {
+        } else if max_depth == 2 {
             Color::Yellow
         } else {
             Color::Green
@@ -214,30 +184,27 @@ mod tests {
 
     #[test]
     fn test_gnomon_while_loop() {
-        let mut visitor = GnomonVisitor::new();
         let stmt = AnalyzedStatement::While {
             condition: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        let max_depth = calculate_max_depth(&[stmt]);
+        assert_eq!(max_depth, 1);
     }
 
     #[test]
     fn test_gnomon_for_loop() {
-        let mut visitor = GnomonVisitor::new();
         let stmt = AnalyzedStatement::For {
             variable: SmolStr::new("x"),
             iterator: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        let max_depth = calculate_max_depth(&[stmt]);
+        assert_eq!(max_depth, 1);
     }
 
     #[test]
     fn test_gnomon_nested_loops() {
-        let mut visitor = GnomonVisitor::new();
         let inner_loop = AnalyzedStatement::For {
             variable: SmolStr::new("y"),
             iterator: dummy_expr(),
@@ -247,7 +214,7 @@ mod tests {
             condition: dummy_expr(),
             body: vec![inner_loop],
         };
-        visitor.visit_statement(&outer_loop);
-        assert_eq!(visitor.max_depth, 2);
+        let max_depth = calculate_max_depth(&[outer_loop]);
+        assert_eq!(max_depth, 2);
     }
 }


### PR DESCRIPTION
🪒 **Razor:** Essentialist Refactoring

### Reduction
**Bloat:** `GnomonVisitor` in `src/tools/gnomon.rs` and `AuditorVisitor` in `src/tools/auditor.rs` used an object-oriented builder/visitor pattern for simple ast traversal.
**Cut:** Flattened both struct objects into pure procedural functions passing simple state structs and avoiding unnecessary state tracking object bloat.
**Saved:** Removed two OOP class implementations, turning them into simpler pure functions.

---
*PR created automatically by Jules for task [2315607348294171283](https://jules.google.com/task/2315607348294171283) started by @madmax983*