### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/022-scholar-api-generator.md
+++ b/docs/adr/022-scholar-api-generator.md
@@ -1,0 +1,21 @@
+# 022. Add Scholar Tool to Developer Experience Tools
+
+Date: 2026-05-10
+
+## Status
+
+Proposed
+
+## Context
+
+The ΓΛΩΣΣΑ compiler needed a way to bridge the gap between raw semantic analysis and human-readable API references. Without documentation, users cannot easily understand defined structures (`εἴδη`), traits (`χαρακτῆρες`), and functions (`ἔργα`).
+
+## Decision
+
+We have added the "Scholar" (`ὁ Σχολαστικός`) tool to the "Developer Experience (Nova)" toolset (`src/tools/scholar.rs`). It acts as an API Doc Generator that parses a program, extracts semantic definitions, and outputs a clean, GitHub-flavored Markdown file.
+
+## Consequences
+
+*   **Positive:** Developers can generate accurate API documentation effortlessly, proving the power of a centralized semantic model.
+*   **Positive:** Integrates seamlessly into the existing semantic AST tooling.
+*   **Negative:** Adds a new tool that must be maintained as part of the `glossa` toolset.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ C4Container
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
         Container(auditor, "The Auditor", "src/tools/auditor.rs", "Static analysis to find unused variables and mutability smells")
         Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
+        Container(scholar, "The Scholar", "src/tools/scholar.rs", "Generates Markdown API documentation")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(catalog, "The Catalog", "src/tools/catalog.rs", "Lexicon Explorer (CLI)")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -73,6 +74,7 @@ C4Container
     Rel(semantic, labyrinth, "Analyzed Program")
     Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, papyrus, "Analyzed Program")
+    Rel(semantic, scholar, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
 
     Rel(morphology, dictionary, "Lexicon Data")


### PR DESCRIPTION
🧠 **Decision:** Drafted ADR 022 for the introduction of `The Scholar` (ὁ Σχολαστικός) tool, detailing the context, decision, and consequences of adding this API Doc Generator.
🗺️ **Visuals:** Updated the C4 Container diagram in `docs/architecture.md` to show the new `Scholar` component within the Developer Experience (Nova) toolset.
🔗 **Link:** See `docs/adr/022-scholar-api-generator.md` for full details.

---
*PR created automatically by Jules for task [14485176155424957548](https://jules.google.com/task/14485176155424957548) started by @madmax983*