### PR TITLE
🎨 Mosaic: UI Polish for CLI Output

### DIFF
--- a/examples/invalid.γλ
+++ b/examples/invalid.γλ
@@ -1,0 +1,1 @@
+not valid syntax

--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -27,7 +27,7 @@ pub fn run_alchemist(input: &Path) -> miette::Result<()> {
     let program = match crate::tools::runner::analyze_source(&source) {
         Ok(p) => p,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -69,7 +69,7 @@ pub fn run_auditor(input: &Path) -> Result<()> {
     let program = match crate::tools::runner::analyze_source(&source) {
         Ok(p) => p,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -52,7 +52,7 @@ pub fn run_map(input: &Path) -> Result<()> {
     let program = match crate::tools::runner::analyze_source(&source) {
         Ok(p) => p,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -139,7 +139,7 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
     let program = match crate::tools::runner::analyze_source(&source) {
         Ok(p) => p,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -39,7 +39,7 @@ pub fn run_labyrinth_inner<W: std::io::Write>(source: &str, writer: &mut W) -> m
     let program = match crate::tools::runner::analyze_source(source) {
         Ok(p) => p,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -413,7 +413,7 @@ pub fn check_file(input: &Path) -> Result<()> {
     let _analyzed = match analyze_source(&source) {
         Ok(a) => a,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };
@@ -439,7 +439,7 @@ pub fn report_file(input: &Path) -> Result<()> {
     let analyzed = match analyze_source(&source) {
         Ok(a) => a,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };
@@ -540,7 +540,7 @@ pub fn bard_file(input: &Path) -> Result<()> {
     let analyzed = match analyze_source(&source) {
         Ok(a) => a,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };

--- a/src/tools/scholar.rs
+++ b/src/tools/scholar.rs
@@ -50,7 +50,7 @@ pub fn run_scholar(input: &Path) -> Result<()> {
     let program = match crate::tools::runner::analyze_source(&source) {
         Ok(p) => p,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -296,7 +296,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                     .fg(Color::White)
                     .add_attribute(Attribute::Bold),
             ]);
-            println!("{success_table}");
+            let success_table_str = success_table.to_string();
+            let indented_table = success_table_str.replace("\n", "\n   ");
+            println!("   {indented_table}");
             println!();
         }
     } else {
@@ -308,7 +310,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                 .fg(Color::White)
                 .add_attribute(Attribute::Bold),
         ]);
-        println!("{failure_table}");
+        let failure_table_str = failure_table.to_string();
+        let indented_table = failure_table_str.replace("\n", "\n   ");
+        println!("   {indented_table}");
         println!();
     }
 
@@ -338,7 +342,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
 
             table.add_row(vec![Cell::new(display_name), status_cell]);
         }
-        println!("{table}");
+        let table_str = table.to_string();
+        let indented_table = table_str.replace("\n", "\n   ");
+        println!("   {indented_table}");
     } else {
         let mut empty_table = Table::new();
         empty_table.load_preset(presets::UTF8_FULL);
@@ -353,13 +359,15 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                 .add_attribute(Attribute::Italic)
                 .set_alignment(CellAlignment::Center),
         ]);
-        println!("{empty_table}");
+        let empty_table_str = empty_table.to_string();
+        let indented_table = empty_table_str.replace("\n", "\n   ");
+        println!("   {indented_table}");
     }
 
     // If there were failures, try to extract and print them nicely
     if !test_output.status.success() {
         println!();
-        println!("{}", "--- 📜 Λεπτoμέρειες (Details) ---".dim());
+        println!("   {}", "--- 📜 Λεπτoμέρειες (Details) ---".dim());
 
         let failures = extract_failures(stdout);
 
@@ -373,20 +381,29 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                         .fg(Color::White)
                         .add_attribute(Attribute::Bold),
                 ]);
-                println!("{header_table}");
+                println!("   {header_table}");
 
                 // Create a box for the error message using comfy_table
                 let mut error_table = Table::new();
                 error_table.load_preset(presets::UTF8_FULL);
                 error_table.add_row(vec![Cell::new(format!("\n{}\n", msg)).fg(Color::Red)]);
-                println!("{error_table}");
+
+                // Indent the table by replacing newlines
+                let error_table_str = error_table.to_string();
+                let indented_table = error_table_str.replace("\n", "\n   ");
+                println!("   {indented_table}");
                 println!();
             }
         } else {
             // Fallback to raw output if extraction failed but tests failed
-            println!("{}", stdout);
+            println!("   {}", stdout.replace("\n", "\n   "));
             if !test_output.stderr.is_empty() {
-                println!("{}", String::from_utf8_lossy(&test_output.stderr).red());
+                println!(
+                    "   {}",
+                    String::from_utf8_lossy(&test_output.stderr)
+                        .replace("\n", "\n   ")
+                        .red()
+                );
             }
         }
     }
@@ -426,7 +443,7 @@ pub fn run_tests(input: &Path) -> Result<()> {
     let analyzed = match crate::tools::runner::analyze_source(&source) {
         Ok(a) => a,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -152,7 +152,11 @@ impl Status {
 
         let msg = self.message.as_str().bold().to_string();
         self.print_done("✕".red(), &msg);
-        eprintln!("{}", err);
+
+        let err_str = err.to_string();
+        if !err_str.is_empty() {
+            eprintln!("{}", err_str.dim());
+        }
         self.active = false;
     }
 

--- a/src/tools/weave.rs
+++ b/src/tools/weave.rs
@@ -41,7 +41,7 @@ pub fn run_weave(input: &Path) -> Result<()> {
     let program = match crate::tools::runner::analyze_source(&source) {
         Ok(p) => p,
         Err(e) => {
-            status.error("Σφάλμα (Error)");
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
             return Err(e);
         }
     };


### PR DESCRIPTION
🖌️ **Before:** Raw error dumps with no visual hierarchy and unindented test result tables that broke the CLI layout consistency.
✨ **After:** Formatted and dimmed error messages to recede into the background, and properly indented test result tables.
🖼️ **Visuals:** Errors no longer scream at the user. Tables in the `test` command now align perfectly with the rest of the CLI dashboard. The "3-Click Rule" doesn't strictly apply, but the Z-Pattern scanning layout is much cleaner without jagged edges.

---
*PR created automatically by Jules for task [3903861821947866217](https://jules.google.com/task/3903861821947866217) started by @madmax983*