### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,7 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+
+**[Trait and Test Recursion Limits]**
+**Learning:** Found an omission in `check_ast_statement_depth` in `src/semantic/validation.rs` where the parser did not check the recursion depth limit for `TraitDefinition`, `TraitImpl`, and `TestDeclaration` nodes, allowing a possible stack overflow DoS.
+**Action:** Added proper depth-limit checks for the bodies inside those statement types, to ensure they abide by `MAX_AST_DEPTH`.

--- a/src/semantic/validation.rs
+++ b/src/semantic/validation.rs
@@ -30,10 +30,28 @@ fn check_ast_statement_depth(stmt: &Statement, depth: usize) -> Result<(), Gloss
                 check_ast_clause_depth(clause, depth + 1)?;
             }
         }
-        Statement::TypeDefinition(_)
-        | Statement::TraitDefinition(_)
-        | Statement::TraitImpl(_)
-        | Statement::TestDeclaration(_) => {}
+        Statement::TypeDefinition(_) => {}
+        Statement::TraitDefinition(trait_def) => {
+            for method in &trait_def.methods {
+                if let Some(body) = &method.body {
+                    for s in body {
+                        check_ast_statement_depth(s, depth + 1)?;
+                    }
+                }
+            }
+        }
+        Statement::TraitImpl(trait_impl) => {
+            for method in &trait_impl.methods {
+                for s in &method.body {
+                    check_ast_statement_depth(s, depth + 1)?;
+                }
+            }
+        }
+        Statement::TestDeclaration(test_decl) => {
+            for s in &test_decl.body {
+                check_ast_statement_depth(s, depth + 1)?;
+            }
+        }
     }
     Ok(())
 }
@@ -247,7 +265,83 @@ fn check_expr_depth(expr: &AnalyzedExpr, depth: usize) -> Result<(), GlossaError
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::{
+        Clause, ImplMethodDef, TestDecl, TraitDef, TraitImplDef, TraitMethodDecl, Word,
+    };
     use crate::semantic::GlossaType;
+
+    fn create_deep_stmt(depth: usize) -> Statement {
+        let mut stmt = Statement::Regular {
+            clauses: vec![Clause {
+                expressions: vec![Expr::Word(Word::new("x"))],
+            }],
+            is_query: false,
+            is_propagate: false,
+        };
+
+        for _ in 0..depth {
+            stmt = Statement::Regular {
+                clauses: vec![Clause {
+                    expressions: vec![Expr::Block(vec![stmt])],
+                }],
+                is_query: false,
+                is_propagate: false,
+            };
+        }
+        stmt
+    }
+
+    #[test]
+    fn test_trait_impl_depth_limit() {
+        let deep_stmt = create_deep_stmt(MAX_AST_DEPTH + 1);
+        let trait_impl = Statement::TraitImpl(TraitImplDef {
+            trait_name: Word::new("Trait"),
+            type_name: Word::new("Type"),
+            methods: vec![ImplMethodDef {
+                name: Word::new("method"),
+                params: vec![],
+                body: vec![deep_stmt],
+            }],
+        });
+
+        let result = check_program_depth(&Program {
+            statements: vec![trait_impl],
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_test_decl_depth_limit() {
+        let deep_stmt = create_deep_stmt(MAX_AST_DEPTH + 1);
+        let test_decl = Statement::TestDeclaration(TestDecl {
+            name: "test".to_string(),
+            body: vec![deep_stmt],
+        });
+
+        let result = check_program_depth(&Program {
+            statements: vec![test_decl],
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_trait_def_depth_limit() {
+        let deep_stmt = create_deep_stmt(MAX_AST_DEPTH + 1);
+        let trait_def = Statement::TraitDefinition(TraitDef {
+            name: Word::new("Trait"),
+            methods: vec![TraitMethodDecl {
+                name: Word::new("method"),
+                params: vec![],
+                is_default: true,
+                body: Some(vec![deep_stmt]),
+            }],
+        });
+
+        let result = check_program_depth(&Program {
+            statements: vec![trait_def],
+        });
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_statement_depth_limit() {


### PR DESCRIPTION
🎯 Target:
`check_ast_statement_depth` inside `src/semantic/validation.rs`

💣 Risk:
Did not check depth limit for AST statements inside of TraitImpl, TraitDefinition and TestDeclaration nodes. This can lead to stack overflow DoS vulnerabilities with heavily nested recursive components. 

🧪 Strategy:
Added explicit statements to recursively check body expressions inside these declarations against `MAX_AST_DEPTH`. Verified using heavily nested statements.

🔬 Verification:
Run `cargo test --lib`

---
*PR created automatically by Jules for task [7375944021354881024](https://jules.google.com/task/7375944021354881024) started by @madmax983*