### PR TITLE
🗣️ Echo: Missing Compiler Errors for Troubleshooting Examples

### DIFF
--- a/docs/echo_dx_audit_issue_missing_errors.md
+++ b/docs/echo_dx_audit_issue_missing_errors.md
@@ -1,0 +1,10 @@
+# 🗣️ Echo: Missing Compiler Errors for Troubleshooting Examples
+
+🤦 **The Confusion:**
+I read the "Troubleshooting" section in `README.md` and tried to intentionally trigger the documented errors to see what they look like. The documentation says I should get `Διπλοῦν ὑποκείμενον` for a double subject (e.g., `ὁ ἄνθρωπος ὁ θεὸς λέγει.`) and `Οὐκ οἶδα τὸ ὄνομα` for an undefined variable (e.g., `ἄγνωστος λέγε.`). I ran these snippets, but instead of getting a helpful error message, the compiler just silently succeeded and exited without printing anything! Am I doing something wrong, or is the compiler just ignoring my mistakes?
+
+🕵️ **The Reality:**
+The compiler actually completely ignores double subjects and undefined variables and silently succeeds, contrary to what the documentation explicitly claims. The user is left staring at a blank terminal instead of a helpful Greek error message.
+
+💡 **The Fix:**
+Either the compiler needs to be fixed to actually throw the `Διπλοῦν ὑποκείμενον` and `Οὐκ οἶδα τὸ ὄνομα` errors, or the documentation should stop lying to me about these errors existing. Since I don't fix compiler bugs, please fix this discrepancy so new users aren't confused by silent failures.


### PR DESCRIPTION
🤦 **The Confusion:**
I read the "Troubleshooting" section in `README.md` and tried to intentionally trigger the documented errors to see what they look like. The documentation says I should get `Διπλοῦν ὑποκείμενον` for a double subject (e.g., `ὁ ἄνθρωπος ὁ θεὸς λέγει.`) and `Οὐκ οἶδα τὸ ὄνομα` for an undefined variable (e.g., `ἄγνωστος λέγε.`). I ran these snippets, but instead of getting a helpful error message, the compiler just silently succeeded and exited without printing anything! Am I doing something wrong, or is the compiler just ignoring my mistakes?

🕵️ **The Reality:**
The compiler actually completely ignores double subjects and undefined variables and silently succeeds, contrary to what the documentation explicitly claims. The user is left staring at a blank terminal instead of a helpful Greek error message.

💡 **The Fix:**
Either the compiler needs to be fixed to actually throw the `Διπλοῦν ὑποκείμενον` and `Οὐκ οἶδα τὸ ὄνομα` errors, or the documentation should stop lying to me about these errors existing. Since I don't fix compiler bugs, please fix this discrepancy so new users aren't confused by silent failures.

---
*PR created automatically by Jules for task [3246042065505477883](https://jules.google.com/task/3246042065505477883) started by @madmax983*