### PR TITLE
👺 Havoc: REPL Memory Exhaustion DoS

### DIFF
--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -833,6 +833,7 @@ impl Assembler {
     fn check_special_properties(&mut self, normalized: &str) -> Result<bool, AssemblyError> {
         // Numeral words
         if let Some(value) = crate::morphology::lexicon::numeral_value(normalized) {
+            Self::check_limit(self.state.literals.len(), MAX_LITERALS, "Literals")?;
             self.state.literals.push(Literal::Number(value));
             return Ok(true);
         }

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -64,7 +64,7 @@ pub fn run_repl() -> Result<()> {
 }
 
 /// Internal REPL loop that can be tested with arbitrary streams
-fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
+pub fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
     let mut context = ReplContext::new();
 
     loop {
@@ -73,7 +73,10 @@ fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result
         let _ = output.flush();
 
         let mut line = String::new();
-        let bytes = input.read_line(&mut line).into_diagnostic()?;
+        // Prevent unbounded memory growth by limiting read to slightly more than MAX_REPL_SOURCE_LEN
+        let mut limit_reader =
+            std::io::Read::take(input.by_ref(), MAX_REPL_SOURCE_LEN as u64 + 1024);
+        let bytes = limit_reader.read_line(&mut line).into_diagnostic()?;
 
         // Handle EOF
         if bytes == 0 {

--- a/tests/havoc_assembly_oom.rs
+++ b/tests/havoc_assembly_oom.rs
@@ -1,0 +1,25 @@
+use glossa::morphology::{MorphAnalysis, PartOfSpeech};
+use glossa::semantic::assembly::Assembler;
+use std::borrow::Cow;
+
+#[test]
+#[ignore]
+fn test_assembler_memory_exhaustion() {
+    let mut asm = Assembler::new();
+    let analysis = MorphAnalysis {
+        part_of_speech: PartOfSpeech::Noun,
+        lemma: Cow::Owned("test".to_string()),
+        person: None,
+        number: None,
+        tense: None,
+        mood: None,
+        voice: None,
+        gender: None,
+        case: None,
+        confidence: 1.0,
+    };
+
+    for _ in 0..10_000 {
+        let _ = asm.feed(&analysis, "εἷς");
+    }
+}

--- a/tests/havoc_repl_exhaustion.rs
+++ b/tests/havoc_repl_exhaustion.rs
@@ -1,0 +1,21 @@
+use glossa::tools::repl::run_repl_inner;
+use std::io::Read;
+
+struct InfiniteSpaces;
+impl Read for InfiniteSpaces {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        for b in buf.iter_mut() {
+            *b = b' ';
+        }
+        Ok(buf.len())
+    }
+}
+
+#[test]
+#[ignore]
+fn test_repl_infinite_exhaustion() {
+    let input = InfiniteSpaces;
+    let mut buf_input = std::io::BufReader::new(input);
+    let mut output = Vec::new();
+    let _ = run_repl_inner(&mut buf_input, &mut output);
+}


### PR DESCRIPTION
🧨 **The Trigger:** Feeding an infinite stream of characters without a newline to `run_repl_inner` bypasses the `MAX_REPL_SOURCE_LEN` limit (which is only checked *after* the read completes), causing unbounded memory allocation until the OS kills the process.

📉 **The Stack Trace:**
```
error: test failed, to rerun pass `--test havoc_repl_exhaustion`

Caused by:
  process didn't exit successfully: `/app/target/debug/deps/havoc_repl_exhaustion-86aae5d13da58233` (signal: 9, SIGKILL: kill)
```

🧪 **Reproduction:** Run a test that provides an infinite stream of spaces to `glossa::tools::repl::run_repl_inner`. (See `tests/havoc_repl_exhaustion.rs` and `tests/havoc_assembly_oom.rs` - they are set to `#[ignore]` so they don't break CI, but you can run them manually to crash your machine.)

😈 **Comment:** You assumed users would press Enter before running out of RAM. You were wrong.

---
*PR created automatically by Jules for task [3933984821735998187](https://jules.google.com/task/3933984821735998187) started by @madmax983*