### PR TITLE
⚒️ Forge: Refactor nova command dispatching

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+
+**Refactored `main.rs` Feature Boilerplate**
+**Learning:** Found massive repetitive boilerplate for experimental `nova` CLI commands causing a 200+ line `main` function.
+**Action:** Extracted the conditional compilation and error handling into a concise `macro_rules! run_nova_cmd`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,36 @@ use glossa::tools::runner::{
     bard_file, build_file, check_file, highlight_file, report_file, run_file,
 };
 
+macro_rules! run_nova_cmd {
+    ($cmd:path, $name:expr) => {
+        {
+            #[cfg(feature = "nova")]
+            $cmd()?;
+
+            #[cfg(not(feature = "nova"))]
+            miette::bail!(
+                "The '{}' command is experimental. Recompile glossa with '--features nova' to enable it.",
+                $name
+            );
+        }
+    };
+    ($cmd:path, $input:expr, $name:expr) => {
+        {
+            #[cfg(feature = "nova")]
+            $cmd($input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = $input;
+                miette::bail!(
+                    "The '{}' command is experimental. Recompile glossa with '--features nova' to enable it.",
+                    $name
+                );
+            }
+        }
+    };
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -22,188 +52,50 @@ fn main() -> Result<()> {
     }
 
     match cli.command {
-        Some(Commands::Run { input }) => {
-            run_file(&input)?;
-        }
+        Some(Commands::Run { input }) => run_file(&input)?,
+        Some(Commands::Build { input, output }) => build_file(&input, output.as_deref())?,
+        Some(Commands::Check { input }) => check_file(&input)?,
+        Some(Commands::Report { input }) => report_file(&input)?,
+        Some(Commands::Highlight { input }) => highlight_file(&input)?,
+        Some(Commands::Bard { input }) => bard_file(&input)?,
+        Some(Commands::Lookup { word }) => lookup_word(&word)?,
+        Some(Commands::Test { input }) => glossa::tools::tester::run_tests(&input)?,
 
-        Some(Commands::Mentor) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::mentor::run_mentor()?;
-
-            #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'mentor' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
-        }
-
-        Some(Commands::Build { input, output }) => {
-            build_file(&input, output.as_deref())?;
-        }
-
-        Some(Commands::Check { input }) => {
-            check_file(&input)?;
-        }
-
-        Some(Commands::Report { input }) => {
-            report_file(&input)?;
-        }
-
-        Some(Commands::Highlight { input }) => {
-            highlight_file(&input)?;
-        }
-
-        Some(Commands::Bard { input }) => {
-            bard_file(&input)?;
-        }
-
-        Some(Commands::Lookup { word }) => {
-            lookup_word(&word)?;
-        }
-
-        Some(Commands::Test { input }) => {
-            glossa::tools::tester::run_tests(&input)?;
-        }
+        Some(Commands::Mentor) => run_nova_cmd!(glossa::tools::mentor::run_mentor, "mentor"),
+        Some(Commands::Catalog) => run_nova_cmd!(glossa::tools::catalog::run_catalog, "catalog"),
 
         Some(Commands::Mosaic { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::mosaic::run_mosaic(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'mosaic' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+            run_nova_cmd!(glossa::tools::mosaic::run_mosaic, &input, "mosaic")
         }
-
         Some(Commands::Map { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::cartographer::run_map(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'map' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+            run_nova_cmd!(glossa::tools::cartographer::run_map, &input, "map")
         }
-
         Some(Commands::Labyrinth { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::labyrinth::run_labyrinth(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'labyrinth' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+            run_nova_cmd!(glossa::tools::labyrinth::run_labyrinth, &input, "labyrinth")
         }
-
         Some(Commands::Weave { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::weave::run_weave(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'weave' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+            run_nova_cmd!(glossa::tools::weave::run_weave, &input, "weave")
         }
-
         Some(Commands::Alchemist { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::alchemist::run_alchemist(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'alchemist' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+            run_nova_cmd!(glossa::tools::alchemist::run_alchemist, &input, "alchemist")
         }
-
         Some(Commands::Papyrus { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::papyrus::run_papyrus(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'papyrus' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+            run_nova_cmd!(glossa::tools::papyrus::run_papyrus, &input, "papyrus")
         }
-
         Some(Commands::Haruspex { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::haruspex::run_haruspex(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'haruspex' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+            run_nova_cmd!(glossa::tools::haruspex::run_haruspex, &input, "haruspex")
         }
-
         Some(Commands::Audit { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::auditor::run_auditor(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'audit' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+            run_nova_cmd!(glossa::tools::auditor::run_auditor, &input, "audit")
         }
-
-        Some(Commands::Catalog) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::catalog::run_catalog()?;
-
-            #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'catalog' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
-        }
-
         Some(Commands::Gnomon { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::gnomon::run_gnomon(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            run_nova_cmd!(glossa::tools::gnomon::run_gnomon, &input, "gnomon")
         }
-
         Some(Commands::Scholar { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::scholar::run_scholar(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'scholar' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
+            run_nova_cmd!(glossa::tools::scholar::run_scholar, &input, "scholar")
         }
 
-        Some(Commands::Repl) | None => {
-            run_repl()?;
-        }
+        Some(Commands::Repl) | None => run_repl()?,
     }
 
     Ok(())


### PR DESCRIPTION
🚮 Smell: Repetitive `#[cfg(feature = "nova")]` boilerplate across 12 subcommands in `main.rs`, bloating the function to nearly 200 lines.
✨ Solution: Extracted the conditional compilation and error handling into a `run_nova_cmd!` macro.
🧼 Benefit: Drastically reduces the size of `main()` and eliminates copy-pasted error messages and `let _ = input;` suppressions.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [4166615922116561881](https://jules.google.com/task/4166615922116561881) started by @madmax983*