### PR TITLE
⚡ Bolt: Use String::with_capacity in Cartographer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+**Pre-allocating format strings for loops**
+**Learning:** `String::new()` in a loop that formats dynamically-sized contents (like function parameters) causes multiple heap reallocations.
+**Action:** Use `String::with_capacity(...)` based on the sequence length and average token size to avoid these reallocations and improve formatting performance.

--- a/patch_cartographer3.sh
+++ b/patch_cartographer3.sh
@@ -1,0 +1,1 @@
+sed -i 's/let mut params_str = String::with_capacity(method.params.len() \* 16);/\/\/ ⚡ Bolt Optimization: Pre-allocate capacity based on param count to avoid heap reallocations\n            let mut params_str = String::with_capacity(method.params.len() * 16);/' src/tools/cartographer.rs

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -166,7 +166,8 @@ fn format_traits(map: &mut String, program: &AnalyzedProgram) {
         let _ = writeln!(map, "    class {} {{", name);
         map.push_str("        <<interface>>\n");
         for method in &trait_def.methods {
-            let mut params_str = String::new();
+            // ⚡ Bolt Optimization: Pre-allocate capacity based on param count to avoid heap reallocations
+            let mut params_str = String::with_capacity(method.params.len() * 16);
             for (i, (n, t)) in method.params.iter().enumerate() {
                 if i > 0 {
                     params_str.push_str(", ");


### PR DESCRIPTION
💡 What: Replaced `String::new()` with `String::with_capacity(method.params.len() * 16)` in `src/tools/cartographer.rs` when building the parameter string for Mermaid trait diagrams.
🎯 Why: The original implementation repeatedly pushed onto a dynamically-sized `String` inside a loop, causing multiple unnecessary heap reallocations.
📊 Impact: Reduces heap reallocations when formatting traits with multiple parameters in the Cartographer tool.
🔬 Measurement: Run `cargo clippy`, `cargo fmt`, and `cargo test`. Observe no regressions or performance hits during AST graph generation.

---
*PR created automatically by Jules for task [17898434519411064018](https://jules.google.com/task/17898434519411064018) started by @madmax983*