### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update for Internal Module Encapsulation

### DIFF
--- a/docs/adr/022-encapsulate-internal-modules.md
+++ b/docs/adr/022-encapsulate-internal-modules.md
@@ -1,0 +1,22 @@
+# 022. Encapsulate Internal Modules
+
+Date: 2026-06-13
+
+## Status
+
+Proposed
+
+## Context
+
+Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`. This violated the principle of encapsulation and created a sprawling public API, breaking internal encapsulation by exposing implementation details to the public API.
+
+## Decision
+
+We modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these internal modules using `pub(crate) mod`.
+We also updated the associated architecture diagrams (`docs/architecture.md`) to explicitly label these internal components with `(Internal)`.
+
+## Consequences
+
+- Better encapsulation of the internal structure of the `tools` module and `semantic/assembly`.
+- Minimized public API surface, ensuring internal structures do not leak outside of their intended domain.
+- Requires developers to be conscious of module boundaries when adding utilities or using DTOs outside of their package structure.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ C4Container
     Container_Boundary(tools, "Developer Experience (Nova)") {
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
         Container(auditor, "The Auditor", "src/tools/auditor.rs", "Static analysis to find unused variables and mutability smells")
-        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
+        Container(cache, "Cache (Internal)", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(catalog, "The Catalog", "src/tools/catalog.rs", "Lexicon Explorer (CLI)")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -48,10 +48,10 @@ C4Container
         Container(narrator, "The Bard", "src/tools/narrator.rs", "Generates English narrative ('Scroll of Logic') from AST")
         Container(papyrus, "Papyrus", "src/tools/papyrus.rs", "Generates SQL CREATE TABLE schemas")
         Container(repl, "REPL", "src/tools/repl.rs", "Interactive Read-Eval-Print Loop")
-        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+        Container(report, "Reporter (Internal)", "src/tools/report.rs", "Generates statistics and structured reports")
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
-        Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(ui, "The Stage (Internal)", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
         Container(weave, "Weave", "src/tools/weave.rs", "Rosetta Stone Markdown Exporter")
     }
 
@@ -96,7 +96,7 @@ C4Component
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
         Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
-        Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
+        Component(assembly_model, "Assembly Model (Internal)", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")


### PR DESCRIPTION
🧠 **Decision:** Recorded the encapsulation of internal tool and assembly components (`cache`, `report`, `ui`, `model`) via `pub(crate)`.
🗺️ **Visuals:** Updated C4 Container and Component diagrams in `docs/architecture.md` to explicitly label the encapsulated components as `(Internal)`.
🔗 **Link:** See `docs/adr/022-encapsulate-internal-modules.md`.

---
*PR created automatically by Jules for task [1245198101571628352](https://jules.google.com/task/1245198101571628352) started by @madmax983*