### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update for New Nova Tools

### DIFF
--- a/docs/adr/022-expand-nova-tool-suite.md
+++ b/docs/adr/022-expand-nova-tool-suite.md
@@ -1,0 +1,23 @@
+# 22. Expand Nova Tool Suite
+
+Date: 2024-11-20
+
+## Status
+
+Accepted
+
+## Context
+
+As the ΓΛΩΣΣΑ compiler ecosystem matures, developers require deeper insights into their code's performance, structure, and usage. The existing Nova tools provided baseline capabilities, but lacked automated documentation generation, raw AST visualization, and complexity estimation.
+
+## Decision
+
+We have formally added three new tools to the Nova Developer Experience suite:
+- **The Scholar (ὁ Σχολαστικός)** (`scholar.rs`): Generates Markdown API documentation (`doc.md`) from the AST.
+- **The Haruspex (ὁ Ἱεροσκόπος)** (`haruspex.rs`): Translates the semantic AST into a Graphviz DOT format for raw tree visualization.
+- **The Gnomon (ὁ Γνώμων)** (`gnomon.rs`): Statically analyzes loop depth to estimate Big-O time complexity.
+
+## Consequences
+
+- **Positive:** Improved developer experience with built-in API doc generation, structural visualization, and static complexity analysis.
+- **Negative:** Increased surface area of the compiler's `tools` module and a slight increase in binary size when the `nova` feature is enabled.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,10 @@ C4Container
         Container(catalog, "The Catalog", "src/tools/catalog.rs", "Lexicon Explorer (CLI)")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
         Container(dictionary, "The Lexicon", "src/tools/dictionary.rs", "The Source of Truth for Words (Dictionary)")
+        Container(gnomon, "The Gnomon", "src/tools/gnomon.rs", "Estimates Big-O time complexity via loop depth analysis")
+        Container(haruspex, "The Haruspex", "src/tools/haruspex.rs", "Generates Graphviz DOT representation of the raw semantic AST")
+        Container(scholar, "The Scholar", "src/tools/scholar.rs", "Generates Markdown API documentation")
+
         Container(highlight, "Highlighter", "src/tools/highlight.rs", "Semantic syntax highlighting")
         Container(interpreter, "Interpreter", "src/tools/interpreter.rs", "In-memory tree-walk simulator")
         Container(labyrinth, "Labyrinth", "src/tools/labyrinth.rs", "Visualizes the control flow graph as a Mermaid flowchart")
@@ -65,6 +69,10 @@ C4Container
     Rel(semantic, narrator, "Analyzed Program")
     Rel(semantic, cartographer, "Analyzed Program")
     Rel(semantic, mentor, "Analyzed Program")
+    Rel(semantic, gnomon, "Analyzed Program")
+    Rel(semantic, haruspex, "Analyzed Program")
+    Rel(semantic, scholar, "Analyzed Program")
+
     Rel(semantic, mosaic, "Analyzed Program")
     Rel(semantic, tester, "Analyzed Program")
     Rel(semantic, interpreter, "Analyzed Program")


### PR DESCRIPTION
🧠 **Decision:** Recorded the formal inclusion of the Scholar, Haruspex, and Gnomon into the Nova Developer Experience suite in `docs/adr/022-expand-nova-tool-suite.md`.
🗺️ **Visuals:** Updated the C4 Container diagram in `docs/architecture.md` to map the new tools and their relationships to the semantic AST.
🔗 **Link:** See `docs/adr/022-expand-nova-tool-suite.md`.

---
*PR created automatically by Jules for task [7747552932239952256](https://jules.google.com/task/7747552932239952256) started by @madmax983*