### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -131,3 +131,7 @@ Signed,
 **2026-04-30 - [Infinite Stream DoS Vulnerability in File Loading]
 **Threat:** The `load_source` function in `src/tools/runner.rs` relied on `fs::metadata().len()` to enforce the `MAX_FILE_SIZE` limit. However, special device files like `/dev/zero` report a length of 0 while producing an infinite stream of bytes when read. Reading these files with `fs::read_to_string` causes a thread hang or Out-Of-Memory (OOM) Denial-of-Service condition.
 **Defense:** Added an explicit `metadata.is_file()` check in `check_file_size` to guarantee that the input path points to a regular file and explicitly reject non-regular file types like directories and device streams. Updated `tests/havoc_dos.rs` and `test_load_source_directory_error` to assert the "Not a valid file" error and pass cleanly without timeouts.
+
+**2024-11-20 - [Anyhow Unsoundness CVE & Unbounded Reads]
+**Threat:** `cargo audit` identified `anyhow` version `1.0.102` as vulnerable to `RUSTSEC-2026-0190` (Unsoundness in `Error::downcast_mut()`). Additionally, `src/tools/scholar.rs` contained unbounded `fs::read_to_string` calls in its test suite, posing a potential (though low-risk in tests) memory exhaustion DoS vector.
+**Defense:** Updated `anyhow` to `1.0.103` using `cargo update -p anyhow`. Replaced `fs::read_to_string` in `src/tools/scholar.rs` tests with explicitly capped readers using `std::io::Read::take(f, 1024 * 1024 + 1)`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"

--- a/src/tools/scholar.rs
+++ b/src/tools/scholar.rs
@@ -147,6 +147,7 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+    use std::io::Read;
 
     #[test]
     fn test_run_scholar_success() {
@@ -199,7 +200,9 @@ mod tests {
         let output_path = input_path.with_extension("doc.md");
         assert!(output_path.exists());
 
-        let md = fs::read_to_string(&output_path).unwrap();
+        let f = std::fs::File::open(&output_path).unwrap();
+        let mut md = String::new();
+        std::io::Read::take(f, 1024 * 1024 + 1).read_to_string(&mut md).unwrap();
         assert!(md.contains("*No fields defined.*"));
         assert!(md.contains("*No methods defined.*"));
     }
@@ -220,7 +223,9 @@ mod tests {
         let output_path = input_path.with_extension("doc.md");
         assert!(output_path.exists());
 
-        let md = fs::read_to_string(&output_path).unwrap();
+        let f = std::fs::File::open(&output_path).unwrap();
+        let mut md = String::new();
+        std::io::Read::take(f, 1024 * 1024 + 1).read_to_string(&mut md).unwrap();
         assert!(md.contains("### `προσθεσις(Ἀριθμός, Ἀριθμός) -> Ἀριθμός`"));
     }
 }


### PR DESCRIPTION
🦠 **Threat:** `cargo audit` identified `anyhow` version `1.0.102` as vulnerable to `RUSTSEC-2026-0190` (Unsoundness in `Error::downcast_mut()`). Additionally, `src/tools/scholar.rs` contained unbounded `fs::read_to_string` calls in its test suite, posing a potential (though low-risk in tests) memory exhaustion DoS vector.
🛡️ **Defense:** Updated `anyhow` to the patched `1.0.103` version via `cargo update -p anyhow`. Replaced `fs::read_to_string` in `src/tools/scholar.rs` tests with explicitly capped readers using `std::io::Read::take(f, 1024 * 1024 + 1)` and properly scoped `use std::io::Read;`.
💥 **Severity:** Low. The `anyhow` unsoundness is highly specific to downcasting mutable errors, and the unbounded reads were only in the test suite logic, but strict defense-in-depth requires eliminating both.
🧪 **Verification:** `cargo audit` passes cleanly. `cargo clippy` and `cargo test` pass with no regressions or `unused_mut` warnings.

---
*PR created automatically by Jules for task [3024559454698747404](https://jules.google.com/task/3024559454698747404) started by @madmax983*