### PR TITLE
🎨 Mosaic: UI Polish for CLI Errors

### DIFF
--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -152,7 +152,12 @@ impl Status {
 
         let msg = self.message.as_str().bold().to_string();
         self.print_done("✕".red(), &msg);
-        eprintln!("{}", err);
+
+        let err_string = format!("{}", err);
+        // Use a styled blockquote for errors!
+        for line in err_string.lines() {
+            eprintln!("{} {}", "│".red(), line);
+        }
         self.active = false;
     }
 


### PR DESCRIPTION
🖌️ **Before:**
CLI errors were dumped as raw text with standard `eprintln!()` logs, looking like untidy log files without a clear visual hierarchy.

✨ **After:**
Errors caught by the `Status` ui tool are now formatted with a structured "dashboard" aesthetic. Multi-line errors are styled as blockquotes, with each line prepended by a red vertical pipe (`│`), making the error visually distinct and easier to read.

🖼️ **Visuals:**
Instead of:
```
✕ Ἔλεγχος (Checking)
Error:   × Σφάλμα συντάξεως: Parse error:  --> 2:1
...
```

It now looks like:
```
✕ Ἔλεγχος (Checking)
│ Error:   × Σφάλμα συντάξεως: Parse error:  --> 2:1
│   |
...
```

---
*PR created automatically by Jules for task [4430530394894846577](https://jules.google.com/task/4430530394894846577) started by @madmax983*