### PR TITLE
🪒 Razor: [Reduction] Flatten Auditor and Gnomon visitors

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,13 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** `AuditorVisitor` in `src/tools/auditor.rs` used an object-oriented visitor pattern to maintain simple state.
+**Cut:** Flattened the object into pure procedural functions (`visit_statement`, `visit_expr`) passing mutable references to HashMaps and HashSets for state tracking.
+**Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** `GnomonVisitor` in `src/tools/gnomon.rs` used an object-oriented visitor pattern to maintain simple state.
+**Cut:** Flattened the object into a pure procedural function (`visit_statement`) passing mutable references to `current_depth` and `max_depth` for state tracking.
+**Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -14,7 +14,7 @@
 //!
 //! The [`run_auditor`](crate::tools::auditor::run_auditor) function drives the analysis:
 //! 1. The code is parsed and semantically analyzed.
-//! 2. A custom visitor (`AuditorVisitor`) traverses every statement and expression in the AST.
+//! 2. A recursive procedural function traverses every statement and expression in the AST.
 //! 3. The visitor tracks variable declarations, usages, and reassignments using HashMaps and HashSets.
 //! 4. After traversal, the findings are cross-referenced to produce a final report,
 //!    which is displayed in a stylized terminal table.
@@ -76,9 +76,17 @@ pub fn run_auditor(input: &Path) -> Result<()> {
 
     status.success();
 
-    let mut visitor = AuditorVisitor::new();
+    let mut usage_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+    let mut mutation_count: FxHashMap<SmolStr, usize> = FxHashMap::default();
+    let mut mutable_vars: FxHashSet<SmolStr> = FxHashSet::default();
+
     for stmt in &program.statements {
-        visitor.visit_statement(stmt);
+        visit_statement(
+            stmt,
+            &mut usage_count,
+            &mut mutation_count,
+            &mut mutable_vars,
+        );
     }
 
     let mut issues = 0;
@@ -101,7 +109,7 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         Cell::new("Message").add_attribute(Attribute::Bold),
     ]);
 
-    for (var, count) in &visitor.usage_count {
+    for (var, count) in &usage_count {
         if *count == 0 {
             table.add_row(vec![
                 Cell::new("⚠️ Unused Variable").fg(Color::Yellow),
@@ -112,11 +120,8 @@ pub fn run_auditor(input: &Path) -> Result<()> {
         }
     }
 
-    for (var, count) in &visitor.mutation_count {
-        if *count == 0
-            && visitor.mutable_vars.contains(var)
-            && visitor.usage_count.get(var).unwrap_or(&0) > &0
-        {
+    for (var, count) in &mutation_count {
+        if *count == 0 && mutable_vars.contains(var) && usage_count.get(var).unwrap_or(&0) > &0 {
             table.add_row(vec![
                 Cell::new("💡 Unnecessary Mutation").fg(Color::Blue),
                 Cell::new(var),
@@ -140,218 +145,201 @@ pub fn run_auditor(input: &Path) -> Result<()> {
     Ok(())
 }
 
-struct AuditorVisitor {
-    /// ⚡ Bolt Optimization: Uses `FxHashMap` instead of the standard `HashMap`
-    /// to reduce cryptographic hashing overhead for small string keys (`SmolStr`).
-    usage_count: FxHashMap<SmolStr, usize>,
-    mutation_count: FxHashMap<SmolStr, usize>,
-    mutable_vars: FxHashSet<SmolStr>,
+fn visit_statement(
+    stmt: &AnalyzedStatement,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match stmt {
+        AnalyzedStatement::Binding {
+            name,
+            value,
+            mutable,
+        } => {
+            usage_count.insert(name.clone(), 0);
+            mutation_count.insert(name.clone(), 0);
+            if *mutable {
+                mutable_vars.insert(name.clone());
+            }
+            visit_expr(value, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedStatement::Assignment { name, value } => {
+            if let Some(count) = mutation_count.get_mut(name) {
+                *count += 1;
+            }
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
+            }
+            visit_expr(value, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedStatement::Print(exprs) => {
+            for expr in exprs {
+                visit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Expression(exprs) => {
+            for expr in exprs {
+                visit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Query(exprs) => {
+            for expr in exprs {
+                visit_expr(expr, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::If {
+            condition,
+            then_body,
+            else_body,
+        } => {
+            visit_expr(condition, usage_count, mutation_count, mutable_vars);
+            for s in then_body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    visit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::While { condition, body } => {
+            visit_expr(condition, usage_count, mutation_count, mutable_vars);
+            for s in body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::For {
+            variable,
+            iterator,
+            body,
+        } => {
+            usage_count.insert(variable.clone(), 0);
+            visit_expr(iterator, usage_count, mutation_count, mutable_vars);
+            for s in body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Match { scrutinee, arms } => {
+            visit_expr(scrutinee, usage_count, mutation_count, mutable_vars);
+            for (expr, stmts) in arms {
+                visit_expr(expr, usage_count, mutation_count, mutable_vars);
+                for s in stmts {
+                    visit_statement(s, usage_count, mutation_count, mutable_vars);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { params, body, .. } => {
+            for (param_name, _) in params {
+                usage_count.insert(param_name.clone(), 0);
+            }
+            for s in body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Return { value } => {
+            if let Some(v) = value {
+                visit_expr(v, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                visit_statement(s, usage_count, mutation_count, mutable_vars);
+            }
+        }
+        AnalyzedStatement::Break
+        | AnalyzedStatement::Continue
+        | AnalyzedStatement::TypeDefinition { .. }
+        | AnalyzedStatement::TraitDefinition { .. }
+        | AnalyzedStatement::TraitImplementation { .. } => {}
+    }
 }
 
-impl AuditorVisitor {
-    fn new() -> Self {
-        Self {
-            usage_count: FxHashMap::default(),
-            mutation_count: FxHashMap::default(),
-            mutable_vars: FxHashSet::default(),
-        }
+fn visit_exprs(
+    exprs: &[AnalyzedExpr],
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    for expr in exprs {
+        visit_expr(expr, usage_count, mutation_count, mutable_vars);
     }
+}
 
-    fn visit_if_statement(
-        &mut self,
-        condition: &AnalyzedExpr,
-        then_body: &[AnalyzedStatement],
-        else_body: &Option<Vec<AnalyzedStatement>>,
-    ) {
-        self.visit_expr(condition);
-        for s in then_body {
-            self.visit_statement(s);
-        }
-        if let Some(else_stmts) = else_body {
-            for s in else_stmts {
-                self.visit_statement(s);
+fn visit_expr(
+    expr: &AnalyzedExpr,
+    usage_count: &mut FxHashMap<SmolStr, usize>,
+    mutation_count: &mut FxHashMap<SmolStr, usize>,
+    mutable_vars: &mut FxHashSet<SmolStr>,
+) {
+    match &expr.expr {
+        AnalyzedExprKind::Variable(name) => {
+            if let Some(count) = usage_count.get_mut(name) {
+                *count += 1;
             }
         }
-    }
-
-    fn visit_while_loop(&mut self, condition: &AnalyzedExpr, body: &[AnalyzedStatement]) {
-        self.visit_expr(condition);
-        for s in body {
-            self.visit_statement(s);
+        AnalyzedExprKind::BinOp { left, right, .. } => {
+            visit_expr(left, usage_count, mutation_count, mutable_vars);
+            visit_expr(right, usage_count, mutation_count, mutable_vars);
         }
-    }
-
-    fn visit_for_loop(
-        &mut self,
-        variable: &smol_str::SmolStr,
-        iterator: &AnalyzedExpr,
-        body: &[AnalyzedStatement],
-    ) {
-        self.usage_count.insert(variable.clone(), 0);
-        self.visit_expr(iterator);
-        for s in body {
-            self.visit_statement(s);
+        AnalyzedExprKind::UnaryOp { operand, .. } => {
+            visit_expr(operand, usage_count, mutation_count, mutable_vars)
         }
-    }
-
-    fn visit_match_statement(
-        &mut self,
-        scrutinee: &AnalyzedExpr,
-        arms: &[(AnalyzedExpr, Vec<AnalyzedStatement>)],
-    ) {
-        self.visit_expr(scrutinee);
-        for (expr, stmts) in arms {
-            self.visit_expr(expr);
-            for s in stmts {
-                self.visit_statement(s);
-            }
+        AnalyzedExprKind::StructInstantiation { args, .. } => {
+            visit_exprs(args, usage_count, mutation_count, mutable_vars)
         }
-    }
-
-    fn visit_function_def(
-        &mut self,
-        params: &[(smol_str::SmolStr, Option<crate::semantic::GlossaType>)],
-        body: &[AnalyzedStatement],
-    ) {
-        for (param_name, _) in params {
-            self.usage_count.insert(param_name.clone(), 0);
+        AnalyzedExprKind::PropertyAccess { owner, .. } => {
+            visit_expr(owner, usage_count, mutation_count, mutable_vars)
         }
-        for s in body {
-            self.visit_statement(s);
+        AnalyzedExprKind::MethodCall { receiver, args, .. } => {
+            visit_expr(receiver, usage_count, mutation_count, mutable_vars);
+            visit_exprs(args, usage_count, mutation_count, mutable_vars);
         }
-    }
-
-    fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
-        match stmt {
-            AnalyzedStatement::Binding {
-                name,
-                value,
-                mutable,
-            } => {
-                self.usage_count.insert(name.clone(), 0);
-                self.mutation_count.insert(name.clone(), 0);
-                if *mutable {
-                    self.mutable_vars.insert(name.clone());
-                }
-                self.visit_expr(value);
-            }
-            AnalyzedStatement::Assignment { name, value } => {
-                if let Some(count) = self.mutation_count.get_mut(name) {
-                    *count += 1;
-                }
-                if let Some(count) = self.usage_count.get_mut(name) {
-                    *count += 1;
-                }
-                self.visit_expr(value);
-            }
-            AnalyzedStatement::Print(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::Expression(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::Query(exprs) => {
-                for expr in exprs {
-                    self.visit_expr(expr);
-                }
-            }
-            AnalyzedStatement::If {
-                condition,
-                then_body,
-                else_body,
-            } => {
-                self.visit_if_statement(condition, then_body, else_body);
-            }
-            AnalyzedStatement::While { condition, body } => {
-                self.visit_while_loop(condition, body);
-            }
-            AnalyzedStatement::For {
-                variable,
-                iterator,
-                body,
-            } => {
-                self.visit_for_loop(variable, iterator, body);
-            }
-            AnalyzedStatement::Match { scrutinee, arms } => {
-                self.visit_match_statement(scrutinee, arms);
-            }
-            AnalyzedStatement::FunctionDef { params, body, .. } => {
-                self.visit_function_def(params, body);
-            }
-            AnalyzedStatement::Return { value } => {
-                if let Some(v) = value {
-                    self.visit_expr(v);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::Break
-            | AnalyzedStatement::Continue
-            | AnalyzedStatement::TypeDefinition { .. }
-            | AnalyzedStatement::TraitDefinition { .. }
-            | AnalyzedStatement::TraitImplementation { .. } => {}
+        AnalyzedExprKind::FunctionCall { args, .. } => {
+            visit_exprs(args, usage_count, mutation_count, mutable_vars)
         }
-    }
-
-    fn visit_exprs(&mut self, exprs: &[AnalyzedExpr]) {
-        for expr in exprs {
-            self.visit_expr(expr);
+        AnalyzedExprKind::VerbCall { args, .. } => {
+            visit_exprs(args, usage_count, mutation_count, mutable_vars)
         }
-    }
-
-    fn visit_expr(&mut self, expr: &AnalyzedExpr) {
-        match &expr.expr {
-            AnalyzedExprKind::Variable(name) => {
-                if let Some(count) = self.usage_count.get_mut(name) {
-                    *count += 1;
-                }
-            }
-            AnalyzedExprKind::BinOp { left, right, .. } => {
-                self.visit_expr(left);
-                self.visit_expr(right);
-            }
-            AnalyzedExprKind::UnaryOp { operand, .. } => self.visit_expr(operand),
-            AnalyzedExprKind::StructInstantiation { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::PropertyAccess { owner, .. } => self.visit_expr(owner),
-            AnalyzedExprKind::MethodCall { receiver, args, .. } => {
-                self.visit_expr(receiver);
-                self.visit_exprs(args);
-            }
-            AnalyzedExprKind::FunctionCall { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::VerbCall { args, .. } => self.visit_exprs(args),
-            AnalyzedExprKind::ArrayLiteral(exprs) => self.visit_exprs(exprs),
-            AnalyzedExprKind::IndexAccess { array, index } => {
-                self.visit_expr(array);
-                self.visit_expr(index);
-            }
-            AnalyzedExprKind::Lambda { body, .. } => self.visit_expr(body),
-            AnalyzedExprKind::Some(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Ok(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Err(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Unwrap(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Try(inner) => self.visit_expr(inner),
-            AnalyzedExprKind::Assert { condition } => self.visit_expr(condition),
-            AnalyzedExprKind::AssertEq { left, right } => {
-                self.visit_expr(left);
-                self.visit_expr(right);
-            }
-            AnalyzedExprKind::Range { start, end, .. } => {
-                self.visit_expr(start);
-                self.visit_expr(end);
-            }
-            AnalyzedExprKind::NumberLiteral(_)
-            | AnalyzedExprKind::StringLiteral(_)
-            | AnalyzedExprKind::BooleanLiteral(_)
-            | AnalyzedExprKind::None
-            | AnalyzedExprKind::CollectionNew { .. } => {}
+        AnalyzedExprKind::ArrayLiteral(exprs) => {
+            visit_exprs(exprs, usage_count, mutation_count, mutable_vars)
         }
+        AnalyzedExprKind::IndexAccess { array, index } => {
+            visit_expr(array, usage_count, mutation_count, mutable_vars);
+            visit_expr(index, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::Lambda { body, .. } => {
+            visit_expr(body, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::Some(inner) => {
+            visit_expr(inner, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::Ok(inner) => visit_expr(inner, usage_count, mutation_count, mutable_vars),
+        AnalyzedExprKind::Err(inner) => {
+            visit_expr(inner, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::Unwrap(inner) => {
+            visit_expr(inner, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::Try(inner) => {
+            visit_expr(inner, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::Assert { condition } => {
+            visit_expr(condition, usage_count, mutation_count, mutable_vars)
+        }
+        AnalyzedExprKind::AssertEq { left, right } => {
+            visit_expr(left, usage_count, mutation_count, mutable_vars);
+            visit_expr(right, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::Range { start, end, .. } => {
+            visit_expr(start, usage_count, mutation_count, mutable_vars);
+            visit_expr(end, usage_count, mutation_count, mutable_vars);
+        }
+        AnalyzedExprKind::NumberLiteral(_)
+        | AnalyzedExprKind::StringLiteral(_)
+        | AnalyzedExprKind::BooleanLiteral(_)
+        | AnalyzedExprKind::None
+        | AnalyzedExprKind::CollectionNew { .. } => {}
     }
 }
 
@@ -395,7 +383,9 @@ mod tests {
 
     #[test]
     fn test_auditor_visitor_coverage_statements() {
-        let mut visitor = AuditorVisitor::new();
+        let mut usage_count = FxHashMap::default();
+        let mut mutation_count = FxHashMap::default();
+        let mut mutable_vars = FxHashSet::default();
 
         let statements = vec![
             AnalyzedStatement::Binding {
@@ -503,13 +493,20 @@ mod tests {
         ];
 
         for stmt in statements {
-            visitor.visit_statement(&stmt);
+            visit_statement(
+                &stmt,
+                &mut usage_count,
+                &mut mutation_count,
+                &mut mutable_vars,
+            );
         }
     }
 
     #[test]
     fn test_auditor_visitor_coverage_expressions() {
-        let mut visitor = AuditorVisitor::new();
+        let mut usage_count = FxHashMap::default();
+        let mut mutation_count = FxHashMap::default();
+        let mut mutable_vars = FxHashSet::default();
 
         let exprs = vec![
             AnalyzedExprKind::Variable("x".into()),
@@ -605,7 +602,12 @@ mod tests {
                 expr: kind,
                 glossa_type: crate::semantic::GlossaType::Boolean,
             };
-            visitor.visit_expr(&expr);
+            visit_expr(
+                &expr,
+                &mut usage_count,
+                &mut mutation_count,
+                &mut mutable_vars,
+            );
         }
     }
 

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -7,7 +7,6 @@
 //!
 //! A gnomon is the part of a sundial that casts a shadow, used to indicate the time.
 //! This tool casts a shadow over the program's AST to estimate its execution time complexity.
-
 use crate::semantic::AnalyzedStatement;
 use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
@@ -16,92 +15,15 @@ use comfy_table::{Attribute, Cell, Color, Table};
 use crossterm::style::Stylize;
 use miette::Result;
 use std::path::Path;
-
 /// A visitor that traverses the Abstract Syntax Tree to calculate loop depth.
 ///
 /// Just as a gnomon casts a shadow to indicate time, this visitor casts a shadow
 /// over the structure of a program to estimate its execution time complexity.
 /// It tracks the maximum nesting depth of `while` and `for` loops.
-#[derive(Default)]
-pub struct GnomonVisitor {
-    /// The current nesting depth of loops during traversal.
-    pub current_depth: usize,
-    /// The maximum nesting depth encountered so far.
-    pub max_depth: usize,
-}
-
-impl GnomonVisitor {
-    /// Creates a new `GnomonVisitor` starting at depth 0.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Recursively visits a statement and updates loop depth metrics.
-    ///
-    /// Increases depth when entering `While` or `For` loops, and explores
-    /// inner statements in branches (`If`, `Match`, functions).
-    pub fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
-        match stmt {
-            AnalyzedStatement::While { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
-            }
-            AnalyzedStatement::For { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
-            }
-            AnalyzedStatement::If {
-                then_body,
-                else_body,
-                ..
-            } => {
-                for s in then_body {
-                    self.visit_statement(s);
-                }
-                if let Some(else_stmts) = else_body {
-                    for s in else_stmts {
-                        self.visit_statement(s);
-                    }
-                }
-            }
-            AnalyzedStatement::Match { arms, .. } => {
-                for (_, stmts) in arms {
-                    for s in stmts {
-                        self.visit_statement(s);
-                    }
-                }
-            }
-            AnalyzedStatement::FunctionDef { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
 /// Analyzes a ΓΛΩΣΣΑ source file and estimates its Big-O time complexity.
 ///
 /// This function coordinates the parsing, semantic analysis, and AST traversal
-/// using the [`GnomonVisitor`]. The result is presented to the user in a
+/// by a procedural traversal function. The result is presented to the user in a
 /// stylized terminal table.
 ///
 /// # Errors
@@ -121,13 +43,67 @@ impl GnomonVisitor {
 ///     eprintln!("Failed to estimate complexity: {}", e);
 /// }
 /// ```
+fn visit_statement(stmt: &AnalyzedStatement, current_depth: &mut usize, max_depth: &mut usize) {
+    match stmt {
+        AnalyzedStatement::While { body, .. } => {
+            *current_depth += 1;
+            if *current_depth > *max_depth {
+                *max_depth = *current_depth;
+            }
+            for s in body {
+                visit_statement(s, current_depth, max_depth);
+            }
+            *current_depth -= 1;
+        }
+        AnalyzedStatement::For { body, .. } => {
+            *current_depth += 1;
+            if *current_depth > *max_depth {
+                *max_depth = *current_depth;
+            }
+            for s in body {
+                visit_statement(s, current_depth, max_depth);
+            }
+            *current_depth -= 1;
+        }
+        AnalyzedStatement::If {
+            then_body,
+            else_body,
+            ..
+        } => {
+            for s in then_body {
+                visit_statement(s, current_depth, max_depth);
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    visit_statement(s, current_depth, max_depth);
+                }
+            }
+        }
+        AnalyzedStatement::Match { arms, .. } => {
+            for (_, stmts) in arms {
+                for s in stmts {
+                    visit_statement(s, current_depth, max_depth);
+                }
+            }
+        }
+        AnalyzedStatement::FunctionDef { body, .. } => {
+            for s in body {
+                visit_statement(s, current_depth, max_depth);
+            }
+        }
+        AnalyzedStatement::TestDeclaration { body, .. } => {
+            for s in body {
+                visit_statement(s, current_depth, max_depth);
+            }
+        }
+        _ => {}
+    }
+}
 pub fn run_gnomon(input: &Path) -> Result<()> {
     if !input.exists() {
         return Err(miette::miette!("Ἀρχεῖον οὐχ εὑρέθη: {}", input.display()));
     }
-
     let status = Status::start_with_symbol("Γνώμων (Estimating Complexity)", "⏳");
-
     let source = match load_source(input) {
         Ok(s) => s,
         Err(e) => {
@@ -135,7 +111,6 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
             return Err(e);
         }
     };
-
     let program = match crate::tools::runner::analyze_source(&source) {
         Ok(p) => p,
         Err(e) => {
@@ -143,14 +118,12 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
             return Err(e);
         }
     };
-
     status.success();
-
-    let mut visitor = GnomonVisitor::new();
+    let mut current_depth = 0;
+    let mut max_depth = 0;
     for stmt in &program.statements {
-        visitor.visit_statement(stmt);
+        visit_statement(stmt, &mut current_depth, &mut max_depth);
     }
-
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   G N O M O N".cyan().bold());
     println!(
@@ -160,7 +133,6 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
             .dim()
     );
     println!();
-
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
     table.set_header(vec![
@@ -169,75 +141,69 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
             .fg(Color::Cyan),
         Cell::new("Value").add_attribute(Attribute::Bold),
     ]);
-
-    let complexity = if visitor.max_depth == 0 {
+    let complexity = if max_depth == 0 {
         "O(1)".to_string()
-    } else if visitor.max_depth == 1 {
+    } else if max_depth == 1 {
         "O(N)".to_string()
     } else {
-        format!("O(N^{})", visitor.max_depth)
+        format!("O(N^{})", max_depth)
     };
-
     table.add_row(vec![
         Cell::new("Max Loop Depth"),
-        Cell::new(visitor.max_depth.to_string()),
+        Cell::new(max_depth.to_string()),
     ]);
     table.add_row(vec![
         Cell::new("Estimated Big-O"),
-        Cell::new(complexity).fg(if visitor.max_depth > 2 {
+        Cell::new(complexity).fg(if max_depth > 2 {
             Color::Red
-        } else if visitor.max_depth == 2 {
+        } else if max_depth == 2 {
             Color::Yellow
         } else {
             Color::Green
         }),
     ]);
-
     println!("{table}");
     println!();
-
     Ok(())
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, GlossaType};
     use smol_str::SmolStr;
-
     fn dummy_expr() -> Box<AnalyzedExpr> {
         Box::new(AnalyzedExpr {
             expr: AnalyzedExprKind::BooleanLiteral(true),
             glossa_type: GlossaType::Boolean,
         })
     }
-
     #[test]
     fn test_gnomon_while_loop() {
-        let mut visitor = GnomonVisitor::new();
+        let mut current_depth = 0;
+        let mut max_depth = 0;
         let stmt = AnalyzedStatement::While {
             condition: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        visit_statement(&stmt, &mut current_depth, &mut max_depth);
+        assert_eq!(max_depth, 1);
     }
-
     #[test]
     fn test_gnomon_for_loop() {
-        let mut visitor = GnomonVisitor::new();
+        let mut current_depth = 0;
+        let mut max_depth = 0;
         let stmt = AnalyzedStatement::For {
             variable: SmolStr::new("x"),
             iterator: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        visit_statement(&stmt, &mut current_depth, &mut max_depth);
+        assert_eq!(max_depth, 1);
     }
-
     #[test]
     fn test_gnomon_nested_loops() {
-        let mut visitor = GnomonVisitor::new();
+        let mut current_depth = 0;
+        let mut max_depth = 0;
         let inner_loop = AnalyzedStatement::For {
             variable: SmolStr::new("y"),
             iterator: dummy_expr(),
@@ -247,7 +213,7 @@ mod tests {
             condition: dummy_expr(),
             body: vec![inner_loop],
         };
-        visitor.visit_statement(&outer_loop);
-        assert_eq!(visitor.max_depth, 2);
+        visit_statement(&outer_loop, &mut current_depth, &mut max_depth);
+        assert_eq!(max_depth, 2);
     }
 }


### PR DESCRIPTION
Removed localized object-oriented `Visitor` patterns from `Auditor` and `Gnomon` tools, replacing them with flattened, recursive procedural functions that pass state using mutable references. This adheres to the KISS principle by reducing unnecessary boilerplate and structural bloat without modifying system behavior. Recorded reductions in `.jules/razor.md`. Fixed `input` warnings in `main.rs` when `nova` feature is disabled.

---
*PR created automatically by Jules for task [1630612324988670819](https://jules.google.com/task/1630612324988670819) started by @madmax983*