### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update for Internal Modules

### DIFF
--- a/docs/adr/022-encapsulate-internal-modules.md
+++ b/docs/adr/022-encapsulate-internal-modules.md
@@ -1,0 +1,21 @@
+# 022. Encapsulate Internal Modules
+
+Date: 2026-04-22
+
+## Status
+
+Proposed
+
+## Context
+
+Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`. This broke encapsulation by unnecessarily exposing internal implementation details and structures to the public API, leading to a sprawling API surface area.
+
+## Decision
+
+We modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict the visibility of these modules to `pub(crate) mod`.
+
+## Consequences
+
+- **Positive:** Achieved higher cohesion by keeping the public API surface minimal.
+- **Positive:** Ensures internal structures and DTOs do not leak out of their intended domains.
+- **Negative:** Internal modules are no longer accessible from outside the crate, requiring careful consideration when integrating new tools.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ C4Container
     Container_Boundary(tools, "Developer Experience (Nova)") {
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
         Container(auditor, "The Auditor", "src/tools/auditor.rs", "Static analysis to find unused variables and mutability smells")
-        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
+        Container(cache, "Cache (Internal)", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(catalog, "The Catalog", "src/tools/catalog.rs", "Lexicon Explorer (CLI)")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -48,10 +48,10 @@ C4Container
         Container(narrator, "The Bard", "src/tools/narrator.rs", "Generates English narrative ('Scroll of Logic') from AST")
         Container(papyrus, "Papyrus", "src/tools/papyrus.rs", "Generates SQL CREATE TABLE schemas")
         Container(repl, "REPL", "src/tools/repl.rs", "Interactive Read-Eval-Print Loop")
-        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+        Container(report, "Reporter (Internal)", "src/tools/report.rs", "Generates statistics and structured reports")
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
-        Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(ui, "The Stage (Internal)", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
         Container(weave, "Weave", "src/tools/weave.rs", "Rosetta Stone Markdown Exporter")
     }
 
@@ -96,7 +96,7 @@ C4Component
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
         Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
-        Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
+        Component(assembly_model, "Assembly Model (Internal)", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")


### PR DESCRIPTION
🧠 **Decision:** Recorded the restriction of module visibility for `cache`, `report`, `ui`, and `model` to `pub(crate) mod` to enforce encapsulation.
🗺️ **Visuals:** Updated C4 Container and Component diagrams in `docs/architecture.md` by appending ` (Internal)` to the titles of the encapsulated modules to visually communicate their new boundaries.
🔗 **Link:** See `docs/adr/022-encapsulate-internal-modules.md`.

---
*PR created automatically by Jules for task [936167963247497880](https://jules.google.com/task/936167963247497880) started by @madmax983*