### PR TITLE
⚒️ Forge: Refactor print_test_results

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,6 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+**Refactored Tester's print_test_results**
+**Learning:** Found a god function handling multiple logical chunks of console formatting (header, status, table, errors) making it >100 lines.
+**Action:** Extracted into `print_test_results_header`, `print_overall_status`, `print_results_table`, and `print_failure_details`.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -280,12 +280,14 @@ fn execute_test_binary(exe_path: &Path, status: &mut Status) -> Result<std::proc
     Ok(test_output)
 }
 
-fn print_test_results(results: &[TestResult], test_output: &std::process::Output, stdout: &str) {
+fn print_test_results_header() {
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
     println!("   {}", "Unit Test Results".italic().dim());
     println!();
+}
 
+fn print_overall_status(results: &[TestResult], test_output: &std::process::Output) {
     if test_output.status.success() {
         if !results.is_empty() {
             let mut success_table = Table::new();
@@ -311,7 +313,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         println!("{failure_table}");
         println!();
     }
+}
 
+fn print_results_table(results: &[TestResult]) {
     if !results.is_empty() {
         let mut table = Table::new();
         table.load_preset(presets::UTF8_FULL);
@@ -355,8 +359,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         ]);
         println!("{empty_table}");
     }
+}
 
-    // If there were failures, try to extract and print them nicely
+fn print_failure_details(test_output: &std::process::Output, stdout: &str) {
     if !test_output.status.success() {
         println!();
         println!("{}", "--- 📜 Λεπτoμέρειες (Details) ---".dim());
@@ -390,6 +395,13 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
             }
         }
     }
+}
+
+fn print_test_results(results: &[TestResult], test_output: &std::process::Output, stdout: &str) {
+    print_test_results_header();
+    print_overall_status(results, test_output);
+    print_results_table(results);
+    print_failure_details(test_output, stdout);
 }
 
 /// Run unit tests defined within a ΓΛΩΣΣΑ file.


### PR DESCRIPTION
🚮 Smell: The `print_test_results` function in `src/tools/tester.rs` was a God Function over 100 lines long, handling multiple distinct formatting tasks (header, status, table generation, failure details).
✨ Solution: Extracted the logic into four smaller, named helper functions (`print_test_results_header`, `print_overall_status`, `print_results_table`, and `print_failure_details`).
🧼 Benefit: Significantly reduces cognitive load and improves readability by giving each formatting step a clear name and separated scope.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [15677551834364379160](https://jules.google.com/task/15677551834364379160) started by @madmax983*