### PR TITLE
🎻 Bard: [Resolved missing documentation warning in codegen]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,7 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+
+## 2026-03-22 - [Rustdoc missing_docs due to intermediate use statements]
+**Confusion:** Placing a `use` statement (like `use std::fmt::Write;`) directly between a `///` doc comment and the function signature it documents (e.g., `pub fn to_rust_type(...)`) breaks the linkage. Rustdoc attaches the documentation to the `use` statement instead of the function, triggering a `missing_docs` warning for the function.
+**Clarification:** To fix this, moved the `use` statement above the documentation block. This successfully resolves the `missing_docs` warning by correctly linking the documentation to the function.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module.
💡 Insight: The `to_rust_type` function was missing documentation because the `///` comment block was separated from the function definition by an intermediate `use std::fmt::Write;` statement. This caused Rustdoc to incorrectly link the documentation to the `use` statement. Moving the `use` statement above the comment fixed the warning.
🧪 Example: Verified via `RUSTDOCFLAGS="-W missing_docs" cargo doc --no-deps`.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [11714773828892062951](https://jules.google.com/task/11714773828892062951) started by @madmax983*