### PR TITLE
⚡ Bolt: [Reduce heap allocations in morphological analysis]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+**[Pre-allocation in Morphology Vectors]**
+**Learning:** Found small, frequently-called functions (`analyze_noun_all`, `analyze_verb_all`) that instantiated `Vec::new()` and then appended multiple (`1..8`) items. Pre-allocating these vectors with `Vec::with_capacity(8)` saves intermediate heap reallocations. Also learned that when injecting new doc comments into existing Rust `///` blocks (especially after markdown lists like `/// - item`), you must insert a blank doc line (`///`) before the new text to prevent `clippy::doc-lazy-continuation` errors.
+**Action:** Use `Vec::with_capacity()` for small vectors populated in hot paths like syntax/morphology disambiguation, and remember to properly format Rust doc comments to appease `clippy`.

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,4 @@
+💡 What: Switched `Vec::new()` to `Vec::with_capacity(8)` in `analyze_noun_all` and `analyze_verb_all`.
+🎯 Why: These functions are called heavily during morphological disambiguation, and typically return between 1 and 8 analyses for ambiguous endings. Pre-allocating capacity avoids intermediate heap reallocations.
+📊 Impact: Reduces intermediate heap allocations for every ambiguous noun/verb analyzed during compilation.
+🔬 Measurement: Run `cargo test` and observe identical functionality with fewer allocs under the hood.

--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -525,8 +525,10 @@ where
 /// For example, "-ε" could be:
 /// - 2nd person singular present imperative (λέγε!)
 /// - 3rd person singular aorist indicative (ἔλυσε)
+///
+/// ⚡ Bolt Optimization: Pre-allocating capacity avoids intermediate heap reallocations.
 pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    let mut analyses = Vec::with_capacity(8);
     analyze_verb_all_into(word, &mut analyses);
     analyses
 }

--- a/src/morphology/declension.rs
+++ b/src/morphology/declension.rs
@@ -203,8 +203,10 @@ where
 /// - Vocative singular (O sea!)
 ///
 /// The caller should use syntactic context to pick the right one.
+///
+/// ⚡ Bolt Optimization: Pre-allocating capacity avoids intermediate heap reallocations.
 pub fn analyze_noun_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    let mut analyses = Vec::with_capacity(8);
     analyze_noun_all_into(word, &mut analyses);
     analyses
 }


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(8)` in `analyze_noun_all` and `analyze_verb_all`.
🎯 Why: These functions are called heavily during morphological disambiguation, and typically return between 1 and 8 analyses for ambiguous endings. Pre-allocating capacity avoids intermediate heap reallocations.
📊 Impact: Reduces intermediate heap allocations for every ambiguous noun/verb analyzed during compilation.
🔬 Measurement: Run `cargo test` and observe identical functionality with fewer allocs under the hood.

---
*PR created automatically by Jules for task [9543090000951399436](https://jules.google.com/task/9543090000951399436) started by @madmax983*