### PR TITLE
⚒️ Forge: Flatten nested loop in report traversal

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,6 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+**Refactored Report tool visit_statement logic**
+**Learning:** Found a Pyramid of Doom with deep nesting inside `TraitImplementation` match arm.
+**Action:** Extracted the logic into a separate `visit_methods_body` helper function to flatten the structure using an early return.

--- a/log_forge.py
+++ b/log_forge.py
@@ -1,0 +1,7 @@
+content = """**Refactored Report tool visit_statement logic**
+**Learning:** Found a Pyramid of Doom with deep nesting inside `TraitImplementation` match arm.
+**Action:** Extracted the logic into a separate `visit_methods_body` helper function to flatten the structure using an early return.
+"""
+
+with open('.jules/forge.md', 'a') as f:
+    f.write(content)

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -185,14 +185,18 @@ impl ProgramStats {
             AnalyzedStatement::TypeDefinition { .. } => {} // Already counted in scope
             AnalyzedStatement::TraitDefinition { .. } => {} // Already counted in scope
             AnalyzedStatement::TraitImplementation { methods, .. } => {
-                // Visit trait method implementations to get complete expression coverage
-                for method in methods {
-                    if let Some(body) = &method.body {
-                        for s in body {
-                            self.visit_statement(s, depth + 1);
-                        }
-                    }
-                }
+                self.visit_methods_body(methods, depth);
+            }
+        }
+    }
+
+    fn visit_methods_body(&mut self, methods: &[crate::semantic::AnalyzedMethod], depth: usize) {
+        for method in methods {
+            let Some(body) = &method.body else {
+                continue;
+            };
+            for s in body {
+                self.visit_statement(s, depth + 1);
             }
         }
     }


### PR DESCRIPTION
🚷 Smell: The `visit_statement` function in `src/tools/report.rs` had a deeply nested Pyramid of Doom (`for` inside `if let` inside `for` inside `match`) when handling `TraitImplementation`.
✨ Solution: Extracted the trait method traversal logic into a new private helper function `visit_methods_body` and used a guard clause (`let Some(body) = ... else { continue; }`) to flatten the nesting.
🧹 Benefit: Reduces cognitive load and strictly follows the "Flatten the structure" principle, making the traversal code significantly easier to read.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [7423235320095993354](https://jules.google.com/task/7423235320095993354) started by @madmax983*