### PR TITLE
⚡ Bolt: [narrator format optimization]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,4 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**[Optimizing recursive type formatting]**\n**Learning:** Using `format!` recursively creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.\n**Action:** Replace recursive `format!` calls with a `write!` macro approach or `push_str` using a pre-allocated `String` buffer (`String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -194,17 +194,6 @@ fn format_exprs(exprs: &[AnalyzedExpr]) -> String {
     buf
 }
 
-fn format_types(types: &[GlossaType]) -> String {
-    let mut buf = String::with_capacity(types.len() * 16);
-    for (i, ty) in types.iter().enumerate() {
-        if i > 0 {
-            buf.push_str(", ");
-        }
-        buf.push_str(&tell_type(ty));
-    }
-    buf
-}
-
 fn add_print(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
     let script = format!("Proclaim: {}", format_exprs(exprs));
     table.add_row(vec![
@@ -563,22 +552,64 @@ fn tell_lambda(
 /// the Scroll of Logic translates these into conventional programming type names
 /// (e.g., `Number`, `[Type]`) to help developers map the Greek concepts to
 /// concepts they already understand.
+/// ⚡ Bolt Optimization:
+/// Replaced recursive `format!` calls with a single mutable `String` buffer.
+/// This prevents multiple intermediate heap-allocated Strings that are immediately
+/// concatenated and dropped during deep type signature formatting.
 fn tell_type(ty: &GlossaType) -> String {
+    let mut buf = String::with_capacity(32);
+    tell_type_into(ty, &mut buf);
+    buf
+}
+
+fn tell_type_into(ty: &GlossaType, buf: &mut String) {
     match ty {
-        GlossaType::Number => "Number".to_string(),
-        GlossaType::String => "String".to_string(),
-        GlossaType::Boolean => "Bool".to_string(),
-        GlossaType::List(inner) => format!("[{}]", tell_type(inner)),
-        GlossaType::Set(inner) => format!("Set<{}>", tell_type(inner)),
-        GlossaType::Map(k, v) => format!("Map<{}, {}>", tell_type(k), tell_type(v)),
-        GlossaType::Option(inner) => format!("Option<{}>", tell_type(inner)),
-        GlossaType::Result(ok, err) => format!("Result<{}, {}>", tell_type(ok), tell_type(err)),
-        GlossaType::Struct { name, .. } => name.to_string(),
-        GlossaType::Function { params, returns } => {
-            format!("Fn({}) -> {}", format_types(params), tell_type(returns))
+        GlossaType::Number => buf.push_str("Number"),
+        GlossaType::String => buf.push_str("String"),
+        GlossaType::Boolean => buf.push_str("Bool"),
+        GlossaType::List(inner) => {
+            buf.push('[');
+            tell_type_into(inner, buf);
+            buf.push(']');
         }
-        GlossaType::Unit => "()".to_string(),
-        GlossaType::Unknown => "?".to_string(),
+        GlossaType::Set(inner) => {
+            buf.push_str("Set<");
+            tell_type_into(inner, buf);
+            buf.push('>');
+        }
+        GlossaType::Map(k, v) => {
+            buf.push_str("Map<");
+            tell_type_into(k, buf);
+            buf.push_str(", ");
+            tell_type_into(v, buf);
+            buf.push('>');
+        }
+        GlossaType::Option(inner) => {
+            buf.push_str("Option<");
+            tell_type_into(inner, buf);
+            buf.push('>');
+        }
+        GlossaType::Result(ok, err) => {
+            buf.push_str("Result<");
+            tell_type_into(ok, buf);
+            buf.push_str(", ");
+            tell_type_into(err, buf);
+            buf.push('>');
+        }
+        GlossaType::Struct { name, .. } => buf.push_str(name),
+        GlossaType::Function { params, returns } => {
+            buf.push_str("Fn(");
+            for (i, p) in params.iter().enumerate() {
+                if i > 0 {
+                    buf.push_str(", ");
+                }
+                tell_type_into(p, buf);
+            }
+            buf.push_str(") -> ");
+            tell_type_into(returns, buf);
+        }
+        GlossaType::Unit => buf.push_str("()"),
+        GlossaType::Unknown => buf.push('?'),
     }
 }
 


### PR DESCRIPTION
💡 What: Replaced recursive `format!` calls in `tell_type` with a single mutable `String` buffer and an inner `tell_type_into` function. Removed dead `format_types`.

🎯 Why: Using `format!` recursively created multiple intermediate heap-allocated `String`s that were immediately concatenated and dropped, leading to unnecessary allocations when formatting deeply nested Glossa semantic types in the narrator.

📊 Impact: Eliminates intermediate string allocations for complex, recursive semantic types in the scroll of logic output, reducing memory pressure.

🔬 Measurement: Run `cargo bench` and `cargo test` and verify no regressions in testing.

---
*PR created automatically by Jules for task [7148932667485787796](https://jules.google.com/task/7148932667485787796) started by @madmax983*