### PR TITLE
🗺️ Atlas: [fix unused variable warning in main]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {


### PR DESCRIPTION
🕸️ Tangle: The experimental `Gnomon` command caused a compiler warning for an unused `input` variable when compiled without the `nova` feature enabled.
📐 Blueprint: Added `let _ = input;` within the `#[cfg(not(feature = "nova"))]` fallback block to explicitly ignore the variable and satisfy the compiler.
🧱 Stability: This change suppresses a compiler warning, bringing us closer to a clean build without any side effects to existing functionality.
🔬 Verification: Ran `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test`. All checks and tests passed successfully.

---
*PR created automatically by Jules for task [12048797644049747250](https://jules.google.com/task/12048797644049747250) started by @madmax983*