### PR TITLE
⚡ Bolt: Replace intermediate `format!` allocations with `write!` in text generators

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+**[Replace `format!` + `push_str` with `writeln!`]
+**Learning:** Building large dynamically-generated strings with `format!` and then pushing them into a `String` buffer incurs unnecessary heap allocations. Using `format!` allocates an intermediate `String`, which is then copied during `push_str`.
+**Action:** Whenever iteratively building a large string (like Python source code or Mermaid.js configs), pre-allocate a `String` (with `.with_capacity()` if possible) and use `std::fmt::Write` with the `write!` or `writeln!` macros to append directly to the buffer, avoiding intermediate allocations.

--- a/patch_alchemist3.py
+++ b/patch_alchemist3.py
@@ -1,0 +1,26 @@
+with open("src/tools/alchemist.rs", "r") as f:
+    content = f.read()
+
+content = content.replace(
+    """        let _ = write!(&mut out, "{}    pass\\n", ind);""",
+    """        let _ = writeln!(&mut out, "{}    pass", ind);"""
+)
+
+content = content.replace(
+    """        let _ = write!(&mut out, "{}else:\\n", ind);""",
+    """        let _ = writeln!(&mut out, "{}else:", ind);"""
+)
+
+content = content.replace(
+    """            let _ = write!(&mut out, "{}    pass\\n", ind);""",
+    """            let _ = writeln!(&mut out, "{}    pass", ind);"""
+)
+
+content = content.replace(
+    """            let _ = write!(&mut out, "{}        pass\\n", ind);""",
+    """            let _ = writeln!(&mut out, "{}        pass", ind);"""
+)
+
+with open("src/tools/alchemist.rs", "w") as f:
+    f.write(content)
+print("Replaced write! newline errors")

--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -131,7 +131,7 @@ fn transpile_statement(stmt: &AnalyzedStatement, indent: usize) -> String {
         AnalyzedStatement::Expression(exprs) => {
             let mut out = String::new();
             for expr in exprs {
-                out.push_str(&format!("{}{}\n", ind, transpile_expr(expr)));
+                let _ = writeln!(&mut out, "{}{}", ind, transpile_expr(expr));
             }
             out.trim_end().to_string()
         }
@@ -165,9 +165,10 @@ fn transpile_if(
     indent: usize,
 ) -> String {
     let ind = "    ".repeat(indent);
-    let mut out = format!("{}if {}:\n", ind, transpile_expr(condition));
+    let mut out = String::new();
+    let _ = writeln!(&mut out, "{}if {}:", ind, transpile_expr(condition));
     if then_body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(&mut out, "{}    pass", ind);
     } else {
         for b_stmt in then_body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -175,9 +176,9 @@ fn transpile_if(
         }
     }
     if let Some(ebody) = else_body {
-        out.push_str(&format!("{}else:\n", ind));
+        let _ = writeln!(&mut out, "{}else:", ind);
         if ebody.is_empty() {
-            out.push_str(&format!("{}    pass\n", ind));
+            let _ = writeln!(&mut out, "{}    pass", ind);
         } else {
             for b_stmt in ebody {
                 out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -190,9 +191,10 @@ fn transpile_if(
 
 fn transpile_while(condition: &AnalyzedExpr, body: &[AnalyzedStatement], indent: usize) -> String {
     let ind = "    ".repeat(indent);
-    let mut out = format!("{}while {}:\n", ind, transpile_expr(condition));
+    let mut out = String::new();
+    let _ = writeln!(&mut out, "{}while {}:", ind, transpile_expr(condition));
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(&mut out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -209,14 +211,16 @@ fn transpile_for(
     indent: usize,
 ) -> String {
     let ind = "    ".repeat(indent);
-    let mut out = format!(
-        "{}for {} in {}:\n",
+    let mut out = String::new();
+    let _ = writeln!(
+        &mut out,
+        "{}for {} in {}:",
         ind,
         sanitize_ident(variable),
         transpile_expr(iterator)
     );
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(&mut out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -233,7 +237,8 @@ fn transpile_function_def(
     indent: usize,
 ) -> String {
     let ind = "    ".repeat(indent);
-    let mut out = format!("{}def {}(", ind, sanitize_ident(name));
+    let mut out = String::new();
+    let _ = write!(&mut out, "{}def {}(", ind, sanitize_ident(name));
     for (i, (p, _)) in params.iter().enumerate() {
         if i > 0 {
             out.push_str(", ");
@@ -243,7 +248,7 @@ fn transpile_function_def(
     out.push_str("):\n");
 
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(&mut out, "{}    pass", ind);
     } else {
         for (i, b_stmt) in body.iter().enumerate() {
             let mut is_last_expr = false;
@@ -255,9 +260,10 @@ fn transpile_function_def(
                 if let AnalyzedStatement::Expression(exprs) = b_stmt {
                     for (j, expr) in exprs.iter().enumerate() {
                         if j == exprs.len() - 1 {
-                            out.push_str(&format!("{}    return {}\n", ind, transpile_expr(expr)));
+                            let _ =
+                                writeln!(&mut out, "{}    return {}", ind, transpile_expr(expr));
                         } else {
-                            out.push_str(&format!("{}    {}\n", ind, transpile_expr(expr)));
+                            let _ = writeln!(&mut out, "{}    {}", ind, transpile_expr(expr));
                         }
                     }
                 }
@@ -276,17 +282,19 @@ fn transpile_type_def(
     indent: usize,
 ) -> String {
     let ind = "    ".repeat(indent);
-    let mut out = format!(
-        "{}@dataclass\n{}class {}:\n",
+    let mut out = String::new();
+    let _ = writeln!(
+        &mut out,
+        "{}@dataclass\n{}class {}:",
         ind,
         ind,
         sanitize_ident(name)
     );
     if fields.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(&mut out, "{}    pass", ind);
     } else {
         for (f_name, _) in fields {
-            out.push_str(&format!("{}    {}: Any\n", ind, sanitize_ident(f_name)));
+            let _ = writeln!(&mut out, "{}    {}: Any", ind, sanitize_ident(f_name));
         }
     }
     out.trim_end().to_string()
@@ -296,9 +304,10 @@ fn transpile_test_declaration(name: &str, body: &[AnalyzedStatement], indent: us
     let ind = "    ".repeat(indent);
     // We can transpile tests as regular functions prefixed with test_
     let safe_name = name.replace(" ", "_").replace("-", "_").replace("\"", "");
-    let mut out = format!("{}def test_{}():\n", ind, safe_name);
+    let mut out = String::new();
+    let _ = writeln!(&mut out, "{}def test_{}():", ind, safe_name);
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(&mut out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -315,15 +324,17 @@ fn transpile_match(
 ) -> String {
     let ind = "    ".repeat(indent);
     // Python 3.10+ match statement
-    let mut out = format!("{}match {}:\n", ind, transpile_expr(scrutinee));
+    let mut out = String::new();
+    let _ = writeln!(&mut out, "{}match {}:", ind, transpile_expr(scrutinee));
     for (pattern_expr, arm_body) in arms {
-        out.push_str(&format!(
-            "{}    case {}:\n",
+        let _ = writeln!(
+            &mut out,
+            "{}    case {}:",
             ind,
             transpile_expr(pattern_expr)
-        ));
+        );
         if arm_body.is_empty() {
-            out.push_str(&format!("{}        pass\n", ind));
+            let _ = writeln!(&mut out, "{}        pass", ind);
         } else {
             for b_stmt in arm_body {
                 out.push_str(&transpile_statement(b_stmt, indent + 2));

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -144,12 +144,14 @@ pub fn generate_cfg(program: &AnalyzedProgram) -> String {
     let end_node = add_node("End", "round", &mut nodes, &mut node_counter);
     add_edge(&current_node, &end_node, None, &mut edges);
 
-    let mut out = String::from("graph TD\n");
+    let mut out = String::with_capacity(nodes.len() * 32 + edges.len() * 32 + 16);
+    out.push_str("graph TD\n");
+    use std::fmt::Write;
     for node in nodes {
-        out.push_str(&format!("    {}\n", node));
+        let _ = writeln!(&mut out, "    {}", node);
     }
     for edge in edges {
-        out.push_str(&format!("    {}\n", edge));
+        let _ = writeln!(&mut out, "    {}", edge);
     }
     out
 }


### PR DESCRIPTION
💡 What: The optimization implemented: replaced numerous usages of `out.push_str(&format!(...))` and string concatenation via intermediate `.to_string()` or `format!` buffers with pre-allocated `String::with_capacity` and `write!` / `writeln!` macros in `src/tools/alchemist.rs` and `src/tools/labyrinth.rs`.
🎯 Why: The bottleneck: `format!` inside iterative loops inherently allocates an intermediate temporary `String` just to copy its characters into the target destination `String` buffer via `push_str`. This causes significant excessive heap allocations during traversal and source-code-generation processes, reducing efficiency.
📊 Impact: Expected gain: Reduces heap allocations substantially during Alchemist Python transpilation loops and Labyrinth CFG diagram generation by writing directly to the pre-allocated backing buffer.
🔬 Measurement: How to verify: Run `cargo bench`, or compile deeply nested statements and notice the reduced overhead and time spent doing malloc. Run tests in `cargo test` to verify zero functional regression.

---
*PR created automatically by Jules for task [14003082777494625562](https://jules.google.com/task/14003082777494625562) started by @madmax983*