### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/022-encapsulate-cache-and-model.md
+++ b/docs/adr/022-encapsulate-cache-and-model.md
@@ -1,0 +1,21 @@
+# 022. Encapsulate Cache and Model Modules
+
+Date: 2026-07-04
+
+## Status
+
+Proposed
+
+## Context
+
+Internal modules within `src/tools/` (specifically `cache`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`. This broke encapsulation by exposing internal implementation details to the public API, which can lead to brittle dependencies and a sprawling, hard-to-maintain public interface.
+
+## Decision
+
+We modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these internal modules by declaring them with `pub(crate) mod` instead of `pub mod`.
+
+## Consequences
+
+- **Positive:** We achieve higher cohesion by keeping the public API surface minimal.
+- **Positive:** Internal structures and implementation details no longer leak out of their intended domains.
+- **Negative:** Developers must be conscious of module boundaries when adding new internal utilities; they cannot simply rely on everything being publicly available across the workspace.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ C4Container
     Container_Boundary(tools, "Developer Experience (Nova)") {
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
         Container(auditor, "The Auditor", "src/tools/auditor.rs", "Static analysis to find unused variables and mutability smells")
-        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
+        Container(cache, "Cache", "src/tools/cache.rs", "[Internal] Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(catalog, "The Catalog", "src/tools/catalog.rs", "Lexicon Explorer (CLI)")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -96,7 +96,7 @@ C4Component
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
         Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
-        Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
+        Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "[Internal] Data Transfer Objects (DTOs)")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")


### PR DESCRIPTION
🧠 **Decision:** Documented the encapsulation of the `cache` and `assembly_model` modules using `pub(crate) mod` to enforce architectural boundaries and prevent internal details from leaking to the public API.
🗺️ **Visuals:** Updated the C4 Container and Component diagrams in `docs/architecture.md` to mark the Cache and Assembly Model components as `[Internal]`.
🔗 **Link:** See `docs/adr/022-encapsulate-cache-and-model.md` for the complete Architecture Decision Record.

---
*PR created automatically by Jules for task [10898603123413436847](https://jules.google.com/task/10898603123413436847) started by @madmax983*