### PR TITLE
🔨 Razor: Flatten object-oriented visitors in tools

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,7 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+## [Reduction]
+**Bloat:** `GnomonVisitor` and `AuditorVisitor` in `src/tools/gnomon.rs` and `src/tools/auditor.rs` used object-oriented visitor patterns with struct wrappers for AST traversal.
+**Cut:** Flattened the visitors into pure procedural functions `visit_statement` and `visit_expr` that directly pass mutable state parameters (`current_depth`, `max_depth` for Gnomon; `usage_count`, `mutation_count`, `mutable_vars` for Auditor).
+**Saved:** Eliminated unnecessary structs and `impl` blocks, simplifying the traversal logic into straightforward procedural calls.

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -14,8 +14,8 @@
 //!
 //! The [`run_auditor`](crate::tools::auditor::run_auditor) function drives the analysis:
 //! 1. The code is parsed and semantically analyzed.
-//! 2. A custom visitor (`AuditorVisitor`) traverses every statement and expression in the AST.
-//! 3. The visitor tracks variable declarations, usages, and reassignments using HashMaps and HashSets.
+//! 2. The `visit_statement` and `visit_expr` functions traverse every statement and expression in the AST.
+//! 3. They track variable declarations, usages, and reassignments using HashMaps and HashSets.
 //! 4. After traversal, the findings are cross-referenced to produce a final report,
 //!    which is displayed in a stylized terminal table.
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement};
@@ -76,9 +76,17 @@ pub fn run_auditor(input: &Path) -> Result<()> {
 
     status.success();
 
-    let mut visitor = AuditorVisitor::new();
+    let mut usage_count = FxHashMap::default();
+    let mut mutation_count = FxHashMap::default();
+    let mut mutable_vars = FxHashSet::default();
+
     for stmt in &program.statements {
-        visitor.visit_statement(stmt);
+        visit_statement(
+            stmt,
+            &mut usage_count,
+            &mut mutation_count,
+            &mut mutable_vars,
+        );
     }
 
     let mut issues = 0;
@@ -101,7 +109,7 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         Cell::new("Message").add_attribute(Attribute::Bold),
     ]);
 
-    for (var, count) in &visitor.usage_count {
+    for (var, count) in &usage_count {
         if *count == 0 {
             table.add_row(vec![
                 Cell::new("⚠️ Unused Variable").fg(Color::Yellow),
@@ -112,11 +120,8 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         }
     }
 
-    for (var, count) in &visitor.mutation_count {
-        if *count == 0
-            && visitor.mutable_vars.contains(var)
-            && visitor.usage_count.get(var).unwrap_or(&0) > &0
-        {
+    for (var, count) in &mutation_count {
+        if *count == 0 && mutable_vars.contains(var) && usage_count.get(var).unwrap_or(&0) > &0 {
             table.add_row(vec![
                 Cell::new("💡 Unnecessary Mutation").fg(Color::Blue),
                 Cell::new(var),
@@ -140,218 +145,161 @@ pub fn run_auditor(input: &Path) -> Result<()> {
     Ok(())
 }
 
-struct AuditorVisitor {
-    /// ⚡ Bolt Optimization: Uses `FxHashMap` instead of the standard `HashMap`
-    /// to reduce cryptographic hashing overhead for small string keys (`SmolStr`).
-    usage_count: FxHashMap<SmolStr, usize>,
-    mutation_count: FxHashMap<SmolStr, usize>,
-    mutable_vars: FxHashSet<SmolStr>,
+fn visit_exprs(exprs: &[AnalyzedExpr], usage_count: &mut FxHashMap<SmolStr, usize>) {
+    for expr in exprs {
+        visit_expr(expr, usage_count);
+    }
 }
 
-impl AuditorVisitor {
-    fn new() -> Self {
-        Self {
-            usage_count: FxHashMap::default(),
-            mutation_count: FxHashMap::default(),
-            mutable_vars: FxHashSet::default(),
+fn visit_expr(expr: &AnalyzedExpr, usage_count: &mut FxHashMap<SmolStr, usize>) {
+    match &expr.expr {
+        AnalyzedExprKind::Variable(name) => {
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
+            }
         }
+        AnalyzedExprKind::BinOp { left, right, .. } => {
+            visit_expr(left, usage_count);
+            visit_expr(right, usage_count);
+        }
+        AnalyzedExprKind::UnaryOp { operand, .. } => visit_expr(operand, usage_count),
+        AnalyzedExprKind::StructInstantiation { args, .. } => visit_exprs(args, usage_count),
+        AnalyzedExprKind::PropertyAccess { owner, .. } => visit_expr(owner, usage_count),
+        AnalyzedExprKind::MethodCall { receiver, args, .. } => {
+            visit_expr(receiver, usage_count);
+            visit_exprs(args, usage_count);
+        }
+        AnalyzedExprKind::FunctionCall { args, .. } => visit_exprs(args, usage_count),
+        AnalyzedExprKind::VerbCall { args, .. } => visit_exprs(args, usage_count),
+        AnalyzedExprKind::ArrayLiteral(exprs) => visit_exprs(exprs, usage_count),
+        AnalyzedExprKind::IndexAccess { array, index } => {
+            visit_expr(array, usage_count);
+            visit_expr(index, usage_count);
+        }
+        AnalyzedExprKind::Lambda { body, .. } => visit_expr(body, usage_count),
+        AnalyzedExprKind::Some(inner) => visit_expr(inner, usage_count),
+        AnalyzedExprKind::Ok(inner) => visit_expr(inner, usage_count),
+        AnalyzedExprKind::Err(inner) => visit_expr(inner, usage_count),
+        AnalyzedExprKind::Unwrap(inner) => visit_expr(inner, usage_count),
+        AnalyzedExprKind::Try(inner) => visit_expr(inner, usage_count),
+        AnalyzedExprKind::Assert { condition } => visit_expr(condition, usage_count),
+        AnalyzedExprKind::AssertEq { left, right } => {
+            visit_expr(left, usage_count);
+            visit_expr(right, usage_count);
+        }
+        AnalyzedExprKind::Range { start, end, .. } => {
+            visit_expr(start, usage_count);
+            visit_expr(end, usage_count);
+        }
+        AnalyzedExprKind::NumberLiteral(_)
+        | AnalyzedExprKind::StringLiteral(_)
+        | AnalyzedExprKind::BooleanLiteral(_)
+        | AnalyzedExprKind::None
+        | AnalyzedExprKind::CollectionNew { .. } => {}
     }
+}
 
-    fn visit_if_statement(
-        &mut self,
-        condition: &AnalyzedExpr,
-        then_body: &[AnalyzedStatement],
-        else_body: &Option<Vec<AnalyzedStatement>>,
-    ) {
-        self.visit_expr(condition);
-        for s in then_body {
-            self.visit_statement(s);
-        }
-        if let Some(else_stmts) = else_body {
-            for s in else_stmts {
-                self.visit_statement(s);
+fn visit_statement(
+    stmt: &AnalyzedStatement,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match stmt {
+        AnalyzedStatement::Binding {
+            name,
+            value,
+            mutable,
+        } => {
+            usage_count.insert(name.clone(), 0);
+            mutation_count.insert(name.clone(), 0);
+            if *mutable {
+                mutable_vars.insert(name.clone());
             }
+            visit_expr(value, usage_count);
         }
-    }
-
-    fn visit_while_loop(&mut self, condition: &AnalyzedExpr, body: &[AnalyzedStatement]) {
-        self.visit_expr(condition);
-        for s in body {
-            self.visit_statement(s);
-        }
-    }
-
-    fn visit_for_loop(
-        &mut self,
-        variable: &smol_str::SmolStr,
-        iterator: &AnalyzedExpr,
-        body: &[AnalyzedStatement],
-    ) {
-        self.usage_count.insert(variable.clone(), 0);
-        self.visit_expr(iterator);
-        for s in body {
-            self.visit_statement(s);
-        }
-    }
-
-    fn visit_match_statement(
-        &mut self,
-        scrutinee: &AnalyzedExpr,
-        arms: &[(AnalyzedExpr, Vec<AnalyzedStatement>)],
-    ) {
-        self.visit_expr(scrutinee);
-        for (expr, stmts) in arms {
-            self.visit_expr(expr);
-            for s in stmts {
-                self.visit_statement(s);
+        AnalyzedStatement::Assignment { name, value } => {
+            if let Some(count) = mutation_count.get_mut(name) {
+                *count += 1;
             }
-        }
-    }
-
-    fn visit_function_def(
-        &mut self,
-        params: &[(smol_str::SmolStr, Option<crate::semantic::GlossaType>)],
-        body: &[AnalyzedStatement],
-    ) {
-        for (param_name, _) in params {
-            self.usage_count.insert(param_name.clone(), 0);
-        }
-        for s in body {
-            self.visit_statement(s);
-        }
-    }
-
-    fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
-        match stmt {
-            AnalyzedStatement::Binding {
-                name,
-                value,
-                mutable,
-            } => {
-                self.usage_count.insert(name.clone(), 0);
-                self.mutation_count.insert(name.clone(), 0);
-                if *mutable {
-                    self.mutable_vars.insert(name.clone());
-                }
-                self.visit_expr(value);
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
             }
-            AnalyzedStatement::Assignment { name, value } => {
-                if let Some(count) = self.mutation_count.get_mut(name) {
-                    *count += 1;
-                }
-                if let Some(count) = self.usage_count.get_mut(name) {
-                    *count += 1;
-                }
-                self.visit_expr(value);
+            visit_expr(value, usage_count);
+        }
+        AnalyzedStatement::Print(exprs) => {
+            visit_exprs(exprs, usage_count);
+        }
+        AnalyzedStatement::Expression(exprs) => {
+            visit_exprs(exprs, usage_count);
+        }
+        AnalyzedStatement::Query(exprs) => {
+            visit_exprs(exprs, usage_count);
+        }
+        AnalyzedStatement::If {
+            condition,
+            then_body,
+            else_body,
+        } => {
+            visit_expr(condition, usage_count);
+            for s in then_body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
             }
-            AnalyzedStatement::Print(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    visit_statement(s, usage_count, mutation_count, mutable_vars);
                 }
             }
-            AnalyzedStatement::Expression(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::Query(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::If {
-                condition,
-                then_body,
-                else_body,
-            } => {
-                self.visit_if_statement(condition, then_body, else_body);
-            }
-            AnalyzedStatement::While { condition, body } => {
-                self.visit_while_loop(condition, body);
-            }
-            AnalyzedStatement::For {
-                variable,
-                iterator,
-                body,
-            } => {
-                self.visit_for_loop(variable, iterator, body);
-            }
-            AnalyzedStatement::Match { scrutinee, arms } => {
-                self.visit_match_statement(scrutinee, arms);
-            }
-            AnalyzedStatement::FunctionDef { params, body, .. } => {
-                self.visit_function_def(params, body);
-            }
-            AnalyzedStatement::Return { value } => {
-                if let Some(v) = value {
-                    self.visit_expr(v);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::Break
-            | AnalyzedStatement::Continue
-            | AnalyzedStatement::TypeDefinition { .. }
-            | AnalyzedStatement::TraitDefinition { .. }
-            | AnalyzedStatement::TraitImplementation { .. } => {}
         }
-    }
-
-    fn visit_exprs(&mut self, exprs: &[AnalyzedExpr]) {
-        for expr in exprs {
-            self.visit_expr(expr);
+        AnalyzedStatement::While { condition, body } => {
+            visit_expr(condition, usage_count);
+            for s in body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
         }
-    }
-
-    fn visit_expr(&mut self, expr: &AnalyzedExpr) {
-        match &expr.expr {
-            AnalyzedExprKind::Variable(name) => {
-                if let Some(count) = self.usage_count.get_mut(name) {
-                    *count += 1;
+        AnalyzedStatement::For {
+            variable,
+            iterator,
+            body,
+        } => {
+            usage_count.insert(variable.clone(), 0);
+            visit_expr(iterator, usage_count);
+            for s in body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Match { scrutinee, arms } => {
+            visit_expr(scrutinee, usage_count);
+            for (expr, stmts) in arms {
+                visit_expr(expr, usage_count);
+                for s in stmts {
+                    visit_statement(s, usage_count, mutation_count, mutable_vars);
                 }
             }
-            AnalyzedExprKind::BinOp { left, right, .. } => {
-                self.visit_expr(left);
-                self.visit_expr(right);
-            }
-            AnalyzedExprKind::UnaryOp { operand, .. } => self.visit_expr(operand),
-            AnalyzedExprKind::StructInstantiation { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::PropertyAccess { owner, .. } => self.visit_expr(owner),
-            AnalyzedExprKind::MethodCall { receiver, args, .. } => {
-                self.visit_expr(receiver);
-                self.visit_exprs(args);
-            }
-            AnalyzedExprKind::FunctionCall { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::VerbCall { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::ArrayLiteral(exprs) => self.visit_exprs(exprs),
-            AnalyzedExprKind::IndexAccess { array, index } => {
-                self.visit_expr(array);
-                self.visit_expr(index);
-            }
-            AnalyzedExprKind::Lambda { body, .. } => self.visit_expr(body),
-            AnalyzedExprKind::Some(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Ok(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Err(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Unwrap(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Try(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Assert { condition } => self.visit_expr(condition),
-            AnalyzedExprKind::AssertEq { left, right } => {
-                self.visit_expr(left);
-                self.visit_expr(right);
-            }
-            AnalyzedExprKind::Range { start, end, .. } => {
-                self.visit_expr(start);
-                self.visit_expr(end);
-            }
-            AnalyzedExprKind::NumberLiteral(_)
-            | AnalyzedExprKind::StringLiteral(_)
-            | AnalyzedExprKind::BooleanLiteral(_)
-            | AnalyzedExprKind::None
-            | AnalyzedExprKind::CollectionNew { .. } => {}
         }
+        AnalyzedStatement::FunctionDef { params, body, .. } => {
+            for (param_name, _) in params {
+                usage_count.insert(param_name.clone(), 0);
+            }
+            for s in body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Return { value } => {
+            if let Some(v) = value {
+                visit_expr(v, usage_count);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Break
+        | AnalyzedStatement::Continue
+        | AnalyzedStatement::TypeDefinition { .. }
+        | AnalyzedStatement::TraitDefinition { .. }
+        | AnalyzedStatement::TraitImplementation { .. } => {}
     }
 }
 
@@ -395,7 +343,9 @@ mod tests {
 
     #[test]
     fn test_auditor_visitor_coverage_statements() {
-        let mut visitor = AuditorVisitor::new();
+        let mut usage_count = FxHashMap::default();
+        let mut mutation_count = FxHashMap::default();
+        let mut mutable_vars = FxHashSet::default();
 
         let statements = vec![
             AnalyzedStatement::Binding {
@@ -503,13 +453,18 @@ mod tests {
         ];
 
         for stmt in statements {
-            visitor.visit_statement(&stmt);
+            super::visit_statement(
+                &stmt,
+                &mut usage_count,
+                &mut mutation_count,
+                &mut mutable_vars,
+            );
         }
     }
 
     #[test]
     fn test_auditor_visitor_coverage_expressions() {
-        let mut visitor = AuditorVisitor::new();
+        let mut usage_count = FxHashMap::default();
 
         let exprs = vec![
             AnalyzedExprKind::Variable("x".into()),
@@ -605,7 +560,7 @@ mod tests {
                 expr: kind,
                 glossa_type: crate::semantic::GlossaType::Boolean,
             };
-            visitor.visit_expr(&expr);
+            super::visit_expr(&expr, &mut usage_count);
         }
     }
 

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -22,86 +22,71 @@ use std::path::Path;
 /// Just as a gnomon casts a shadow to indicate time, this visitor casts a shadow
 /// over the structure of a program to estimate its execution time complexity.
 /// It tracks the maximum nesting depth of `while` and `for` loops.
-#[derive(Default)]
-pub struct GnomonVisitor {
-    /// The current nesting depth of loops during traversal.
-    pub current_depth: usize,
-    /// The maximum nesting depth encountered so far.
-    pub max_depth: usize,
-}
-
-impl GnomonVisitor {
-    /// Creates a new `GnomonVisitor` starting at depth 0.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Recursively visits a statement and updates loop depth metrics.
-    ///
-    /// Increases depth when entering `While` or `For` loops, and explores
-    /// inner statements in branches (`If`, `Match`, functions).
-    pub fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
-        match stmt {
-            AnalyzedStatement::While { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
+/// Recursively visits a statement and updates loop depth metrics.
+///
+/// Increases depth when entering `While` or `For` loops, and explores
+/// inner statements in branches (`If`, `Match`, functions).
+pub fn visit_statement(stmt: &AnalyzedStatement, current_depth: &mut usize, max_depth: &mut usize) {
+    match stmt {
+        AnalyzedStatement::While { body, .. } => {
+            *current_depth += 1;
+            if *current_depth > *max_depth {
+                *max_depth = *current_depth;
             }
-            AnalyzedStatement::For { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
+            for s in body {
+                visit_statement(s, current_depth, max_depth);
             }
-            AnalyzedStatement::If {
-                then_body,
-                else_body,
-                ..
-            } => {
-                for s in then_body {
-                    self.visit_statement(s);
-                }
-                if let Some(else_stmts) = else_body {
-                    for s in else_stmts {
-                        self.visit_statement(s);
-                    }
-                }
-            }
-            AnalyzedStatement::Match { arms, .. } => {
-                for (_, stmts) in arms {
-                    for s in stmts {
-                        self.visit_statement(s);
-                    }
-                }
-            }
-            AnalyzedStatement::FunctionDef { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            _ => {}
+            *current_depth -= 1;
         }
+        AnalyzedStatement::For { body, .. } => {
+            *current_depth += 1;
+            if *current_depth > *max_depth {
+                *max_depth = *current_depth;
+            }
+            for s in body {
+                visit_statement(s, current_depth, max_depth);
+            }
+            *current_depth -= 1;
+        }
+        AnalyzedStatement::If {
+            then_body,
+            else_body,
+            ..
+        } => {
+            for s in then_body {
+                visit_statement(s, current_depth, max_depth);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    visit_statement(s, current_depth, max_depth);
+                }
+            }
+        }
+        AnalyzedStatement::Match { arms, .. } => {
+            for (_, stmts) in arms {
+                for s in stmts {
+                    visit_statement(s, current_depth, max_depth);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { body, .. } => {
+            for s in body {
+                visit_statement(s, current_depth, max_depth);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                visit_statement(s, current_depth, max_depth);
+            }
+        }
+        _ => {}
     }
 }
 
 /// Analyzes a ΓΛΩΣΣΑ source file and estimates its Big-O time complexity.
 ///
 /// This function coordinates the parsing, semantic analysis, and AST traversal
-/// using the [`GnomonVisitor`]. The result is presented to the user in a
+/// using `visit_statement`. The result is presented to the user in a
 /// stylized terminal table.
 ///
 /// # Errors
@@ -146,9 +131,10 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
 
     status.success();
 
-    let mut visitor = GnomonVisitor::new();
+    let mut current_depth = 0;
+    let mut max_depth = 0;
     for stmt in &program.statements {
-        visitor.visit_statement(stmt);
+        visit_statement(stmt, &mut current_depth, &mut max_depth);
     }
 
     println!();
@@ -170,23 +156,23 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
         Cell::new("Value").add_attribute(Attribute::Bold),
     ]);
 
-    let complexity = if visitor.max_depth == 0 {
+    let complexity = if max_depth == 0 {
         "O(1)".to_string()
-    } else if visitor.max_depth == 1 {
+    } else if max_depth == 1 {
         "O(N)".to_string()
     } else {
-        format!("O(N^{})", visitor.max_depth)
+        format!("O(N^{})", max_depth)
     };
 
     table.add_row(vec![
         Cell::new("Max Loop Depth"),
-        Cell::new(visitor.max_depth.to_string()),
+        Cell::new(max_depth.to_string()),
     ]);
     table.add_row(vec![
         Cell::new("Estimated Big-O"),
-        Cell::new(complexity).fg(if visitor.max_depth > 2 {
+        Cell::new(complexity).fg(if max_depth > 2 {
             Color::Red
-        } else if visitor.max_depth == 2 {
+        } else if max_depth == 2 {
             Color::Yellow
         } else {
             Color::Green
@@ -214,30 +200,33 @@ mod tests {
 
     #[test]
     fn test_gnomon_while_loop() {
-        let mut visitor = GnomonVisitor::new();
+        let mut current_depth = 0;
+        let mut max_depth = 0;
         let stmt = AnalyzedStatement::While {
             condition: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        super::visit_statement(&stmt, &mut current_depth, &mut max_depth);
+        assert_eq!(max_depth, 1);
     }
 
     #[test]
     fn test_gnomon_for_loop() {
-        let mut visitor = GnomonVisitor::new();
+        let mut current_depth = 0;
+        let mut max_depth = 0;
         let stmt = AnalyzedStatement::For {
             variable: SmolStr::new("x"),
             iterator: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        super::visit_statement(&stmt, &mut current_depth, &mut max_depth);
+        assert_eq!(max_depth, 1);
     }
 
     #[test]
     fn test_gnomon_nested_loops() {
-        let mut visitor = GnomonVisitor::new();
+        let mut current_depth = 0;
+        let mut max_depth = 0;
         let inner_loop = AnalyzedStatement::For {
             variable: SmolStr::new("y"),
             iterator: dummy_expr(),
@@ -247,7 +236,7 @@ mod tests {
             condition: dummy_expr(),
             body: vec![inner_loop],
         };
-        visitor.visit_statement(&outer_loop);
-        assert_eq!(visitor.max_depth, 2);
+        super::visit_statement(&outer_loop, &mut current_depth, &mut max_depth);
+        assert_eq!(max_depth, 2);
     }
 }


### PR DESCRIPTION
🔨 **Smell:** `GnomonVisitor` and `AuditorVisitor` in `src/tools/gnomon.rs` and `src/tools/auditor.rs` used object-oriented visitor patterns with struct wrappers for AST traversal, which is unnecessarily complex for simple logic flows in Rust.
✨ **Solution:** Flattened the object into pure procedural functions `visit_statement` and `visit_expr` passing mutable references to state (`current_depth`, `max_depth` for Gnomon; `usage_count`, `mutation_count`, `mutable_vars` for Auditor).
🧹 **Benefit:** Replaced a localized object-oriented abstraction with standard procedural Rust functions, saving lines of code and reducing cognitive load.
🛡️ **Verification:** Tests in `tools::gnomon` and `tools::auditor` pass successfully, and `cargo clippy` emits no warnings for the modified files.

---
*PR created automatically by Jules for task [12565966933106679806](https://jules.google.com/task/12565966933106679806) started by @madmax983*