### PR TITLE
🌟 Nova: Nomothetes - JSON Schema Generator

### DIFF
--- a/.jules/nova.md
+++ b/.jules/nova.md
@@ -52,3 +52,13 @@
 **Concept:** A CLI tool (`glossa gnomon`) that estimates the Big-O time complexity of a ΓΛΩΣΣΑ program by statically analyzing loop depth in the semantic AST.
 **Fate:** Proposed
 **Lesson:** Statically analyzing the semantic AST provides an easy and dependency-free way to estimate program complexity. The `AnalyzedStatement` enum variants effectively map the control flow (like `While` and `For` loops). Building a visitor pattern over these structures allows powerful tooling with minimal effort.
+
+## 🌟 The Nomothetes (ὁ Νομοθέτης)
+**Concept:** A JSON Schema generator (`glossa nomothetes`) that transpiles Glossa structs (`εἶδος`) directly to standard JSON Schema definitions.
+**Fate:** Merged
+**Lesson:** Treating Glossa as a Data Definition Language bridges ancient syntax with modern web services and API contracts. The semantic type model is robust enough to easily export into various structural formats.
+
+## 🌟 The Nomothetes (ὁ Νομοθέτης)
+**Concept:** A JSON Schema generator (`glossa nomothetes`) that transpiles Glossa structs (`εἶδος`) directly to standard JSON Schema definitions.
+**Fate:** Merged
+**Lesson:** Treating Glossa as a Data Definition Language bridges ancient syntax with modern web services and API contracts. The semantic type model is robust enough to easily export into various structural formats.

--- a/patch_cleanup.sh
+++ b/patch_cleanup.sh
@@ -1,0 +1,1 @@
+rm -f patch_cli.py patch_main.py patch_tools_mod.py

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,19 @@ fn main() -> Result<()> {
             }
         }
 
+        Some(Commands::Nomothetes { input }) => {
+            #[cfg(feature = "nova")]
+            glossa::tools::nomothetes::run_nomothetes(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'nomothetes' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
+        }
+
         Some(Commands::Repl) | None => {
             run_repl()?;
         }

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -218,4 +218,10 @@ pub enum Commands {
         /// Input file (.γλ)
         input: PathBuf,
     },
+
+    /// Generate a JSON Schema for type definitions (Requires "nova" feature)
+    Nomothetes {
+        /// Input file (.γλ)
+        input: PathBuf,
+    },
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -49,6 +49,9 @@ pub mod mentor;
 #[cfg(feature = "nova")]
 pub mod mosaic;
 pub mod narrator;
+/// The Nomothetes (ὁ Νομοθέτης) tool for JSON Schema generation.
+#[cfg(feature = "nova")]
+pub mod nomothetes;
 /// The Papyrus (Πάπυρος) tool for SQL schema generation.
 ///
 /// This experimental tool reads Glossa type definitions and automatically

--- a/src/tools/nomothetes.rs
+++ b/src/tools/nomothetes.rs
@@ -1,0 +1,211 @@
+//! The Nomothetes (ὁ Νομοθέτης) - JSON Schema Generator
+//!
+//! This module implements the "Nomothetes" tool, which inspects the type definitions
+//! (`εἶδος`) within a ΓΛΩΣΣΑ program and translates them into JSON Schema format.
+//!
+//! # Purpose
+//!
+//! A Nomothetes was an ancient Greek lawmaker. In the digital realm, JSON Schema
+//! is the law that governs data shapes. This tool allows ΓΛΩΣΣΑ to act as the
+//! single source of truth for API contracts, generating standard JSON Schema
+//! that can be consumed by frontend applications, validators, and other services.
+
+use crate::semantic::{AnalyzedStatement, GlossaType};
+use crate::tools::runner::load_source;
+use crate::tools::ui::Status;
+use comfy_table::{Attribute, Cell, Color, Table, presets};
+use crossterm::style::Stylize;
+use miette::Result;
+use std::fmt::Write;
+use std::path::Path;
+
+/// Runs the Nomothetes tool to generate JSON Schemas from Glossa types.
+///
+/// The Nomothetes (Νομοθέτης) reads the provided source file, compiles it, and
+/// generates standard JSON Schema definitions for any `εἶδος` (structs) found.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use glossa::tools::nomothetes::run_nomothetes;
+/// use std::path::Path;
+///
+/// let input = Path::new("schema.γλ");
+/// if let Err(e) = run_nomothetes(&input) {
+///     eprintln!("Schema generation failed: {}", e);
+/// }
+/// ```
+pub fn run_nomothetes(input: &Path) -> Result<()> {
+    if !input.exists() {
+        return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
+    }
+
+    let status = Status::start_with_symbol("Νομοθέτης (Generating JSON Schema)", "⚖️");
+
+    let source = match load_source(input) {
+        Ok(s) => s,
+        Err(e) => {
+            status.error("Σφάλμα ἀρχείου (File Error)");
+            return Err(e);
+        }
+    };
+
+    let program = match crate::tools::runner::analyze_source(&source) {
+        Ok(p) => p,
+        Err(e) => {
+            status.error("Σφάλμα ἀναλύσεως (Analysis Error)");
+            return Err(e);
+        }
+    };
+
+    status.success();
+
+    let mut output = String::new();
+
+    for stmt in &program.statements {
+        if let AnalyzedStatement::TypeDefinition { name, fields } = stmt {
+            let mut properties = Vec::new();
+            let mut required = Vec::new();
+
+            for (field_name, field_type) in fields {
+                let prop_json = glossa_type_to_json_schema(field_type);
+                properties.push(format!(r#"      "{}": {}"#, field_name, prop_json));
+
+                if !matches!(field_type, GlossaType::Option(_)) {
+                    required.push(format!(r#""{}""#, field_name));
+                }
+            }
+
+            let properties_json = properties.join(",\n");
+            let required_json = required.join(", ");
+
+            let req_block = if !required.is_empty() {
+                format!(
+                    r#",
+    "required": [{}]"#,
+                    required_json
+                )
+            } else {
+                "".to_string()
+            };
+
+            let schema = format!(
+                r#"{{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "{}",
+  "type": "object",
+  "properties": {{
+{}
+  }}{}
+}}"#,
+                name, properties_json, req_block
+            );
+
+            let _ = writeln!(output, "--- {} Schema ---\n{}\n", name, schema);
+        }
+    }
+
+    if output.is_empty() {
+        let _ = writeln!(output, "No types found in the program.");
+    }
+
+    println!();
+    println!(
+        "   {}",
+        "Γ Λ Ω Σ Σ Α   N O M O T H E T E S".bold().magenta()
+    );
+    println!("   {}", "JSON Schema Generator".italic().dim());
+    println!();
+
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL);
+
+    table.set_header(vec![
+        Cell::new("JSON Schema")
+            .add_attribute(Attribute::Bold)
+            .fg(Color::Magenta),
+    ]);
+
+    let formatted_code = format!("```json\n{}\n```", output.trim());
+    table.add_row(vec![Cell::new(formatted_code)]);
+
+    println!("{table}");
+    println!();
+
+    Ok(())
+}
+
+fn glossa_type_to_json_schema(g_type: &GlossaType) -> String {
+    match g_type {
+        GlossaType::Number => r#"{"type": "integer"}"#.to_string(),
+        GlossaType::String => r#"{"type": "string"}"#.to_string(),
+        GlossaType::Boolean => r#"{"type": "boolean"}"#.to_string(),
+        GlossaType::List(inner) => {
+            let inner_schema = glossa_type_to_json_schema(inner);
+            format!(r#"{{"type": "array", "items": {}}}"#, inner_schema)
+        }
+        GlossaType::Set(inner) => {
+            let inner_schema = glossa_type_to_json_schema(inner);
+            format!(
+                r#"{{"type": "array", "uniqueItems": true, "items": {}}}"#,
+                inner_schema
+            )
+        }
+        GlossaType::Map(_, v) => {
+            let v_schema = glossa_type_to_json_schema(v);
+            format!(
+                r#"{{"type": "object", "additionalProperties": {}}}"#,
+                v_schema
+            )
+        }
+        GlossaType::Option(inner) => {
+            let inner_schema = glossa_type_to_json_schema(inner);
+            format!(r#"{{"anyOf": [{{"type": "null"}}, {}]}}"#, inner_schema)
+        }
+        _ => r#"{"type": "object"}"#.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_glossa_type_to_json_schema() {
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Number),
+            r#"{"type": "integer"}"#
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::String),
+            r#"{"type": "string"}"#
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Boolean),
+            r#"{"type": "boolean"}"#
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::List(Box::new(GlossaType::Number))),
+            r#"{"type": "array", "items": {"type": "integer"}}"#
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Set(Box::new(GlossaType::Number))),
+            r#"{"type": "array", "uniqueItems": true, "items": {"type": "integer"}}"#
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Map(
+                Box::new(GlossaType::String),
+                Box::new(GlossaType::Number)
+            )),
+            r#"{"type": "object", "additionalProperties": {"type": "integer"}}"#
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Option(Box::new(GlossaType::Number))),
+            r#"{"anyOf": [{"type": "null"}, {"type": "integer"}]}"#
+        );
+        assert_eq!(
+            glossa_type_to_json_schema(&GlossaType::Unknown),
+            r#"{"type": "object"}"#
+        );
+    }
+}

--- a/tests/nomothetes_coverage.rs
+++ b/tests/nomothetes_coverage.rs
@@ -1,0 +1,53 @@
+use glossa::tools::nomothetes::run_nomothetes;
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn test_run_nomothetes_success() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("test_nomo.γλ");
+
+    fs::write(&input_path, "εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. }.").unwrap();
+
+    let result = run_nomothetes(&input_path);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_run_nomothetes_file_not_found() {
+    let path = PathBuf::from("non_existent_file.γλ");
+    let result = run_nomothetes(&path);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("οὐχ εὑρέθη"));
+}
+
+#[test]
+fn test_run_nomothetes_empty_program() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("test_nomo_empty.γλ");
+
+    fs::write(&input_path, "ξ 1 ἔστω.").unwrap();
+
+    let result = run_nomothetes(&input_path);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_run_nomothetes_parse_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("test_nomo_parse_error.γλ");
+    fs::write(&input_path, "invalid syntax").unwrap();
+
+    let result = run_nomothetes(&input_path);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_run_nomothetes_semantic_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("test_nomo_semantic_error.γλ");
+    fs::write(&input_path, "ψ 10 γίγνεται.").unwrap();
+
+    let result = run_nomothetes(&input_path);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
💡 **The Spark:** We already have Papyrus for SQL schemas, but modern API services use JSON. What if we could use Glossa structural definitions as the source of truth for frontend API contracts?
🚀 **The Feature:** Implemented `Nomothetes` (`glossa nomothetes`), a new CLI tool under the `nova` feature that transpiles Glossa `εἶδος` (Structs) into standard JSON Schema representations.
🔮 **The Potential:** Bridges ancient syntax with modern HTTP frameworks, allowing data validators to dynamically adapt to Glossa structs. Could be integrated into language servers.
⚠️ **Risk:** Low. Completely isolated behind the `nova` flag as an experimental tool. It's a read-only pass over the `AnalyzedProgram`.

---
*PR created automatically by Jules for task [9710073957841666044](https://jules.google.com/task/9710073957841666044) started by @madmax983*