### PR TITLE
🗣️ Echo: Fix Unused Variable Warning when Compiling without `nova` Feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {


### PR DESCRIPTION
🤦 **The Confusion:** Tried to build `glossa` binary on default and there was an unused variable warning for `input` in `gnomon` argument handling in `src/main.rs`!
🕵️ **The Reality:** Turns out, without the `nova` feature, `input` variable was not used.
💡 **The Fix:** Add `let _ = input;` inside the non-nova condition for `Commands::Gnomon` to explicitly ignore the unused variable warning.

---
*PR created automatically by Jules for task [9546900693743610997](https://jules.google.com/task/9546900693743610997) started by @madmax983*