### PR TITLE
📜 Codex: ADR 012 & Architecture Diagram Update

### DIFF
--- a/docs/adr/012-storage-split.md
+++ b/docs/adr/012-storage-split.md
@@ -1,0 +1,19 @@
+# Decouple Storage from Core
+
+Date: 2024-10-24
+
+## Status
+
+Proposed
+
+## Context
+
+Circular dependencies were causing build failures, and the `storage` module was deeply intertwined with the `core` logic. This made the codebase harder to maintain and test, and increased compile times significantly.
+
+## Decision
+
+Move persistence logic to a dedicated crate or isolated module (`storage`), decoupling it from the `core` components. The `Core` module now relies on `Storage` via Trait Bounds, breaking the circular dependency.
+
+## Consequences
+
+Build times improve, and the system is more modular, but FFI or trait-based complexity increases slightly to support the decoupled boundary.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,3 +131,23 @@ C4Component
 
     Rel(model, types, "Uses")
 ```
+
+## Storage Component Map
+
+```mermaid
+classDiagram
+  class Core
+  class Storage
+  Core --> Storage : Uses (Trait Bound)
+  %% Removed the circular dependency arrow
+```
+
+## Flow Sequence Diagram
+
+```mermaid
+sequenceDiagram
+  participant Core
+  participant Storage
+  Core->>Storage: request_data()
+  Storage-->>Core: data_payload
+```


### PR DESCRIPTION
🧠 **Decision:** Recorded the move to `storage` crate.
🗺️ **Visuals:** Updated C4 Component diagram to show new boundaries.
🔗 **Link:** See `docs/adr/012-storage-split.md`.

---
*PR created automatically by Jules for task [4176793000783191156](https://jules.google.com/task/4176793000783191156) started by @madmax983*