### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1582,6 +1582,70 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_bin_op_checked_sub() {
+        let left = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(10),
+            glossa_type: GlossaType::Number,
+        };
+        let right = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(5),
+            glossa_type: GlossaType::Number,
+        };
+        let code = generate_bin_op(BinaryOp::Sub, &left, &right).to_string();
+        assert!(code.contains("checked_sub"));
+        assert!(code.contains("expect"));
+        assert!(code.contains("arithmetic overflow"));
+    }
+
+    #[test]
+    fn test_generate_bin_op_checked_mul() {
+        let left = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(10),
+            glossa_type: GlossaType::Number,
+        };
+        let right = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(5),
+            glossa_type: GlossaType::Number,
+        };
+        let code = generate_bin_op(BinaryOp::Mul, &left, &right).to_string();
+        assert!(code.contains("checked_mul"));
+        assert!(code.contains("expect"));
+        assert!(code.contains("arithmetic overflow"));
+    }
+
+    #[test]
+    fn test_generate_bin_op_checked_div() {
+        let left = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(10),
+            glossa_type: GlossaType::Number,
+        };
+        let right = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(5),
+            glossa_type: GlossaType::Number,
+        };
+        let code = generate_bin_op(BinaryOp::Div, &left, &right).to_string();
+        assert!(code.contains("checked_div"));
+        assert!(code.contains("expect"));
+        assert!(code.contains("division by zero"));
+    }
+
+    #[test]
+    fn test_generate_bin_op_checked_rem() {
+        let left = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(10),
+            glossa_type: GlossaType::Number,
+        };
+        let right = AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(5),
+            glossa_type: GlossaType::Number,
+        };
+        let code = generate_bin_op(BinaryOp::Mod, &left, &right).to_string();
+        assert!(code.contains("checked_rem"));
+        assert!(code.contains("expect"));
+        assert!(code.contains("division by zero"));
+    }
+
+    #[test]
     fn test_generate_checked_op() {
         let left = quote! { a };
         let right = quote! { b };

--- a/src/semantic/resolver.rs
+++ b/src/semantic/resolver.rs
@@ -634,6 +634,15 @@ mod tests {
     }
 
     #[test]
+    fn test_resolver_scope_current_level_after_excess_exits() {
+        let mut scope = Scope::new();
+        scope.exit();
+        scope.exit();
+
+        let _ = scope.current_level(); // Should not panic since exit() protects the root level
+    }
+
+    #[test]
     fn test_scope_exit_underflow_protection() {
         let mut scope = Scope::new();
         // A new scope starts with 1 level


### PR DESCRIPTION
🛡️ Sentry: Test coverage improvements for code generation panics and scope boundaries

🎯 Target: `src/codegen.rs` and `src/semantic/resolver.rs`
💣 Risk: Code generation of `checked_sub`, `checked_mul`, `checked_div`, and `checked_rem` arithmetic panics lacked coverage ensuring the correct `expect(...)` branches are emitted. Furthermore, the `current_level` function in semantic resolution contained an `.expect()` for root scope underflow that wasn't thoroughly exercised after excessive `exit()` operations.
🧪 Strategy: Added specific unit tests in `src/codegen.rs` to assert that binary arithmetic operations produce the correct `checked_*` methods and overflow panic text. Added a test in `src/semantic/resolver.rs` to safely pop the scope twice and retrieve the `current_level`, asserting that the root state prevents underflow panics.
🔬 Verification: `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` run and verified.

---
*PR created automatically by Jules for task [1954259245048244105](https://jules.google.com/task/1954259245048244105) started by @madmax983*