### PR TITLE
⚡ Bolt: [Remove format! allocations on text processing tools]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+**[Optimized format allocations]**
+**Learning:** Formatting directly via format!("{} (+ {})", string, extra_string) allocates intermediate memory. We can avoid multiple concatenations by measuring capacity, then pushing into a properly pre-allocated mutable string instance.
+**Action:** Always utilize String::with_capacity and .push_str for hot paths in formatters avoiding unnecessary layout allocations.

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -155,7 +155,12 @@ fn format_subject(asm: &AssembledStatement) -> String {
 
     if !extra_noms.is_empty() {
         if !subject.is_empty() {
-            format!("{} (+ {})", subject, extra_noms)
+            let mut result = String::with_capacity(subject.len() + extra_noms.len() + 5);
+            result.push_str(&subject);
+            result.push_str(" (+ ");
+            result.push_str(&extra_noms);
+            result.push(')');
+            result
         } else {
             extra_noms
         }

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -193,7 +193,11 @@ fn clean_panic_message(current: &str) -> Option<String> {
     }
 
     let panicked_idx = current.find("panicked at")?;
-    let mut clean_panic = format!("{}panicked", &current[..panicked_idx]);
+
+    // ⚡ Bolt Optimization: Pre-allocate String based on known index size, avoiding format! allocation
+    let mut clean_panic = String::with_capacity(panicked_idx + 8);
+    clean_panic.push_str(&current[..panicked_idx]);
+    clean_panic.push_str("panicked");
 
     // Remove the "(pid)" thread id
     #[allow(clippy::collapsible_if)]


### PR DESCRIPTION
💡 What: Replaced `format!` macro usage with `String::with_capacity` and `push_str` in `src/tools/tester.rs` (`clean_panic_message`) and `src/tools/mosaic.rs` (`format_subject`).
🎯 Why: `format!` macros perform multiple internal allocations and layout calculations. In hot paths like test parsing and syntax formatting, avoiding `format!` in favor of explicitly pre-allocated string buffers reduces unnecessary heap allocations and improves text processing throughput.
📊 Impact: Eliminates multiple heap allocations per formatted subject/panic message string when running tests or the syntax assembler tool.
🔬 Measurement: Run `cargo bench` and observe any string-heavy text processing logic execution.

---
*PR created automatically by Jules for task [10691956951101208106](https://jules.google.com/task/10691956951101208106) started by @madmax983*