### PR TITLE
👺 Havoc: Codegen & Semantic AST Stack Overflow

### DIFF
--- a/HAVOC_ISSUE.md
+++ b/HAVOC_ISSUE.md
@@ -1,0 +1,35 @@
+👺 Havoc: Codegen Stack Overflow via proc_macro2
+
+🧨 **The Trigger:**
+A deeply nested AST expression (depth 50,000) generated programmatically causes a stack overflow during code generation. Specifically, the `output.to_string()` call on `TokenStream` within `generate_rust_file` crashes internally within the `proc_macro2` crate's stringification logic because `stacker::maybe_grow` does not protect the internals of external macro crates.
+
+📉 **The Stack Trace:**
+```
+thread 'havoc_codegen_stack_overflow' has overflowed its stack
+fatal runtime error: stack overflow, aborting
+```
+
+🧪 **Reproduction:**
+Run `cargo test --test havoc_codegen_stack_overflow`. It will spawn a subprocess that detonates by building an AST of depth 50,000 and attempting to generate Rust code for it.
+
+😈 **Comment:**
+You assumed that wrapping your own AST traversal in `stacker::maybe_grow` would save you. You forgot that `proc_macro2` has its own recursive stringification logic that you cannot control. You were wrong.
+
+---
+
+👺 Havoc: Semantic AST Clone & Drop Stack Overflow
+
+🧨 **The Trigger:**
+A deeply nested Semantic AST expression (depth 50,000) causes a stack overflow when cloned or dropped. While the `ast.rs` parser types use `stacker::maybe_grow`, the Semantic AST types (`AnalyzedExpr`, `AnalyzedStatement`) rely on derived `Clone` and implicit `Drop`, providing no recursion limit protections.
+
+📉 **The Stack Trace:**
+```
+thread 'havoc_semantic_clone_drop_stack_overflow' has overflowed its stack
+fatal runtime error: stack overflow, aborting
+```
+
+🧪 **Reproduction:**
+Run `cargo test --test havoc_semantic_stack_overflow`. It will spawn a subprocess that detonates by building a Semantic AST of depth 50,000 and then attempting to clone and drop it.
+
+😈 **Comment:**
+You guarded the front door (parser) but left the back door wide open. You assumed `stacker::maybe_grow` on the initial AST would magically protect your derived `Clone` on an entirely different recursive data structure. You were wrong.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,5 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. **Explore Codebase**: Investigate areas susceptible to crashes based on Havoc's targets: `unwrap`, `expect`, `unsafe`, thread synchronization, deep recursion, and memory exhaustion.
+2. **Identify Weakness**: I've successfully identified a vulnerability in the `proc_macro2` dependency used by the `codegen` module. Even though `stacker::maybe_grow` was correctly implemented in parser recursive structures, it wasn't implemented everywhere, and the Semantic AST `AnalyzedExpr`'s derived `Clone` causes a crash when deep recursion happens.
+3. **Draft the report**: I've written `HAVOC_ISSUE.md` describing the crash with precise details.
+4. **Pre-commit**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Submit**: Submit `HAVOC_ISSUE.md` (or directly via PR) to present the wreckage without "fixing" the bug as strictly enforced by Havoc.


### PR DESCRIPTION
👺 Havoc: Codegen & Semantic AST Stack Overflow

🧨 **The Trigger:** 
A deeply nested Semantic AST expression (depth 50,000) generated programmatically causes a stack overflow during code generation and when dropping the AST. The AST `Expr` types are protected using `stacker::maybe_grow`, but the Semantic AST types (`AnalyzedExpr`, `AnalyzedStatement`) rely on derived `Clone` and implicit `Drop` making them vulnerable. Furthermore, the `output.to_string()` call on `TokenStream` within `generate_rust_file` crashes internally within the `proc_macro2` crate's stringification logic because `stacker::maybe_grow` does not protect the internals of external macro crates.

📉 **The Stack Trace:**
```
thread 'havoc_semantic_clone_drop_stack_overflow' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

🧪 **Reproduction:** 
Run `cargo test --test havoc_semantic_stack_overflow`. It will spawn a subprocess that detonates by building an AST of depth 50,000 and attempting to clone and drop it. Run `cargo test --test havoc_codegen_stack_overflow` to see it crash during stringification.

😈 **Comment:** 
You guarded the front door (parser) but left the back door wide open. You assumed `stacker::maybe_grow` on the initial AST would magically protect your derived `Clone` and `Drop` on an entirely different recursive data structure. You also assumed `proc_macro2` could magically stringify infinite tokens without overflowing. You were wrong.

---
*PR created automatically by Jules for task [13716284045995938998](https://jules.google.com/task/13716284045995938998) started by @madmax983*