### PR TITLE
🎨 Mosaic: UI Polish for Mosaic

### DIFF
--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -102,10 +102,10 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
                     table.add_row(vec![
                         Cell::new(i + 1),
                         Cell::new(format!("Error: {}", e)).fg(Color::Red),
-                        Cell::new(""),
-                        Cell::new(""),
-                        Cell::new(""),
-                        Cell::new(""),
+                        Cell::new("-").fg(Color::DarkGrey),
+                        Cell::new("-").fg(Color::DarkGrey),
+                        Cell::new("-").fg(Color::DarkGrey),
+                        Cell::new("-").fg(Color::DarkGrey),
                     ]);
                 }
             }
@@ -123,10 +123,10 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
                 Cell::new(type_name)
                     .fg(Color::Blue)
                     .add_attribute(Attribute::Italic),
-                Cell::new(""),
-                Cell::new(""),
-                Cell::new(""),
-                Cell::new(""),
+                Cell::new("-").fg(Color::DarkGrey),
+                Cell::new("-").fg(Color::DarkGrey),
+                Cell::new("-").fg(Color::DarkGrey),
+                Cell::new("-").fg(Color::DarkGrey),
             ]);
         }
     }
@@ -358,13 +358,29 @@ fn add_row(table: &mut Table, line: usize, asm: &AssembledStatement) {
 
     let other_column = format_other_column(asm);
 
+    let mk_cell = |s: &str| {
+        if s.is_empty() {
+            Cell::new("-").fg(Color::DarkGrey)
+        } else {
+            Cell::new(s)
+        }
+    };
+
+    let mk_other = |s: &str| {
+        if s.is_empty() {
+            Cell::new("-").fg(Color::DarkGrey)
+        } else {
+            Cell::new(s).fg(Color::DarkGrey)
+        }
+    };
+
     table.add_row(vec![
         Cell::new(line),
-        Cell::new(full_subject),
-        Cell::new(verb),
-        Cell::new(object),
-        Cell::new(indirect),
-        Cell::new(other_column).fg(Color::DarkGrey),
+        mk_cell(&full_subject),
+        mk_cell(&verb),
+        mk_cell(&object),
+        mk_cell(&indirect),
+        mk_other(&other_column),
     ]);
 }
 


### PR DESCRIPTION
🖌️ **Before:** When a grammatical slot (like Subject, Object, or Indirect Object) was missing in the Mosaic output, the table cell was simply blank, leaving the user to guess if it was intentional or a bug.
✨ **After:** Missing slots are now explicitly marked with a dim `-` (dash), clearly indicating that the slot is empty by design.
🖼️ **Visuals:** Empty cells in the table now show a `-` with a `DarkGrey` color instead of being completely empty.

---
*PR created automatically by Jules for task [7710844542642935760](https://jules.google.com/task/7710844542642935760) started by @madmax983*