### PR TITLE
🎻 Bard: Fix missing documentation for to_rust_type in codegen.rs

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -102,6 +102,7 @@ use crate::semantic::{
 use crate::text::normalize_greek;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
+use std::fmt::Write;
 // ==================================================================================
 // UTILS
 // ==================================================================================
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module.
🔦 Insight: The `to_rust_type` function was missing documentation because the `use std::fmt::Write;` import was placed between the `///` rustdoc block and the function signature. This orphaned the documentation block, causing `cargo doc` to fail when running with `-D missing_docs`. I moved the import to the top of the file and removed the empty line to ensure the docs correctly attach to the function.
🧪 Example: Verified via `RUSTDOCFLAGS="-D warnings -D missing_docs" cargo doc --no-deps` which now passes successfully without warnings.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [6299285075579879470](https://jules.google.com/task/6299285075579879470) started by @madmax983*