### PR TITLE
⚡ Bolt: [Replace `Vec::new()` with `Vec::with_capacity()`]

### DIFF
--- a/src/morphology/conjugation.rs
+++ b/src/morphology/conjugation.rs
@@ -526,7 +526,8 @@ where
 /// - 2nd person singular present imperative (λέγε!)
 /// - 3rd person singular aorist indicative (ἔλυσε)
 pub fn analyze_verb_all(word: &str) -> Vec<MorphAnalysis> {
-    let mut analyses = Vec::new();
+    // ⚡ Bolt Optimization: Uses `Vec::with_capacity` to prevent reallocation.
+    let mut analyses = Vec::with_capacity(4); // Typically 1-4 analyses for ambiguous forms
     analyze_verb_all_into(word, &mut analyses);
     analyses
 }

--- a/src/semantic/declarations.rs
+++ b/src/semantic/declarations.rs
@@ -448,7 +448,8 @@ fn extract_parameters_from_expr(
     expr: &Expr,
     scope: &Scope,
 ) -> Result<Vec<(SmolStr, Option<GlossaType>)>, GlossaError> {
-    let mut params = Vec::new();
+    // ⚡ Bolt Optimization: Uses `Vec::with_capacity` to prevent reallocation.
+    let mut params = Vec::with_capacity(4);
 
     // Collect all words from the expression
     let words = collect_words_from_expr(expr);
@@ -506,7 +507,8 @@ fn extract_parameters_from_expr(
 
 /// Collect all Word nodes from an expression (flattening phrases)
 fn collect_words_from_expr(expr: &Expr) -> Vec<&crate::ast::Word> {
-    let mut words = Vec::new();
+    // ⚡ Bolt Optimization: Uses `Vec::with_capacity` to prevent reallocation.
+    let mut words = Vec::with_capacity(8);
     collect_words_from_expr_into(expr, &mut words);
     words
 }


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity()` in `src/semantic/declarations.rs` and `src/morphology/conjugation.rs`.
🎯 Why: Avoiding intermediate vector re-allocations during operations where the typical or max bounds of the vector are generally known (e.g. collecting words from expressions, getting 1-4 analyses for ambiguous forms).
📊 Impact: Eliminates unnecessary heap re-allocations as the vectors grow.
🔬 Measurement: Verify tests run successfully using `cargo test` and `cargo bench`.

---
*PR created automatically by Jules for task [16969935774854301752](https://jules.google.com/task/16969935774854301752) started by @madmax983*