### PR TITLE
test: Add fallback mechanism to CARGO_BIN_EXE_glossa in tests

### DIFF
--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -734,8 +734,24 @@ mod tests {
             let llvm_cov_path = "target/llvm-cov-target/debug/glossa";
             if std::path::Path::new(llvm_cov_path).exists() {
                 llvm_cov_path.to_string()
-            } else {
+            } else if std::path::Path::new("target/debug/glossa").exists() {
                 "target/debug/glossa".to_string()
+            } else if std::path::Path::new("target/release/glossa").exists() {
+                "target/release/glossa".to_string()
+            } else {
+                std::env::current_exe()
+                    .expect("Failed to get current exe")
+                    .parent()
+                    .unwrap()
+                    .parent()
+                    .unwrap()
+                    .join(if cfg!(windows) {
+                        "glossa.exe"
+                    } else {
+                        "glossa"
+                    })
+                    .to_string_lossy()
+                    .to_string()
             }
         });
         let mut cmd = std::process::Command::new(bin_path);

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -500,8 +500,24 @@ mod tests {
             let llvm_cov_path = "target/llvm-cov-target/debug/glossa";
             if std::path::Path::new(llvm_cov_path).exists() {
                 llvm_cov_path.to_string()
-            } else {
+            } else if std::path::Path::new("target/debug/glossa").exists() {
                 "target/debug/glossa".to_string()
+            } else if std::path::Path::new("target/release/glossa").exists() {
+                "target/release/glossa".to_string()
+            } else {
+                std::env::current_exe()
+                    .expect("Failed to get current exe")
+                    .parent()
+                    .unwrap()
+                    .parent()
+                    .unwrap()
+                    .join(if cfg!(windows) {
+                        "glossa.exe"
+                    } else {
+                        "glossa"
+                    })
+                    .to_string_lossy()
+                    .to_string()
             }
         });
         let mut cmd = std::process::Command::new(bin_path);


### PR DESCRIPTION
The tests `tools::tester::tests::test_run_tests_rustc_missing` and
`tools::runner::tests::test_run_rustc_error` fail under test frameworks
where the `CARGO_BIN_EXE_glossa` environment variable is not set or valid.
We have added a fallback logic that locates the executable from `target/debug/glossa`,
`target/release/glossa`, or uses the current test runner's executable path
by traveling up the `target/debug/deps` directories to locate the `glossa` binary.

---
*PR created automatically by Jules for task [7582101015159443675](https://jules.google.com/task/7582101015159443675) started by @madmax983*