### PR TITLE
🛡️ Sentry: [test coverage improvement] Unknown struct type parsing

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,6 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+**Unknown Struct Type Parsing**
+**Learning:** When manually constructing AST nodes to test specific semantic error paths (e.g., 'Unknown Type' in Glossa), ensure the mocked syntax structure is otherwise completely valid (including all required arguments, correct term counts, and correctly accented tokens). Otherwise, the test may silently pass by triggering an unrelated, earlier validation error.
+**Action:** Always verify the required parameters and logic bounds for the structure being tested. For struct instantiation (`try_parse_struct_instantiation`), the clause must contain a phrase with at least 4 terms: the variable name, the adjective ("νέον" with accent), the type name, any arguments, and the binding verb ("ἔστω").

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -267,7 +267,7 @@ pub fn try_parse_struct_instantiation(
 }
 
 fn parse_struct_args(
-    args_terms: &[Expr],
+    args_terms: &[crate::ast::Expr],
     fields_info: &[(SmolStr, GlossaType)],
     scope: &Scope,
 ) -> Option<Vec<AnalyzedExpr>> {
@@ -1518,6 +1518,30 @@ mod coverage_tests {
 
         let result = parse_struct_args(&terms, &fields, &scope);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_try_parse_struct_instantiation_unknown_type() {
+        let mut scope = Scope::new();
+
+        let stmt = crate::ast::Statement::Regular {
+            clauses: vec![crate::ast::Clause {
+                expressions: vec![crate::ast::Expr::Phrase(vec![
+                    crate::ast::Expr::Word(crate::ast::Word::new("var")),
+                    crate::ast::Expr::Word(crate::ast::Word::new("νέον")),
+                    crate::ast::Expr::Word(crate::ast::Word::new("UnknownType")),
+                    crate::ast::Expr::NumberLiteral(1),
+                    crate::ast::Expr::Word(crate::ast::Word::new("ἔστω")),
+                ])],
+            }],
+            is_query: false,
+            is_propagate: false,
+        };
+
+        let result = try_parse_struct_instantiation(&stmt, &mut scope);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Άγνωστος τύπος"));
     }
 
     #[test]


### PR DESCRIPTION
🎯 Target: `src/semantic/patterns.rs` (`try_parse_struct_instantiation`)
💣 Risk: If `lookup_type` fails to find a type during struct instantiation, it should gracefully return an error instead of panicking or returning `Ok(None)`. This ensures proper error handling.
🧪 Strategy: Added a new test `test_try_parse_struct_instantiation_unknown_type` that attempts to parse a struct instantiation statement with an undefined type name, verifying that it returns an `Err(GlossaError)`.
🔬 Verification: Run `cargo test test_try_parse_struct_instantiation_unknown_type`.

---
*PR created automatically by Jules for task [544779173176684578](https://jules.google.com/task/544779173176684578) started by @madmax983*