### PR TITLE
👺 Havoc: Stack Overflow in GlossaType Clone/Drop

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/tests/havoc_type_stack_overflow.rs
+++ b/tests/havoc_type_stack_overflow.rs
@@ -1,0 +1,26 @@
+#![allow(missing_docs)]
+use glossa::semantic::GlossaType;
+
+/// 👺 Havoc: Stack Overflow in GlossaType
+///
+/// Warden secured Expr, but GlossaType uses derived Clone, PartialEq, Eq, and Hash.
+/// Deep nesting will overflow the stack.
+#[test]
+#[ignore = "Stack overflow"]
+fn havoc_type_stack_overflow() {
+    let depth = 50_000;
+    let mut t = GlossaType::Number;
+    for _ in 0..depth {
+        t = GlossaType::List(Box::new(t));
+    }
+
+    println!("Cloning deep type (depth {})...", depth);
+    let t2 = t.clone();
+
+    println!("Comparing deep type...");
+    assert!(t == t2);
+
+    println!("Dropping deep type...");
+    drop(t2);
+    drop(t);
+}


### PR DESCRIPTION
🧨 **The Trigger:** The `GlossaType` enumeration in the semantic model uses derived implementations for `Clone`, `PartialEq`, `Eq`, and `Hash` (e.g., `#[derive(Clone, PartialEq, Eq, Hash)]`). When encountering deeply nested recursive type structures (such as a `List` containing a `List`), these operations recursively consume stack frames without limits, leading to an immediate stack overflow thread panic. Unlike `Expr`, there is no `stacker::maybe_grow` protection here.

📉 **The Stack Trace:**
```
thread 'havoc_type_stack_overflow' has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `--test havoc_type_stack_overflow`

Caused by:
  process didn't exit successfully: `/app/target/debug/deps/havoc_type_stack_overflow-fc79c10f1412f18f --ignored --nocapture` (signal: 6, SIGABRT: process abort signal)
```

🧪 **Reproduction:** Run `cargo test --test havoc_type_stack_overflow --features nova -- --ignored --nocapture`

😈 **Comment:** You protected the AST, but forgot the Semantic Type Model! A deeply nested type crashes the compiler. I assume no one will ever try to nest 50,000 lists. You were wrong.

---
*PR created automatically by Jules for task [13413043625366522233](https://jules.google.com/task/13413043625366522233) started by @madmax983*