### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-06-13 - The Misplaced Import Doc Stealer
+**Confusion:** The documentation for `to_rust_type` in `src/codegen.rs` was throwing a `missing_docs` warning, even though it had a massive rustdoc block right above it.
+**Clarification:** The `use std::fmt::Write;` statement was placed *between* the doc block and the function. In Rust, doc comments attach to the immediately following item. By separating the doc block and the function with a `use` statement, the documentation was attached to the import instead of the public function. Moved the import statement to resolve the issue.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -246,6 +246,7 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // ==================================================================================
 // TYPES
 // ==================================================================================
+use std::fmt::Write;
 
 /// Convert a Glossa type to its Rust equivalent string
 ///
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The Codegen module's missing documentation.
🔦 Insight: The `to_rust_type` function was reporting missing documentation despite having a large docblock. The doc block was inadvertently attaching to an intervening `use std::fmt::Write;` import rather than the function itself. Moving the import resolved the warning.
🧪 Example: Rendered docs now display `to_rust_type` with examples.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [17301794749248836385](https://jules.google.com/task/17301794749248836385) started by @madmax983*