### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+**[Optimizing String Concatenation in Iterator Loops]**
+**Learning:** Using `format!` inside a loop and appending the result to another `String` using `.push_str()` causes multiple unnecessary heap allocations. This pattern is often seen when generating block texts like code graphs.
+**Action:** Replace `out.push_str(&format!("...", args));` with `use std::fmt::Write; let _ = writeln!(out, "...", args);` to directly append to the pre-allocated `String` buffer without creating intermediate strings. Combine this with `Vec::with_capacity()` for collections parsed inside loops for maximal efficiency.

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -123,9 +123,12 @@ pub fn run_labyrinth_inner<W: std::io::Write>(source: &str, writer: &mut W) -> m
 /// let cfg = generate_cfg(&program);
 /// assert!(cfg.contains("graph TD"));
 /// ```
+/// ⚡ Bolt Optimization: Uses `Vec::with_capacity` to prevent reallocations
+/// and `writeln!` to avoid intermediate `String` allocations during graph assembly.
 pub fn generate_cfg(program: &AnalyzedProgram) -> String {
-    let mut nodes = Vec::new();
-    let mut edges = Vec::new();
+    use std::fmt::Write;
+    let mut nodes = Vec::with_capacity(32);
+    let mut edges = Vec::with_capacity(32);
     let mut node_counter = 0;
 
     let start_node = add_node("Start", "round", &mut nodes, &mut node_counter);
@@ -146,10 +149,10 @@ pub fn generate_cfg(program: &AnalyzedProgram) -> String {
 
     let mut out = String::from("graph TD\n");
     for node in nodes {
-        out.push_str(&format!("    {}\n", node));
+        let _ = writeln!(out, "    {}", node);
     }
     for edge in edges {
-        out.push_str(&format!("    {}\n", edge));
+        let _ = writeln!(out, "    {}", edge);
     }
     out
 }


### PR DESCRIPTION
💡 What: Replaced intermediate `String` allocation loop `out.push_str(&format!(...))` with `writeln!(out, ...)` and pre-allocated `nodes` and `edges` vectors using `Vec::with_capacity(32)` in `src/tools/labyrinth.rs`.
🎯 Why: `format!` inside a loop creates temporary heap-allocated `String` objects that are immediately appended and discarded. `.push()` or `.reserve()` without capacity initialization causes intermediate vector reallocations.
📊 Impact: Reduces heap allocations directly correlating to the number of nodes and edges in the generated AST Control Flow Graph.
🔬 Measurement: Run `cargo test --features nova labyrinth` and observe performance.

---
*PR created automatically by Jules for task [8746587329818131882](https://jules.google.com/task/8746587329818131882) started by @madmax983*