### PR TITLE
🎨 Mosaic: UI Polish for Gnomon and Tester outputs

### DIFF
--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -164,10 +164,10 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
     table.set_header(vec![
-        Cell::new("Metric")
+        Cell::new("Μετρική (Metric)")
             .add_attribute(Attribute::Bold)
             .fg(Color::Cyan),
-        Cell::new("Value").add_attribute(Attribute::Bold),
+        Cell::new("Τιμή (Value)").add_attribute(Attribute::Bold),
     ]);
 
     let complexity = if visitor.max_depth == 0 {
@@ -179,11 +179,11 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
     };
 
     table.add_row(vec![
-        Cell::new("Max Loop Depth"),
+        Cell::new("Μέγιστον Βάθος (Max Depth)"),
         Cell::new(visitor.max_depth.to_string()),
     ]);
     table.add_row(vec![
-        Cell::new("Estimated Big-O"),
+        Cell::new("Πολυπλοκότης (Big-O)"),
         Cell::new(complexity).fg(if visitor.max_depth > 2 {
             Color::Red
         } else if visitor.max_depth == 2 {

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -384,10 +384,29 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
             }
         } else {
             // Fallback to raw output if extraction failed but tests failed
-            println!("{}", stdout);
+            let mut raw_table = Table::new();
+            raw_table.load_preset(presets::UTF8_FULL);
+            raw_table.add_row(vec![
+                Cell::new(" FAILED: Raw Output ")
+                    .bg(Color::DarkRed)
+                    .fg(Color::White)
+                    .add_attribute(Attribute::Bold),
+            ]);
+            println!("{raw_table}");
+
+            let mut error_table = Table::new();
+            error_table.load_preset(presets::UTF8_FULL);
+            let raw_out = stdout.trim();
+            let mut content = if raw_out.is_empty() {
+                String::new()
+            } else {
+                format!("{}\n", raw_out)
+            };
             if !test_output.stderr.is_empty() {
-                println!("{}", String::from_utf8_lossy(&test_output.stderr).red());
+                content.push_str(&String::from_utf8_lossy(&test_output.stderr));
             }
+            error_table.add_row(vec![Cell::new(format!("\n{}\n", content)).fg(Color::Red)]);
+            println!("{error_table}");
         }
     }
 }


### PR DESCRIPTION
🎨 Mosaic: UI Polish for Gnomon and Tester outputs

🖌️ **Before:** The Test command fallback displayed ugly, unformatted, raw rustc terminal string blocks when test failures didn't match the extraction patterns (e.g. panic locations). The Gnomon command outputted a generic text table structure that didn't align with the Greek UI strings elsewhere.
✨ **After:** Wrapped the raw fallback errors in `comfy_table` with proper red highlights to maintain visual hierarchy. Corrected the `gnomon.rs` report table to use the thematic dual-language text standard headers `Μετρική (Metric)` and `Τιμή (Value)`.
🖼️ **Visuals:** Now when extraction fails, a large red table reads "FAILED: Raw Output" and safely encompasses the unformatted stack traces. Gnomon correctly shows localized table column headers for complexity metrics.

---
*PR created automatically by Jules for task [2186149724053814042](https://jules.google.com/task/2186149724053814042) started by @madmax983*