### PR TITLE
👺 Havoc: Semantic AST Clone and Drop Stack Overflow

### DIFF
--- a/HAVOC_ISSUE.md
+++ b/HAVOC_ISSUE.md
@@ -1,0 +1,13 @@
+👺 Havoc: Semantic AST Clone and Drop Stack Overflow
+
+🧨 **The Trigger:** A deeply nested `AnalyzedExpr` tree constructed programmatically or bypassing limits causes a stack overflow when implicitly dropping or calling `.clone()` on it.
+
+📉 **The Stack Trace:**
+```
+thread 'havoc_semantic_clone_drop_stack_overflow' (16750) has overflowed its stack
+fatal runtime error: stack overflow, aborting
+```
+
+🧪 **Reproduction:** Run `HAVOC_DETONATE_SEMANTIC_OVERFLOW=1 cargo test --test havoc_semantic_stack_overflow -- havoc_semantic_clone_drop_stack_overflow --nocapture`.
+
+😈 **Comment:** Warden meticulously secured the parser's AST but left the Semantic AST (`AnalyzedExpr` and `AnalyzedStatement`) completely exposed to stack overflows via derived `Clone` and implicit `Drop`. If I can crash it, I win.

--- a/tests/havoc_proptest_tools.rs
+++ b/tests/havoc_proptest_tools.rs
@@ -13,8 +13,10 @@ proptest! {
 
     #[test]
     fn test_tell_tale_fuzz(s in "\\PC*") {
-        if let Ok(ast) = parse(&s) && let Ok(analyzed) = analyze_program(&ast) {
+        if let Ok(ast) = parse(&s) {
+            if let Ok(analyzed) = analyze_program(&ast) {
                 let _ = tell_tale(&analyzed);
             }
         }
+    }
 }


### PR DESCRIPTION
🧨 **The Trigger:** "A deeply nested `AnalyzedExpr` tree constructed programmatically or bypassing limits causes a stack overflow when implicitly dropping or calling `.clone()` on it."

📉 **The Stack Trace:**
```
thread 'havoc_semantic_clone_drop_stack_overflow' (16750) has overflowed its stack
fatal runtime error: stack overflow, aborting
```

🧪 **Reproduction:** "Run `HAVOC_DETONATE_SEMANTIC_OVERFLOW=1 cargo test --test havoc_semantic_stack_overflow -- havoc_semantic_clone_drop_stack_overflow --nocapture`."

😈 **Comment:** "Warden meticulously secured the parser's AST but left the Semantic AST (`AnalyzedExpr` and `AnalyzedStatement`) completely exposed to stack overflows via derived `Clone` and implicit `Drop`. If I can crash it, I win."

---
*PR created automatically by Jules for task [1870969241447271399](https://jules.google.com/task/1870969241447271399) started by @madmax983*