### PR TITLE
🪒 Razor: Fix unused variable in Gnomon command

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction] Fix unused variable warning in Gnomon
+**Bloat:** Unused variable `input` warning for `Commands::Gnomon` without `nova` feature.
+**Cut:** Bound the variable explicitly using `let _ = input;` to avoid the clippy warning.
+**Saved:** 0 lines, but eliminates noise and cognitive load on CI.

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {


### PR DESCRIPTION
## 🪒 Razor's Cut

**Bloat:** Unused variable `input` warning for `Commands::Gnomon` without `nova` feature.
**Cut:** Bound the variable explicitly using `let _ = input;` to avoid the clippy warning.
**Saved:** 0 lines, but eliminates noise and cognitive load on CI.

---
*PR created automatically by Jules for task [2799998558650565537](https://jules.google.com/task/2799998558650565537) started by @madmax983*