### PR TITLE
🎨 Mosaic: UI Polish for tester and report modules

### DIFF
--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -354,7 +354,9 @@ impl Display for GlossaReport<'_> {
         writeln!(f, "   {}", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan())?;
         writeln!(f, "   {}", "Language Metrics Dashboard".italic().dim())?;
         writeln!(f)?;
-        writeln!(f, "{}", table)?;
+        for line in table.to_string().lines() {
+            writeln!(f, "   {}", line)?;
+        }
 
         // If there are top-level functions, list them
         let mut functions = self.program.scope.functions().peekable();
@@ -390,7 +392,9 @@ impl Display for GlossaReport<'_> {
                     Cell::new(ret).fg(Color::Yellow),
                 ]);
             }
-            writeln!(f, "{}", func_table)?;
+            for line in func_table.to_string().lines() {
+                writeln!(f, "   {}", line)?;
+            }
         }
 
         Ok(())
@@ -493,7 +497,9 @@ impl Display for CompilationReport {
         writeln!(f, "   {}", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan())?;
         writeln!(f, "   {}", "Compilation Metrics Dashboard".italic().dim())?;
         writeln!(f)?;
-        writeln!(f, "{}", table)?;
+        for line in table.to_string().lines() {
+            writeln!(f, "   {}", line)?;
+        }
 
         Ok(())
     }

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -296,7 +296,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                     .fg(Color::White)
                     .add_attribute(Attribute::Bold),
             ]);
-            println!("{success_table}");
+            for line in success_table.to_string().lines() {
+                println!("   {}", line);
+            }
             println!();
         }
     } else {
@@ -308,7 +310,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                 .fg(Color::White)
                 .add_attribute(Attribute::Bold),
         ]);
-        println!("{failure_table}");
+        for line in failure_table.to_string().lines() {
+            println!("   {}", line);
+        }
         println!();
     }
 
@@ -338,7 +342,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
 
             table.add_row(vec![Cell::new(display_name), status_cell]);
         }
-        println!("{table}");
+        for line in table.to_string().lines() {
+            println!("   {}", line);
+        }
     } else {
         let mut empty_table = Table::new();
         empty_table.load_preset(presets::UTF8_FULL);
@@ -353,7 +359,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                 .add_attribute(Attribute::Italic)
                 .set_alignment(CellAlignment::Center),
         ]);
-        println!("{empty_table}");
+        for line in empty_table.to_string().lines() {
+            println!("   {}", line);
+        }
     }
 
     // If there were failures, try to extract and print them nicely
@@ -373,13 +381,17 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                         .fg(Color::White)
                         .add_attribute(Attribute::Bold),
                 ]);
-                println!("{header_table}");
+                for line in header_table.to_string().lines() {
+                    println!("   {}", line);
+                }
 
                 // Create a box for the error message using comfy_table
                 let mut error_table = Table::new();
                 error_table.load_preset(presets::UTF8_FULL);
                 error_table.add_row(vec![Cell::new(format!("\n{}\n", msg)).fg(Color::Red)]);
-                println!("{error_table}");
+                for line in error_table.to_string().lines() {
+                    println!("   {}", line);
+                }
                 println!();
             }
         } else {


### PR DESCRIPTION
🖌️ **Before:** Tables generated via comfy_table in `src/tools/tester.rs` and `src/tools/report.rs` were being dumped directly to stdout without respecting the established `"   "` CLI margin indentation, making the output visually unaligned with the rest of the application dashboard.
✨ **After:** Tables are properly iterated and printed line-by-line, prepended with the intended 3-space indentation to enforce visual hierarchy and consistency across the CLI suite.
🖼️ **Visuals:** Test results and Metrics report tables are now flush with context messages and spinners.

---
*PR created automatically by Jules for task [15000702584392712888](https://jules.google.com/task/15000702584392712888) started by @madmax983*