### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-06-25 - [The Missing Docs Trap]
+**Confusion:** The function `to_rust_type` in `src/codegen.rs` threw a `missing_docs` warning despite having a documentation block directly above it.
+**Clarification:** The doc block was separated from the function definition by a `use std::fmt::Write;` statement. In Rust, documentation comments (`///`) attach only to the immediately following item. Intervening statements prevent the documentation from attaching to the function. Moving the doc block below the `use` statement resolves the issue.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module.
💡 Insight: Fixed a missing docs warning in `to_rust_type` by moving the documentation block to correctly attach to the function, removing intervening statements.
🧪 Example: Documentation now correctly renders for `to_rust_type`.
🖼️ Preview: No visual changes, but `missing_docs` warnings are removed.

---
*PR created automatically by Jules for task [8620132180778408154](https://jules.google.com/task/8620132180778408154) started by @madmax983*