### PR TITLE
⚡ Bolt: Remove intermediate allocations in AST formatting

### DIFF
--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -14,7 +14,7 @@ use crate::morphology::lexicon::{BinaryOp, UnaryOp};
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
-use std::fmt::Write;
+
 use std::path::Path;
 
 /// Run the Alchemist tool on a file
@@ -71,16 +71,6 @@ pub fn transpile_to_python(program: &AnalyzedProgram) -> String {
     out
 }
 
-fn format_transpiled_exprs(exprs: &[AnalyzedExpr]) -> String {
-    let mut buf = String::with_capacity(exprs.len() * 16);
-    for (i, expr) in exprs.iter().enumerate() {
-        if i > 0 {
-            buf.push_str(", ");
-        }
-        buf.push_str(&transpile_expr(expr));
-    }
-    buf
-}
 
 fn transpile_statement(stmt: &AnalyzedStatement, indent: usize) -> String {
     let ind = "    ".repeat(indent);
@@ -95,7 +85,9 @@ fn transpile_statement(stmt: &AnalyzedStatement, indent: usize) -> String {
             )
         }
         AnalyzedStatement::Query(exprs) => {
-            format!("{}print({})", ind, format_transpiled_exprs(exprs))
+            let mut exprs_buf = String::with_capacity(exprs.len() * 16);
+            write_format_transpiled_exprs(exprs, &mut exprs_buf);
+            format!("{}print({})", ind, exprs_buf)
         }
         AnalyzedStatement::Assignment { name, value } => {
             format!(
@@ -126,7 +118,9 @@ fn transpile_statement(stmt: &AnalyzedStatement, indent: usize) -> String {
             }
         }
         AnalyzedStatement::Print(exprs) => {
-            format!("{}print({})", ind, format_transpiled_exprs(exprs))
+            let mut exprs_buf = String::with_capacity(exprs.len() * 16);
+            write_format_transpiled_exprs(exprs, &mut exprs_buf);
+            format!("{}print({})", ind, exprs_buf)
         }
         AnalyzedStatement::Expression(exprs) => {
             let mut out = String::new();
@@ -334,98 +328,105 @@ fn transpile_match(
     out.trim_end().to_string()
 }
 
+/// ⚡ Bolt Optimization: Uses a mutable `String` buffer to avoid O(n) heap allocations during recursive AST formatting.
 fn transpile_expr(expr: &AnalyzedExpr) -> String {
+    let mut buf = String::with_capacity(64);
+    write_transpiled_expr(expr, &mut buf);
+    buf
+}
+
+fn write_transpiled_expr(expr: &AnalyzedExpr, buf: &mut String) {
+    use std::fmt::Write;
+
     match &expr.expr {
-        AnalyzedExprKind::NumberLiteral(n) => n.to_string(),
-        AnalyzedExprKind::StringLiteral(s) => format!("\"{}\"", s),
-        AnalyzedExprKind::BooleanLiteral(b) => (if *b { "True" } else { "False" }).to_string(),
-        AnalyzedExprKind::Variable(name) => sanitize_ident(name),
+        AnalyzedExprKind::NumberLiteral(n) => { let _ = write!(buf, "{}", n); }
+        AnalyzedExprKind::StringLiteral(s) => { let _ = write!(buf, "\"{}\"", s); }
+        AnalyzedExprKind::BooleanLiteral(b) => { buf.push_str(if *b { "True" } else { "False" }); }
+        AnalyzedExprKind::Variable(name) => { buf.push_str(&sanitize_ident(name)); }
         AnalyzedExprKind::PropertyAccess { owner, property } => {
-            format!("{}.{}", transpile_expr(owner), sanitize_ident(property))
+            write_transpiled_expr(owner, buf);
+            let _ = write!(buf, ".{}", sanitize_ident(property));
         }
         AnalyzedExprKind::VerbCall { verb, args } => {
             // Map certain known verbs to Python built-ins if applicable. For now, general function call.
-            format!(
-                "{}({})",
-                sanitize_ident(verb),
-                format_transpiled_exprs(args)
-            )
+            let _ = write!(buf, "{}(", sanitize_ident(verb));
+            write_format_transpiled_exprs(args, buf);
+            buf.push(')');
         }
         AnalyzedExprKind::FunctionCall { func, args } => {
-            format!(
-                "{}({})",
-                sanitize_ident(func),
-                format_transpiled_exprs(args)
-            )
+            let _ = write!(buf, "{}(", sanitize_ident(func));
+            write_format_transpiled_exprs(args, buf);
+            buf.push(')');
         }
-        AnalyzedExprKind::StructInstantiation {
-            type_name,
-            fields,
-            args,
-        } => {
-            let mut kw_args_buf = String::with_capacity(fields.len() * 16);
+        AnalyzedExprKind::StructInstantiation { type_name, fields, args } => {
+            let _ = write!(buf, "{}(", sanitize_ident(type_name));
             for (i, (f, a)) in fields.iter().zip(args.iter()).enumerate() {
-                if i > 0 {
-                    kw_args_buf.push_str(", ");
-                }
-                let _ = write!(
-                    &mut kw_args_buf,
-                    "{}={}",
-                    sanitize_ident(f),
-                    transpile_expr(a)
-                );
+                if i > 0 { buf.push_str(", "); }
+                let _ = write!(buf, "{}=", sanitize_ident(f));
+                write_transpiled_expr(a, buf);
             }
-            format!("{}({})", sanitize_ident(type_name), kw_args_buf)
+            buf.push(')');
         }
-        AnalyzedExprKind::Range {
-            start,
-            end,
-            inclusive,
-        } => {
-            let s = transpile_expr(start);
-            let e = transpile_expr(end);
-            if *inclusive {
-                format!("range({}, {} + 1)", s, e)
-            } else {
-                format!("range({}, {})", s, e)
-            }
+        AnalyzedExprKind::Range { start, end, inclusive } => {
+            buf.push_str("range(");
+            write_transpiled_expr(start, buf);
+            buf.push_str(", ");
+            write_transpiled_expr(end, buf);
+            if *inclusive { buf.push_str(" + 1"); }
+            buf.push(')');
         }
         AnalyzedExprKind::ArrayLiteral(exprs) => {
-            format!("[{}]", format_transpiled_exprs(exprs))
+            buf.push('[');
+            write_format_transpiled_exprs(exprs, buf);
+            buf.push(']');
         }
         AnalyzedExprKind::BinOp { left, op, right } => {
-            let l = transpile_expr(left);
-            let r = transpile_expr(right);
+            buf.push('(');
+            write_transpiled_expr(left, buf);
             let op_str = match op {
-                BinaryOp::Add => "+",
-                BinaryOp::Sub => "-",
-                BinaryOp::Mul => "*",
-                BinaryOp::Div => "//", // Integer division in Python
-                BinaryOp::Mod => "%",
-                BinaryOp::Eq => "==",
-                BinaryOp::Ne => "!=",
-                BinaryOp::Lt => "<",
-                BinaryOp::Le => "<=",
-                BinaryOp::Gt => ">",
-                BinaryOp::Ge => ">=",
-                BinaryOp::And => "and",
-                BinaryOp::Or => "or",
+                BinaryOp::Add => " + ",
+                BinaryOp::Sub => " - ",
+                BinaryOp::Mul => " * ",
+                BinaryOp::Div => " // ",
+                BinaryOp::Mod => " % ",
+                BinaryOp::Eq => " == ",
+                BinaryOp::Ne => " != ",
+                BinaryOp::Lt => " < ",
+                BinaryOp::Le => " <= ",
+                BinaryOp::Gt => " > ",
+                BinaryOp::Ge => " >= ",
+                BinaryOp::And => " and ",
+                BinaryOp::Or => " or ",
             };
-            format!("({} {} {})", l, op_str, r)
+            buf.push_str(op_str);
+            write_transpiled_expr(right, buf);
+            buf.push(')');
         }
         AnalyzedExprKind::UnaryOp { op, operand } => {
-            let o = transpile_expr(operand);
             match op {
-                UnaryOp::Neg => format!("-{}", o),
-                UnaryOp::Not => format!("not {}", o),
-                UnaryOp::Ref => o, // Python does not have explicit references
+                UnaryOp::Neg => {
+                    buf.push('-');
+                    write_transpiled_expr(operand, buf);
+                }
+                UnaryOp::Not => {
+                    buf.push_str("not ");
+                    write_transpiled_expr(operand, buf);
+                }
+                UnaryOp::Ref => {
+                    write_transpiled_expr(operand, buf);
+                }
             }
         }
-        // Fallback for unsupported complex expressions like Try, Option variants, etc.
-        _ => format!(
-            "/* Unimplemented expr: {} */",
-            crate::tools::narrator::tell_expr(expr)
-        ),
+        _ => {
+            let _ = write!(buf, "/* Unimplemented expr: {} */", crate::tools::narrator::tell_expr(expr));
+        }
+    }
+}
+
+fn write_format_transpiled_exprs(exprs: &[AnalyzedExpr], buf: &mut String) {
+    for (i, expr) in exprs.iter().enumerate() {
+        if i > 0 { buf.push_str(", "); }
+        write_transpiled_expr(expr, buf);
     }
 }
 

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -183,16 +183,6 @@ fn add_assignment(table: &mut Table, prefix: &str, name: &str, value: &AnalyzedE
     ]);
 }
 
-fn format_exprs(exprs: &[AnalyzedExpr]) -> String {
-    let mut buf = String::with_capacity(exprs.len() * 16);
-    for (i, expr) in exprs.iter().enumerate() {
-        if i > 0 {
-            buf.push_str(", ");
-        }
-        buf.push_str(&tell_expr(expr));
-    }
-    buf
-}
 
 fn format_types(types: &[GlossaType]) -> String {
     let mut buf = String::with_capacity(types.len() * 16);
@@ -206,7 +196,9 @@ fn format_types(types: &[GlossaType]) -> String {
 }
 
 fn add_print(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
-    let script = format!("Proclaim: {}", format_exprs(exprs));
+            let mut exprs_buf = String::with_capacity(exprs.len() * 16);
+            write_exprs(exprs, &mut exprs_buf);
+    let script = format!("Proclaim: {}", exprs_buf);
     table.add_row(vec![
         Cell::new("PRINT").fg(Color::Green),
         Cell::new(format!("{}{}", prefix, script)),
@@ -215,7 +207,9 @@ fn add_print(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
 }
 
 fn add_expression(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
-    let script = format!("Do: {}", format_exprs(exprs));
+            let mut exprs_buf = String::with_capacity(exprs.len() * 16);
+            write_exprs(exprs, &mut exprs_buf);
+    let script = format!("Do: {}", exprs_buf);
     table.add_row(vec![
         Cell::new("EXPR").fg(Color::DarkGrey),
         Cell::new(format!("{}{}", prefix, script)),
@@ -224,7 +218,9 @@ fn add_expression(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
 }
 
 fn add_query(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
-    let script = format!("Query oracle: {}", format_exprs(exprs));
+            let mut exprs_buf = String::with_capacity(exprs.len() * 16);
+            write_exprs(exprs, &mut exprs_buf);
+    let script = format!("Query oracle: {}", exprs_buf);
     table.add_row(vec![
         Cell::new("QUERY").fg(Color::Magenta),
         Cell::new(format!("{}{}", prefix, script)),
@@ -452,109 +448,132 @@ fn add_test_decl(
 /// into linear, human-readable strings. Unlike a standard `Debug` representation
 /// which outputs nested structs, this formats operations in a pseudo-code style
 /// that is immediately recognizable to developers.
+/// ⚡ Bolt Optimization: Uses a mutable `String` buffer to avoid O(n) heap allocations during recursive AST formatting.
 pub(crate) fn tell_expr(expr: &AnalyzedExpr) -> String {
+    let mut buf = String::with_capacity(64);
+    write_expr(expr, &mut buf);
+    buf
+}
+
+fn write_expr(expr: &AnalyzedExpr, buf: &mut String) {
+    use std::fmt::Write;
     match &expr.expr {
-        AnalyzedExprKind::StringLiteral(s) => format!("\"{}\"", s),
-        AnalyzedExprKind::NumberLiteral(n) => format!("{}", n),
-        AnalyzedExprKind::BooleanLiteral(b) => format!("{}", b),
-        AnalyzedExprKind::Variable(name) => format!("`{}`", name),
-        AnalyzedExprKind::VerbCall { verb, args } => tell_verb_call(verb, args),
+        AnalyzedExprKind::StringLiteral(s) => { let _ = write!(buf, "\"{}\"", s); }
+        AnalyzedExprKind::NumberLiteral(n) => { let _ = write!(buf, "{}", n); }
+        AnalyzedExprKind::BooleanLiteral(b) => { let _ = write!(buf, "{}", b); }
+        AnalyzedExprKind::Variable(name) => { let _ = write!(buf, "`{}`", name); }
+        AnalyzedExprKind::VerbCall { verb, args } => {
+            let _ = write!(buf, "{}(", verb);
+            write_exprs(args, buf);
+            buf.push(')');
+        }
         AnalyzedExprKind::BinOp { left, op, right } => {
-            format!("({} {:?} {})", tell_expr(left), op, tell_expr(right))
+            buf.push('(');
+            write_expr(left, buf);
+            let _ = write!(buf, " {:?} ", op);
+            write_expr(right, buf);
+            buf.push(')');
         }
         AnalyzedExprKind::UnaryOp { op, operand } => {
-            format!("({:?} {})", op, tell_expr(operand))
+            let _ = write!(buf, "({:?} ", op);
+            write_expr(operand, buf);
+            buf.push(')');
         }
-        AnalyzedExprKind::Range {
-            start,
-            end,
-            inclusive,
-        } => {
-            let range_op = if *inclusive { "..=" } else { ".." };
-            format!("{}{}{}", tell_expr(start), range_op, tell_expr(end))
+        AnalyzedExprKind::Range { start, end, inclusive } => {
+            write_expr(start, buf);
+            buf.push_str(if *inclusive { "..=" } else { ".." });
+            write_expr(end, buf);
         }
-        AnalyzedExprKind::ArrayLiteral(exprs) => tell_array_literal(exprs),
-        AnalyzedExprKind::Some(e) => format!("Some({})", tell_expr(e)),
-        AnalyzedExprKind::None => "None".to_string(),
-        AnalyzedExprKind::Ok(e) => format!("Ok({})", tell_expr(e)),
-        AnalyzedExprKind::Err(e) => format!("Err({})", tell_expr(e)),
-        AnalyzedExprKind::Unwrap(e) => format!("{}!", tell_expr(e)),
-        AnalyzedExprKind::Try(e) => format!("{}?", tell_expr(e)),
+        AnalyzedExprKind::ArrayLiteral(exprs) => {
+            buf.push('[');
+            write_exprs(exprs, buf);
+            buf.push(']');
+        }
+        AnalyzedExprKind::Some(e) => {
+            buf.push_str("Some(");
+            write_expr(e, buf);
+            buf.push(')');
+        }
+        AnalyzedExprKind::None => buf.push_str("None"),
+        AnalyzedExprKind::Ok(e) => {
+            buf.push_str("Ok(");
+            write_expr(e, buf);
+            buf.push(')');
+        }
+        AnalyzedExprKind::Err(e) => {
+            buf.push_str("Err(");
+            write_expr(e, buf);
+            buf.push(')');
+        }
+        AnalyzedExprKind::Unwrap(e) => {
+            write_expr(e, buf);
+            buf.push('!');
+        }
+        AnalyzedExprKind::Try(e) => {
+            write_expr(e, buf);
+            buf.push('?');
+        }
         AnalyzedExprKind::IndexAccess { array, index } => {
-            format!("{}[{}]", tell_expr(array), tell_expr(index))
+            write_expr(array, buf);
+            buf.push('[');
+            write_expr(index, buf);
+            buf.push(']');
         }
-        AnalyzedExprKind::FunctionCall { func, args } => tell_function_call(func, args),
-        AnalyzedExprKind::MethodCall {
-            receiver,
-            method,
-            args,
-        } => tell_method_call(receiver, method, args),
-        AnalyzedExprKind::StructInstantiation {
-            type_name,
-            fields,
-            args,
-        } => tell_struct_instantiation(type_name, fields, args),
-        AnalyzedExprKind::Lambda {
-            params,
-            body,
-            capture_mode,
-        } => tell_lambda(params, body, capture_mode),
+        AnalyzedExprKind::FunctionCall { func, args } => {
+            let _ = write!(buf, "{}(", func);
+            write_exprs(args, buf);
+            buf.push(')');
+        }
+        AnalyzedExprKind::MethodCall { receiver, method, args } => {
+            write_expr(receiver, buf);
+            let _ = write!(buf, ".{}(", method);
+            write_exprs(args, buf);
+            buf.push(')');
+        }
+        AnalyzedExprKind::StructInstantiation { type_name, fields, args } => {
+            let _ = write!(buf, "{} {{ ", type_name);
+            for (i, (f, a)) in fields.iter().zip(args.iter()).enumerate() {
+                if i > 0 { buf.push_str(", "); }
+                let _ = write!(buf, "{}: ", f);
+                write_expr(a, buf);
+            }
+            buf.push_str(" }");
+        }
+        AnalyzedExprKind::Lambda { params, body, capture_mode } => {
+            let mode = match capture_mode {
+                CaptureMode::Borrow => "",
+                CaptureMode::Move => "move ",
+            };
+            let _ = write!(buf, "{}|{}| ", mode, params.join(", "));
+            write_expr(body, buf);
+        }
         AnalyzedExprKind::CollectionNew { collection_type } => {
-            format!("{}::new()", collection_type)
+            let _ = write!(buf, "{}::new()", collection_type);
         }
         AnalyzedExprKind::Assert { condition } => {
-            format!("assert({})", tell_expr(condition))
+            buf.push_str("assert(");
+            write_expr(condition, buf);
+            buf.push(')');
         }
         AnalyzedExprKind::AssertEq { left, right } => {
-            format!("assert_eq({}, {})", tell_expr(left), tell_expr(right))
+            buf.push_str("assert_eq(");
+            write_expr(left, buf);
+            buf.push_str(", ");
+            write_expr(right, buf);
+            buf.push(')');
         }
         AnalyzedExprKind::PropertyAccess { owner, property } => {
-            format!("{}.{}", tell_expr(owner), property)
+            write_expr(owner, buf);
+            let _ = write!(buf, ".{}", property);
         }
     }
 }
 
-fn tell_verb_call(verb: &str, args: &[AnalyzedExpr]) -> String {
-    format!("{}({})", verb, format_exprs(args))
-}
-
-fn tell_array_literal(exprs: &[AnalyzedExpr]) -> String {
-    format!("[{}]", format_exprs(exprs))
-}
-
-fn tell_function_call(func: &str, args: &[AnalyzedExpr]) -> String {
-    format!("{}({})", func, format_exprs(args))
-}
-
-fn tell_method_call(receiver: &AnalyzedExpr, method: &str, args: &[AnalyzedExpr]) -> String {
-    format!("{}.{}({})", tell_expr(receiver), method, format_exprs(args))
-}
-
-fn tell_struct_instantiation(
-    type_name: &str,
-    fields: &[smol_str::SmolStr],
-    args: &[AnalyzedExpr],
-) -> String {
-    let mut buf = String::with_capacity(fields.len() * 16);
-    for (i, (f, a)) in fields.iter().zip(args.iter()).enumerate() {
-        if i > 0 {
-            buf.push_str(", ");
-        }
-        let _ = write!(&mut buf, "{}: {}", f, tell_expr(a));
+fn write_exprs(exprs: &[AnalyzedExpr], buf: &mut String) {
+    for (i, expr) in exprs.iter().enumerate() {
+        if i > 0 { buf.push_str(", "); }
+        write_expr(expr, buf);
     }
-    format!("{} {{ {} }}", type_name, buf)
-}
-
-fn tell_lambda(
-    params: &[smol_str::SmolStr],
-    body: &AnalyzedExpr,
-    capture_mode: &CaptureMode,
-) -> String {
-    let mode = match capture_mode {
-        CaptureMode::Borrow => "",
-        CaptureMode::Move => "move ",
-    };
-    format!("{}|{}| {}", mode, params.join(", "), tell_expr(body))
 }
 
 /// Converts a semantic type into a familiar Rust-like type signature string.


### PR DESCRIPTION
💡 What: Replaced recursive `format!` calls returning `String` in `narrator.rs` and `alchemist.rs` with `write_...` functions taking `&mut String`. Added doc comments explaining the optimization. Removed the dead `format_exprs` code.
🎯 Why: To avoid O(n) heap allocations during stringification of complex AST expressions.
📊 Impact: Removes redundant heap allocations proportional to the depth of the AST for transpilation and logs.
🔬 Measurement: Run `cargo test` to verify behavior hasn't changed.

---
*PR created automatically by Jules for task [14897565635388810976](https://jules.google.com/task/14897565635388810976) started by @madmax983*