### PR TITLE
🎸 Bard: Clarified and enforced Double Subject and Undefined Name errors

### DIFF
--- a/src/errors/assembly.rs
+++ b/src/errors/assembly.rs
@@ -22,8 +22,18 @@ use thiserror::Error;
 pub enum AssemblyError {
     /// Two subjects found in the same statement (Nominative collision)
     ///
+    /// This error prevents ambiguity in sentences by ensuring there is only ever one
+    /// active subject (nominative noun) driving the action of the verb.
+    ///
     /// # Example
     /// `ὁ ἄνθρωπος ὁ θεὸς λέγει` (The man the god says)
+    ///
+    /// ```rust
+    /// use glossa::errors::AssemblyError;
+    ///
+    /// let error = AssemblyError::DoubleSubject;
+    /// assert!(error.to_string().contains("Διπλοῦν ὑποκείμενον"));
+    /// ```
     #[error("Διπλοῦν ὑποκείμενον! Δύο βασιλεῖς οὐ δύνανται μιᾶς πόλεως ἄρχειν.")]
     #[diagnostic(code(glossa::assembly::double_subject))]
     DoubleSubject,
@@ -54,8 +64,18 @@ pub enum AssemblyError {
 
     /// Missing verb in a statement
     ///
+    /// This error ensures that all complete thoughts and actions have a driving force.
+    /// Without a verb, the compiler cannot determine the semantic intent of the statement.
+    ///
     /// # Example
     /// `ὁ ἄνθρωπος.` (The man.)
+    ///
+    /// ```rust
+    /// use glossa::errors::AssemblyError;
+    ///
+    /// let error = AssemblyError::MissingVerb;
+    /// assert!(error.to_string().contains("Ῥῆμα οὐχ εὑρέθη"));
+    /// ```
     #[error("Ῥῆμα οὐχ εὑρέθη! ἄνευ ῥήματος πρᾶξις οὐκ ἔστιν.")]
     #[diagnostic(code(glossa::assembly::missing_verb))]
     MissingVerb,

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -235,6 +235,18 @@ impl GlossaError {
 
     /// Creates a new `GlossaError::UndefinedName`.
     ///
+    /// This error is returned when you try to use a variable or function that has not
+    /// been explicitly defined (e.g. using `ἔστω` for bindings or `ὁρίζειν` for functions).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use glossa::errors::GlossaError;
+    ///
+    /// let error = GlossaError::undefined("ἄγνωστος");
+    /// assert!(matches!(error, GlossaError::UndefinedName { .. }));
+    /// ```
+    ///
     /// This specific semantic error is thrown when code attempts to reference a variable,
     /// type, or function that hasn't been defined in the current or parent [`Scope`].
     ///


### PR DESCRIPTION
📖 Chapter: Compiler Errors\n💡 Insight: Added context on *why* `DoubleSubject`, `MissingVerb`, and `UndefinedName` errors exist.\n🧪 Example: Included executable doctests for error constructors.\n🖼️ Preview: All doctests passing.

---
*PR created automatically by Jules for task [11190558099702692949](https://jules.google.com/task/11190558099702692949) started by @madmax983*