### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/022-add-haruspex-gnomon-scholar.md
+++ b/docs/adr/022-add-haruspex-gnomon-scholar.md
@@ -1,0 +1,23 @@
+# 022. Add Haruspex, Gnomon, and Scholar Tools
+
+Date: 2026-06-25
+
+## Status
+
+Proposed
+
+## Context
+
+We recently added three new developer experience tools in the `nova` feature suite:
+- **Haruspex** (`src/tools/haruspex.rs`): A tool that translates the semantic AST of a program into a DOT graph for visualization with Graphviz. This helps compiler developers inspect the raw semantic tree structure.
+- **Gnomon** (`src/tools/gnomon.rs`): A tool that estimates the Big-O time complexity of a program by statically analyzing loop depth in the semantic AST.
+- **Scholar** (`src/tools/scholar.rs`): An API doc generator that distills structures, traits, and functions into GitHub-flavored Markdown.
+
+## Decision
+
+We integrated these experimental tools into `src/tools/`, exposed them via `src/tools/mod.rs`, and gated them under the `nova` feature flag. We also updated `src/main.rs` and the CLI module to register these commands.
+
+## Consequences
+
+- These tools provide greater introspection into semantic assembly and complexity.
+- Increases the CLI surface area and maintainance overhead, which is mitigated by keeping them behind the `nova` experimental feature flag.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,9 @@ C4Container
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
         Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(gnomon, "The Gnomon", "src/tools/gnomon.rs", "Estimates Big-O time complexity by analyzing loop depth")
+        Container(haruspex, "The Haruspex", "src/tools/haruspex.rs", "Visualizes the Semantic AST as a DOT graph")
+        Container(scholar, "The Scholar", "src/tools/scholar.rs", "Generates Markdown API documentation from the program")
         Container(weave, "Weave", "src/tools/weave.rs", "Rosetta Stone Markdown Exporter")
     }
 
@@ -72,6 +75,9 @@ C4Container
     Rel(semantic, auditor, "Analyzed Program")
     Rel(semantic, labyrinth, "Analyzed Program")
     Rel(semantic, weave, "Analyzed Program")
+    Rel(semantic, gnomon, "Analyzed Program")
+    Rel(semantic, haruspex, "Analyzed Program")
+    Rel(semantic, scholar, "Analyzed Program")
     Rel(semantic, papyrus, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 


### PR DESCRIPTION
🧠 **Decision:** Recorded the integration of the experimental tools Haruspex, Gnomon, and Scholar into the `src/tools` crate under the `nova` feature flag in `docs/adr/022-add-haruspex-gnomon-scholar.md`.
🗺️ **Visuals:** Updated the C4 Component diagram in `docs/architecture.md` to show the new boundaries and include these 3 tools.
🔗 **Link:** See `docs/adr/022-add-haruspex-gnomon-scholar.md`.

---
*PR created automatically by Jules for task [2899339530498177477](https://jules.google.com/task/2899339530498177477) started by @madmax983*