### PR TITLE
🔒 Warden: Update anyhow dependency to resolve RUSTSEC-2026-0190

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -131,3 +131,7 @@ Signed,
 **2026-04-30 - [Infinite Stream DoS Vulnerability in File Loading]
 **Threat:** The `load_source` function in `src/tools/runner.rs` relied on `fs::metadata().len()` to enforce the `MAX_FILE_SIZE` limit. However, special device files like `/dev/zero` report a length of 0 while producing an infinite stream of bytes when read. Reading these files with `fs::read_to_string` causes a thread hang or Out-Of-Memory (OOM) Denial-of-Service condition.
 **Defense:** Added an explicit `metadata.is_file()` check in `check_file_size` to guarantee that the input path points to a regular file and explicitly reject non-regular file types like directories and device streams. Updated `tests/havoc_dos.rs` and `test_load_source_directory_error` to assert the "Not a valid file" error and pass cleanly without timeouts.
+
+**2026-06-29 - [Update anyhow dependency to resolve RUSTSEC-2026-0190]**
+**Threat:** The `anyhow` crate version `1.0.102` has an unsoundness vulnerability in `Error::downcast_mut()` (RUSTSEC-2026-0190), which could allow undefined behavior.
+**Defense:** Updated `anyhow` to version `1.0.103` using `cargo update -p anyhow`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"


### PR DESCRIPTION
🦠 Threat: The `anyhow` crate version `1.0.102` has an unsoundness vulnerability in `Error::downcast_mut()` (RUSTSEC-2026-0190), which could allow undefined behavior.
🛡️ Defense: Updated `anyhow` to version `1.0.103` using `cargo update -p anyhow`.
💥 Severity: High - Unsoundness can lead to arbitrary memory corruption.
🧪 Verification: Ran `cargo audit` to confirm the vulnerability is mitigated and the test suite passes successfully.

---
*PR created automatically by Jules for task [9718452329441065453](https://jules.google.com/task/9718452329441065453) started by @madmax983*