### PR TITLE
🔒 Warden: [Prevent unbounded memory exhaustion in REPL/Mentor inputs]

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -131,3 +131,7 @@ Signed,
 **2026-04-30 - [Infinite Stream DoS Vulnerability in File Loading]
 **Threat:** The `load_source` function in `src/tools/runner.rs` relied on `fs::metadata().len()` to enforce the `MAX_FILE_SIZE` limit. However, special device files like `/dev/zero` report a length of 0 while producing an infinite stream of bytes when read. Reading these files with `fs::read_to_string` causes a thread hang or Out-Of-Memory (OOM) Denial-of-Service condition.
 **Defense:** Added an explicit `metadata.is_file()` check in `check_file_size` to guarantee that the input path points to a regular file and explicitly reject non-regular file types like directories and device streams. Updated `tests/havoc_dos.rs` and `test_load_source_directory_error` to assert the "Not a valid file" error and pass cleanly without timeouts.
+
+**2026-08-01 - [Unbounded Stream DoS in CLI REPL]**
+**Threat:** The interactive standard input wrappers in `src/tools/repl.rs` (`run_repl_inner`) and `src/tools/mentor.rs` (`run_mentor_inner`) used unbounded `read_line` calls. An attacker could pipe an infinite stream of characters without newlines (like `/dev/zero`) into these interactive tools to cause a memory exhaustion crash (Denial of Service).
+**Defense:** Applied a capped reader defense using `std::io::Read::take()` and `MAX_REPL_SOURCE_LEN`. By wrapping the input borrow in a bounded adapter, we protect the process memory while preserving the REPL state and test integration capabilities.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,8 @@ fn main() -> Result<()> {
         Some(Commands::Gnomon { input }) => {
             #[cfg(feature = "nova")]
             glossa::tools::gnomon::run_gnomon(&input)?;
+            #[cfg(not(feature = "nova"))]
+            let _ = input;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -127,7 +127,14 @@ fn run_mentor_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Resu
             output.flush().into_diagnostic()?;
 
             let mut line = String::new();
-            let bytes = input.read_line(&mut line).into_diagnostic()?;
+            // 🔒 Warden: Defense against unbounded input exhaustion (DoS)
+            let bytes = {
+                let mut take = std::io::Read::take(
+                    input.by_ref(),
+                    crate::tools::repl::MAX_REPL_SOURCE_LEN as u64,
+                );
+                take.read_line(&mut line).into_diagnostic()?
+            };
 
             if bytes == 0 {
                 return Ok(()); // EOF

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -268,6 +268,16 @@ mod tests {
     }
 
     #[test]
+    fn test_run_mentor_inner_capped() {
+        let input_data = " ".repeat(crate::tools::repl::MAX_REPL_SOURCE_LEN + 10);
+        let mut input = std::io::Cursor::new(input_data);
+        let mut output = Vec::new();
+
+        let result = run_mentor_inner(&mut input, &mut output);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_run_mentor_inner_flow() {
         // Simulate completing first lesson
         let input_data = "ξ 10 ἔστω.\n\n.exit\n"; // Code -> Enter (continue) -> Exit

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -571,6 +571,17 @@ mod tests {
     }
 
     #[test]
+    fn test_run_repl_inner_capped() {
+        let input_data = " ".repeat(MAX_REPL_SOURCE_LEN + 10);
+        let mut input = std::io::Cursor::new(input_data);
+        let mut output = Vec::new();
+
+        let result = run_repl_inner(&mut input, &mut output);
+        assert!(result.is_ok());
+        // The execution passes because the input gets truncated and just evaluates to whitespace/empty.
+    }
+
+    #[test]
     fn test_run_repl_inner_workflow() {
         let input_data = "\
 ξ πέντε ἔστω.\n\

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -35,7 +35,7 @@ use crate::semantic::{AnalyzedStatement, GlossaType, Scope};
 /// Maximum number of bindings to track in REPL history
 const MAX_REPL_BINDINGS: usize = 50;
 /// Maximum total source size for REPL history
-const MAX_REPL_SOURCE_LEN: usize = 50_000;
+pub const MAX_REPL_SOURCE_LEN: usize = 50_000;
 
 /// Entry point for the REPL using stdin/stdout
 ///
@@ -73,7 +73,11 @@ fn run_repl_inner<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result
         let _ = output.flush();
 
         let mut line = String::new();
-        let bytes = input.read_line(&mut line).into_diagnostic()?;
+        // 🔒 Warden: Defense against unbounded input exhaustion (DoS)
+        let bytes = {
+            let mut take = std::io::Read::take(input.by_ref(), MAX_REPL_SOURCE_LEN as u64);
+            take.read_line(&mut line).into_diagnostic()?
+        };
 
         // Handle EOF
         if bytes == 0 {


### PR DESCRIPTION
🦠 Threat: The interactive shells (`repl` and `mentor`) read input directly from a standard stream with `.read_line()` into an unbounded `String`. An attacker could exploit this by piping a massive amount of bytes without newlines (e.g. `cat /dev/zero | glossa repl`), causing the tool to allocate indefinitely and crash via an Out-Of-Memory (OOM) panic, creating a Denial of Service (DoS) vulnerability.
🛡️ Defense: Implemented capped readers for both `repl` and `mentor` tools. Instead of reading lines indefinitely, the input stream is now limited using the existing `MAX_REPL_SOURCE_LEN` constant inside `std::io::Read::take()`. The `take` wrapper securely clamps the incoming buffer size, stopping infinite inputs before they exhaust available system memory.
💥 Severity: Moderate - could crash the terminal or exhaust local host memory during interactive tool usage.
🔬 Verification: Verified behavior and passed all cargo tests and cargo clippy checks.

---
*PR created automatically by Jules for task [9981578510384044814](https://jules.google.com/task/9981578510384044814) started by @madmax983*