### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,4 @@
+📖 Chapter: `src/codegen.rs` documentation structure
+💡 Insight: The `to_rust_type` function was missing documentation according to `rustdoc` because a `use std::fmt::Write;` statement was placed between its doc comment and the function signature. This detaches the doc comment, so I moved the import to the top of the file to fix the warning.
+🧪 Example: N/A - structural fix for existing docs.
+🖼️ Preview: N/A

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -102,6 +102,7 @@ use crate::semantic::{
 use crate::text::normalize_greek;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
+use std::fmt::Write;
 // ==================================================================================
 // UTILS
 // ==================================================================================
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: `src/codegen.rs` documentation structure
💡 Insight: The `to_rust_type` function was missing documentation according to `rustdoc` because a `use std::fmt::Write;` statement was placed between its doc comment and the function signature. This detaches the doc comment, so I moved the import to the top of the file to fix the warning.
🧪 Example: N/A - structural fix for existing docs.
🖼️ Preview: N/A

---
*PR created automatically by Jules for task [12348838773189174651](https://jules.google.com/task/12348838773189174651) started by @madmax983*