### PR TITLE
🎻 Bard: Document to_rust_type in codegen

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-03-24 - Documenting codegen::to_rust_type
+**Confusion:** The `to_rust_type` function in `src/codegen.rs` was missing documentation and examples. This led to warnings when building docs with `-W missing-docs` and obscured how Glossa semantic types mapped to Rust types during code generation.
+**Clarification:** I added comprehensive rustdoc comments including an `# Examples` section with executable doc-tests. I also fixed the doc-tests to use `use glossa::semantic::GlossaType` to resolve private module errors since the `types` module is private but the enum is exported.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -275,6 +275,21 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// ```
 use std::fmt::Write;
 
+/// Converts a `GlossaType` into its corresponding Rust type representation as a String.
+///
+/// This function maps the semantic types used in the Glossa AST to concrete Rust
+/// types used during code generation.
+///
+/// # Examples
+///
+/// ```
+/// use glossa::semantic::GlossaType;
+/// use glossa::codegen::to_rust_type;
+///
+/// assert_eq!(to_rust_type(&GlossaType::Number), "i64");
+/// assert_eq!(to_rust_type(&GlossaType::String), "String");
+/// assert_eq!(to_rust_type(&GlossaType::Boolean), "bool");
+/// ```
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module's type mapping
🔦 Insight: Explained how `to_rust_type` maps `GlossaType` AST types to concrete Rust types.
🧪 Example: Added an executable doctest to demonstrate the mapping of Number, String, and Boolean.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [13358659906132475761](https://jules.google.com/task/13358659906132475761) started by @madmax983*