### PR TITLE
🎨 Mosaic: UI Polish for Scholar and Tester

### DIFF
--- a/src/tools/scholar.rs
+++ b/src/tools/scholar.rs
@@ -132,6 +132,22 @@ pub fn run_scholar(input: &Path) -> Result<()> {
     println!("   {}", "Γ Λ Ω Σ Σ Α   S C H O L A R".bold().cyan());
     println!("   {}", "API Documentation Generated".italic().dim());
     println!();
+
+    let mut table = comfy_table::Table::new();
+    table
+        .load_preset(comfy_table::presets::UTF8_FULL)
+        .set_content_arrangement(comfy_table::ContentArrangement::Dynamic)
+        .set_header(vec![
+            comfy_table::Cell::new("Markdown Preview").add_attribute(comfy_table::Attribute::Bold),
+        ]);
+
+    // Format the markdown preview into the table
+    // Using a single cell with the full markdown content to maintain formatting
+    table.add_row(vec![comfy_table::Cell::new(&md)]);
+
+    println!("{table}");
+
+    println!();
     println!(
         "   {} {}",
         "Saved to:".bold(),

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -345,7 +345,7 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         empty_table.set_header(vec![
             Cell::new("Status")
                 .add_attribute(Attribute::Bold)
-                .fg(Color::Yellow),
+                .fg(Color::DarkGrey),
         ]);
         empty_table.add_row(vec![
             Cell::new("No tests found.")
@@ -354,6 +354,7 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                 .set_alignment(CellAlignment::Center),
         ]);
         println!("{empty_table}");
+        println!();
     }
 
     // If there were failures, try to extract and print them nicely


### PR DESCRIPTION
🖌️ **Before:** The `scholar` tool only printed "Saved to: doc.md" with no dashboard preview, and the `tester` tool displayed "No tests found" with bright yellow colors that didn't properly recede into the visual hierarchy.
✨ **After:** The `scholar` tool now prints a full Markdown Preview inside a comfy-table, making it consistent with other analysis tools. The `tester` tool displays the empty state table using dark grey colors to push it back in the visual hierarchy.
🖼️ **Visuals:** A comfy-table displaying the exact generated markdown text is output when using `scholar`, and the `tester` empty table has padding and uses `Color::DarkGrey`.

**Assumption Documented:** As per the prompt to proceed autonomously, it is assumed that outputting the markdown generated by `scholar` using `comfy_table` is acceptable and that displaying the content won't be overwhelmingly large, or that the CLI environment gracefully handles tall table outputs.

---
*PR created automatically by Jules for task [13012530905487915706](https://jules.google.com/task/13012530905487915706) started by @madmax983*