### PR TITLE
🗣️ Echo: Getting Started errors don't match the documentation and confusing warnings

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -105,9 +105,9 @@ pub enum GlossaError {
     ///
     /// # Example Output
     /// ```text
-    /// Ἄγνωστον ὄνομα: ξ
+    /// Οὐκ οἶδα τὸ ὄνομα: ξ
     /// ```
-    #[error("Ἄγνωστον ὄνομα: {name}")]
+    #[error("Οὐκ οἶδα τὸ ὄνομα: {name}")]
     #[diagnostic(code(glossa::undefined))]
     UndefinedName {
         /// The identifier (variable or function name) that the compiler could not resolve in the current scope.
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     fn test_undefined_error() {
         let err = GlossaError::undefined("ξ");
-        assert!(err.to_string().contains("Ἄγνωστον ὄνομα"));
+        assert!(err.to_string().contains("Οὐκ οἶδα τὸ ὄνομα"));
         assert!(err.to_string().contains("ξ"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,11 +183,13 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
-
         Some(Commands::Scholar { input }) => {
             #[cfg(feature = "nova")]
             glossa::tools::scholar::run_scholar(&input)?;

--- a/tests/razor_coverage.rs
+++ b/tests/razor_coverage.rs
@@ -26,7 +26,7 @@ fn test_errors_display_impls() {
     assert_eq!(err_semantic.category_greek(), "Σημασία");
 
     let err_undefined = GlossaError::undefined("x");
-    assert!(format!("{}", err_undefined).contains("Ἄγνωστον ὄνομα"));
+    assert!(format!("{}", err_undefined).contains("Οὐκ οἶδα τὸ ὄνομα"));
     assert_eq!(err_undefined.category_greek(), "Ὄνομα");
 
     let err_agreement = GlossaError::agreement("test");

--- a/tests/reproduce_silent_failure.rs
+++ b/tests/reproduce_silent_failure.rs
@@ -22,7 +22,7 @@ fn test_undefined_struct_type_error() {
             assert!(
                 msg.contains("Χρήστος")
                     || msg.contains("undefined")
-                    || msg.contains("Ἄγνωστον")
+                    || msg.contains("Οὐκ οἶδα τὸ")
                     || msg.contains("Άγνωστον")
             );
         }


### PR DESCRIPTION
🤦 **The Confusion:** "I tried following the README's troubleshooting table when I forgot to declare a variable, but the compiler spat out `Ἄγνωστον ὄνομα` instead of the promised `Οὐκ οἶδα τὸ ὄνομα`. Also, just running the compiler throws a warning about an unused `input` in `gnomon` when I don't even have the `nova` feature enabled!"
🕵️ **The Reality:** "The error message in the code diverged from the documentation. Also, the `Gnomon` command didn't discard its `input` variable when compiled without `nova`."
💡 **The Fix:** "Changed the compiler's error message to actually match what the README promises (`Οὐκ οἶδα τὸ ὄνομα`), and fixed the unused variable warning."

---
*PR created automatically by Jules for task [12978456484383325324](https://jules.google.com/task/12978456484383325324) started by @madmax983*