### PR TITLE
🗺️ Atlas: [The Facade: Tools and Assembly Encapsulation]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -20,3 +20,7 @@
 **Tangle:** Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`, breaking encapsulation by exposing internal implementation details to the public API.
 **Blueprint:** Modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these modules with `pub(crate) mod`.
 **Stability:** Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains.
+
+**[The Facade: Tools and Assembly Encapsulation]**
+**Tangle:** The `src/tools/mod.rs` and `src/semantic/mod.rs` exposed their internal modules (`cli`, `runner`, `mosaic`, `assembly`, etc.) as `pub mod`. This created a "Leaky Abstraction" where consumers relied on the deep internal file structure, increasing coupling and exposing implementation details.
+**Blueprint:** Converted all internal tool modules in `src/tools/mod.rs` and the `assembly` module in `src/semantic/mod.rs` to `pub(crate) mod`. Introduced `pub use` statements at the module roots to act as a Facade, exporting only the explicit entry points needed by the CLI and external consumers. Updated `src/main.rs` and the test suite to depend solely on the flattened public API.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,10 @@
 use clap::Parser;
 use miette::Result;
 
-use glossa::tools::cli::{Cli, Commands};
-use glossa::tools::dictionary::lookup_word;
-use glossa::tools::repl::run_repl;
-use glossa::tools::runner::{
+use glossa::tools::{Cli, Commands};
+use glossa::tools::lookup_word;
+use glossa::tools::run_repl;
+use glossa::tools::{
     bard_file, build_file, check_file, highlight_file, report_file, run_file,
 };
 
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Mentor) => {
             #[cfg(feature = "nova")]
-            glossa::tools::mentor::run_mentor()?;
+            glossa::tools::run_mentor()?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(
@@ -61,12 +61,12 @@ fn main() -> Result<()> {
         }
 
         Some(Commands::Test { input }) => {
-            glossa::tools::tester::run_tests(&input)?;
+            glossa::tools::run_tests(&input)?;
         }
 
         Some(Commands::Mosaic { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::mosaic::run_mosaic(&input)?;
+            glossa::tools::run_mosaic(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -79,7 +79,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Map { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::cartographer::run_map(&input)?;
+            glossa::tools::run_map(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -92,7 +92,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Labyrinth { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::labyrinth::run_labyrinth(&input)?;
+            glossa::tools::run_labyrinth(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -105,7 +105,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Weave { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::weave::run_weave(&input)?;
+            glossa::tools::run_weave(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -118,7 +118,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Alchemist { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::alchemist::run_alchemist(&input)?;
+            glossa::tools::run_alchemist(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -131,7 +131,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Papyrus { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::papyrus::run_papyrus(&input)?;
+            glossa::tools::run_papyrus(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -144,7 +144,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Haruspex { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::haruspex::run_haruspex(&input)?;
+            glossa::tools::run_haruspex(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -157,7 +157,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Audit { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::auditor::run_auditor(&input)?;
+            glossa::tools::run_auditor(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -170,7 +170,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Catalog) => {
             #[cfg(feature = "nova")]
-            glossa::tools::catalog::run_catalog()?;
+            glossa::tools::run_catalog()?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(
@@ -180,17 +180,20 @@ fn main() -> Result<()> {
 
         Some(Commands::Gnomon { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::gnomon::run_gnomon(&input)?;
+            glossa::tools::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::scholar::run_scholar(&input)?;
+            glossa::tools::run_scholar(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -160,7 +160,7 @@ pub use model::*;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::semantic::assembly::Assembler;
+/// use glossa::semantic::Assembler;
 /// let mut asm = Assembler::new();
 /// // Then feed analysis and finalise statement
 /// ```

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -34,7 +34,7 @@
 pub(crate) mod analyzer;
 #[cfg(test)]
 mod assembler_tests;
-pub mod assembly;
+pub(crate) mod assembly;
 #[cfg(test)]
 mod classification_tests;
 pub(crate) mod control_flow;

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -38,7 +38,7 @@ use std::path::Path;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::auditor::run_auditor;
+/// use glossa::tools::run_auditor;
 /// use std::path::Path;
 ///
 /// let input = Path::new("main.γλ");

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -57,7 +57,7 @@ use std::path::PathBuf;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::cli::Cli;
+/// use glossa::tools::Cli;
 /// use clap::Parser;
 ///
 /// // You can parse arguments from an iterator, which is useful for testing!
@@ -87,7 +87,7 @@ pub struct Cli {
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::cli::Commands;
+/// use glossa::tools::Commands;
 /// use std::path::PathBuf;
 ///
 /// let run_cmd = Commands::Run { input: PathBuf::from("main.γλ") };

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -113,7 +113,7 @@ impl GnomonVisitor {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::gnomon::run_gnomon;
+/// use glossa::tools::run_gnomon;
 /// use std::path::Path;
 ///
 /// let input = Path::new("algorithm.γλ");

--- a/src/tools/highlight.rs
+++ b/src/tools/highlight.rs
@@ -24,7 +24,7 @@
 //! # Usage
 //!
 //! ```rust
-//! use glossa::highlight::highlight;
+//! use glossa::highlight;
 //!
 //! let source = "ὁ ἄνθρωπος τὸν λόγον λέγει.";
 //! let highlighted = highlight(source).unwrap();

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -32,7 +32,7 @@ use std::fmt;
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::Value;
+/// use glossa::tools::Value;
 ///
 /// // Create a numerical truth
 /// let count = Value::Number(42);
@@ -79,7 +79,7 @@ impl fmt::Display for Value {
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::EvalError;
+/// use glossa::tools::EvalError;
 ///
 /// let missing_var = EvalError::VariableNotFound("x".into());
 /// assert!(missing_var.to_string().contains("μεταβλητὴ"));
@@ -135,7 +135,7 @@ pub enum EvalError {
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::Interpreter;
+/// use glossa::tools::Interpreter;
 ///
 /// let mut interp = Interpreter::new();
 /// // You could then run a program via `interp.run(&analyzed_program)`
@@ -163,7 +163,7 @@ impl Interpreter {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::interpreter::Interpreter;
+    /// use glossa::tools::Interpreter;
     ///
     /// let interp = Interpreter::new();
     /// assert_eq!(interp.get_output(), "");
@@ -180,7 +180,7 @@ impl Interpreter {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::interpreter::Interpreter;
+    /// use glossa::tools::Interpreter;
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
     ///

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -113,7 +113,7 @@ pub fn run_labyrinth_inner<W: std::io::Write>(source: &str, writer: &mut W) -> m
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::labyrinth::generate_cfg;
+/// use glossa::tools::generate_cfg;
 /// use glossa::semantic::analyze_program;
 /// use glossa::parser::parse;
 ///

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -34,7 +34,7 @@ use std::io::{BufRead, Write};
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::mentor::Lesson;
+/// use glossa::tools::Lesson;
 /// use glossa::semantic::AnalyzedProgram;
 ///
 /// let first_lesson = Lesson {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,45 +17,72 @@
 //! * `ui`: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
 
 #[cfg(feature = "nova")]
-pub mod alchemist;
+pub(crate) mod alchemist;
+#[cfg(feature = "nova")]
+pub use alchemist::{run_alchemist, transpile_to_python};
 /// The Auditor (Λογιστής) tool for static analysis.
 ///
 /// This experimental tool analyzes Glossa code to detect unused variables,
 /// unnecessary mutable bindings, and other code quality issues.
 #[cfg(feature = "nova")]
-pub mod auditor;
+pub(crate) mod auditor;
+#[cfg(feature = "nova")]
+pub use auditor::run_auditor;
 pub(crate) mod cache;
 pub use cache::Cache;
 #[cfg(feature = "nova")]
-pub mod cartographer;
+pub(crate) mod cartographer;
 #[cfg(feature = "nova")]
-pub mod catalog;
-pub mod cli;
-pub mod dictionary;
+pub use cartographer::{run_map, generate_map};
+#[cfg(feature = "nova")]
+pub(crate) mod catalog;
+#[cfg(feature = "nova")]
+pub use catalog::run_catalog;
+pub(crate) mod cli;
+pub use cli::{Cli, Commands};
+pub(crate) mod dictionary;
+pub use dictionary::lookup_word;
 /// The Haruspex (ὁ Ἱεροσκόπος) tool for visualizing the Semantic AST.
 ///
 /// This experimental tool exports the analyzed program as a Graphviz DOT diagram.
 #[cfg(feature = "nova")]
-pub mod gnomon;
+pub(crate) mod gnomon;
 #[cfg(feature = "nova")]
-pub mod haruspex;
-pub mod highlight;
+pub use gnomon::{run_gnomon, GnomonVisitor};
 #[cfg(feature = "nova")]
-pub mod interpreter;
+pub(crate) mod haruspex;
 #[cfg(feature = "nova")]
-pub mod labyrinth;
+pub use haruspex::run_haruspex;
+pub(crate) mod highlight;
+pub use highlight::highlight;
 #[cfg(feature = "nova")]
-pub mod mentor;
+pub(crate) mod interpreter;
 #[cfg(feature = "nova")]
-pub mod mosaic;
-pub mod narrator;
+pub use interpreter::{Interpreter, Value, EvalError};
+#[cfg(feature = "nova")]
+pub(crate) mod labyrinth;
+#[cfg(feature = "nova")]
+pub use labyrinth::{run_labyrinth, run_labyrinth_inner, generate_cfg};
+#[cfg(feature = "nova")]
+pub(crate) mod mentor;
+#[cfg(feature = "nova")]
+pub use mentor::{run_mentor, Lesson};
+#[cfg(feature = "nova")]
+pub(crate) mod mosaic;
+#[cfg(feature = "nova")]
+pub use mosaic::{run_mosaic, run_mosaic_inner};
+pub(crate) mod narrator;
+pub use narrator::tell_tale;
 /// The Papyrus (Πάπυρος) tool for SQL schema generation.
 ///
 /// This experimental tool reads Glossa type definitions and automatically
 /// generates corresponding SQL `CREATE TABLE` statements.
 #[cfg(feature = "nova")]
-pub mod papyrus;
-pub mod repl;
+pub(crate) mod papyrus;
+#[cfg(feature = "nova")]
+pub use papyrus::run_papyrus;
+pub(crate) mod repl;
+pub use repl::{run_repl, ReplOutput};
 pub(crate) mod report;
 /// The engine room for executing and building Glossa programs
 ///
@@ -75,10 +102,16 @@ pub(crate) mod report;
 ///     eprintln!("Execution failed: {}", e);
 /// }
 /// ```
-pub mod runner;
+pub(crate) mod runner;
+pub use runner::{analyze_source, bard_file, build_file, check_file, highlight_file, report_file, run_file};
 #[cfg(feature = "nova")]
-pub mod scholar;
-pub mod tester;
+pub(crate) mod scholar;
+#[cfg(feature = "nova")]
+pub use scholar::run_scholar;
+pub(crate) mod tester;
+pub use tester::run_tests;
 pub(crate) mod ui;
 #[cfg(feature = "nova")]
-pub mod weave;
+pub(crate) mod weave;
+#[cfg(feature = "nova")]
+pub use weave::run_weave;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -93,7 +93,7 @@ pub(crate) mod report;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::runner::run_file;
+/// use glossa::tools::run_file;
 /// use std::path::Path;
 ///
 /// // Execute a Glossa file directly from its path

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -37,7 +37,7 @@ use std::fmt::Write;
 /// ```
 /// use glossa::parser::parse;
 /// use glossa::semantic::analyze_program;
-/// use glossa::tools::narrator::tell_tale;
+/// use glossa::tools::tell_tale;
 ///
 /// let source = "ξ 5 ἔστω.";
 /// let ast = parse(source).unwrap();

--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -33,7 +33,7 @@ use std::path::Path;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::papyrus::run_papyrus;
+/// use glossa::tools::run_papyrus;
 /// use std::path::Path;
 ///
 /// let input = Path::new("schema.γλ");

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -48,7 +48,7 @@ const MAX_FILE_SIZE: u64 = 1024 * 1024;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::runner::analyze_source;
+/// use glossa::tools::analyze_source;
 ///
 /// // Parse a simple Glossa program
 /// let source = "ξ 10 ἔστω. ξ λέγε.";
@@ -160,7 +160,7 @@ pub(crate) fn load_source(input: &Path) -> Result<String> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::build_file;
+/// use glossa::tools::build_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -252,7 +252,7 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::run_file;
+/// use glossa::tools::run_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -392,7 +392,7 @@ fn execute_binary(executable: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::check_file;
+/// use glossa::tools::check_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -471,7 +471,7 @@ pub fn report_file(input: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::highlight_file;
+/// use glossa::tools::highlight_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -520,7 +520,7 @@ pub fn highlight_file(input: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::bard_file;
+/// use glossa::tools::bard_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;

--- a/src/tools/scholar.rs
+++ b/src/tools/scholar.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 /// ## Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::scholar::run_scholar;
+/// use glossa::tools::run_scholar;
 /// use std::path::Path;
 ///
 /// let input = Path::new("library.γλ");

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -403,7 +403,7 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::tester::run_tests;
+/// use glossa::tools::run_tests;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;

--- a/tests/alchemist_coverage.rs
+++ b/tests/alchemist_coverage.rs
@@ -5,7 +5,7 @@ use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::alchemist::{run_alchemist, transpile_to_python};
+use glossa::tools::{run_alchemist, transpile_to_python};
 use std::io::Write;
 use tempfile::Builder;
 

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -19,7 +19,7 @@ fn test_dos_dev_zero() {
 
         // We expect run_file to fail either due to file size check (if fixed) or some other error.
         // If it hangs, it won't return.
-        let result = glossa::tools::runner::run_file(path);
+        let result = glossa::tools::run_file(path);
         // Send the result back
         // If run_file hangs, this line is never reached.
         let _ = tx.send(result);

--- a/tests/havoc_proptest_normalization.rs
+++ b/tests/havoc_proptest_normalization.rs
@@ -9,7 +9,7 @@ proptest! {
     }
 }
 
-use glossa::tools::highlight::highlight;
+use glossa::tools::highlight;
 
 proptest! {
     #[test]

--- a/tests/havoc_proptest_tools.rs
+++ b/tests/havoc_proptest_tools.rs
@@ -1,8 +1,8 @@
 #![allow(missing_docs)]
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
-use glossa::tools::highlight::highlight;
-use glossa::tools::narrator::tell_tale;
+use glossa::tools::highlight;
+use glossa::tools::tell_tale;
 use proptest::prelude::*;
 
 proptest! {

--- a/tests/havoc_repl_empty.rs
+++ b/tests/havoc_repl_empty.rs
@@ -1,4 +1,4 @@
-use glossa::tools::repl::run_repl;
+use glossa::tools::run_repl;
 
 // test wrapper for REPL crash
 #[test]

--- a/tests/havoc_transliteration.rs
+++ b/tests/havoc_transliteration.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/labyrinth_coverage.rs
+++ b/tests/labyrinth_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::labyrinth::{run_labyrinth, run_labyrinth_inner};
+use glossa::tools::{run_labyrinth, run_labyrinth_inner};
 
 #[test]
 fn test_run_labyrinth_comfy_table_output() {

--- a/tests/mosaic_coverage.rs
+++ b/tests/mosaic_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::mosaic::run_mosaic_inner;
+use glossa::tools::run_mosaic_inner;
 
 #[test]
 fn test_mosaic_comprehensive_coverage() {

--- a/tests/narrator_coverage.rs
+++ b/tests/narrator_coverage.rs
@@ -3,7 +3,7 @@ use glossa::parser::parse;
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, CaptureMode, GlossaType, analyze_program,
 };
-use glossa::tools::narrator::tell_tale;
+use glossa::tools::tell_tale;
 
 fn compile_and_tell(source: &str) -> String {
     let ast = parse(source).expect("AST build failed");

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 
 use std::io::Read;
 use std::io::Write;
@@ -18,7 +18,7 @@ fn test_run_weave_success() {
     let source = "«χαῖρε κόσμε» λέγε.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::weave::run_weave(temp_file.path());
+    let result = glossa::tools::run_weave(temp_file.path());
     assert!(result.is_ok(), "Weave failed: {:?}", result.err());
 
     let output_path = temp_file.path().with_extension("md");
@@ -49,14 +49,14 @@ fn test_run_papyrus_success() {
     let source = "εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. ἡλικία ἀριθμοῦ. }. ξ 5 ἔστω.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_ok(), "Papyrus failed: {:?}", result.err());
 }
 
 #[test]
 fn test_run_papyrus_file_not_found() {
     let path = PathBuf::from("non_existent_file.gl");
-    let result = glossa::tools::papyrus::run_papyrus(&path);
+    let result = glossa::tools::run_papyrus(&path);
     assert!(result.is_err());
     assert!(
         result
@@ -79,7 +79,7 @@ fn test_run_papyrus_file_too_large() {
         f.write_all(&data).unwrap();
     }
 
-    let result = glossa::tools::papyrus::run_papyrus(&input_path);
+    let result = glossa::tools::run_papyrus(&input_path);
     assert!(result.is_err());
     assert!(
         result
@@ -98,7 +98,7 @@ fn test_run_papyrus_syntax_error() {
 
     write!(temp_file, "invalid syntax").expect("Failed to write");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Parse error"));
 }
@@ -112,7 +112,7 @@ fn test_run_papyrus_semantic_error() {
 
     write!(temp_file, "ψ πέντε γίγνεται.").expect("Failed to write");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_err());
     let err_str = result.unwrap_err().to_string();
     assert!(
@@ -233,7 +233,7 @@ fn test_run_scholar_success() {
     «γεια» λέγε.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::scholar::run_scholar(temp_file.path());
+    let result = glossa::tools::run_scholar(temp_file.path());
     assert!(result.is_ok(), "Scholar failed: {:?}", result.err());
 
     let output_path = temp_file.path().with_extension("doc.md");
@@ -257,7 +257,7 @@ fn test_run_scholar_success() {
 #[test]
 fn test_run_scholar_file_not_found() {
     let path = PathBuf::from("non_existent_file.gl");
-    let result = glossa::tools::scholar::run_scholar(&path);
+    let result = glossa::tools::run_scholar(&path);
     assert!(result.is_err());
     assert!(
         result
@@ -276,7 +276,7 @@ fn test_run_scholar_syntax_error() {
 
     write!(temp_file, "invalid syntax").expect("Failed to write");
 
-    let result = glossa::tools::scholar::run_scholar(temp_file.path());
+    let result = glossa::tools::run_scholar(temp_file.path());
     assert!(result.is_err());
 }
 

--- a/tests/sentry_tester_tests.rs
+++ b/tests/sentry_tester_tests.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 use std::fs;
 
 #[test]

--- a/tests/warden_limits.rs
+++ b/tests/warden_limits.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/warden_overflow_sim.rs
+++ b/tests/warden_overflow_sim.rs
@@ -4,7 +4,7 @@ use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::interpreter::Interpreter;
+use glossa::tools::Interpreter;
 
 #[test]
 fn test_warden_overflow_sim_defense() {


### PR DESCRIPTION
🗺️ Atlas: The Facade: Tools and Assembly Encapsulation

🕸️ Tangle: The `src/tools/mod.rs` and `src/semantic/mod.rs` modules exposed their internal structural hierarchy to the outside world via `pub mod`, breaking encapsulation and coupling the public API to internal file arrangements. This manifested as deep dependency paths in `src/main.rs` and across the test suite (e.g., `glossa::tools::alchemist::run_alchemist`).
📐 Blueprint: Converted the internal `tools` modules and the `semantic::assembly` module to `pub(crate) mod`. Re-exported the necessary items (e.g., `run_file`, `Cli`, `lookup_word`) at the root of `src/tools/mod.rs` using `pub use` to create a clean, unified Facade. Updated `src/main.rs` and 14 integration tests to consume the new flattened API.
🧱 Stability: Significantly reduces the public surface area of the `glossa` library crate, decoupling consumers from the compiler's internal directory structure and enforcing strict structural encapsulation.
🔭 Verification: `cargo build` and `cargo test --features nova` complete successfully with zero warnings under `cargo clippy`.

---
*PR created automatically by Jules for task [8201588975810601176](https://jules.google.com/task/8201588975810601176) started by @madmax983*