### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,10 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-05-04 - Unused variable in feature-gated code
+**Confusion:** When the `nova` feature is disabled, the compiler complains about an unused variable `input` in the `Commands::Gnomon` match arm because the only code that uses it (`glossa::tools::gnomon::run_gnomon(&input)?`) is gated behind `#[cfg(feature = "nova")]`.
+**Clarification:** Explicitly ignored the variable when the feature is disabled using `let _ = input;` inside the `#[cfg(not(feature = "nova"))]` block to prevent compiler warnings.
+
+## 2026-05-04 - Missing Docs on `to_rust_type`
+**Confusion:** `cargo doc` produced a warning about missing documentation for `pub fn to_rust_type` in `src/codegen.rs`. A `use std::fmt::Write;` statement was placed between the doc comments and the function, detaching the docs.
+**Clarification:** Moved the `use std::fmt::Write;` statement above the doc comment block so that the documentation attaches correctly to the function.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {


### PR DESCRIPTION
📖 Chapter: The Missing Documentation & The Unused Ghost Param
💡 Insight: Fixed detached doc comments in `codegen.rs` caused by an intermediate `use` statement. Fixed unused variable warnings in `main.rs` caused by feature-gated code ignoring `input` when compiled without `--all-features`.
🧪 Example: N/A (Structural & lint fixes)
🖼️ Preview: `cargo doc` and `cargo clippy` now pass with zero warnings!

---
*PR created automatically by Jules for task [12427044664093103148](https://jules.google.com/task/12427044664093103148) started by @madmax983*