### PR TITLE
🔒 Warden: [security fix] Update anyhow to fix RUSTSEC-2026-0190

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -134,3 +134,6 @@ Signed,
 **YYYY-MM-DD - [DoS Mitigation]
 **Threat:** Memory Exhaustion / Unbounded Allocations via standard IO.
 **Defense:** Wrapped mutable readers using `.by_ref().take(LIMIT)` inside `repl.rs` and `mentor.rs`.
+**2026-06-25 - [anyhow vulnerability]
+**Threat:** Unsoundness in `Error::downcast_mut()` in `anyhow` crate (RUSTSEC-2026-0190)
+**Defense:** Bumped `anyhow` dependency to secure version `1.0.103` using `cargo update -p anyhow`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"


### PR DESCRIPTION
🦠 Threat: Unsoundness in `Error::downcast_mut()` in `anyhow` crate (RUSTSEC-2026-0190).
🛡️ Defense: Updated `anyhow` to a secure version `v1.0.103` using `cargo update -p anyhow`.
💥 Severity: Critical - allows undefined behavior.
🧪 Verification: Ran `cargo audit` to confirm the vulnerability is resolved.

---
*PR created automatically by Jules for task [8418255401197333808](https://jules.google.com/task/8418255401197333808) started by @madmax983*