### PR TITLE
⚡ Bolt: Pre-allocate capacity in morphology analysis

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**Pre-allocating Vectors in Morphology Analysis**
+**Learning:** Functions like `analyze_verb_all` and `analyze_noun_all` are called frequently on the hot path during semantic parsing. Using `Vec::new()` requires the vector to reallocate heap memory multiple times as forms are generated.
+**Action:** When a function routinely returns a small, bounded number of elements (like 2-4 morphological variants), prefer `Vec::with_capacity(4)` over `Vec::new()` to eliminate reallocation overhead while keeping memory footprint negligible.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,16 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1.  **Refactor `analyze_verb_all` and `analyze_noun_all` to pre-allocate capacity**
+    -   In `src/morphology/conjugation.rs`, modify `analyze_verb_all` to use `Vec::with_capacity(4)` instead of `Vec::new()`.
+    -   In `src/morphology/declension.rs`, modify `analyze_noun_all` to use `Vec::with_capacity(4)` instead of `Vec::new()`.
+    -   This prevents reallocations on the hot path for morphology matching, which is called frequently during lexical analysis.
+
+2.  **Add documentation explaining the optimization**
+    -   Add doc comments with `/// ⚡ Bolt Optimization:` explaining that we pre-allocate to prevent reallocation during morphology analysis.
+
+3.  **Run tests and linters**
+    -   Execute `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test` and `cargo fmt --all`.
+
+4.  **Complete pre commit steps**
+    -   Ensure proper testing, verification, review, and reflection are done.
+
+5.  **Submit PR**
+    -   Create a pull request titled "⚡ Bolt: Pre-allocate capacity in morphology analysis" following the PR format.

--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -526,7 +526,8 @@ where
 /// - 2nd person singular present imperative (λέγε!)
 /// - 3rd person singular aorist indicative (ἔλυσε)
 pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    // ⚡ Bolt Optimization: Pre-allocate capacity to prevent reallocation on hot path
+    let mut analyses = Vec::with_capacity(4);
     analyze_verb_all_into(word, &mut analyses);
     analyses
 }

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -204,7 +204,8 @@ where
 ///
 /// The caller should use syntactic context to pick the right one.
 pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    // ⚡ Bolt Optimization: Pre-allocate capacity to prevent reallocation on hot path
+    let mut analyses = Vec::with_capacity(4);
     analyze_noun_all_into(word, &mut analyses);
     analyses
 }


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(4)` in `analyze_verb_all` and `analyze_noun_all`.
🎯 Why: These functions are called frequently during lexical analysis, and pre-allocating avoids reallocation overhead on the hot path.
📊 Impact: Reduces heap allocations and reallocations when collecting morphological analyses.
🔬 Measurement: Run `cargo test` and `cargo bench` if available to verify there are no regressions.

---
*PR created automatically by Jules for task [13708852056642959125](https://jules.google.com/task/13708852056642959125) started by @madmax983*