### PR TITLE
🎨 Mosaic: UI Polish for CLI Tools

### DIFF
--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -53,7 +53,9 @@ pub fn run_alchemist(input: &Path) -> miette::Result<()> {
     let formatted_code = format!("```python\n{}\n```", python_code.trim());
     table.add_row(vec![Cell::new(formatted_code)]);
 
-    println!("{table}");
+    for line in table.to_string().lines() {
+        println!("   {}", line);
+    }
     println!();
 
     Ok(())

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -133,7 +133,9 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         );
         println!();
     } else {
-        println!("{table}");
+        for line in table.to_string().lines() {
+            println!("   {}", line);
+        }
         println!("\n   Total issues found: {}", issues);
     }
 

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -80,7 +80,9 @@ pub fn run_map(input: &Path) -> Result<()> {
                 .fg(Color::DarkGrey)
                 .add_attribute(Attribute::Italic),
         ]);
-        println!("{table}");
+        for line in table.to_string().lines() {
+            println!("   {}", line);
+        }
         println!();
     } else {
         table.set_header(vec![
@@ -94,7 +96,9 @@ pub fn run_map(input: &Path) -> Result<()> {
 
         table.add_row(vec![Cell::new(formatted_map)]);
 
-        println!("{table}");
+        for line in table.to_string().lines() {
+            println!("   {}", line);
+        }
         println!();
         println!("   {}", "📋 Usage Instructions:".bold().underlined());
         println!("   1. Copy the code block above.");

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -55,7 +55,9 @@ pub fn run_catalog() -> Result<()> {
         }
 
         println!("\n  {}", format!("{:?} Lexicon", pos).yellow().bold());
-        println!("{table}");
+        for line in table.to_string().lines() {
+            println!("   {}", line);
+        }
     }
 
     Ok(())

--- a/src/tools/dictionary.rs
+++ b/src/tools/dictionary.rs
@@ -159,7 +159,9 @@ fn print_lexicon_entry(entry: &crate::morphology::lexicon::LexiconEntry) {
         table.add_row(vec![Cell::new("Voice"), Cell::new(format!("{:?}", v))]);
     }
 
-    println!("{table}");
+    for line in table.to_string().lines() {
+        println!("   {}", line);
+    }
     println!();
 }
 
@@ -248,7 +250,9 @@ fn print_morphological_analyses(analyses: &[crate::morphology::models::MorphAnal
         ]);
     }
 
-    println!("{table}");
+    for line in table.to_string().lines() {
+        println!("   {}", line);
+    }
     println!();
 }
 

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -193,7 +193,9 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
         }),
     ]);
 
-    println!("{table}");
+    for line in table.to_string().lines() {
+        println!("   {}", line);
+    }
     println!();
 
     Ok(())

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -56,7 +56,9 @@ pub fn run_mosaic(input_path: &Path) -> Result<()> {
     println!("   {}", "Γ Λ Ω Σ Σ Α   M O S A I C".bold().cyan());
     println!("   {}", "Semantic Sentence Structure".italic().dim());
     println!();
-    println!("{}", output);
+    for line in output.lines() {
+        println!("   {}", line);
+    }
 
     Ok(())
 }

--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -106,7 +106,9 @@ pub fn run_papyrus(input: &Path) -> Result<()> {
     let formatted_code = format!("```sql\n{}\n```", output.trim());
     table.add_row(vec![Cell::new(formatted_code)]);
 
-    println!("{table}");
+    for line in table.to_string().lines() {
+        println!("   {}", line);
+    }
     println!();
 
     Ok(())

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -296,7 +296,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                     .fg(Color::White)
                     .add_attribute(Attribute::Bold),
             ]);
-            println!("{success_table}");
+            for line in success_table.to_string().lines() {
+                println!("   {}", line);
+            }
             println!();
         }
     } else {
@@ -308,7 +310,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                 .fg(Color::White)
                 .add_attribute(Attribute::Bold),
         ]);
-        println!("{failure_table}");
+        for line in failure_table.to_string().lines() {
+            println!("   {}", line);
+        }
         println!();
     }
 
@@ -338,7 +342,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
 
             table.add_row(vec![Cell::new(display_name), status_cell]);
         }
-        println!("{table}");
+        for line in table.to_string().lines() {
+            println!("   {}", line);
+        }
     } else {
         let mut empty_table = Table::new();
         empty_table.load_preset(presets::UTF8_FULL);
@@ -353,7 +359,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                 .add_attribute(Attribute::Italic)
                 .set_alignment(CellAlignment::Center),
         ]);
-        println!("{empty_table}");
+        for line in empty_table.to_string().lines() {
+            println!("   {}", line);
+        }
     }
 
     // If there were failures, try to extract and print them nicely
@@ -373,13 +381,17 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                         .fg(Color::White)
                         .add_attribute(Attribute::Bold),
                 ]);
-                println!("{header_table}");
+                for line in header_table.to_string().lines() {
+                    println!("   {}", line);
+                }
 
                 // Create a box for the error message using comfy_table
                 let mut error_table = Table::new();
                 error_table.load_preset(presets::UTF8_FULL);
                 error_table.add_row(vec![Cell::new(format!("\n{}\n", msg)).fg(Color::Red)]);
-                println!("{error_table}");
+                for line in error_table.to_string().lines() {
+                    println!("   {}", line);
+                }
                 println!();
             }
         } else {


### PR DESCRIPTION
🖌️ **Before:** Tables output by commands like `mosaic` or `haruspex` were printed using `println!("{table}");`, which dumped the `comfy-table` content flush against the left side of the terminal, breaking the indented visual hierarchy of the CLI dashboards.
✨ **After:** Table rendering now converts the table to a string and iterates over its lines, applying a 3-space indentation (`println!("   {}", line);`) to each row, aligning it perfectly with the tool headers and footers.
🖼️ **Visuals:** All CLI diagnostic tools (Mosaic, Gnomon, Cartographer, etc.) now present their data tables beautifully aligned and padded from the terminal edge.

---
*PR created automatically by Jules for task [14922284623025378155](https://jules.google.com/task/14922284623025378155) started by @madmax983*