### PR TITLE
🎨 Mosaic: UI Polish for Mosaic

### DIFF
--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -101,7 +101,9 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
                 Err(e) => {
                     table.add_row(vec![
                         Cell::new(i + 1),
-                        Cell::new(format!("Error: {}", e)).fg(Color::Red),
+                        Cell::new(format!("⚠️ Σφάλμα (Error):\n{}", e))
+                            .fg(Color::Red)
+                            .add_attribute(Attribute::Bold),
                         Cell::new(""),
                         Cell::new(""),
                         Cell::new(""),


### PR DESCRIPTION
🖌️ **Before:** The Mosaic Tool ("Ψηφιδωτόν") prints AssemblyErrors directly onto the Subject column as a squashed text without specific warning indicators, e.g. "Error: Διπλοῦν ὑποκείμενον...".

✨ **After:** The Mosaic Tool ("Ψηφιδωτόν") wraps AssemblyErrors onto the Subject column with a descriptive `⚠️ Σφάλμα (Error):` label, new line and bold text for clarity and visual hierarchy.

🖼️ **Visuals:** The "Subject (Nom)" column now contains the following styled item when encountering an assembly error:
⚠️ Σφάλμα (Error):
Διπλοῦν ὑποκείμενον! Δύο βασιλεῖς οὐ δύνανται μιᾶς πόλεως ἄρχειν.

---
*PR created automatically by Jules for task [16969759486810092588](https://jules.google.com/task/16969759486810092588) started by @madmax983*