### PR TITLE
👺 Havoc: Stack Overflow in Semantic AST (Clone/Drop)

### DIFF
--- a/HAVOC_ISSUE.md
+++ b/HAVOC_ISSUE.md
@@ -1,0 +1,17 @@
+# 👺 Havoc: Stack Overflow in Semantic AST (Clone/Drop)
+
+🧨 **The Trigger:**
+Programmatically constructing a deeply nested `AnalyzedExpr` AST node (depth > 50,000) and allowing it to be implicitly dropped, cloned via the derived `Clone` implementation, or validated. While the parser's syntax AST (`Expr`) is protected by `stacker::maybe_grow`, the Semantic AST (`AnalyzedExpr` and `AnalyzedStatement`) remains completely unprotected, leading to an immediate stack overflow when traversing the recursive enums during deallocation.
+
+📉 **The Stack Trace:**
+```
+thread 'havoc_semantic_clone_drop_stack_overflow' has overflowed its stack
+fatal runtime error: stack overflow, aborting
+error: test failed, to rerun pass `-p glossa --test havoc_semantic_stack_overflow`
+```
+
+🧪 **Reproduction:**
+Run `cargo test --features nova -p glossa --test havoc_semantic_stack_overflow -- --ignored --nocapture`
+
+😈 **Comment:**
+You armored the front gates (Parser AST) but left the inner keep (Semantic AST) wide open. I bypassed your linear depth scanner and crafted a recursive payload directly. Your default `Drop` and derived `Clone` implementations simply walk off the edge of the stack into the abyss.

--- a/tests/havoc_semantic_stack_overflow.rs
+++ b/tests/havoc_semantic_stack_overflow.rs
@@ -1,8 +1,6 @@
 #![allow(missing_docs)]
 use glossa::morphology::BinaryOp;
 use glossa::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
-use std::env;
-use std::process::Command;
 
 /// 👺 Havoc: Stack Overflow in AnalyzedExpr Clone and Drop
 ///
@@ -15,60 +13,36 @@ use std::process::Command;
 /// constructed programmatically, dropping or cloning it will immediately crash
 /// the thread with a stack overflow.
 #[test]
+#[ignore = "Havoc triggers runner crash intentionally"]
 fn havoc_semantic_clone_drop_stack_overflow() {
-    if env::var("HAVOC_DETONATE_SEMANTIC_OVERFLOW").is_ok() {
-        let depth = 50_000;
-        let mut expr = AnalyzedExpr {
-            expr: AnalyzedExprKind::NumberLiteral(1),
+    let depth = 50_000;
+    let mut expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(1),
+        glossa_type: GlossaType::Number,
+    };
+    for _ in 0..depth {
+        expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::BinOp {
+                left: Box::new(expr),
+                op: BinaryOp::Add,
+                right: Box::new(AnalyzedExpr {
+                    expr: AnalyzedExprKind::NumberLiteral(1),
+                    glossa_type: GlossaType::Number,
+                }),
+            },
             glossa_type: GlossaType::Number,
         };
-        for _ in 0..depth {
-            expr = AnalyzedExpr {
-                expr: AnalyzedExprKind::BinOp {
-                    left: Box::new(expr),
-                    op: BinaryOp::Add,
-                    right: Box::new(AnalyzedExpr {
-                        expr: AnalyzedExprKind::NumberLiteral(1),
-                        glossa_type: GlossaType::Number,
-                    }),
-                },
-                glossa_type: GlossaType::Number,
-            };
-        }
-
-        // 💥 DETONATE
-        println!("Cloning deep expression (depth {})...", depth);
-        let expr2 = expr.clone();
-
-        println!("Dropping cloned expression...");
-        drop(expr2);
-
-        println!("Dropping original expression...");
-        drop(expr);
-
-        println!("Survived and mitigated!");
-        std::process::exit(0);
     }
 
-    // We are the test runner orchestrator.
-    // Spawn a subprocess to run this exact test.
-    // We EXPECT it to crash, so we verify that it FAILED.
-    let exe = env::current_exe().expect("Failed to get current executable");
+    // 💥 DETONATE
+    println!("Cloning deep expression (depth {})...", depth);
+    let expr2 = expr.clone();
 
-    let status = Command::new(exe)
-        .env("HAVOC_DETONATE_SEMANTIC_OVERFLOW", "1")
-        .arg("--nocapture")
-        .arg("havoc_semantic_clone_drop_stack_overflow")
-        .status()
-        .expect("Failed to spawn subprocess");
+    println!("Dropping cloned expression...");
+    drop(expr2);
 
-    // The test SUCCEEDS if the subprocess CRASHED (stack overflow)
-    // The "Red Phase" of Havoc requires writing a test that fails. Wait, "If it works, you failed."
-    // Actually, we want to deliver the test itself that proves it panics.
-    // If the process crashes, `status.success()` is false.
-    // We assert that the status is NOT success, which proves the vulnerability exists.
-    assert!(
-        !status.success(),
-        "Subprocess should have crashed due to stack overflow!"
-    );
+    println!("Dropping original expression...");
+    drop(expr);
+
+    println!("Survived and mitigated!");
 }


### PR DESCRIPTION
# 👺 Havoc: Stack Overflow in Semantic AST (Clone/Drop)

🧨 **The Trigger:**
Programmatically constructing a deeply nested `AnalyzedExpr` AST node (depth > 50,000) and allowing it to be implicitly dropped, cloned via the derived `Clone` implementation, or validated. While the parser's syntax AST (`Expr`) is protected by `stacker::maybe_grow`, the Semantic AST (`AnalyzedExpr` and `AnalyzedStatement`) remains completely unprotected, leading to an immediate stack overflow when traversing the recursive enums during deallocation.

📉 **The Stack Trace:**
```
thread 'havoc_semantic_clone_drop_stack_overflow' has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `-p glossa --test havoc_semantic_stack_overflow`
```

🧪 **Reproduction:**
Run `cargo test --features nova -p glossa --test havoc_semantic_stack_overflow -- --ignored --nocapture`

😈 **Comment:**
You armored the front gates (Parser AST) but left the inner keep (Semantic AST) wide open. I bypassed your linear depth scanner and crafted a recursive payload directly. Your default `Drop` and derived `Clone` implementations simply walk off the edge of the stack into the abyss.

---
*PR created automatically by Jules for task [16225465392001323909](https://jules.google.com/task/16225465392001323909) started by @madmax983*