### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,4 @@
+📖 Chapter: The `codegen` module
+💡 Insight: Fixed a detached documentation block for `to_rust_type` by moving a `use std::fmt::Write;` statement to prevent `cargo doc` warnings.
+🧪 Example: N/A - formatting fix only.
+🖼️ Preview: Resolved all missing documentation warnings.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module
💡 Insight: Fixed a detached documentation block for `to_rust_type` by moving a `use std::fmt::Write;` statement to prevent `cargo doc` warnings.
🧪 Example: N/A - formatting fix only.
🖼️ Preview: Resolved all missing documentation warnings.

---
*PR created automatically by Jules for task [6169806340800086169](https://jules.google.com/task/6169806340800086169) started by @madmax983*