### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-03-22 - Detached doc comments cause missing_docs
+**Confusion:** The function `to_rust_type` in `src/codegen.rs` triggered a `missing_docs` warning despite having a valid rustdoc block immediately above it.
+**Clarification:** A `use std::fmt::Write;` import was placed between the doc comment and the function definition, detaching the doc comment from the function. Rearranging the file to place imports correctly fixed the warning.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -94,6 +94,7 @@
 
 #![allow(clippy::needless_doctest_main)]
 
+use std::fmt::Write;
 use crate::morphology::lexicon::{BinaryOp, UnaryOp};
 use crate::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedMethod, AnalyzedProgram, AnalyzedStatement,
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module.
🔦 Insight: Fixed a missing_docs warning by reattaching a doc comment that was separated from its function by an import statement.
🧪 Example: Verified via `cargo doc` that the warning is resolved.
🖼️ Preview: (no visual change)

---
*PR created automatically by Jules for task [3775656904072478518](https://jules.google.com/task/3775656904072478518) started by @madmax983*