### PR TITLE
🛡️ Sentry: [prevent codegen stack overflow via AST depth re-validation]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,7 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+
+**[Havoc Codegen Stack Overflow]**
+**Learning:** If an `AnalyzedProgram` is constructed programmatically, bypassing the `check_program_depth` in `glossa::semantic::analyze_program`, the `generate_rust` function in `src/codegen.rs` could crash with a stack overflow when recursively iterating over deep `AnalyzedExpr` nodes.
+**Action:** Enforce `validate_program(&program)` validation as the first step within `generate_rust()` to ensure all programs meet the safe depth limit prior to any recursive traversal. Use `.expect()` to fail gracefully with the specific `LimitExceeded` error instead of encountering a hard abort. Update test cases to verify the correct error message.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -403,6 +403,15 @@ pub fn generate_type_tokens(ty: &GlossaType) -> TokenStream {
 /// assert!(rust_code.contains("println"));
 /// ```
 pub fn generate_rust(program: &AnalyzedProgram) -> String {
+    // 🛡️ Sentry: Validate the AST depth before generating code to prevent stack overflows
+    // from deeply nested expressions that were programmatically created, bypassing the parser limits.
+    if let Err(e) = crate::semantic::validation::validate_program(program) {
+        panic!(
+            "Code generation failed: deeply nested expression would cause stack overflow: {:?}",
+            e
+        );
+    }
+
     // Separate trait defs, struct defs, trait impls, function defs, tests, and main body statements
     // ⚡ Bolt Optimization: Pre-allocate vectors based on statement length.
     // This reduces internal reallocation overhead during partitioning.

--- a/tests/havoc_codegen_stack_overflow.rs
+++ b/tests/havoc_codegen_stack_overflow.rs
@@ -58,11 +58,16 @@ fn havoc_codegen_stack_overflow() {
         .env("HAVOC_DETONATE_CODEGEN_OVERFLOW", "1")
         .arg("--nocapture")
         .arg("havoc_codegen_stack_overflow")
-        .status()
+        .output()
         .expect("Failed to spawn subprocess");
 
+    assert!(!status.status.success(), "Subprocess should have failed!");
+    let stderr = String::from_utf8_lossy(&status.stderr);
     assert!(
-        !status.success(),
-        "Subprocess should have crashed due to stack overflow!"
+        stderr.contains(
+            "Code generation failed: deeply nested expression would cause stack overflow"
+        ) || stderr.contains("has overflowed its stack"),
+        "Did not fail with the expected depth limit panic: {}",
+        stderr
     );
 }


### PR DESCRIPTION
🎯 Target: `glossa::codegen::generate_rust` inside `src/codegen.rs`
💣 Risk: Prevents unrecoverable SIGABRT thread stack overflows when processing deeply nested AST nodes that were programmatically constructed (bypassing normal `MAX_EXPRESSION_DEPTH` parser limits).
🧪 Strategy: Injected explicit `crate::semantic::validation::validate_program(program)` logic at the very beginning of the `generate_rust` routine. If exceeded, this translates the memory fault into a clean Rust `panic!` with an actionable error trace. Updated `tests/havoc_codegen_stack_overflow.rs` to capture and verify standard error.
🔬 Verification: `cargo test --test havoc_codegen_stack_overflow`

---
*PR created automatically by Jules for task [10654546868114646295](https://jules.google.com/task/10654546868114646295) started by @madmax983*