### PR TITLE
🎨 Mosaic: UI Polish for src/tools/tester.rs

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -184,12 +184,43 @@ fn capture_failure_message(lines: &mut std::iter::Peekable<std::str::Lines>) -> 
         message.push('\n');
         lines.next();
     }
-    message.trim().to_string()
+
+    // Polish the assertion error if it's there
+    let formatted_message = message.trim().to_string();
+    if formatted_message.contains("assertion `left == right` failed") {
+        let mut clean = String::new();
+        clean.push_str("💥 Ἀποτυχία Ἰσότητος (Equality Failure)\n");
+        let mut left = "Unknown";
+        let mut right = "Unknown";
+
+        for line in formatted_message.lines() {
+            let line = line.trim();
+            if line.starts_with("left:") {
+                left = line.trim_start_matches("left:").trim();
+                // strip backticks if they exist
+                left = left.trim_matches('`');
+            } else if line.starts_with("right:") {
+                right = line.trim_start_matches("right:").trim();
+                // strip backticks if they exist
+                right = right.trim_matches('`');
+            }
+        }
+        clean.push_str(&format!("Ἀναμενόμενον (Expected): {}\n", right));
+        clean.push_str(&format!("Εὑρέθη (Found):        {}", left));
+        return clean;
+    }
+
+    formatted_message
 }
 
 fn clean_panic_message(current: &str) -> Option<String> {
     if !current.starts_with("thread '") {
         return None;
+    }
+
+    // Since we are parsing out the equality failure we don't want to show the thread panicked message
+    if current.contains("assertion `left == right` failed") {
+        return Some("".to_string());
     }
 
     let panicked_idx = current.find("panicked at")?;


### PR DESCRIPTION
🖌️ **Before:** The tester tool output raw Rust panics when test assertions failed (e.g., `thread 'test_will_fail' panicked \n assertion left == right failed`), looking clunky and hard to read.
✨ **After:** Test failures are now parsed to extract left/right operands and present a structured, domain-appropriate message: `💥 Ἀποτυχία Ἰσότητος (Equality Failure)`, with clear `Ἀναμενόμενον (Expected):` and `Εὑρέθη (Found):` labels.
🖼️ **Visuals:** The raw assertion trace is completely hidden and instead the Z-pattern directs the eye right to the problem values in a tidy table box.

---
*PR created automatically by Jules for task [7243479129071457139](https://jules.google.com/task/7243479129071457139) started by @madmax983*