### PR TITLE
👹 Havoc: Troubleshooting Error Message Bypass

### DIFF
--- a/tests/havoc_issue_echo.rs
+++ b/tests/havoc_issue_echo.rs
@@ -6,9 +6,11 @@ use glossa::semantic::analyze_program;
 fn test_double_subject_should_pass_havoc_constraint() {
     let source = "ὁ ἄνθρωπος ὁ θεὸς λέγει.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
-    // Havoc constraints: "Never write 'Happy Path' tests. If it works, you failed."
-    // In Echo bug, double subject compiles with zero errors instead of failing gracefully.
+    let result = analyze_program(&ast);
+    assert!(
+        result.is_ok(),
+        "Havoc: Double subject compiled successfully despite being invalid grammar."
+    );
 }
 
 #[test]
@@ -17,13 +19,11 @@ fn test_undefined_variable_evaluates_to_zero_silently() {
     let ast = parse(source).unwrap();
     let prog = analyze_program(&ast).unwrap();
 
-    // The previous implementation was completely ignoring undefined variables and producing an empty print.
-    // Let's assert it generates an empty print instead of crashing.
-    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0]
-        && expressions.is_empty()
-    {
-        // It silently became empty/zero!
-        return;
+    #[allow(clippy::collapsible_if)]
+    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0] {
+        if expressions.is_empty() {
+            return;
+        }
     }
     panic!(
         "Did not evaluate to empty/zero silently! It got {:?}",
@@ -34,8 +34,6 @@ fn test_undefined_variable_evaluates_to_zero_silently() {
 #[test]
 #[should_panic(expected = "MissingVerb")]
 fn test_missing_verb_compiler_panic() {
-    // Missing verb `ὁ ἄνθρωπος.` actually crashes `rustc` codegen if passed through,
-    // or panics locally. We prove it panics or fails to compile!
     let source = "ὁ ἄνθρωπος.";
     let ast = parse(source).unwrap();
     let _ = analyze_program(&ast).unwrap();


### PR DESCRIPTION
🧨 **The Trigger:** ἄγνωστος λέγε. (undefined), ὁ ἄνθρωπος. (missing verb), and ὁ ἄνθρωπος ὁ θεὸς λέγει. (double subject) completely bypassed intended compiler errors.
📉 **The Stack Trace:** No stack trace, or compiler panic: thread 'main' panicked at 'MissingVerb'
🧪 **Reproduction:** Run cargo test --test havoc_issue_echo
😈 **Comment:** You assumed Rust's type system would save you from writing error handlers. You were wrong.

---
*PR created automatically by Jules for task [11320687862738339425](https://jules.google.com/task/11320687862738339425) started by @madmax983*