### PR TITLE
🛡️ Sentry: [test coverage improvement] codegen panic checks

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,7 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+
+## 2024-06-17 - Codegen Array Bounds Checks
+**Learning:** The array index bounds check during code generation panics gracefully via `expect` inside the generated Rust code. We should also verify that negative literals in array indexing during compilation can panic.
+**Action:** Wrote `sentry_codegen_bounds.rs` to verify that `expect()` and panic are properly injected into output code.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,6 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. **Explore `src/codegen.rs` to fix `.unwrap()`, `.expect()`, and panic issues.**
+   - Wrote three tests (`tests/sentry_codegen_bounds.rs`, `tests/sentry_codegen_arithmetic.rs`, `tests/sentry_codegen_unwrap.rs`) to verify that the compiler injects `.expect()` and `panic!` calls into the generated code properly to handle runtime errors gracefully.
+
+2. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+3. **Submit the change.**
+   - I will submit the change with a descriptive commit message "🛡️ Sentry: [test coverage improvement] for codegen panic checks".

--- a/tests/sentry_codegen_arithmetic.rs
+++ b/tests/sentry_codegen_arithmetic.rs
@@ -1,0 +1,17 @@
+use glossa::codegen::generate_rust;
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_generate_checked_arithmetic_overflow_panic_checks() {
+    let source = "
+    ξ 5 ἔστω.
+    ψ 3 ἔστω.
+    ζ 5 ἄθροισμα 3 ἔστω.
+    ";
+    let ast = parse(source).unwrap();
+    let program = analyze_program(&ast).unwrap();
+    let rust_code = generate_rust(&program).replace(" ", "");
+    assert!(rust_code.contains("checked_add"));
+    assert!(rust_code.contains("expect(\"arithmeticoverflow\")"));
+}

--- a/tests/sentry_codegen_bounds.rs
+++ b/tests/sentry_codegen_bounds.rs
@@ -1,0 +1,18 @@
+use glossa::codegen::generate_rust;
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_array_indexing_generates_panic_bounds_checks() {
+    let source = "
+    ξ [1, 2, 3] ἔστω.
+    ξ[5] λέγε.
+    ";
+    let ast = parse(source).unwrap();
+    let program = analyze_program(&ast).unwrap();
+    let rust_code = generate_rust(&program).replace(" ", "");
+
+    assert!(rust_code.contains("panic!(\"indexoutofbounds:negativeindex{}\",idx)"));
+    assert!(rust_code.contains("expect(\"indexoutofbounds:toolarge\")"));
+    assert!(rust_code.contains("expect(\"indexoutofbounds:indextoolarge\")"));
+}

--- a/tests/sentry_codegen_unwrap.rs
+++ b/tests/sentry_codegen_unwrap.rs
@@ -1,0 +1,15 @@
+use glossa::codegen::generate_rust;
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+fn test_generate_unwrap_panic() {
+    let source = "
+    ξ πέντε ἔστω.
+    ξ! λέγε.
+    ";
+    let ast = parse(source).unwrap();
+    let program = analyze_program(&ast).unwrap();
+    let rust_code = generate_rust(&program).replace(" ", "");
+    assert!(rust_code.contains("expect(\"attemptedtounwrapanemptyvalue\")"));
+}


### PR DESCRIPTION
Added test coverage to verify that the code generator inserts `.expect()` and `panic!` safely in the generated Rust files.
    - tests/sentry_codegen_arithmetic.rs
    - tests/sentry_codegen_bounds.rs
    - tests/sentry_codegen_unwrap.rs
    - Added record to .jules/sentry.md

---
*PR created automatically by Jules for task [15862345475913097526](https://jules.google.com/task/15862345475913097526) started by @madmax983*