### PR TITLE
⚡ Bolt: [Zero-Cost Abstract type string builder]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,9 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**[Optimizing recursive type formatting]**
+**Learning:** Using  recursively (e.g., in  for nested types like ) creates multiple intermediate heap-allocated s that are immediately concatenated and dropped.
+**Action:** Replace recursive  calls with appending to a mutable  buffer (e.g., using  or ) passed down via a mutable reference (). This drastically reduces memory allocations and is simpler than involving  when only static strings are needed.
+**[Optimizing recursive type formatting]**
+**Learning:** Using `format!` recursively (e.g., in `tell_type` for nested types like `Map<Option<Number>, String>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
+**Action:** Replace recursive `format!` calls with appending to a mutable `String` buffer (e.g., using `push_str` or `push`) passed down via a mutable reference (`&mut String`). This drastically reduces memory allocations and is simpler than involving `std::fmt::Write` when only static strings are needed.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,17 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1.  **Refactor `tell_type` in `src/tools/narrator.rs`**:
+    - Right now, `tell_type` builds up type strings using recursive `format!` calls, causing unnecessary heap allocations for nested types like `Map<Option<Number>, String>`.
+    - Following the pattern from `.jules/bolt.md` for "Optimizing recursive type formatting", we will change `tell_type` to use a `write!` approach with a single pre-allocated `String` buffer.
+    - We will define `write_tell_type(ty: &GlossaType, out: &mut String) -> std::fmt::Result` to handle the recursive logic.
+    - `tell_type` will simply allocate a `String::with_capacity(32)` and call `write_tell_type(&ty, &mut buf)`.
+    - `format_types` will be updated to write directly into the buffer, completely eliminating intermediate strings!
+
+2.  **Verify the change**:
+    - Run `cargo fmt` and `cargo clippy`.
+    - Run `cargo test` to ensure we didn't break any narrator functionality or tests.
+
+3.  **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done**.
+    - Invoke `pre_commit_instructions` and follow the provided steps.
+
+4.  **Submit the PR**:
+    - Title: `⚡ Bolt: [Zero-Cost Abstract type string builder]`
+    - Description: Following the Bolt format, specifying the removal of intermediate `format!` allocations via `std::fmt::Write`.

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -194,15 +194,13 @@ fn format_exprs(exprs: &[AnalyzedExpr]) -> String {
     buf
 }
 
-fn format_types(types: &[GlossaType]) -> String {
-    let mut buf = String::with_capacity(types.len() * 16);
+fn write_format_types(types: &[GlossaType], out: &mut String) {
     for (i, ty) in types.iter().enumerate() {
         if i > 0 {
-            buf.push_str(", ");
+            out.push_str(", ");
         }
-        buf.push_str(&tell_type(ty));
+        write_tell_type(ty, out);
     }
-    buf
 }
 
 fn add_print(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
@@ -563,23 +561,56 @@ fn tell_lambda(
 /// the Scroll of Logic translates these into conventional programming type names
 /// (e.g., `Number`, `[Type]`) to help developers map the Greek concepts to
 /// concepts they already understand.
-fn tell_type(ty: &GlossaType) -> String {
+fn write_tell_type(ty: &GlossaType, out: &mut String) {
     match ty {
-        GlossaType::Number => "Number".to_string(),
-        GlossaType::String => "String".to_string(),
-        GlossaType::Boolean => "Bool".to_string(),
-        GlossaType::List(inner) => format!("[{}]", tell_type(inner)),
-        GlossaType::Set(inner) => format!("Set<{}>", tell_type(inner)),
-        GlossaType::Map(k, v) => format!("Map<{}, {}>", tell_type(k), tell_type(v)),
-        GlossaType::Option(inner) => format!("Option<{}>", tell_type(inner)),
-        GlossaType::Result(ok, err) => format!("Result<{}, {}>", tell_type(ok), tell_type(err)),
-        GlossaType::Struct { name, .. } => name.to_string(),
-        GlossaType::Function { params, returns } => {
-            format!("Fn({}) -> {}", format_types(params), tell_type(returns))
+        GlossaType::Number => out.push_str("Number"),
+        GlossaType::String => out.push_str("String"),
+        GlossaType::Boolean => out.push_str("Bool"),
+        GlossaType::List(inner) => {
+            out.push('[');
+            write_tell_type(inner, out);
+            out.push(']');
         }
-        GlossaType::Unit => "()".to_string(),
-        GlossaType::Unknown => "?".to_string(),
+        GlossaType::Set(inner) => {
+            out.push_str("Set<");
+            write_tell_type(inner, out);
+            out.push('>');
+        }
+        GlossaType::Map(k, v) => {
+            out.push_str("Map<");
+            write_tell_type(k, out);
+            out.push_str(", ");
+            write_tell_type(v, out);
+            out.push('>');
+        }
+        GlossaType::Option(inner) => {
+            out.push_str("Option<");
+            write_tell_type(inner, out);
+            out.push('>');
+        }
+        GlossaType::Result(ok, err) => {
+            out.push_str("Result<");
+            write_tell_type(ok, out);
+            out.push_str(", ");
+            write_tell_type(err, out);
+            out.push('>');
+        }
+        GlossaType::Struct { name, .. } => out.push_str(name),
+        GlossaType::Function { params, returns } => {
+            out.push_str("Fn(");
+            write_format_types(params, out);
+            out.push_str(") -> ");
+            write_tell_type(returns, out);
+        }
+        GlossaType::Unit => out.push_str("()"),
+        GlossaType::Unknown => out.push('?'),
     }
+}
+
+fn tell_type(ty: &GlossaType) -> String {
+    let mut buf = String::with_capacity(32);
+    write_tell_type(ty, &mut buf);
+    buf
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- 💡 What: Replaced recursive `format!` allocations in `tell_type` and `format_types` with `push_str`/`push` to a mutable `String` buffer.
- 🎯 Why: Using `format!` recursively for complex nested AST types creates multiple intermediate short-lived heap-allocated `String`s that are immediately concatenated and dropped.
- 📊 Impact: Pre-allocating a single `String` buffer (e.g., `String::with_capacity`) and passing a mutable reference down drastically reduces memory allocations and completely removes formatting overhead.
- 🔬 Measurement: Verify with `cargo test`.

---
*PR created automatically by Jules for task [4078617532499517255](https://jules.google.com/task/4078617532499517255) started by @madmax983*