### PR TITLE
🎨 Mosaic: UI Polish for Error Handling

### DIFF
--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -152,7 +152,12 @@ impl Status {
 
         let msg = self.message.as_str().bold().to_string();
         self.print_done("✕".red(), &msg);
-        eprintln!("{}", err);
+
+        let err_str = err.to_string();
+        for line in err_str.lines() {
+            eprintln!("{} {}", "│".red(), line.red());
+        }
+
         self.active = false;
     }
 


### PR DESCRIPTION
🖌️ **Before:**
Raw errors (like missing variables) were dumped to standard error using default unformatted `miette` output without boundaries, making the CLI feel like a log file (e.g. `Error:   × Ἄγνωστον ὄνομα: αριθμοι`).

✨ **After:**
Errors bubbled up through the UI `Status::error` mechanism are now wrapped in a visually distinct, high-contrast block. The raw text is framed with styled borders to act as a proper CLI dashboard element.

🖼️ **Visuals:**
The CLI displays a clean red `✕` with the status name, followed by an indented, bordered red block containing the exact error message.

---
*PR created automatically by Jules for task [4167174807677316383](https://jules.google.com/task/4167174807677316383) started by @madmax983*