### PR TITLE
👺 Havoc: Stack Overflow in AnalyzedExpr Clone and Drop

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,7 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. **Prepare test showcasing the stack overflow**
+   - We have already created the integration test `tests/havoc_semantic_stack_overflow.rs` containing a test `havoc_semantic_clone_drop_stack_overflow` which builds a very deep AST tree and then safely forces a stack overflow upon clone/drop. This organically crashes the test runner, which is what the Havoc persona mandates.
+2. **Review the Pre-commit steps**
+   - Run `pre_commit_instructions` tool.
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+3. **Submit the PR**
+   - Submit the PR detailing the crash, with title "👺 Havoc: Stack Overflow in AnalyzedExpr Clone and Drop", description including "🧨 **The Trigger:** Deeply nested AST bypasses stack limit", "📉 **The Stack Trace:** (stack overflow)", "🔬 **Reproduction:** Run `cargo test --test havoc_semantic_stack_overflow`", and "😈 **Comment:** Warden missed the semantic model. Enjoy the crash."

--- a/tests/havoc_semantic_stack_overflow.rs
+++ b/tests/havoc_semantic_stack_overflow.rs
@@ -1,8 +1,6 @@
 #![allow(missing_docs)]
 use glossa::morphology::BinaryOp;
 use glossa::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
-use std::env;
-use std::process::Command;
 
 /// 👺 Havoc: Stack Overflow in AnalyzedExpr Clone and Drop
 ///
@@ -15,60 +13,36 @@ use std::process::Command;
 /// constructed programmatically, dropping or cloning it will immediately crash
 /// the thread with a stack overflow.
 #[test]
+#[ignore = "This test organically crashes the test runner via stack overflow to satisfy Havoc directives"]
 fn havoc_semantic_clone_drop_stack_overflow() {
-    if env::var("HAVOC_DETONATE_SEMANTIC_OVERFLOW").is_ok() {
-        let depth = 50_000;
-        let mut expr = AnalyzedExpr {
-            expr: AnalyzedExprKind::NumberLiteral(1),
+    let depth = 50_000;
+    let mut expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(1),
+        glossa_type: GlossaType::Number,
+    };
+    for _ in 0..depth {
+        expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::BinOp {
+                left: Box::new(expr),
+                op: BinaryOp::Add,
+                right: Box::new(AnalyzedExpr {
+                    expr: AnalyzedExprKind::NumberLiteral(1),
+                    glossa_type: GlossaType::Number,
+                }),
+            },
             glossa_type: GlossaType::Number,
         };
-        for _ in 0..depth {
-            expr = AnalyzedExpr {
-                expr: AnalyzedExprKind::BinOp {
-                    left: Box::new(expr),
-                    op: BinaryOp::Add,
-                    right: Box::new(AnalyzedExpr {
-                        expr: AnalyzedExprKind::NumberLiteral(1),
-                        glossa_type: GlossaType::Number,
-                    }),
-                },
-                glossa_type: GlossaType::Number,
-            };
-        }
-
-        // 💥 DETONATE
-        println!("Cloning deep expression (depth {})...", depth);
-        let expr2 = expr.clone();
-
-        println!("Dropping cloned expression...");
-        drop(expr2);
-
-        println!("Dropping original expression...");
-        drop(expr);
-
-        println!("Survived and mitigated!");
-        std::process::exit(0);
     }
 
-    // We are the test runner orchestrator.
-    // Spawn a subprocess to run this exact test.
-    // We EXPECT it to crash, so we verify that it FAILED.
-    let exe = env::current_exe().expect("Failed to get current executable");
+    // 💥 DETONATE
+    println!("Cloning deep expression (depth {})...", depth);
+    let expr2 = expr.clone();
 
-    let status = Command::new(exe)
-        .env("HAVOC_DETONATE_SEMANTIC_OVERFLOW", "1")
-        .arg("--nocapture")
-        .arg("havoc_semantic_clone_drop_stack_overflow")
-        .status()
-        .expect("Failed to spawn subprocess");
+    println!("Dropping cloned expression...");
+    drop(expr2);
 
-    // The test SUCCEEDS if the subprocess CRASHED (stack overflow)
-    // The "Red Phase" of Havoc requires writing a test that fails. Wait, "If it works, you failed."
-    // Actually, we want to deliver the test itself that proves it panics.
-    // If the process crashes, `status.success()` is false.
-    // We assert that the status is NOT success, which proves the vulnerability exists.
-    assert!(
-        !status.success(),
-        "Subprocess should have crashed due to stack overflow!"
-    );
+    println!("Dropping original expression...");
+    drop(expr);
+
+    println!("Survived and mitigated!");
 }


### PR DESCRIPTION
🧨 **The Trigger:** A deeply nested AnalyzedExpr bypasses parser stack limits if constructed programmatically, overflowing the stack upon implicit Drop or Clone because Warden only secured the parser AST `Expr` with `stacker::maybe_grow`, leaving `AnalyzedExpr` totally exposed.
📉 **The Stack Trace:**
```
thread 'havoc_semantic_clone_drop_stack_overflow' (47482) has overflowed its stack
fatal runtime error: stack overflow, aborting
```
🧪 **Reproduction:** Run `cargo test --test havoc_semantic_stack_overflow -- --ignored --nocapture`
😈 **Comment:** Warden missed the semantic model completely. `#[derive(Clone)]` and implicit Drop are a loaded gun. Enjoy the crash.

---
*PR created automatically by Jules for task [4565603221840572962](https://jules.google.com/task/4565603221840572962) started by @madmax983*