### PR TITLE
⚒️ Forge: Refactor print_test_results in tester.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,6 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+**Refactored Tester's print_test_results**
+**Learning:** Found a god object function > 100 lines handling multiple distinct concerns: formatting success messages, formatting test rows, and extracting failure details.
+**Action:** Extracted logic into `print_summary_banner`, `print_test_rows`, and `print_failure_details` to reduce cognitive load and simplify the structure.

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -281,6 +281,12 @@ fn execute_test_binary(exe_path: &Path, status: &mut Status) -> Result<std::proc
 }
 
 fn print_test_results(results: &[TestResult], test_output: &std::process::Output, stdout: &str) {
+    print_summary_banner(results, test_output);
+    print_test_rows(results);
+    print_failure_details(test_output, stdout);
+}
+
+fn print_summary_banner(results: &[TestResult], test_output: &std::process::Output) {
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
     println!("   {}", "Unit Test Results".italic().dim());
@@ -311,7 +317,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         println!("{failure_table}");
         println!();
     }
+}
 
+fn print_test_rows(results: &[TestResult]) {
     if !results.is_empty() {
         let mut table = Table::new();
         table.load_preset(presets::UTF8_FULL);
@@ -355,7 +363,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         ]);
         println!("{empty_table}");
     }
+}
 
+fn print_failure_details(test_output: &std::process::Output, stdout: &str) {
     // If there were failures, try to extract and print them nicely
     if !test_output.status.success() {
         println!();


### PR DESCRIPTION
🚮 Smell: The `print_test_results` function in `src/tools/tester.rs` was a 111-line God function handling multiple different rendering states (success banners, loop tables, error details extraction).
✨ Solution: Extracted the logic into three smaller helper functions: `print_summary_banner`, `print_test_rows`, and `print_failure_details`.
🧼 Benefit: Reduces cognitive load and flattening the structure.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [18233479403749839558](https://jules.google.com/task/18233479403749839558) started by @madmax983*