### PR TITLE
🎻 Bard: Add missing Ghost Params documentation in semantic and codegen modules

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -171,6 +171,8 @@ impl<'a> std::fmt::Display for Sanitizer<'a> {
 /// // Keyword safety (even Rust keywords are safe due to g_ prefix)
 /// assert_eq!(sanitize_name("if"), "g_if");
 /// ```
+///
+/// * `name` - The string to sanitize.
 pub fn sanitize_name(name: &str) -> String {
     // Use the zero-allocation Sanitizer to generate the string
     Sanitizer {
@@ -204,6 +206,8 @@ pub fn sanitize_name(name: &str) -> String {
 /// assert_eq!(transliterate("λογος"), "_u3bb__u3bf__u3b3__u3bf__u3c2_");
 /// assert_eq!(transliterate("φιλοσοφια"), "_u3c6__u3b9__u3bb__u3bf__u3c3__u3bf__u3c6__u3b9__u3b1_");
 /// ```
+///
+/// * `greek` - The Greek string to transliterate.
 pub fn transliterate(greek: &str) -> String {
     if greek.is_empty() {
         return "_var_empty".to_string();
@@ -275,6 +279,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// ```
 use std::fmt::Write;
 
+///
+/// * `ty` - The Glossa type to convert.
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();
@@ -339,6 +345,8 @@ fn write_rust_type(ty: &GlossaType, out: &mut String) -> std::fmt::Result {
 /// let tokens = generate_type_tokens(&GlossaType::Number);
 /// assert_eq!(tokens.to_string(), "i64");
 /// ```
+///
+/// * `ty` - The Glossa type to generate tokens for.
 pub fn generate_type_tokens(ty: &GlossaType) -> TokenStream {
     match ty {
         GlossaType::Number => quote! { i64 },
@@ -402,6 +410,8 @@ pub fn generate_type_tokens(ty: &GlossaType) -> TokenStream {
 /// let rust_code = generate_rust(&program);
 /// assert!(rust_code.contains("println"));
 /// ```
+///
+/// * `program` - The analyzed program to generate Rust code for.
 pub fn generate_rust(program: &AnalyzedProgram) -> String {
     // Separate trait defs, struct defs, trait impls, function defs, tests, and main body statements
     // ⚡ Bolt Optimization: Pre-allocate vectors based on statement length.
@@ -503,6 +513,8 @@ fn generate_panic_hook() -> TokenStream {
 /// let rust_file = generate_rust_file(&program);
 /// assert!(rust_file.contains("fn main"));
 /// ```
+///
+/// * `program` - The analyzed program to generate a full Rust file for.
 pub fn generate_rust_file(program: &AnalyzedProgram) -> String {
     let code = generate_rust(program);
 
@@ -542,6 +554,8 @@ pub fn generate_rust_file(program: &AnalyzedProgram) -> String {
 /// let rust_code = generate_statement_code(&stmt);
 /// // The resulting code string is `let g__u3be_ = 5i64 ;`
 /// ```
+///
+/// * `stmt` - The analyzed statement to generate Rust code for.
 pub fn generate_statement_code(stmt: &AnalyzedStatement) -> String {
     generate_statement(stmt).to_string()
 }

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -69,6 +69,9 @@ pub struct AnalyzedProgram {
 /// assert_eq!(statements.len(), 1);
 /// assert!(scope.lookup_binding("ξ").is_some());
 /// ```
+///
+/// * `stmt` - The statement to analyze.
+/// * `scope` - The scope to check and update bindings.
 pub fn analyze_statement(
     stmt: &Statement,
     scope: &mut Scope,
@@ -158,6 +161,8 @@ fn extract_block_statements(stmt: &Statement) -> Option<&Vec<Statement>> {
 /// Perform semantic analysis on a program
 ///
 /// This is the entry point for semantic analysis.
+///
+/// * `program` - The full AST program to analyze.
 pub fn analyze_program(program: &Program) -> Result<AnalyzedProgram, GlossaError> {
     crate::semantic::validation::check_program_depth(program)?;
 

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -225,6 +225,9 @@ impl Assembler {
     ///
     /// It parses a string into morphologic traits and saves it to the ongoing statement structure. It exists as the primary interface to collect terms.
     ///
+    /// * `analysis` - The morphologically analyzed properties of the word.
+    /// * `original` - The original string as it appeared in source code.
+    ///
     /// # Examples
     ///
     /// ```rust,ignore
@@ -241,6 +244,10 @@ impl Assembler {
     ///
     /// This is a zero-allocation path when the normalized form is already known (e.g. from AST).
     /// It bypasses the costly `normalize_greek` call which may allocate strings.
+    ///
+    /// * `analysis` - The morphologically analyzed properties of the word.
+    /// * `original` - The original string as it appeared in source code.
+    /// * `normalized` - The pre-computed normalized form of the string.
     ///
     /// # Examples
     ///

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -52,6 +52,9 @@ use crate::morphology::lexicon;
 /// let result = analyze_control_flow(&stmt, &mut scope).unwrap();
 /// assert!(result.is_none());
 /// ```
+///
+/// * `stmt` - The AST statement to analyze.
+/// * `scope` - The current semantic scope.
 pub fn analyze_control_flow(
     stmt: &Statement,
     scope: &mut Scope,

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -90,6 +90,9 @@ use crate::semantic::{Constituent, Literal};
 /// let result = convert_assembled_to_analyzed(&asm, &mut scope);
 /// assert!(result.is_ok());
 /// ```
+///
+/// * `asm_stmt` - The assembled statement to convert.
+/// * `scope` - The current semantic scope.
 pub fn convert_assembled_to_analyzed(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
@@ -134,6 +137,9 @@ pub fn convert_assembled_to_analyzed(
 ///     _ => panic!("Expected Print statement"),
 /// }
 /// ```
+///
+/// * `asm_stmt` - The assembled statement to classify.
+/// * `scope` - The current semantic scope.
 pub fn classify_assembled_statement(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
@@ -1608,6 +1614,9 @@ fn extract_object_fallback(
 ///     _ => panic!("Expected NumberLiteral"),
 /// }
 /// ```
+///
+/// * `asm_stmt` - The assembled statement to extract a value from.
+/// * `scope` - The current semantic scope.
 pub fn extract_value(
     asm_stmt: &AssembledStatement,
     scope: &Scope,

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -32,6 +32,9 @@ use smol_str::SmolStr;
 ///
 /// * Updates `scope` with the new type definition.
 /// * Allows recursive types via `Box`, `Vec`, etc., but prevents direct infinite recursion.
+///
+/// * `type_def` - The AST Type definition to analyze.
+/// * `scope` - The current semantic scope.
 pub fn analyze_type_definition(
     type_def: &crate::ast::TypeDef,
     scope: &mut Scope,
@@ -111,6 +114,9 @@ fn check_recursive_type(target_name: &str, ty: &GlossaType) -> bool {
 ///     τύπωσις(εαυτός). // Method signature
 /// }.
 /// ```
+///
+/// * `trait_def` - The AST trait definition to analyze.
+/// * `scope` - The current semantic scope.
 pub fn analyze_trait_definition(
     trait_def: &crate::ast::TraitDef,
     scope: &mut Scope,
@@ -210,6 +216,9 @@ pub fn analyze_trait_definition(
 ///     τύπωσις(εαυτός) { ... }
 /// }.
 /// ```
+///
+/// * `trait_impl` - The AST trait implementation to analyze.
+/// * `scope` - The current semantic scope.
 pub fn analyze_trait_impl(
     trait_impl: &crate::ast::TraitImplDef,
     scope: &mut Scope,
@@ -340,6 +349,9 @@ pub fn resolve_type_name(name: &str, scope: &Scope) -> Result<GlossaType, Glossa
 ///
 /// 1. **Header**: Name + `ὁρίζειν` + Parameters (Dative + Genitive type).
 /// 2. **Body**: Expressions separated by middle dot (·).
+///
+/// * `stmt` - The AST statement to analyze.
+/// * `scope` - The current semantic scope.
 pub fn parse_function_definition(
     stmt: &Statement,
     scope: &mut Scope,
@@ -536,6 +548,9 @@ pub fn infer_return_type_from_body(body: &[AnalyzedStatement]) -> Option<GlossaT
 }
 
 /// Analyze a test declaration statement
+///
+/// * `test_decl` - The AST test declaration to analyze.
+/// * `scope` - The current semantic scope.
 pub fn analyze_test_declaration(
     test_decl: &crate::ast::TestDecl,
     scope: &mut Scope,

--- a/src/semantic/expressions.rs
+++ b/src/semantic/expressions.rs
@@ -364,6 +364,8 @@ fn analyze_unaryop(
 ///
 /// assert_eq!(get_first_word(&stmt).unwrap(), "ει");
 /// ```
+///
+/// * `stmt` - The statement to extract the first word from.
 pub fn get_first_word(stmt: &Statement) -> Result<smol_str::SmolStr, GlossaError> {
     if let Some(first_clause) = stmt.clauses().first()
         && let Some(first_expr) = first_clause.expressions.first()
@@ -409,6 +411,8 @@ pub fn get_first_word(stmt: &Statement) -> Result<smol_str::SmolStr, GlossaError
 ///
 /// assert!(contains_function_definition_verb(&stmt));
 /// ```
+///
+/// * `stmt` - The statement to check.
 pub fn contains_function_definition_verb(stmt: &Statement) -> bool {
     for clause in stmt.clauses() {
         for expr in &clause.expressions {
@@ -443,6 +447,9 @@ pub fn contains_function_definition_verb(stmt: &Statement) -> bool {
 /// assert!(contains_verb_in_expr(&expr, "λεγει"));
 /// assert!(!contains_verb_in_expr(&expr, "οριζειν"));
 /// ```
+///
+/// * `expr` - The expression to search in.
+/// * `verb` - The normalized verb lemma to look for.
 pub fn contains_verb_in_expr(expr: &Expr, verb: &str) -> bool {
     match expr {
         Expr::Word(word) => word.normalized == verb,

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -95,6 +95,8 @@ use crate::errors::GlossaError;
 /// // The verb slot should be filled
 /// assert!(assembled.verb.is_some());
 /// ```
+///
+/// * `stmt` - The AST statement to assemble into semantic slots.
 pub fn assemble_statement(stmt: &Statement) -> Result<AssembledStatement, GlossaError> {
     let mut asm = Assembler::new();
     asm.set_query(stmt.is_query());

--- a/src/semantic/patterns.rs
+++ b/src/semantic/patterns.rs
@@ -61,6 +61,9 @@ use smol_str::SmolStr;
 /// ```
 ///
 /// Returns `Some(analyzed_statement)` if this is a standalone method call, `None` otherwise.
+///
+/// * `stmt` - The AST statement to analyze.
+/// * `scope` - The current semantic scope.
 pub fn try_parse_method_call(
     stmt: &Statement,
     scope: &mut Scope,
@@ -143,6 +146,9 @@ pub fn try_parse_method_call(
 /// ```
 ///
 /// Returns `Some(analyzed_statement)` if this is a struct instantiation, `None` otherwise.
+///
+/// * `stmt` - The AST statement to analyze.
+/// * `scope` - The current semantic scope.
 pub fn try_parse_struct_instantiation(
     stmt: &Statement,
     scope: &mut Scope,
@@ -370,6 +376,9 @@ fn parse_struct_args(
 /// | **Quantifier** | "Any" (`τι`) + `>` | `.any(predicate)` |
 /// | **Quantifier** | "All" (`πάντα`) + `>` | `.all(predicate)` |
 /// | **Verb** | "Find" (`εὑρέ`) | `.find(predicate)` |
+///
+/// * `asm_stmt` - The assembled statement to check for functional patterns.
+/// * `scope` - The current semantic scope.
 pub fn detect_iterator_pattern(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -183,6 +183,10 @@ impl Scope {
     }
 
     /// Define a function in this scope
+    ///
+    /// * `name` - The identifier of the function to define.
+    /// * `param_types` - The list of types expected as arguments.
+    /// * `return_type` - The return type of the function, or None if it's void.
     pub fn define_function(
         &mut self,
         name: impl Into<SmolStr>,
@@ -216,6 +220,9 @@ impl Scope {
     }
 
     /// Define a type in this scope
+    ///
+    /// * `name` - The identifier of the new type.
+    /// * `glossa_type` - The `GlossaType` defining the underlying structure.
     pub fn define_type(&mut self, name: impl Into<SmolStr>, glossa_type: GlossaType) {
         self.current_level().types.insert(name.into(), glossa_type);
     }
@@ -231,6 +238,9 @@ impl Scope {
     }
 
     /// Define a trait in this scope
+    ///
+    /// * `name` - The identifier of the new trait.
+    /// * `trait_def` - The structural definition of the trait.
     pub fn define_trait(
         &mut self,
         name: impl Into<SmolStr>,
@@ -250,6 +260,8 @@ impl Scope {
     }
 
     /// Register a trait implementation
+    ///
+    /// * `impl_def` - The concrete implementation associating a type with a trait.
     pub fn register_trait_impl(&mut self, impl_def: crate::semantic::model::TraitImpl) {
         self.current_level().trait_impls.push(impl_def);
     }

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -262,6 +262,8 @@ impl GlossaType {
 /// assert_eq!(name, "HashMap");
 /// assert!(matches!(ty, GlossaType::Map(..)));
 /// ```
+///
+/// * `type_name` - The string representing a potential collection type.
 pub fn detect_collection_type(type_name: &str) -> Option<(&'static str, GlossaType)> {
     match type_name {
         "συνολον" => Some(("HashSet", GlossaType::Set(Box::new(GlossaType::Unknown)))),


### PR DESCRIPTION
📖 Chapter: Semantic Module and Codegen Module
💡 Insight: Added missing contextual explanations for Ghost Parameters across core logic modules, answering "why" these parameters are passed down.
🧪 Example: Parameters in `try_parse_method_call`, `detect_iterator_pattern`, and `extract_value` are now fully documented.
🖼️ Preview: All `cargo doc` rendering works gracefully with correct parameter list structures.

---
*PR created automatically by Jules for task [15573044155076654367](https://jules.google.com/task/15573044155076654367) started by @madmax983*