### PR TITLE
🎻 Bard: Missing docs for to_rust_type

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,7 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+
+## 2026-03-23 - The Invisible Function Doc
+**Confusion:** The function `to_rust_type` in `src/codegen.rs` had comprehensive documentation but still triggered a `missing_docs` warning. The issue was an import statement (`use std::fmt::Write;`) placed between the rustdoc comment and the function signature.
+**Clarification:** Rustdoc associates the documentation block with the immediate next statement. By placing a `use` statement between the doc and the function, the doc became attached to the `use` statement, leaving the function completely undocumented. Imports must be moved above the doc block.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -246,6 +246,7 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // ==================================================================================
 // TYPES
 // ==================================================================================
+use std::fmt::Write;
 
 /// Convert a Glossa type to its Rust equivalent string
 ///
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module.
🔦 Insight: Fixed a `missing_docs` warning for `to_rust_type`. The rustdoc block was erroneously associated with an interleaved `use std::fmt::Write;` statement rather than the function itself. Moved the import above the documentation block.
🧪 Example: Verified via `RUSTDOCFLAGS="-W missing_docs" cargo doc` without any warnings.
🖼️ Preview: Documentation for `to_rust_type` now successfully generates and renders properly.

---
*PR created automatically by Jules for task [5216647075009817126](https://jules.google.com/task/5216647075009817126) started by @madmax983*