### PR TITLE
👺 Havoc: [Type system recursive stack overflows]

### DIFF
--- a/tests/havoc_semantic_stack_overflow.rs
+++ b/tests/havoc_semantic_stack_overflow.rs
@@ -72,3 +72,27 @@ fn havoc_semantic_clone_drop_stack_overflow() {
         "Subprocess should have crashed due to stack overflow!"
     );
 }
+
+#[test]
+#[ignore = "Demonstrating stack overflow"]
+fn havoc_deep_type_clone() {
+    let mut t = GlossaType::Number;
+    for _ in 0..100000 {
+        t = GlossaType::List(Box::new(t));
+    }
+    // Deeply nested Clone triggers stack overflow
+    let _cloned = t.clone();
+    std::mem::forget(t);
+    std::mem::forget(_cloned);
+}
+
+#[test]
+#[ignore = "Demonstrating stack overflow"]
+fn havoc_deep_type_drop() {
+    let mut t = GlossaType::Number;
+    for _ in 0..100000 {
+        t = GlossaType::List(Box::new(t));
+    }
+    // Implicitly dropping deeply nested type triggers stack overflow
+    drop(t);
+}


### PR DESCRIPTION
🧨 **The Trigger:** Constructing deeply nested types (e.g., arrays of arrays) causes the Rust compiler's derived recursive implementations (`Clone`, `Drop`) on `GlossaType` to overflow the thread stack.

📉 **The Stack Trace:**
```text
running 1 test
thread 'havoc_deep_type_clone' (139754) has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `--test havoc_semantic_stack_overflow`
Caused by:
  process didn't exit successfully: `/app/target/debug/deps/havoc_semantic_stack_overflow-182e33be82ff7785 --ignored --nocapture` (signal: 6, SIGABRT: process abort signal)
```

🧪 **Reproduction:** Run `cargo test --test havoc_semantic_stack_overflow -- --ignored --nocapture`.

😈 **Comment:** You assumed developers wouldn't define 100,000-dimensional arrays or deep nesting. You were wrong. A malicious or auto-generated type definition will fatally crash the compiler because your `GlossaType` struct depends on derived `Clone` and `Drop` without guarding recursion.

---
*PR created automatically by Jules for task [358652094951457276](https://jules.google.com/task/358652094951457276) started by @madmax983*