### PR TITLE
⚒️ Forge: Extract Scholar Markdown generation logic

### DIFF
--- a/refactor_scholar.py
+++ b/refactor_scholar.py
@@ -1,0 +1,124 @@
+import re
+
+with open("src/tools/scholar.rs", "r") as f:
+    content = f.read()
+
+# Define the new helper functions and the new run_scholar
+new_functions = """
+fn write_types_docs(md: &mut String, program: &crate::semantic::AnalyzedProgram) {
+    let mut types = program.scope.types().peekable();
+    if types.peek().is_some() {
+        writeln!(md, "## Types (Εἴδη)\\n").unwrap();
+        for (name, type_def) in types {
+            writeln!(md, "### `{}`\\n", name).unwrap();
+            if let crate::semantic::GlossaType::Struct { fields, .. } = type_def {
+                if !fields.is_empty() {
+                    writeln!(md, "| Field | Type |\\n|-------|------|").unwrap();
+                    for (field_name, field_type) in fields {
+                        writeln!(md, "| `{}` | `{}` |", field_name, field_type).unwrap();
+                    }
+                    md.push('\\n');
+                } else {
+                    writeln!(md, "*No fields defined.*\\n").unwrap();
+                }
+            }
+        }
+    }
+}
+
+fn write_traits_docs(md: &mut String, program: &crate::semantic::AnalyzedProgram) {
+    let mut traits = program.scope.traits().peekable();
+    if traits.peek().is_some() {
+        writeln!(md, "## Traits (Χαρακτῆρες)\\n").unwrap();
+        for (name, trait_def) in traits {
+            writeln!(md, "### `{}`\\n", name).unwrap();
+            if !trait_def.methods.is_empty() {
+                for method in &trait_def.methods {
+                    writeln!(md, "* `{}`", method.name).unwrap();
+                }
+                md.push('\\n');
+            } else {
+                writeln!(md, "*No methods defined.*\\n").unwrap();
+            }
+        }
+    }
+}
+
+fn write_functions_docs(md: &mut String, program: &crate::semantic::AnalyzedProgram) {
+    let mut functions = program.scope.functions().peekable();
+    if functions.peek().is_some() {
+        writeln!(md, "## Functions (Ἔργα)\\n").unwrap();
+        for func in functions {
+            // ⚡ Bolt Optimization: Use `write!` to build strings dynamically without intermediate `Vec` collections.
+            write!(md, "### `{}(", func.name).unwrap();
+            for (i, t) in func.param_types.iter().enumerate() {
+                if i > 0 {
+                    write!(md, ", ").unwrap();
+                }
+                write!(md, "{}", t).unwrap();
+            }
+            write!(md, ") -> ").unwrap();
+            if let Some(ret_type) = &func.return_type {
+                write!(md, "{}", ret_type).unwrap();
+            } else {
+                write!(md, "Οὐδέν").unwrap();
+            }
+            writeln!(md, "`\\n").unwrap();
+        }
+    }
+}
+
+pub fn run_scholar(input: &Path) -> Result<()> {
+    let source = load_source(input)?;
+    let status = Status::start_with_symbol("Συγγραφή (Generating Docs)", "📜");
+
+    let program = match crate::tools::runner::analyze_source(&source) {
+        Ok(p) => p,
+        Err(e) => {
+            status.error("Σφάλμα (Error)");
+            return Err(e);
+        }
+    };
+
+    let mut md = String::with_capacity(4096);
+    let filename = input.file_name().unwrap_or_default().to_string_lossy();
+
+    writeln!(md, "# API Documentation: `{}`\\n", filename).unwrap();
+
+    write_types_docs(&mut md, &program);
+    write_traits_docs(&mut md, &program);
+    write_functions_docs(&mut md, &program);
+
+    let output_path = input.with_extension("doc.md");
+    if let Err(e) = std::fs::write(&output_path, &md) {
+        status.error("Σφάλμα ἀρχείου (File Error)");
+        return Err(miette::miette!("Failed to write documentation file: {}", e));
+    }
+
+    status.success();
+
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   S C H O L A R".bold().cyan());
+    println!("   {}", "API Documentation Generated".italic().dim());
+    println!();
+    println!(
+        "   {} {}",
+        "Saved to:".bold(),
+        output_path.display().to_string().cyan()
+    );
+    println!();
+
+    Ok(())
+}
+"""
+
+start_idx = content.find("pub fn run_scholar(input: &Path) -> Result<()> {")
+end_idx = content.find("#[cfg(test)]", start_idx)
+
+if start_idx != -1 and end_idx != -1:
+    new_content = content[:start_idx] + new_functions + content[end_idx:]
+    with open("src/tools/scholar.rs", "w") as f:
+        f.write(new_content)
+    print("Refactored src/tools/scholar.rs successfully.")
+else:
+    print("Failed to find replacement boundaries.")

--- a/src/tools/scholar.rs
+++ b/src/tools/scholar.rs
@@ -42,25 +42,7 @@ use std::path::Path;
 /// if let Err(e) = run_scholar(&input) {
 ///     eprintln!("Documentation generation failed: {}", e);
 /// }
-/// ```
-pub fn run_scholar(input: &Path) -> Result<()> {
-    let source = load_source(input)?;
-    let status = Status::start_with_symbol("Συγγραφή (Generating Docs)", "📜");
-
-    let program = match crate::tools::runner::analyze_source(&source) {
-        Ok(p) => p,
-        Err(e) => {
-            status.error("Σφάλμα (Error)");
-            return Err(e);
-        }
-    };
-
-    let mut md = String::with_capacity(4096);
-    let filename = input.file_name().unwrap_or_default().to_string_lossy();
-
-    writeln!(md, "# API Documentation: `{}`\n", filename).unwrap();
-
-    // Document Types (Structs)
+fn write_types_docs(md: &mut String, program: &crate::semantic::AnalyzedProgram) {
     let mut types = program.scope.types().peekable();
     if types.peek().is_some() {
         writeln!(md, "## Types (Εἴδη)\n").unwrap();
@@ -79,8 +61,9 @@ pub fn run_scholar(input: &Path) -> Result<()> {
             }
         }
     }
+}
 
-    // Document Traits (Characters)
+fn write_traits_docs(md: &mut String, program: &crate::semantic::AnalyzedProgram) {
     let mut traits = program.scope.traits().peekable();
     if traits.peek().is_some() {
         writeln!(md, "## Traits (Χαρακτῆρες)\n").unwrap();
@@ -96,8 +79,9 @@ pub fn run_scholar(input: &Path) -> Result<()> {
             }
         }
     }
+}
 
-    // Document Functions (Verbs)
+fn write_functions_docs(md: &mut String, program: &crate::semantic::AnalyzedProgram) {
     let mut functions = program.scope.functions().peekable();
     if functions.peek().is_some() {
         writeln!(md, "## Functions (Ἔργα)\n").unwrap();
@@ -119,6 +103,28 @@ pub fn run_scholar(input: &Path) -> Result<()> {
             writeln!(md, "`\n").unwrap();
         }
     }
+}
+
+pub fn run_scholar(input: &Path) -> Result<()> {
+    let source = load_source(input)?;
+    let status = Status::start_with_symbol("Συγγραφή (Generating Docs)", "📜");
+
+    let program = match crate::tools::runner::analyze_source(&source) {
+        Ok(p) => p,
+        Err(e) => {
+            status.error("Σφάλμα (Error)");
+            return Err(e);
+        }
+    };
+
+    let mut md = String::with_capacity(4096);
+    let filename = input.file_name().unwrap_or_default().to_string_lossy();
+
+    writeln!(md, "# API Documentation: `{}`\n", filename).unwrap();
+
+    write_types_docs(&mut md, &program);
+    write_traits_docs(&mut md, &program);
+    write_functions_docs(&mut md, &program);
 
     let output_path = input.with_extension("doc.md");
     if let Err(e) = std::fs::write(&output_path, &md) {
@@ -141,7 +147,6 @@ pub fn run_scholar(input: &Path) -> Result<()> {
 
     Ok(())
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/test.py
+++ b/test.py
@@ -1,0 +1,4 @@
+with open("src/tools/scholar.rs", "r") as f:
+    for i, line in enumerate(f.readlines()):
+        if 80 <= i + 1 <= 126:
+            print(f"{i+1}: {line.rstrip()}")

--- a/test_refactor.py
+++ b/test_refactor.py
@@ -1,0 +1,13 @@
+import re
+
+def refactor_tester():
+    with open('src/tools/tester.rs', 'r') as f:
+        content = f.read()
+
+    # Refactor compile_test_harness to extract error cleaning logic
+    print("Testing refactor on compile_test_harness...")
+
+    # Refactor run_tests to extract test binary path generation
+    print("Testing refactor on run_tests...")
+
+refactor_tester()


### PR DESCRIPTION
🚮 Smell: The `run_scholar` function in `src/tools/scholar.rs` was almost 100 lines long, acting as a God Function that mixed file loading, error handling, printing UI elements, and formatting Markdown for Types, Traits, and Functions. This caused deep nesting and reduced readability.
✨ Solution: Extracted the Markdown generation logic into three focused, private helper functions: `write_types_docs`, `write_traits_docs`, and `write_functions_docs`. Updated `run_scholar` to call these sequentially.
🧼 Benefit: Dramatically flattens `run_scholar`, improving readability by isolating structural iteration logic from file management and CLI status reporting.
🛡️ Verification: Tests passed. No logic changed. Run `cargo clippy` and `cargo test`.

---
*PR created automatically by Jules for task [16438639602715881146](https://jules.google.com/task/16438639602715881146) started by @madmax983*