### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,7 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+
+**[Formatting CodeGen Output in Tests]**
+**Learning:** Checking the generated Rust code `.to_string()` directly using `.contains("!true")` fails because the underlying `quote!` library inserts extra spaces (e.g., `! true` or `HashMap :: new ()`).
+**Action:** When testing string containment for `codegen.rs` elements like `!`, `-`, `&`, or type paths, always strip spaces via `code.replace(" ", "")` before running the assertion to ensure robust token matching.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1760,4 +1760,62 @@ mod tests {
             assert!(result.contains("trait G_trait_0"));
         }
     }
+    #[test]
+    fn test_generate_expr_unwrap_sentry() {
+        let expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::Unwrap(Box::new(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable("x".into()),
+                glossa_type: GlossaType::Option(Box::new(GlossaType::Number)),
+            })),
+            glossa_type: GlossaType::Number,
+        };
+        let code = generate_expr(&expr).to_string();
+        let s = code.replace(" ", "");
+        assert!(
+            s.contains("attemptedtounwrapanemptyvalue")
+                || code.contains("attempted to unwrap an empty value")
+        );
+    }
+
+    #[test]
+    fn test_generate_unary_op_not_coverage() {
+        let expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::BooleanLiteral(true),
+            glossa_type: GlossaType::Boolean,
+        };
+        let tokens = generate_unary_op(UnaryOp::Not, &expr);
+        let s = tokens.to_string().replace(" ", "");
+        assert!(s.contains("!true"));
+    }
+
+    #[test]
+    fn test_generate_unary_op_neg_non_number_coverage() {
+        let expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable("x".into()),
+            glossa_type: GlossaType::Unknown,
+        };
+        let tokens = generate_unary_op(UnaryOp::Neg, &expr);
+        let s = tokens.to_string().replace(" ", "");
+        assert!(s.contains("-g_x") || s.contains("-x"));
+    }
+
+    #[test]
+    fn test_generate_unary_op_ref_coverage() {
+        let expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable("x".into()),
+            glossa_type: GlossaType::Number,
+        };
+        let tokens = generate_unary_op(UnaryOp::Ref, &expr);
+        let s = tokens.to_string().replace(" ", "");
+        assert!(s.contains("&g_x") || s.contains("&x"));
+    }
+
+    #[test]
+    fn test_is_self_param_coverage() {
+        assert!(is_self_parameter("τω", 0));
+        assert!(is_self_parameter("τῷ", 0));
+        assert!(is_self_parameter("self", 0));
+        assert!(is_self_parameter("my_self_var", 0));
+        assert!(!is_self_parameter("other", 0));
+    }
 }

--- a/tests/sentry_codegen_perf.rs
+++ b/tests/sentry_codegen_perf.rs
@@ -57,10 +57,15 @@ fn test_codegen_runtime_unwrap_panic() {
 
     let mut code = generate_rust_file(&program);
     // Replace the specific initialization that fails to infer type in rustc
-    code = code.replace(
-        "= None",
-        ": std::option::Option<i64> = std::option::Option::None",
-    );
+    code = code
+        .replace(
+            "= None;",
+            ": std::option::Option<i64> = std::option::Option::None;",
+        )
+        .replace(
+            "= None ;",
+            ": std::option::Option<i64> = std::option::Option::None;",
+        );
 
     fs::write(&rs_path, code).unwrap();
 


### PR DESCRIPTION
`🎯 Target:` `generate_unary_op`, `is_self_parameter`, and `generate_expr_unwrap` in `src/codegen.rs`
`💣 Risk:` Uncovered branches in the rust code generation module could mask runtime panics or fallback operator bugs
`🧪 Strategy:` Added targeted unit tests inside `src/codegen.rs` (stripping spaces to avoid `quote!` formatting variations) and fixed brittle test assertions in integration tests.
`🔬 Verification:` `cargo test test_codegen_runtime_unwrap_panic` and `cargo test test_generate_unary_op_not_coverage`

---
*PR created automatically by Jules for task [1406185531499395828](https://jules.google.com/task/1406185531499395828) started by @madmax983*