### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,7 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+
+## 2024-07-06 - [Doc Comment Misplacement on to_rust_type]
+**Confusion:** The function `to_rust_type` in `src/codegen.rs` was reported as having missing documentation because its doc block was attached to the preceding `use std::fmt::Write;` instead of the function itself.
+**Clarification:** Rearranged the `use` statement so the documentation is correctly attached directly to the `pub fn to_rust_type` item, making it fully visible in `cargo doc`.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The 'codegen' module
🔦 Insight: Explained the 'to_rust_type' function
🧪 Example: Corrected attachment of existing executable doctests
🖼️ Preview: Documentation is now visible on 'cargo doc' output

---
*PR created automatically by Jules for task [16970076218064231840](https://jules.google.com/task/16970076218064231840) started by @madmax983*