### PR TITLE
🗣️ Echo: Fix troubleshooting compilation errors and undefined behavior

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,10 @@
+# 🗣️ Echo: Getting Started example is broken
+
+🤦 **The Confusion:**
+"Tried to run the troubleshooting examples from `README.md` to trigger 'Οὐκ οἶδα τὸ ὄνομα', 'Διπλοῦν ὑποκείμενον', and 'Ῥῆμα οὐχ εὑρέθη'. Compiler either crashed entirely (INTERNAL COMPILER ERROR) or silently compiled with zero errors, outputting nothing instead of the helpful Greek diagnostic."
+
+🕵️ **The Reality:**
+"Turns out the semantic assembler had specific hardcoded values (`ανθρωπος`) ignoring verbs or skipping specific error blocks for variables. Unrecognized variables were silently defaulting to zero (`Unknown`) values without throwing the semantic errors."
+
+💡 **The Fix:**
+"Add proper semantic validation logic in `assembler` and `conversion` blocks to correctly throw the missing verb and undefined variable errors instead of compiling silently or crashing the `rustc` pipeline. I've correctly routed unmatched subjects and variables to throw `GlossaError::undefined` displaying the correct Greek error representation."

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -105,9 +105,9 @@ pub enum GlossaError {
     ///
     /// # Example Output
     /// ```text
-    /// Ἄγνωστον ὄνομα: ξ
+    /// Οὐκ οἶδα τὸ ὄνομα: ξ
     /// ```
-    #[error("Ἄγνωστον ὄνομα: {name}")]
+    #[error("Οὐκ οἶδα τὸ ὄνομα: {name}")]
     #[diagnostic(code(glossa::undefined))]
     UndefinedName {
         /// The identifier (variable or function name) that the compiler could not resolve in the current scope.
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     fn test_undefined_error() {
         let err = GlossaError::undefined("ξ");
-        assert!(err.to_string().contains("Ἄγνωστον ὄνομα"));
+        assert!(err.to_string().contains("Οὐκ οἶδα τὸ ὄνομα"));
         assert!(err.to_string().contains("ξ"));
     }
 

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -653,7 +653,8 @@ impl Assembler {
                 is_match_arm: !self.state.adjectives.is_empty()
                     || (self.state.subject.is_some()
                         && self.state.object.is_none()
-                        && self.state.literals.is_empty()),
+                        && self.state.literals.is_empty()
+                        && self.state.operators.is_empty()),
             };
             self.check_missing_verb(&ctx)?;
         }
@@ -664,9 +665,11 @@ impl Assembler {
             if !self.state.nominatives.is_empty()
                 && self.state.operators.is_empty()
                 && !crate::morphology::lexicon::is_binding_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_print_verb(&verb.lemma)
                 && !crate::morphology::lexicon::is_find_verb(&verb.lemma)
+                && !crate::morphology::lexicon::is_print_verb(&verb.lemma)
             {
+                // In "ξ β μείζονα λέγε." (print greater than beta), β is parsed as a nominative.
+                // We shouldn't throw DoubleSubject when the verb is print!
                 return Err(AssemblyError::DoubleSubject);
             }
         } else if self.state.subject.is_some()
@@ -674,17 +677,17 @@ impl Assembler {
             && self.state.operators.is_empty()
         {
             // Unhandled double subject when there's no verb and no operators
-            // Exception: Function definition / pattern calls
             let is_function_call = !self.state.nested_phrases.is_empty()
                 || !self.state.blocks.is_empty()
                 || !self.state.literals.is_empty();
             let is_special_pattern =
                 !self.state.property_accesses.is_empty() || self.state.is_query;
-            // Note: If self.state.verb.is_some(), we would have entered the previous block, not this 'else if' block!
-            // Wait, we are in 'else if self.state.subject.is_some()', which means verb is NONE.
-            // Oh, so Double Subject logic wasn't fully firing in the previous block either. Let me adjust.
-            if !is_function_call && !is_special_pattern {
-                // No verb, stacked nominatives...
+            let is_match_arm = !self.state.adjectives.is_empty()
+                || (self.state.subject.is_some()
+                    && self.state.object.is_none()
+                    && self.state.literals.is_empty()
+                    && self.state.operators.is_empty());
+            if !is_function_call && !is_special_pattern && !is_match_arm {
                 return Err(AssemblyError::DoubleSubject);
             }
         }

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -953,9 +953,17 @@ fn try_print_default(
     let mut args =
         build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 
-    if let Some(ref subj) = asm_stmt.subject
-        && let Some(var_type) = scope.lookup(&subj.lemma)
-    {
+    if let Some(ref subj) = asm_stmt.subject {
+        if !scope.is_defined(&subj.lemma) && !scope.is_defined(&subj.normalized) {
+            let is_trait = scope.traits().any(|_| true);
+            if !is_trait {
+                return Err(GlossaError::undefined(subj.normalized.clone()));
+            }
+        }
+        let var_type = scope
+            .lookup(&subj.lemma)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown);
         args.insert(
             0,
             AnalyzedExpr {
@@ -965,9 +973,17 @@ fn try_print_default(
         );
     }
 
-    if let Some(ref obj) = asm_stmt.object
-        && let Some(var_type) = scope.lookup(&obj.lemma)
-    {
+    if let Some(ref obj) = asm_stmt.object {
+        if !scope.is_defined(&obj.lemma) && !scope.is_defined(&obj.normalized) {
+            let is_trait = scope.traits().any(|_| true);
+            if !is_trait {
+                return Err(GlossaError::undefined(obj.normalized.clone()));
+            }
+        }
+        let var_type = scope
+            .lookup(&obj.lemma)
+            .cloned()
+            .unwrap_or(GlossaType::Unknown);
         args.push(AnalyzedExpr {
             expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
             glossa_type: var_type.clone(),
@@ -1028,6 +1044,25 @@ fn classify_query(
         exprs.push(literal_to_analyzed_expr(lit));
     }
     if let Some(ref subj) = asm_stmt.subject {
+        if !scope.is_defined(&subj.lemma) && !scope.is_defined(&subj.normalized) {
+            let is_trait = scope.traits().any(|_| true);
+            let l = subj.lemma.as_str();
+            if !is_trait
+                && l != "μηδεν"
+                && l != "εν"
+                && l != "αλλο"
+                && l != "αληθης"
+                && l != "ψευδης"
+                && crate::morphology::lexicon::numeral_value(l).is_none()
+                && !crate::morphology::lexicon::is_none_word(l)
+                && !crate::morphology::lexicon::is_some_word(l)
+                && !crate::morphology::lexicon::is_ok_word(l)
+                && !crate::morphology::lexicon::is_err_word(l)
+                && !(l.starts_with('«') && l.ends_with('»'))
+            {
+                return Err(GlossaError::undefined(subj.normalized.clone()));
+            }
+        }
         let var_type = scope
             .lookup(&subj.lemma)
             .cloned()
@@ -1157,11 +1192,59 @@ fn classify_expression(
     // Fallback: If no literals/ops, check Subject/Object
     if exprs.is_empty() {
         if let Some(ref subj) = asm_stmt.subject {
+            if !asm_stmt.is_propagate {
+                let is_trait = scope.traits().any(|_| true);
+                let l = subj.lemma.as_str();
+                #[allow(clippy::collapsible_if)]
+                if !is_trait
+                    && !scope.is_defined(&subj.lemma)
+                    && !scope.is_defined(&subj.normalized)
+                    && l != "μηδεν"
+                    && l != "εν"
+                    && l != "αλλο"
+                    && l != "αληθης"
+                    && l != "ψευδης"
+                    && crate::morphology::lexicon::numeral_value(l).is_none()
+                    && !crate::morphology::lexicon::is_none_word(l)
+                    && !crate::morphology::lexicon::is_some_word(l)
+                    && !crate::morphology::lexicon::is_ok_word(l)
+                    && !crate::morphology::lexicon::is_err_word(l)
+                    && !(l.starts_with('«') && l.ends_with('»'))
+                {
+                    if asm_stmt.genitives.is_empty() && asm_stmt.property_accesses.is_empty() {
+                        return Err(GlossaError::undefined(subj.normalized.clone()));
+                    }
+                }
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,
             });
         } else if let Some(ref obj) = asm_stmt.object {
+            if !asm_stmt.is_propagate {
+                let is_trait = scope.traits().any(|_| true);
+                let l = obj.lemma.as_str();
+                #[allow(clippy::collapsible_if)]
+                if !is_trait
+                    && !scope.is_defined(&obj.lemma)
+                    && !scope.is_defined(&obj.normalized)
+                    && l != "μηδεν"
+                    && l != "εν"
+                    && l != "αλλο"
+                    && l != "αληθης"
+                    && l != "ψευδης"
+                    && crate::morphology::lexicon::numeral_value(l).is_none()
+                    && !crate::morphology::lexicon::is_none_word(l)
+                    && !crate::morphology::lexicon::is_some_word(l)
+                    && !crate::morphology::lexicon::is_ok_word(l)
+                    && !crate::morphology::lexicon::is_err_word(l)
+                    && !(l.starts_with('«') && l.ends_with('»'))
+                {
+                    if asm_stmt.genitives.is_empty() && asm_stmt.property_accesses.is_empty() {
+                        return Err(GlossaError::undefined(obj.normalized.clone()));
+                    }
+                }
+            }
             exprs.push(AnalyzedExpr {
                 expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
                 glossa_type: GlossaType::Unknown,

--- a/tests/havoc_issue_echo.rs
+++ b/tests/havoc_issue_echo.rs
@@ -6,37 +6,22 @@ use glossa::semantic::analyze_program;
 fn test_double_subject_should_pass_havoc_constraint() {
     let source = "ὁ ἄνθρωπος ὁ θεὸς λέγει.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
-    // Havoc constraints: "Never write 'Happy Path' tests. If it works, you failed."
-    // In Echo bug, double subject compiles with zero errors instead of failing gracefully.
+    let analyzed = analyze_program(&ast);
+    assert!(analyzed.is_err());
 }
 
 #[test]
 fn test_undefined_variable_evaluates_to_zero_silently() {
     let source = "ἄγνωστος λέγε."; // 'unknown say' -> undefined variable
     let ast = parse(source).unwrap();
-    let prog = analyze_program(&ast).unwrap();
-
-    // The previous implementation was completely ignoring undefined variables and producing an empty print.
-    // Let's assert it generates an empty print instead of crashing.
-    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0]
-        && expressions.is_empty()
-    {
-        // It silently became empty/zero!
-        return;
-    }
-    panic!(
-        "Did not evaluate to empty/zero silently! It got {:?}",
-        prog.statements[0]
-    );
+    let prog = analyze_program(&ast);
+    assert!(prog.is_err());
 }
 
 #[test]
-#[should_panic(expected = "MissingVerb")]
 fn test_missing_verb_compiler_panic() {
-    // Missing verb `ὁ ἄνθρωπος.` actually crashes `rustc` codegen if passed through,
-    // or panics locally. We prove it panics or fails to compile!
     let source = "ὁ ἄνθρωπος.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
+    let analyzed = analyze_program(&ast);
+    assert!(analyzed.is_err());
 }

--- a/tests/razor_coverage.rs
+++ b/tests/razor_coverage.rs
@@ -26,7 +26,7 @@ fn test_errors_display_impls() {
     assert_eq!(err_semantic.category_greek(), "Σημασία");
 
     let err_undefined = GlossaError::undefined("x");
-    assert!(format!("{}", err_undefined).contains("Ἄγνωστον ὄνομα"));
+    assert!(format!("{}", err_undefined).contains("Οὐκ οἶδα τὸ ὄνομα"));
     assert_eq!(err_undefined.category_greek(), "Ὄνομα");
 
     let err_agreement = GlossaError::agreement("test");

--- a/tests/reproduce_silent_failure.rs
+++ b/tests/reproduce_silent_failure.rs
@@ -22,8 +22,7 @@ fn test_undefined_struct_type_error() {
             assert!(
                 msg.contains("Χρήστος")
                     || msg.contains("undefined")
-                    || msg.contains("Ἄγνωστον")
-                    || msg.contains("Άγνωστον")
+                    || msg.contains("Οὐκ οἶδα τὸ ὄνομα")
             );
         }
     }

--- a/tests/word_order_tests.rs
+++ b/tests/word_order_tests.rs
@@ -71,8 +71,8 @@ fn test_number_binding_variations() {
 fn test_article_disambiguation_context() {
     // ὁ ἄνθρωπος should be recognized as masculine nominative singular
     // τὸν λόγον should be recognized as masculine accusative singular
-    // These don't produce Rust code yet, but they should parse without error
-    let ast = parse("ὁ ἄνθρωπος λέγει.").expect("Should parse");
+    // We bind it so it doesn't fail the UndefinedName check
+    let ast = parse("ἔστω ὁ ἄνθρωπος 1. ὁ ἄνθρωπος λέγει.").expect("Should parse");
     let _analyzed = analyze_program(&ast).expect("Should analyze");
 }
 


### PR DESCRIPTION
# 🗣️ Echo: Getting Started example is broken

🤦 **The Confusion:**
"Tried to run the troubleshooting examples from `README.md` to trigger 'Οὐκ οἶδα τὸ ὄνομα', 'Διπλοῦν ὑποκείμενον', and 'Ῥῆμα οὐχ εὑρέθη'. Compiler either crashed entirely (INTERNAL COMPILER ERROR) or silently compiled with zero errors, outputting nothing instead of the helpful Greek diagnostic."

🕵️ **The Reality:**
"Turns out the semantic assembler had specific hardcoded values (`ανθρωπος`) ignoring verbs or skipping specific error blocks for variables. Unrecognized variables were silently defaulting to zero (`Unknown`) values without throwing the semantic errors."

💡 **The Fix:**
"Add proper semantic validation logic in `assembler` and `conversion` blocks to correctly throw the missing verb and undefined variable errors instead of compiling silently or crashing the `rustc` pipeline. I've correctly routed unmatched subjects and variables to throw `GlossaError::undefined` displaying the correct Greek error representation."

---
*PR created automatically by Jules for task [10004617777534123286](https://jules.google.com/task/10004617777534123286) started by @madmax983*