### PR TITLE
🗺️ Atlas: Restrict assembly module visibility

### DIFF
--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -160,7 +160,7 @@ pub use model::*;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::semantic::assembly::Assembler;
+/// use glossa::semantic::Assembler;
 /// let mut asm = Assembler::new();
 /// // Then feed analysis and finalise statement
 /// ```

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -34,7 +34,7 @@
 pub(crate) mod analyzer;
 #[cfg(test)]
 mod assembler_tests;
-pub mod assembly;
+pub(crate) mod assembly;
 #[cfg(test)]
 mod classification_tests;
 pub(crate) mod control_flow;


### PR DESCRIPTION
🕸️ Tangle: The `src/semantic/assembly` module was exposed as `pub mod` via `src/semantic/mod.rs`, breaking encapsulation by leaking internal implementation details (e.g., `AssembledStatement`, `Assembler`, `Constituent`, etc.) to the public API.
📐 Blueprint: Modified `src/semantic/mod.rs` to restrict the `assembly` module with `pub(crate) mod`. Updated doc tests in `src/semantic/assembly/mod.rs` to import `Assembler` from the root `glossa::semantic` instead.
🧱 Stability: Achieved higher cohesion by keeping the public API surface minimal and ensuring internal semantic structures don't leak out of their intended domains.
🔭 Verification: `cargo test` and `cargo clippy` run successfully, and all internal structure usage remains working via `crate::` and `pub(crate)` rules.

---
*PR created automatically by Jules for task [9229676109727778307](https://jules.google.com/task/9229676109727778307) started by @madmax983*