### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-03-22 - Missing doc for `to_rust_type` due to intermediate import
+**Confusion:** The documentation for `to_rust_type` in `src/codegen.rs` was not being correctly registered by `cargo doc`, leading to missing documentation warnings (`missing_docs`).
+**Clarification:** The `use std::fmt::Write;` import was placed immediately before the `pub fn to_rust_type` function, but after its doc comment. Rustdoc attaches the preceding doc block to the immediately following item, which was the `use` statement, thus skipping the function itself. Moving the import to the top of the section, above the doc comment, fixes the documentation attachment issue.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();


### PR DESCRIPTION
📖 Chapter: The `codegen` module.
🔦 Insight: Fixed a missing_docs issue where `cargo doc` was attaching the `///` comment intended for `pub fn to_rust_type` to an intervening `use std::fmt::Write;` statement. Moved the `use` statement above the documentation block.
🧪 Example: N/A, this is a pure doc-attachment fix, the examples inside the doc block remain unchanged and now correctly associate with the function.
🖼️ Preview: (The documentation for `to_rust_type` is now correctly included in the generated HTML and `missing_docs` warnings are resolved.)

---
*PR created automatically by Jules for task [9999279607083691465](https://jules.google.com/task/9999279607083691465) started by @madmax983*