### PR TITLE
⚒️ Forge: Refactor generate_fn_def to use Context struct

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,6 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+**Refactored codegen generate_fn_def to Context Struct**
+**Learning:** Found a function `generate_fn_def` with 4 parameters in `src/codegen.rs`.
+**Action:** Extracted the parameters into `FnDefCtx<'_>` struct to improve readability.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -580,7 +580,12 @@ fn generate_statement(stmt: &AnalyzedStatement) -> TokenStream {
             params,
             body,
             return_type,
-        } => generate_fn_def(name, params, body, return_type),
+        } => generate_fn_def(FnDefCtx {
+            name: name.as_str(),
+            params: params.as_slice(),
+            body: body.as_slice(),
+            return_type,
+        }),
         AnalyzedStatement::TypeDefinition { name, fields } => generate_struct_def(name, fields),
         AnalyzedStatement::TraitDefinition { name, methods } => generate_trait_def(name, methods),
         AnalyzedStatement::TraitImplementation {
@@ -732,12 +737,19 @@ fn generate_match(
     }
 }
 
-fn generate_fn_def(
-    name: &str,
-    params: &[(smol_str::SmolStr, Option<GlossaType>)],
-    body: &[AnalyzedStatement],
-    return_type: &Option<GlossaType>,
-) -> TokenStream {
+struct FnDefCtx<'a> {
+    name: &'a str,
+    params: &'a [(smol_str::SmolStr, Option<GlossaType>)],
+    body: &'a [AnalyzedStatement],
+    return_type: &'a Option<GlossaType>,
+}
+
+fn generate_fn_def(ctx: FnDefCtx<'_>) -> TokenStream {
+    let name = ctx.name;
+    let params = ctx.params;
+    let body = ctx.body;
+    let return_type = ctx.return_type;
+
     let fn_name = sanitize_ident(name);
     let body_stmts = generate_statements(body);
 


### PR DESCRIPTION
⚒️ Forge: Refactor generate_fn_def to use FnDefCtx

Smell: `generate_fn_def` in `src/codegen.rs` took 4 separate parameters making the function call slightly messy.
Solution: Extracted these parameters into a single `FnDefCtx<'_>` struct.
Benefit: Improves code readability and flattens arguments.
Verification: Ran standard build, `cargo test`, `cargo fmt`, and `cargo clippy`.

---
*PR created automatically by Jules for task [8700802263893503596](https://jules.google.com/task/8700802263893503596) started by @madmax983*