### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-06-15 - Doc Comments Must Directly Precede Items
+**Confusion:** The documentation for `to_rust_type` was completely detached from the function because a `use std::fmt::Write;` statement was placed between the doc comment block and the function signature. This triggered a `missing_docs` warning despite the documentation existing.
+**Clarification:** I moved the `use` statement above the documentation block so that the doc comment is directly attached to the function, resolving the warning and ensuring the documentation renders correctly for the item.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,7 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The Code Generator (`src/codegen.rs`)
💡 Insight: The `to_rust_type` function was missing documentation because a `use std::fmt::Write;` statement interrupted the doc comment block, detaching it from the function signature. I moved the `use` statement so the docs are correctly associated with the function.
🧪 Example: Verified via `RUSTDOCFLAGS="-W missing_docs" cargo doc`.
🖼️ Preview: Documentation now correctly renders for `to_rust_type`.

---
*PR created automatically by Jules for task [10210662620214009446](https://jules.google.com/task/10210662620214009446) started by @madmax983*