### PR TITLE
🗣️ Echo: Fix silent failures for Double Subject and Undefined Variables

### DIFF
--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -661,14 +661,21 @@ impl Assembler {
         if let (Some(subject), Some(verb)) = (&self.state.subject, &self.state.verb) {
             self.check_agreement(subject, verb)?;
             // If we have a verb, a subject, and extra nominatives, but it's not a function definition or binary operation
+
+            let is_print_allowed = crate::morphology::lexicon::is_print_verb(&verb.lemma)
+                && verb.mood == Some(crate::morphology::Mood::Imperative);
+
+            let verb_allows_multiple = crate::morphology::lexicon::is_binding_verb(&verb.lemma)
+                || crate::morphology::lexicon::is_find_verb(&verb.lemma)
+                || is_print_allowed;
+
             if !self.state.nominatives.is_empty()
                 && self.state.operators.is_empty()
-                && !crate::morphology::lexicon::is_binding_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_print_verb(&verb.lemma)
-                && !crate::morphology::lexicon::is_find_verb(&verb.lemma)
+                && !verb_allows_multiple
             {
                 return Err(AssemblyError::DoubleSubject);
             }
+
         } else if self.state.subject.is_some()
             && !self.state.nominatives.is_empty()
             && self.state.operators.is_empty()

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -950,6 +950,11 @@ fn try_print_default(
     asm_stmt: &AssembledStatement,
     scope: &mut Scope,
 ) -> Result<Vec<AnalyzedExpr>, GlossaError> {
+    if !asm_stmt.participles.is_empty() {
+        let name = &asm_stmt.participles[0].original;
+        return Err(GlossaError::undefined(name.as_str()));
+    }
+
     let mut args =
         build_expressions_from_literals_and_ops(&asm_stmt.literals, &asm_stmt.operators)?;
 

--- a/tests/havoc_issue_echo.rs
+++ b/tests/havoc_issue_echo.rs
@@ -6,29 +6,16 @@ use glossa::semantic::analyze_program;
 fn test_double_subject_should_pass_havoc_constraint() {
     let source = "ὁ ἄνθρωπος ὁ θεὸς λέγει.";
     let ast = parse(source).unwrap();
-    let _ = analyze_program(&ast).unwrap();
-    // Havoc constraints: "Never write 'Happy Path' tests. If it works, you failed."
-    // In Echo bug, double subject compiles with zero errors instead of failing gracefully.
+    let analyzed = analyze_program(&ast);
+    assert!(analyzed.is_err(), "Expected DoubleSubject error!");
 }
 
 #[test]
 fn test_undefined_variable_evaluates_to_zero_silently() {
-    let source = "ἄγνωστος λέγε."; // 'unknown say' -> undefined variable
+    let source = "ἄγνωστον λέγε."; // 'unknown say' -> undefined variable
     let ast = parse(source).unwrap();
-    let prog = analyze_program(&ast).unwrap();
-
-    // The previous implementation was completely ignoring undefined variables and producing an empty print.
-    // Let's assert it generates an empty print instead of crashing.
-    if let glossa::semantic::AnalyzedStatement::Print(ref expressions) = prog.statements[0]
-        && expressions.is_empty()
-    {
-        // It silently became empty/zero!
-        return;
-    }
-    panic!(
-        "Did not evaluate to empty/zero silently! It got {:?}",
-        prog.statements[0]
-    );
+    let prog = analyze_program(&ast);
+    assert!(prog.is_err(), "Expected UndefinedName error!");
 }
 
 #[test]


### PR DESCRIPTION
🤦 **The Confusion:** "When running `cargo run -- <file>` with invalid Glossa code (e.g. double subjects or undefined variables), the compiler exited successfully without printing any error message, leading to a frustrating developer experience where errors were swallowed."
🕵️ **The Reality:** "The `DoubleSubject` check bypassed all print verbs rather than just imperative print verbs. Undefined variables in print statements were matched as participles and ignored. Furthermore, the compiler cache disguised these failures by running old cached binaries."
💡 **The Fix:** "Fixed `src/semantic/assembly/mod.rs` to only bypass `DoubleSubject` for imperative print verbs, and patched `src/semantic/conversion.rs` to throw `UndefinedName` if unconsumed participles remain. Added tests to verify these errors correctly surface."

---
*PR created automatically by Jules for task [2113844950128222279](https://jules.google.com/task/2113844950128222279) started by @madmax983*