### PR TITLE
⚡ Bolt: Optimize string concatenation capacity allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+**[String Concatenation Optimization]
+**Learning:** Intermediate string allocations from `join` and subsequent concatenations are common on hot paths like REPL execution loops or semantic evaluation.
+**Action:** Use `iter().map().sum()` to calculate the exact total capacity needed beforehand, then instantiate `String::with_capacity` and iterate with `push_str` and `push` to avoid intermediate buffer re-allocations entirely.

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -506,7 +506,13 @@ fn extract_parameters_from_expr(
 
 /// Collect all Word nodes from an expression (flattening phrases)
 fn collect_words_from_expr(expr: &Expr) -> Vec<&crate::ast::Word> {
-    let mut words = Vec::new();
+    // ⚡ Bolt Optimization: Use `Vec::with_capacity` if it's a phrase to prevent reallocation
+    let capacity = if let Expr::Phrase(terms) = expr {
+        terms.len()
+    } else {
+        1
+    };
+    let mut words = Vec::with_capacity(capacity);
     collect_words_from_expr_into(expr, &mut words);
     words
 }

--- a/src/tools/repl.rs
+++ b/src/tools/repl.rs
@@ -313,8 +313,11 @@ impl ReplContext {
         // 1. Construct the Virtual Source File
         // We simulate a single persistent file by concatenating previous valid bindings
         // with the new input. This allows variable references to resolve correctly.
-        let mut full_source = self.bindings.join("\n");
-        if !full_source.is_empty() {
+        // ⚡ Bolt Optimization: Calculate exact capacity to avoid intermediate `.join()` allocation and reallocations.
+        let capacity = self.bindings.iter().map(|b| b.len() + 1).sum::<usize>() + input.len();
+        let mut full_source = String::with_capacity(capacity);
+        for binding in &self.bindings {
+            full_source.push_str(binding);
             full_source.push('\n');
         }
         full_source.push_str(input);


### PR DESCRIPTION
💡 **What:** 
- In `src/tools/repl.rs`, replaced `self.bindings.join("\n")` with an exact capacity calculation and a `String::with_capacity` buffer.
- In `src/semantic/declarations.rs`, used `Vec::with_capacity` based on the Phrase token length instead of default initialization in `collect_words_from_expr`.

🎯 **Why:** 
String concatenation on hot paths, especially in tools like the REPL which reconstructs history on every input, often creates unnecessary intermediate allocations that trigger buffer reallocations.

📊 **Impact:** 
Reduces intermediate heap allocations in the REPL and during AST traversal.

🔬 **Measurement:**
Run `cargo test repl` and `cargo test declarations` to verify correctness. Memory profilers will show fewer reallocations on large interactive sessions.

---
*PR created automatically by Jules for task [5258307794397776042](https://jules.google.com/task/5258307794397776042) started by @madmax983*