### PR TITLE
⚡ Bolt: string formatting optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**[Optimizing String Concatenation with `std::fmt::Write`]**
+**Learning:** Using `out.push_str(&format!(...))` forces a heap allocation for an intermediate `String` before it is appended.
+**Action:** Replace `out.push_str(&format!(...))` with `writeln!(out, ...)` or `write!(out, ...)` to write directly into the buffer and eliminate the intermediate allocation. Ensure `std::fmt::Write` is in scope, and preallocate `String::with_capacity` where bounds are easily guessable.

--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -131,7 +131,7 @@ fn transpile_statement(stmt: &AnalyzedStatement, indent: usize) -> String {
         AnalyzedStatement::Expression(exprs) => {
             let mut out = String::new();
             for expr in exprs {
-                out.push_str(&format!("{}{}\n", ind, transpile_expr(expr)));
+                let _ = writeln!(out, "{}{}", ind, transpile_expr(expr));
             }
             out.trim_end().to_string()
         }
@@ -167,7 +167,7 @@ fn transpile_if(
     let ind = "    ".repeat(indent);
     let mut out = format!("{}if {}:\n", ind, transpile_expr(condition));
     if then_body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in then_body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -175,9 +175,9 @@ fn transpile_if(
         }
     }
     if let Some(ebody) = else_body {
-        out.push_str(&format!("{}else:\n", ind));
+        let _ = writeln!(out, "{}else:", ind);
         if ebody.is_empty() {
-            out.push_str(&format!("{}    pass\n", ind));
+            let _ = writeln!(out, "{}    pass", ind);
         } else {
             for b_stmt in ebody {
                 out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -192,7 +192,7 @@ fn transpile_while(condition: &AnalyzedExpr, body: &[AnalyzedStatement], indent:
     let ind = "    ".repeat(indent);
     let mut out = format!("{}while {}:\n", ind, transpile_expr(condition));
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -216,7 +216,7 @@ fn transpile_for(
         transpile_expr(iterator)
     );
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -243,7 +243,7 @@ fn transpile_function_def(
     out.push_str("):\n");
 
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for (i, b_stmt) in body.iter().enumerate() {
             let mut is_last_expr = false;
@@ -255,9 +255,9 @@ fn transpile_function_def(
                 if let AnalyzedStatement::Expression(exprs) = b_stmt {
                     for (j, expr) in exprs.iter().enumerate() {
                         if j == exprs.len() - 1 {
-                            out.push_str(&format!("{}    return {}\n", ind, transpile_expr(expr)));
+                            let _ = writeln!(out, "{}    return {}", ind, transpile_expr(expr));
                         } else {
-                            out.push_str(&format!("{}    {}\n", ind, transpile_expr(expr)));
+                            let _ = writeln!(out, "{}    {}", ind, transpile_expr(expr));
                         }
                     }
                 }
@@ -283,10 +283,10 @@ fn transpile_type_def(
         sanitize_ident(name)
     );
     if fields.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for (f_name, _) in fields {
-            out.push_str(&format!("{}    {}: Any\n", ind, sanitize_ident(f_name)));
+            let _ = writeln!(out, "{}    {}: Any", ind, sanitize_ident(f_name));
         }
     }
     out.trim_end().to_string()
@@ -298,7 +298,7 @@ fn transpile_test_declaration(name: &str, body: &[AnalyzedStatement], indent: us
     let safe_name = name.replace(" ", "_").replace("-", "_").replace("\"", "");
     let mut out = format!("{}def test_{}():\n", ind, safe_name);
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -317,13 +317,9 @@ fn transpile_match(
     // Python 3.10+ match statement
     let mut out = format!("{}match {}:\n", ind, transpile_expr(scrutinee));
     for (pattern_expr, arm_body) in arms {
-        out.push_str(&format!(
-            "{}    case {}:\n",
-            ind,
-            transpile_expr(pattern_expr)
-        ));
+        let _ = writeln!(out, "{}    case {}:", ind, transpile_expr(pattern_expr));
         if arm_body.is_empty() {
-            out.push_str(&format!("{}        pass\n", ind));
+            let _ = writeln!(out, "{}        pass", ind);
         } else {
             for b_stmt in arm_body {
                 out.push_str(&transpile_statement(b_stmt, indent + 2));

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -144,12 +144,15 @@ pub fn generate_cfg(program: &AnalyzedProgram) -> String {
     let end_node = add_node("End", "round", &mut nodes, &mut node_counter);
     add_edge(&current_node, &end_node, None, &mut edges);
 
-    let mut out = String::from("graph TD\n");
+    use std::fmt::Write;
+    let capacity = 10 + nodes.len() * 30 + edges.len() * 40;
+    let mut out = String::with_capacity(capacity);
+    out.push_str("graph TD\n");
     for node in nodes {
-        out.push_str(&format!("    {}\n", node));
+        let _ = writeln!(out, "    {}", node);
     }
     for edge in edges {
-        out.push_str(&format!("    {}\n", edge));
+        let _ = writeln!(out, "    {}", edge);
     }
     out
 }


### PR DESCRIPTION
💡 What: Replaced usages of `out.push_str(&format!(...))` with direct `writeln!(out, ...)` and `write!(out, ...)` in `src/tools/alchemist.rs` and `src/tools/labyrinth.rs`.
🎯 Why: Constructing a new string with `format!` and immediately appending it using `push_str` forces unnecessary intermediate heap allocations that get dropped immediately. Writing directly to the buffer eliminates this overhead.
📊 Impact: Considerably reduces heap allocations within string formatting tasks in both tools. Furthermore, dynamically pre-allocating the string capacity via `String::with_capacity` in `labyrinth.rs` reduces reallocation operations as the graph text is compiled.
🔬 Measurement: Run bench tests on code generation and run `cargo test --features nova` to verify that standard functionalities are maintained without regressions.

---
*PR created automatically by Jules for task [7715830748444263440](https://jules.google.com/task/7715830748444263440) started by @madmax983*