### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-06-11 - Documenting `to_rust_type` and fixing unused variables
+**Confusion:** The documentation for `to_rust_type` in `src/codegen.rs` had `use std::fmt::Write;` intercepting its rustdoc, throwing `missing_docs` warnings. The `Gnomon` command in `src/main.rs` was missing a `let _ = input;` when `nova` feature was disabled.
+**Clarification:** Moved `use std::fmt::Write;` higher up to correctly attribute the rustdocs to `pub fn to_rust_type`. Ignored `input` appropriately in the `Gnomon` match arm to prevent warnings.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -246,6 +246,7 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // ==================================================================================
 // TYPES
 // ==================================================================================
+use std::fmt::Write;
 
 /// Convert a Glossa type to its Rust equivalent string
 ///
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {


### PR DESCRIPTION
I fixed the `missing_docs` warning by ensuring `to_rust_type` documentation corresponds correctly to its declaration in `src/codegen.rs`. Additionally, I resolved an `unused_variables` warning in `src/main.rs` for the `Gnomon` command block when the `nova` feature is disabled by ignoring `input`. Pre-commit steps including tests and journal entries have been completed.

---
*PR created automatically by Jules for task [11094236846110957222](https://jules.google.com/task/11094236846110957222) started by @madmax983*