### PR TITLE
🎨 Mosaic: UI Polish for Test Runner

### DIFF
--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -257,10 +257,15 @@ fn compile_test_harness(temp_path: &Path, exe_path: &Path, status: Status) -> Re
         }
 
         status.error("Σφάλμα μεταγλωττίσεως δοκιμῶν (Test Compilation Error)");
+
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
+        table.add_row(vec![Cell::new(clean_stderr.trim()).fg(Color::Red)]);
+
         return Err(miette::miette!(
             "{}\n{}",
-            "Rustc Error:".red(),
-            clean_stderr.trim()
+            "Rustc Error:".red().bold(),
+            table
         ));
     }
 
@@ -384,10 +389,15 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
             }
         } else {
             // Fallback to raw output if extraction failed but tests failed
-            println!("{}", stdout);
+            let mut fallback_table = Table::new();
+            fallback_table.load_preset(presets::UTF8_FULL);
+            fallback_table.add_row(vec![Cell::new(stdout.trim()).fg(Color::Yellow)]);
+
             if !test_output.stderr.is_empty() {
-                println!("{}", String::from_utf8_lossy(&test_output.stderr).red());
+                let stderr_str = String::from_utf8_lossy(&test_output.stderr);
+                fallback_table.add_row(vec![Cell::new(stderr_str.trim()).fg(Color::Red)]);
             }
+            println!("{}\n{}", "Raw Output:".yellow().bold(), fallback_table);
         }
     }
 }


### PR DESCRIPTION
🖌️ **Before:** Raw `stderr` and `stdout` dumps from rustc and the test binary printed directly to the console when compilation or unstructured panics happened in the `tester` tool.
✨ **After:** Raw rustc errors and fallback `stdout`/`stderr` from the test runner are now enclosed beautifully inside `comfy-table` boundaries that fit the rest of the toolkit's design aesthetic.
🖼️ **Visuals:** Replaced raw `println!` streams with boxed grid displays for Rustc errors and generic panics in `src/tools/tester.rs`.

---
*PR created automatically by Jules for task [18229729412502304086](https://jules.google.com/task/18229729412502304086) started by @madmax983*