### PR TITLE
👺 Havoc: Fix Echo issue bugs bypassing compiler validation

### DIFF
--- a/.jules/havoc.md
+++ b/.jules/havoc.md
@@ -6,3 +6,6 @@
 2. `cargo-fuzz` survived `126,000` iterations directly into FFI/Morphology boundaries without a single panic.
 3. `havoc_dos` verified `/dev/zero` infinite stream aborts safely with no OOM.
 4. Attempted stack exhaustion on clone/drop of `Program` / `Statement` handled safely by `stacker`.
+**[Fix Echo Compiler Bugs]**
+**Learning:** I encountered and resolved cases where compiler validations for Double Subject and Missing Verb were easily bypassed during semantic analysis, leaving edge cases that would trigger panic (`rustc` ICE) and undefined evaluation behavior.
+**Action:** Implemented strict, front-loaded validation logic in `check_missing_verb` and `finalize` to forcefully reject generic stacked nominatives and verbless generic statements early, returning explicit custom `GlossaError` diagnostic values as designed, preventing silent zero evaluation and ICEs.

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -105,9 +105,9 @@ pub enum GlossaError {
     ///
     /// # Example Output
     /// ```text
-    /// Ἄγνωστον ὄνομα: ξ
+    /// Οὐκ οἶδα τὸ ὄνομα: ξ
     /// ```
-    #[error("Ἄγνωστον ὄνομα: {name}")]
+    #[error("Οὐκ οἶδα τὸ ὄνομα: {name}")]
     #[diagnostic(code(glossa::undefined))]
     UndefinedName {
         /// The identifier (variable or function name) that the compiler could not resolve in the current scope.
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     fn test_undefined_error() {
         let err = GlossaError::undefined("ξ");
-        assert!(err.to_string().contains("Ἄγνωστον ὄνομα"));
+        assert!(err.to_string().contains("Οὐκ οἶδα τὸ ὄνομα"));
         assert!(err.to_string().contains("ξ"));
     }
 

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -653,40 +653,36 @@ impl Assembler {
                 is_match_arm: !self.state.adjectives.is_empty()
                     || (self.state.subject.is_some()
                         && self.state.object.is_none()
-                        && self.state.literals.is_empty()),
+                        && self.state.literals.is_empty()
+                        && self.state.nominatives.is_empty()),
             };
             self.check_missing_verb(&ctx)?;
         }
+        // Check for double subjects
+        if self.state.subject.is_some() && !self.state.nominatives.is_empty() {
+            let mut is_allowed = false;
+
+            // Allow multiple nominatives if it's an operator expression (e.g. `ὁ χρυσοῦς > ὁ ἀργυροῦς`)
+            if !self.state.operators.is_empty() {
+                is_allowed = true;
+            }
+
+            // Allow if it's a binding verb like 'ἔστω'
+            if let Some(verb) = &self.state.verb {
+                #[allow(clippy::collapsible_if)]
+                if crate::morphology::lexicon::is_binding_verb(&verb.lemma) {
+                    is_allowed = true;
+                }
+            }
+
+            if !is_allowed {
+                return Err(AssemblyError::DoubleSubject);
+            }
+        }
+
         // Check subject-verb agreement if both present
         if let (Some(subject), Some(verb)) = (&self.state.subject, &self.state.verb) {
             self.check_agreement(subject, verb)?;
-            // If we have a verb, a subject, and extra nominatives, but it's not a function definition or binary operation
-            if !self.state.nominatives.is_empty()
-                && self.state.operators.is_empty()
-                && !crate::morphology::lexicon::is_binding_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_print_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_find_verb(&verb.lemma)
-            {
-                return Err(AssemblyError::DoubleSubject);
-            }
-        } else if self.state.subject.is_some()
-            && !self.state.nominatives.is_empty()
-            && self.state.operators.is_empty()
-        {
-            // Unhandled double subject when there's no verb and no operators
-            // Exception: Function definition / pattern calls
-            let is_function_call = !self.state.nested_phrases.is_empty()
-                || !self.state.blocks.is_empty()
-                || !self.state.literals.is_empty();
-            let is_special_pattern =
-                !self.state.property_accesses.is_empty() || self.state.is_query;
-            // Note: If self.state.verb.is_some(), we would have entered the previous block, not this 'else if' block!
-            // Wait, we are in 'else if self.state.subject.is_some()', which means verb is NONE.
-            // Oh, so Double Subject logic wasn't fully firing in the previous block either. Let me adjust.
-            if !is_function_call && !is_special_pattern {
-                // No verb, stacked nominatives...
-                return Err(AssemblyError::DoubleSubject);
-            }
         }
         // Return the assembled statement
         let statement = std::mem::take(&mut self.state);

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -953,25 +953,46 @@ fn try_print_default(
     let mut args =
         build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 
-    if let Some(ref subj) = asm_stmt.subject
-        && let Some(var_type) = scope.lookup(&subj.lemma)
-    {
-        args.insert(
-            0,
-            AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: var_type.clone(),
-            },
-        );
+    if let Some(ref subj) = asm_stmt.subject {
+        if let Some(var_type) = scope.lookup(&subj.lemma) {
+            args.insert(
+                0,
+                AnalyzedExpr {
+                    expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                    glossa_type: var_type.clone(),
+                },
+            );
+        } else {
+            if !asm_stmt.genitives.is_empty() || subj.lemma == "self" {
+                args.insert(
+                    0,
+                    AnalyzedExpr {
+                        expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+                        glossa_type: GlossaType::Unknown,
+                    },
+                );
+            } else {
+                return Err(GlossaError::undefined(subj.lemma.as_str()));
+            }
+        }
     }
 
-    if let Some(ref obj) = asm_stmt.object
-        && let Some(var_type) = scope.lookup(&obj.lemma)
-    {
-        args.push(AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-            glossa_type: var_type.clone(),
-        });
+    if let Some(ref obj) = asm_stmt.object {
+        if let Some(var_type) = scope.lookup(&obj.lemma) {
+            args.push(AnalyzedExpr {
+                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+                glossa_type: var_type.clone(),
+            });
+        } else {
+            if !asm_stmt.genitives.is_empty() || obj.lemma == "self" {
+                args.push(AnalyzedExpr {
+                    expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+                    glossa_type: GlossaType::Unknown,
+                });
+            } else {
+                return Err(GlossaError::undefined(obj.lemma.as_str()));
+            }
+        }
     }
 
     Ok(args)

--- a/tests/havoc_issue_echo.rs
+++ b/tests/havoc_issue_echo.rs
@@ -6,37 +6,41 @@ use glossa::semantic::analyze_program;
 fn test_double_subject_should_pass_havoc_constraint() {
     let source = "ὁ ἄνθρωπος ὁ θεὸς λέγει.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
-    // Havoc constraints: "Never write 'Happy Path' tests. If it works, you failed."
-    // In Echo bug, double subject compiles with zero errors instead of failing gracefully.
+    let result = analyze_program(&ast);
+    if result.is_ok() {
+        panic!("Havoc: Double subject successfully compiled when it should have crashed!");
+    }
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Διπλοῦν ὑποκείμενον")
+    );
 }
 
 #[test]
 fn test_undefined_variable_evaluates_to_zero_silently() {
     let source = "ἄγνωστος λέγε."; // 'unknown say' -> undefined variable
     let ast = parse(source).unwrap();
-    let prog = analyze_program(&ast).unwrap();
-
-    // The previous implementation was completely ignoring undefined variables and producing an empty print.
-    // Let's assert it generates an empty print instead of crashing.
-    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0]
-        && expressions.is_empty()
-    {
-        // It silently became empty/zero!
-        return;
+    let result = analyze_program(&ast);
+    if result.is_ok() {
+        panic!("Havoc: Undefined variable silently evaluated instead of panicking!");
     }
-    panic!(
-        "Did not evaluate to empty/zero silently! It got {:?}",
-        prog.statements[0]
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Οὐκ οἶδα τὸ ὄνομα")
     );
 }
 
 #[test]
-#[should_panic(expected = "MissingVerb")]
 fn test_missing_verb_compiler_panic() {
-    // Missing verb `ὁ ἄνθρωπος.` actually crashes `rustc` codegen if passed through,
-    // or panics locally. We prove it panics or fails to compile!
     let source = "ὁ ἄνθρωπος.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
+    let result = analyze_program(&ast);
+    if result.is_ok() {
+        panic!("Havoc: Missing verb returned Ok(()) which caused a codegen ICE!");
+    }
+    assert!(result.unwrap_err().to_string().contains("Ῥῆμα οὐχ εὑρέθη"));
 }


### PR DESCRIPTION
👺 Havoc: Fix Echo issue bugs bypassing compiler validation

🧊 **The Trigger:** 
Submitting unverified edge cases (`ἄγνωστος λέγε.`, `ὁ ἄνθρωπος ὁ θεὸς λέγει.`, `ὁ ἄνθρωπος.`) caused the compiler to silently compile undefined variables to `0`, successfully compile Double Subjects without warning, and trigger an ICE Panic for missing verbs on bare subjects.

📉 **The Stack Trace:**
```rust
error[E0425]: cannot find value `g__u3b1__u3bd__u3b8__u3c1__u3c9__u3c0__u3bf__u3c2_` in this scope
   --> /home/jules/.cache/.glossa/cache/ae4c31b12e598b6adf5755a1151219d309e27033ab9add5638bb62b4cb1dc8ce.rs:7:1032
```

🧪 **Reproduction:**
Run `cargo test --test havoc_issue_echo`.

😈 **Comment:** 
You assumed edge cases would fall graciously into existing validations. You were wrong. Added strict, early validations for Double Subject, Missing Verb, and Undefined Variables to proactively capture logic gaps before they reach semantic output. Also corrected the Undefined Variable error code localization according to the Troubleshooting guide.

---
*PR created automatically by Jules for task [11012982369689437839](https://jules.google.com/task/11012982369689437839) started by @madmax983*