### PR TITLE
🗺️ Atlas: Encapsulating Tools with a Facade

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -20,3 +20,11 @@
 **Tangle:** Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`, breaking encapsulation by exposing internal implementation details to the public API.
 **Blueprint:** Modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these modules with `pub(crate) mod`.
 **Stability:** Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains.
+
+## [Encapsulating Tools with a Facade]
+**Tangle:** The `src/tools/` directory exposed its internal modules (`runner`, `tester`, `interpreter`, etc.) as `pub mod`. This breaks encapsulation and allows external code (or the `src/main.rs` binary) to depend tightly on the internal hierarchy of the tools ecosystem.
+**Blueprint:**
+1. Modified `src/tools/mod.rs` to mark all submodules (e.g., `cli`, `runner`, `repl`) as `pub(crate) mod`.
+2. Created a public Facade in `src/tools/mod.rs` using `pub use` to selectively re-export only the exact structs and functions the `glossa` binary target needs.
+3. Updated `src/main.rs` and all integration tests to import directly from the Facade (`glossa::tools::*`) rather than the inner modules.
+**Stability:** Enforces high cohesion and strictly defines the boundary between the compiler library (`src/lib.rs`) and the binary (`src/main.rs`), eliminating the "Leaky Abstraction".

--- a/patch_more11.sh
+++ b/patch_more11.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+cat << 'PY_EOF' > patch_tools8.py
+import re
+with open('src/tools/mod.rs', 'r') as f:
+    content = f.read()
+
+exports = """
+#[cfg(feature = "nova")]
+pub use mentor::Lesson;
+#[cfg(feature = "nova")]
+pub use labyrinth::generate_cfg;
+"""
+if "pub use mentor::Lesson;" not in content:
+    content += exports
+
+with open('src/tools/mod.rs', 'w') as f:
+    f.write(content)
+PY_EOF
+python3 patch_tools8.py

--- a/patch_tools8.py
+++ b/patch_tools8.py
@@ -1,0 +1,15 @@
+import re
+with open('src/tools/mod.rs', 'r') as f:
+    content = f.read()
+
+exports = """
+#[cfg(feature = "nova")]
+pub use mentor::Lesson;
+#[cfg(feature = "nova")]
+pub use labyrinth::generate_cfg;
+"""
+if "pub use mentor::Lesson;" not in content:
+    content += exports
+
+with open('src/tools/mod.rs', 'w') as f:
+    f.write(content)

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,10 @@
 use clap::Parser;
 use miette::Result;
 
-use glossa::tools::cli::{Cli, Commands};
-use glossa::tools::dictionary::lookup_word;
-use glossa::tools::repl::run_repl;
-use glossa::tools::runner::{
-    bard_file, build_file, check_file, highlight_file, report_file, run_file,
-};
+use glossa::tools::lookup_word;
+use glossa::tools::run_repl;
+use glossa::tools::{Cli, Commands};
+use glossa::tools::{bard_file, build_file, check_file, highlight_file, report_file, run_file};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -28,7 +26,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Mentor) => {
             #[cfg(feature = "nova")]
-            glossa::tools::mentor::run_mentor()?;
+            glossa::tools::run_mentor()?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(
@@ -61,12 +59,12 @@ fn main() -> Result<()> {
         }
 
         Some(Commands::Test { input }) => {
-            glossa::tools::tester::run_tests(&input)?;
+            glossa::tools::run_tests(&input)?;
         }
 
         Some(Commands::Mosaic { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::mosaic::run_mosaic(&input)?;
+            glossa::tools::run_mosaic(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -79,7 +77,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Map { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::cartographer::run_map(&input)?;
+            glossa::tools::run_map(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -92,7 +90,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Labyrinth { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::labyrinth::run_labyrinth(&input)?;
+            glossa::tools::run_labyrinth(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -105,7 +103,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Weave { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::weave::run_weave(&input)?;
+            glossa::tools::run_weave(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -118,7 +116,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Alchemist { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::alchemist::run_alchemist(&input)?;
+            glossa::tools::run_alchemist(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -131,7 +129,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Papyrus { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::papyrus::run_papyrus(&input)?;
+            glossa::tools::run_papyrus(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -144,7 +142,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Haruspex { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::haruspex::run_haruspex(&input)?;
+            glossa::tools::run_haruspex(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -157,7 +155,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Audit { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::auditor::run_auditor(&input)?;
+            glossa::tools::run_auditor(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {
@@ -170,7 +168,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Catalog) => {
             #[cfg(feature = "nova")]
-            glossa::tools::catalog::run_catalog()?;
+            glossa::tools::run_catalog()?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(
@@ -180,7 +178,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Gnomon { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::gnomon::run_gnomon(&input)?;
+            glossa::tools::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
             miette::bail!(
@@ -190,7 +188,7 @@ fn main() -> Result<()> {
 
         Some(Commands::Scholar { input }) => {
             #[cfg(feature = "nova")]
-            glossa::tools::scholar::run_scholar(&input)?;
+            glossa::tools::run_scholar(&input)?;
 
             #[cfg(not(feature = "nova"))]
             {

--- a/src/tools/auditor.rs
+++ b/src/tools/auditor.rs
@@ -38,7 +38,7 @@ use std::path::Path;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::auditor::run_auditor;
+/// use glossa::tools::run_auditor;
 /// use std::path::Path;
 ///
 /// let input = Path::new("main.γλ");

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -57,7 +57,7 @@ use std::path::PathBuf;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::cli::Cli;
+/// use glossa::tools::Cli;
 /// use clap::Parser;
 ///
 /// // You can parse arguments from an iterator, which is useful for testing!
@@ -87,7 +87,7 @@ pub struct Cli {
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::cli::Commands;
+/// use glossa::tools::Commands;
 /// use std::path::PathBuf;
 ///
 /// let run_cmd = Commands::Run { input: PathBuf::from("main.γλ") };

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -113,7 +113,7 @@ impl GnomonVisitor {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::gnomon::run_gnomon;
+/// use glossa::tools::run_gnomon;
 /// use std::path::Path;
 ///
 /// let input = Path::new("algorithm.γλ");

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -32,7 +32,7 @@ use std::fmt;
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::Value;
+/// use glossa::tools::Value;
 ///
 /// // Create a numerical truth
 /// let count = Value::Number(42);
@@ -79,7 +79,7 @@ impl fmt::Display for Value {
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::EvalError;
+/// use glossa::tools::EvalError;
 ///
 /// let missing_var = EvalError::VariableNotFound("x".into());
 /// assert!(missing_var.to_string().contains("μεταβλητὴ"));
@@ -135,7 +135,7 @@ pub enum EvalError {
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::interpreter::Interpreter;
+/// use glossa::tools::Interpreter;
 ///
 /// let mut interp = Interpreter::new();
 /// // You could then run a program via `interp.run(&analyzed_program)`
@@ -163,7 +163,7 @@ impl Interpreter {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::interpreter::Interpreter;
+    /// use glossa::tools::Interpreter;
     ///
     /// let interp = Interpreter::new();
     /// assert_eq!(interp.get_output(), "");
@@ -180,7 +180,7 @@ impl Interpreter {
     /// # Examples
     ///
     /// ```rust
-    /// use glossa::tools::interpreter::Interpreter;
+    /// use glossa::tools::Interpreter;
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
     ///

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -113,7 +113,7 @@ pub fn run_labyrinth_inner<W: std::io::Write>(source: &str, writer: &mut W) -> m
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::labyrinth::generate_cfg;
+/// use glossa::tools::generate_cfg;
 /// use glossa::semantic::analyze_program;
 /// use glossa::parser::parse;
 ///

--- a/src/tools/mentor.rs
+++ b/src/tools/mentor.rs
@@ -34,7 +34,7 @@ use std::io::{BufRead, Write};
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::mentor::Lesson;
+/// use glossa::tools::Lesson;
 /// use glossa::semantic::AnalyzedProgram;
 ///
 /// let first_lesson = Lesson {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,45 +17,45 @@
 //! * `ui`: **The Stage** - Terminal UI helpers (status spinners, emojis, etc.).
 
 #[cfg(feature = "nova")]
-pub mod alchemist;
+pub(crate) mod alchemist;
 /// The Auditor (Λογιστής) tool for static analysis.
 ///
 /// This experimental tool analyzes Glossa code to detect unused variables,
 /// unnecessary mutable bindings, and other code quality issues.
 #[cfg(feature = "nova")]
-pub mod auditor;
+pub(crate) mod auditor;
 pub(crate) mod cache;
 pub use cache::Cache;
 #[cfg(feature = "nova")]
-pub mod cartographer;
+pub(crate) mod cartographer;
 #[cfg(feature = "nova")]
-pub mod catalog;
-pub mod cli;
-pub mod dictionary;
+pub(crate) mod catalog;
+pub(crate) mod cli;
+pub(crate) mod dictionary;
 /// The Haruspex (ὁ Ἱεροσκόπος) tool for visualizing the Semantic AST.
 ///
 /// This experimental tool exports the analyzed program as a Graphviz DOT diagram.
 #[cfg(feature = "nova")]
-pub mod gnomon;
+pub(crate) mod gnomon;
 #[cfg(feature = "nova")]
-pub mod haruspex;
+pub(crate) mod haruspex;
 pub mod highlight;
 #[cfg(feature = "nova")]
-pub mod interpreter;
+pub(crate) mod interpreter;
 #[cfg(feature = "nova")]
-pub mod labyrinth;
+pub(crate) mod labyrinth;
 #[cfg(feature = "nova")]
-pub mod mentor;
+pub(crate) mod mentor;
 #[cfg(feature = "nova")]
-pub mod mosaic;
-pub mod narrator;
+pub(crate) mod mosaic;
+pub(crate) mod narrator;
 /// The Papyrus (Πάπυρος) tool for SQL schema generation.
 ///
 /// This experimental tool reads Glossa type definitions and automatically
 /// generates corresponding SQL `CREATE TABLE` statements.
 #[cfg(feature = "nova")]
-pub mod papyrus;
-pub mod repl;
+pub(crate) mod papyrus;
+pub(crate) mod repl;
 pub(crate) mod report;
 /// The engine room for executing and building Glossa programs
 ///
@@ -66,7 +66,7 @@ pub(crate) mod report;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::runner::run_file;
+/// use glossa::tools::run_file;
 /// use std::path::Path;
 ///
 /// // Execute a Glossa file directly from its path
@@ -75,10 +75,61 @@ pub(crate) mod report;
 ///     eprintln!("Execution failed: {}", e);
 /// }
 /// ```
-pub mod runner;
+pub(crate) mod runner;
 #[cfg(feature = "nova")]
-pub mod scholar;
-pub mod tester;
+pub(crate) mod scholar;
+pub(crate) mod tester;
 pub(crate) mod ui;
 #[cfg(feature = "nova")]
-pub mod weave;
+pub(crate) mod weave;
+
+// Public API Facade
+#[cfg(feature = "nova")]
+pub use alchemist::run_alchemist;
+#[cfg(feature = "nova")]
+pub use auditor::run_auditor;
+#[cfg(feature = "nova")]
+pub use cartographer::run_map;
+#[cfg(feature = "nova")]
+pub use catalog::run_catalog;
+pub use cli::{Cli, Commands};
+pub use dictionary::lookup_word;
+#[cfg(feature = "nova")]
+pub use gnomon::run_gnomon;
+#[cfg(feature = "nova")]
+pub use haruspex::run_haruspex;
+#[cfg(feature = "nova")]
+pub use interpreter::{EvalError, Interpreter, Value};
+#[cfg(feature = "nova")]
+pub use labyrinth::run_labyrinth;
+#[cfg(feature = "nova")]
+pub use mentor::run_mentor;
+#[cfg(feature = "nova")]
+pub use mosaic::run_mosaic;
+#[cfg(feature = "nova")]
+pub use papyrus::run_papyrus;
+pub use repl::run_repl;
+pub use runner::{bard_file, build_file, check_file, highlight_file, report_file, run_file};
+#[cfg(feature = "nova")]
+pub use scholar::run_scholar;
+pub use tester::run_tests;
+#[cfg(feature = "nova")]
+pub use weave::run_weave;
+
+#[cfg(feature = "nova")]
+pub use alchemist::transpile_to_python;
+
+pub use narrator::tell_tale;
+
+#[cfg(feature = "nova")]
+pub use mosaic::run_mosaic_inner;
+
+#[cfg(feature = "nova")]
+pub use labyrinth::run_labyrinth_inner;
+
+pub use runner::analyze_source;
+
+#[cfg(feature = "nova")]
+pub use mentor::Lesson;
+#[cfg(feature = "nova")]
+pub use labyrinth::generate_cfg;

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -37,7 +37,7 @@ use std::fmt::Write;
 /// ```
 /// use glossa::parser::parse;
 /// use glossa::semantic::analyze_program;
-/// use glossa::tools::narrator::tell_tale;
+/// use glossa::tools::tell_tale;
 ///
 /// let source = "ξ 5 ἔστω.";
 /// let ast = parse(source).unwrap();

--- a/src/tools/papyrus.rs
+++ b/src/tools/papyrus.rs
@@ -33,7 +33,7 @@ use std::path::Path;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::papyrus::run_papyrus;
+/// use glossa::tools::run_papyrus;
 /// use std::path::Path;
 ///
 /// let input = Path::new("schema.γλ");

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -53,7 +53,7 @@ impl ProgramStats {
     /// ```rust,ignore
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
-    /// use glossa::tools::report::ProgramStats;
+    /// use glossa::tools::ProgramStats;
     ///
     /// let source = "ξ πέντε ἔστω.";
     /// let ast = parse(source).unwrap();
@@ -274,7 +274,7 @@ impl<'a> GlossaReport<'a> {
     /// ```rust,ignore
     /// use glossa::parser::parse;
     /// use glossa::semantic::analyze_program;
-    /// use glossa::tools::report::GlossaReport;
+    /// use glossa::tools::GlossaReport;
     ///
     /// let source = "ξ πέντε ἔστω.";
     /// let ast = parse(source).unwrap();

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -48,7 +48,7 @@ const MAX_FILE_SIZE: u64 = 1024 * 1024;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::tools::runner::analyze_source;
+/// use glossa::tools::analyze_source;
 ///
 /// // Parse a simple Glossa program
 /// let source = "ξ 10 ἔστω. ξ λέγε.";
@@ -99,7 +99,7 @@ fn check_file_size(input: &Path) -> Result<()> {
 /// # Examples
 ///
 /// ```text
-/// use glossa::tools::runner::load_source;
+/// use glossa::tools::load_source;
 /// use std::path::Path;
 ///
 /// // Load the source from a given path
@@ -160,7 +160,7 @@ pub(crate) fn load_source(input: &Path) -> Result<String> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::build_file;
+/// use glossa::tools::build_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -252,7 +252,7 @@ pub fn build_file(input: &Path, output: Option<&Path>) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::run_file;
+/// use glossa::tools::run_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -392,7 +392,7 @@ fn execute_binary(executable: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::check_file;
+/// use glossa::tools::check_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -471,7 +471,7 @@ pub fn report_file(input: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::highlight_file;
+/// use glossa::tools::highlight_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;
@@ -520,7 +520,7 @@ pub fn highlight_file(input: &Path) -> Result<()> {
 /// ## Examples
 ///
 /// ```
-/// use glossa::tools::runner::bard_file;
+/// use glossa::tools::bard_file;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;

--- a/src/tools/scholar.rs
+++ b/src/tools/scholar.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 /// ## Examples
 ///
 /// ```rust,no_run
-/// use glossa::tools::scholar::run_scholar;
+/// use glossa::tools::run_scholar;
 /// use std::path::Path;
 ///
 /// let input = Path::new("library.γλ");

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -403,7 +403,7 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
 /// ## Examples
 ///
 /// ```rust
-/// use glossa::tools::tester::run_tests;
+/// use glossa::tools::run_tests;
 /// use std::path::PathBuf;
 /// use std::fs;
 /// use tempfile::tempdir;

--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -31,7 +31,7 @@ use std::time::Instant;
 /// # Examples
 ///
 /// ```rust,ignore
-/// use glossa::tools::ui::Status;
+/// use glossa::tools::Status;
 ///
 /// let mut status = Status::start("Compiling");
 /// status.update("Analyzing");
@@ -51,7 +51,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let status = Status::start("Compiling...");
     /// status.success();
     /// ```
@@ -65,7 +65,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let status = Status::start_with_symbol("Testing", "🧪");
     /// status.success();
     /// ```
@@ -94,7 +94,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let mut status = Status::start("Running Phase 1");
     /// // ... work ...
     /// status.update("Running Phase 2");
@@ -115,7 +115,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let status = Status::start("Connecting");
     /// // ... work ...
     /// status.success(); // Prints "✓ Connecting (0.01s)"
@@ -140,7 +140,7 @@ impl Status {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use glossa::tools::ui::Status;
+    /// use glossa::tools::Status;
     /// let status = Status::start("Downloading");
     /// // ... fail ...
     /// status.error("Connection Refused"); // Prints "✕ Downloading" and then the error

--- a/tests/alchemist_coverage.rs
+++ b/tests/alchemist_coverage.rs
@@ -5,7 +5,7 @@ use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::alchemist::{run_alchemist, transpile_to_python};
+use glossa::tools::{run_alchemist, transpile_to_python};
 use std::io::Write;
 use tempfile::Builder;
 

--- a/tests/havoc_dos.rs
+++ b/tests/havoc_dos.rs
@@ -19,7 +19,7 @@ fn test_dos_dev_zero() {
 
         // We expect run_file to fail either due to file size check (if fixed) or some other error.
         // If it hangs, it won't return.
-        let result = glossa::tools::runner::run_file(path);
+        let result = glossa::tools::run_file(path);
         // Send the result back
         // If run_file hangs, this line is never reached.
         let _ = tx.send(result);

--- a/tests/havoc_proptest_tools.rs
+++ b/tests/havoc_proptest_tools.rs
@@ -2,7 +2,7 @@
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
 use glossa::tools::highlight::highlight;
-use glossa::tools::narrator::tell_tale;
+use glossa::tools::tell_tale;
 use proptest::prelude::*;
 
 proptest! {

--- a/tests/havoc_repl_empty.rs
+++ b/tests/havoc_repl_empty.rs
@@ -1,4 +1,4 @@
-use glossa::tools::repl::run_repl;
+use glossa::tools::run_repl;
 
 // test wrapper for REPL crash
 #[test]

--- a/tests/havoc_transliteration.rs
+++ b/tests/havoc_transliteration.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/labyrinth_coverage.rs
+++ b/tests/labyrinth_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::labyrinth::{run_labyrinth, run_labyrinth_inner};
+use glossa::tools::{run_labyrinth, run_labyrinth_inner};
 
 #[test]
 fn test_run_labyrinth_comfy_table_output() {

--- a/tests/mosaic_coverage.rs
+++ b/tests/mosaic_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::mosaic::run_mosaic_inner;
+use glossa::tools::run_mosaic_inner;
 
 #[test]
 fn test_mosaic_comprehensive_coverage() {

--- a/tests/narrator_coverage.rs
+++ b/tests/narrator_coverage.rs
@@ -3,7 +3,7 @@ use glossa::parser::parse;
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedStatement, CaptureMode, GlossaType, analyze_program,
 };
-use glossa::tools::narrator::tell_tale;
+use glossa::tools::tell_tale;
 
 fn compile_and_tell(source: &str) -> String {
     let ast = parse(source).expect("AST build failed");

--- a/tests/nova_coverage.rs
+++ b/tests/nova_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 #![cfg(feature = "nova")]
 
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 
 use std::io::Read;
 use std::io::Write;
@@ -18,7 +18,7 @@ fn test_run_weave_success() {
     let source = "«χαῖρε κόσμε» λέγε.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::weave::run_weave(temp_file.path());
+    let result = glossa::tools::run_weave(temp_file.path());
     assert!(result.is_ok(), "Weave failed: {:?}", result.err());
 
     let output_path = temp_file.path().with_extension("md");
@@ -49,14 +49,14 @@ fn test_run_papyrus_success() {
     let source = "εἶδος Χρήστης ὁρίζειν { ὄνομα ὀνόματος. ἡλικία ἀριθμοῦ. }. ξ 5 ἔστω.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_ok(), "Papyrus failed: {:?}", result.err());
 }
 
 #[test]
 fn test_run_papyrus_file_not_found() {
     let path = PathBuf::from("non_existent_file.gl");
-    let result = glossa::tools::papyrus::run_papyrus(&path);
+    let result = glossa::tools::run_papyrus(&path);
     assert!(result.is_err());
     assert!(
         result
@@ -79,7 +79,7 @@ fn test_run_papyrus_file_too_large() {
         f.write_all(&data).unwrap();
     }
 
-    let result = glossa::tools::papyrus::run_papyrus(&input_path);
+    let result = glossa::tools::run_papyrus(&input_path);
     assert!(result.is_err());
     assert!(
         result
@@ -98,7 +98,7 @@ fn test_run_papyrus_syntax_error() {
 
     write!(temp_file, "invalid syntax").expect("Failed to write");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Parse error"));
 }
@@ -112,7 +112,7 @@ fn test_run_papyrus_semantic_error() {
 
     write!(temp_file, "ψ πέντε γίγνεται.").expect("Failed to write");
 
-    let result = glossa::tools::papyrus::run_papyrus(temp_file.path());
+    let result = glossa::tools::run_papyrus(temp_file.path());
     assert!(result.is_err());
     let err_str = result.unwrap_err().to_string();
     assert!(
@@ -233,7 +233,7 @@ fn test_run_scholar_success() {
     «γεια» λέγε.";
     write!(temp_file, "{}", source).expect("Failed to write to temp file");
 
-    let result = glossa::tools::scholar::run_scholar(temp_file.path());
+    let result = glossa::tools::run_scholar(temp_file.path());
     assert!(result.is_ok(), "Scholar failed: {:?}", result.err());
 
     let output_path = temp_file.path().with_extension("doc.md");
@@ -257,7 +257,7 @@ fn test_run_scholar_success() {
 #[test]
 fn test_run_scholar_file_not_found() {
     let path = PathBuf::from("non_existent_file.gl");
-    let result = glossa::tools::scholar::run_scholar(&path);
+    let result = glossa::tools::run_scholar(&path);
     assert!(result.is_err());
     assert!(
         result
@@ -276,7 +276,7 @@ fn test_run_scholar_syntax_error() {
 
     write!(temp_file, "invalid syntax").expect("Failed to write");
 
-    let result = glossa::tools::scholar::run_scholar(temp_file.path());
+    let result = glossa::tools::run_scholar(temp_file.path());
     assert!(result.is_err());
 }
 

--- a/tests/sentry_tester_tests.rs
+++ b/tests/sentry_tester_tests.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::tester::run_tests;
+use glossa::tools::run_tests;
 use std::fs;
 
 #[test]

--- a/tests/warden_limits.rs
+++ b/tests/warden_limits.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-use glossa::tools::runner::run_file;
+use glossa::tools::run_file;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;

--- a/tests/warden_overflow_sim.rs
+++ b/tests/warden_overflow_sim.rs
@@ -4,7 +4,7 @@ use glossa::morphology::{BinaryOp, UnaryOp};
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use glossa::tools::interpreter::Interpreter;
+use glossa::tools::Interpreter;
 
 #[test]
 fn test_warden_overflow_sim_defense() {


### PR DESCRIPTION
🕸️ Tangle: The `src/tools/` directory exposed all its internal submodules (`runner`, `tester`, `interpreter`, `cli`, etc.) as `pub mod`. This broke encapsulation, creating a leaky abstraction where `src/main.rs`, integration tests, and external code could tightly couple with the internal hierarchy.

📐 Blueprint:
1. Converted all submodules in `src/tools/mod.rs` to `pub(crate) mod`.
2. Created a strictly defined public API Facade inside `src/tools/mod.rs` using `pub use` to explicitly export only what `src/main.rs` and the tests need.
3. Updated `src/main.rs`, all `tests/*.rs` integration tests, and all doctests across the tools to import strictly from the Facade (e.g., `glossa::tools::run_file` instead of `glossa::tools::runner::run_file`).

🧱 Stability: Enforces high cohesion, reduces public API surface area, and clearly delineates the boundary between the internal library and the binary executor.

🔬 Verification: Builds successfully, all unit and integration tests pass, strict separation enforced.

---
*PR created automatically by Jules for task [14591038050322264109](https://jules.google.com/task/14591038050322264109) started by @madmax983*