### PR TITLE
🪒 Razor: Flatten object-oriented bloat in codegen and reporting

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,7 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+## [Reduction]
+**Bloat:** Unnecessary object-oriented `Sanitizer` and `GlossaReport` structs implementing `Display` for simple string building.
+**Cut:** Flattened both into standard procedural functions (`format_sanitized` and `generate_report`).
+**Saved:** Replaced localized object-oriented abstractions with direct formatting, saving code and indirection without sacrificing clarity.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -108,38 +108,25 @@ use quote::{format_ident, quote};
 
 /// Helper to sanitize a name and format it as an Ident
 pub(crate) fn sanitize_ident(name: &str) -> Ident {
-    format_ident!(
-        "{}",
-        Sanitizer {
-            name,
-            capitalize: false
-        }
-        .to_string()
-    )
+    format_ident!("{}", format_sanitized(name, false))
 }
 
 /// Zero-allocation sanitizer for Rust identifiers
-struct Sanitizer<'a> {
-    name: &'a str,
-    capitalize: bool,
-}
-
-impl<'a> std::fmt::Display for Sanitizer<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.capitalize {
-            f.write_str("G_")?;
-        } else {
-            f.write_str("g_")?;
-        }
-
-        transliterate_fmt(self.name, f)?;
-
-        if self.name.is_empty() {
-            f.write_str("_var_empty")?;
-        }
-
-        Ok(())
+fn format_sanitized(name: &str, capitalize: bool) -> String {
+    let mut s = String::with_capacity(name.len() + 2);
+    if capitalize {
+        s.push_str("G_");
+    } else {
+        s.push_str("g_");
     }
+
+    let _ = transliterate_fmt(name, &mut s);
+
+    if name.is_empty() {
+        s.push_str("_var_empty");
+    }
+
+    s
 }
 
 /// Sanitize a Greek name for use as a Rust identifier
@@ -172,12 +159,7 @@ impl<'a> std::fmt::Display for Sanitizer<'a> {
 /// assert_eq!(sanitize_name("if"), "g_if");
 /// ```
 pub fn sanitize_name(name: &str) -> String {
-    // Use the zero-allocation Sanitizer to generate the string
-    Sanitizer {
-        name,
-        capitalize: false,
-    }
-    .to_string()
+    format_sanitized(name, false)
 }
 
 /// Transliterate Greek to Latin characters via Hex Encoding
@@ -317,11 +299,7 @@ fn write_rust_type(ty: &GlossaType, out: &mut String) -> std::fmt::Result {
         }
         GlossaType::Unit => write!(out, "()"),
         GlossaType::Struct { name, .. } => {
-            let sanitized = Sanitizer {
-                name,
-                capitalize: true,
-            }
-            .to_string();
+            let sanitized = format_sanitized(name, true);
             write!(out, "{}", sanitized)
         }
         // TODO: Better representation for function types if they appear in type signatures
@@ -369,14 +347,7 @@ pub fn generate_type_tokens(ty: &GlossaType) -> TokenStream {
         GlossaType::Unit => quote! { () },
         GlossaType::Struct { name, .. } => {
             // Directly sanitize and create identifier without intermediate string allocation for the type name
-            let ident = format_ident!(
-                "{}",
-                Sanitizer {
-                    name,
-                    capitalize: true
-                }
-                .to_string()
-            );
+            let ident = format_ident!("{}", format_sanitized(name, true));
             quote! { #ident }
         }
         // Function types are not fully supported in type signatures yet, fallback to generic
@@ -771,14 +742,7 @@ fn generate_fn_def(
 
 fn generate_struct_def(name: &str, fields: &[(smol_str::SmolStr, GlossaType)]) -> TokenStream {
     // Capitalize struct name for Rust conventions
-    let struct_name = format_ident!(
-        "{}",
-        Sanitizer {
-            name,
-            capitalize: true
-        }
-        .to_string()
-    );
+    let struct_name = format_ident!("{}", format_sanitized(name, true));
 
     // Generate field list
     let field_tokens = fields.iter().map(|(field_name, field_type)| {
@@ -829,14 +793,7 @@ fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
 
 fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
     // Capitalize trait name for Rust conventions
-    let trait_name = format_ident!(
-        "{}",
-        Sanitizer {
-            name,
-            capitalize: true
-        }
-        .to_string()
-    );
+    let trait_name = format_ident!("{}", format_sanitized(name, true));
 
     // Generate method signatures
     let method_tokens = methods.iter().map(|method| {
@@ -884,22 +841,8 @@ fn generate_trait_impl(
     methods: &[AnalyzedMethod],
 ) -> TokenStream {
     // Capitalize trait and type names for Rust conventions
-    let trait_ident = format_ident!(
-        "{}",
-        Sanitizer {
-            name: trait_name,
-            capitalize: true
-        }
-        .to_string()
-    );
-    let type_ident = format_ident!(
-        "{}",
-        Sanitizer {
-            name: type_name,
-            capitalize: true
-        }
-        .to_string()
-    );
+    let trait_ident = format_ident!("{}", format_sanitized(trait_name, true));
+    let type_ident = format_ident!("{}", format_sanitized(type_name, true));
 
     // Generate method implementations
     let method_tokens = methods.iter().map(|method| {
@@ -1145,14 +1088,7 @@ fn generate_struct_lit(
     args: &[AnalyzedExpr],
 ) -> TokenStream {
     // Capitalize struct name for Rust conventions
-    let struct_name = format_ident!(
-        "{}",
-        Sanitizer {
-            name: type_name,
-            capitalize: true
-        }
-        .to_string()
-    );
+    let struct_name = format_ident!("{}", format_sanitized(type_name, true));
 
     // Generate field: value pairs using actual field names
     let field_assignments = fields.iter().zip(args.iter()).map(|(field_name, arg)| {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/report.rs
+++ b/src/tools/report.rs
@@ -259,142 +259,125 @@ impl ProgramStats {
     }
 }
 
-/// A human-readable report for an analyzed program
-pub struct GlossaReport<'a> {
-    program: &'a AnalyzedProgram,
-    stats: ProgramStats,
-    filename: String,
-}
+/// Generates a human-readable report for an analyzed program
+///
+/// ## Examples
+///
+/// ```rust,ignore
+/// use glossa::parser::parse;
+/// use glossa::semantic::analyze_program;
+/// use glossa::tools::report::generate_report;
+///
+/// let source = "ξ πέντε ἔστω.";
+/// let ast = parse(source).unwrap();
+/// let program = analyze_program(&ast).unwrap();
+/// let report = generate_report(&program, "main.γλ");
+///
+/// assert!(report.contains("main.γλ"));
+/// assert!(report.contains("1")); // Statement count
+/// ```
+pub fn generate_report(program: &AnalyzedProgram, filename: &str) -> String {
+    use std::fmt::Write;
+    let mut f = String::new();
+    let stats = ProgramStats::new(program);
 
-impl<'a> GlossaReport<'a> {
-    /// Creates a new GlossaReport.
-    ///
-    /// ## Examples
-    ///
-    /// ```rust,ignore
-    /// use glossa::parser::parse;
-    /// use glossa::semantic::analyze_program;
-    /// use glossa::tools::report::GlossaReport;
-    ///
-    /// let source = "ξ πέντε ἔστω.";
-    /// let ast = parse(source).unwrap();
-    /// let program = analyze_program(&ast).unwrap();
-    /// let report = GlossaReport::new(&program, "main.γλ".to_string());
-    ///
-    /// let output = format!("{}", report);
-    /// assert!(output.contains("main.γλ"));
-    /// assert!(output.contains("1")); // Statement count
-    /// ```
-    pub fn new(program: &'a AnalyzedProgram, filename: String) -> Self {
-        let stats = ProgramStats::new(program);
-        Self {
-            program,
-            stats,
-            filename,
-        }
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL).set_header(vec![
+        Cell::new("Μετρική (Metric)")
+            .add_attribute(comfy_table::Attribute::Bold)
+            .fg(Color::Cyan),
+        Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
+    ]);
+
+    table.add_row(vec![
+        Cell::new("Ἀρχεῖον (File)"),
+        Cell::new(filename).fg(Color::Green),
+    ]);
+    table.add_row(vec![
+        Cell::new("Προτάσεις (Statements)"),
+        Cell::new(stats.statement_count),
+    ]);
+    table.add_row(vec![
+        Cell::new("Εκφράσεις (Expressions)"),
+        Cell::new(stats.expression_count),
+    ]);
+    table.add_row(vec![
+        Cell::new("Μεταβλητές (Bindings)"),
+        Cell::new(stats.binding_count),
+    ]);
+
+    if stats.function_count > 0 {
+        table.add_row(vec![
+            Cell::new("Συναρτήσεις (Functions)"),
+            Cell::new(stats.function_count),
+        ]);
     }
-}
 
-impl Display for GlossaReport<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL).set_header(vec![
-            Cell::new("Μετρική (Metric)")
-                .add_attribute(comfy_table::Attribute::Bold)
-                .fg(Color::Cyan),
-            Cell::new("Τιμή (Value)").add_attribute(comfy_table::Attribute::Bold),
-        ]);
-
+    if stats.type_count > 0 {
         table.add_row(vec![
-            Cell::new("Ἀρχεῖον (File)"),
-            Cell::new(&self.filename).fg(Color::Green),
+            Cell::new("Τύποι (Types)"),
+            Cell::new(stats.type_count),
         ]);
+    }
+
+    if stats.loop_count > 0 {
         table.add_row(vec![
-            Cell::new("Προτάσεις (Statements)"),
-            Cell::new(self.stats.statement_count),
+            Cell::new("Βρόχοι (Loops)"),
+            Cell::new(stats.loop_count),
         ]);
+    }
+
+    if stats.max_depth > 0 {
         table.add_row(vec![
-            Cell::new("Εκφράσεις (Expressions)"),
-            Cell::new(self.stats.expression_count),
+            Cell::new("Βάθος (Max Depth)"),
+            Cell::new(stats.max_depth),
         ]);
-        table.add_row(vec![
-            Cell::new("Μεταβλητές (Bindings)"),
-            Cell::new(self.stats.binding_count),
+    }
+
+    writeln!(&mut f).unwrap();
+    writeln!(&mut f, "   {}", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan()).unwrap();
+    writeln!(&mut f, "   {}", "Language Metrics Dashboard".italic().dim()).unwrap();
+    writeln!(&mut f).unwrap();
+    writeln!(&mut f, "{}", table).unwrap();
+
+    // If there are top-level functions, list them
+    let mut functions = program.scope.functions().peekable();
+    if functions.peek().is_some() {
+        writeln!(&mut f, "\n{}", "ΣΥΝΑΡΤΗΣΕΙΣ (FUNCTIONS)".bold()).unwrap();
+        let mut func_table = Table::new();
+        func_table.load_preset(presets::UTF8_FULL).set_header(vec![
+            "Ὄνομα (Name)",
+            "Παράμετροι (Params)",
+            "Επιστροφή (Returns)",
         ]);
 
-        if self.stats.function_count > 0 {
-            table.add_row(vec![
-                Cell::new("Συναρτήσεις (Functions)"),
-                Cell::new(self.stats.function_count),
-            ]);
-        }
-
-        if self.stats.type_count > 0 {
-            table.add_row(vec![
-                Cell::new("Τύποι (Types)"),
-                Cell::new(self.stats.type_count),
-            ]);
-        }
-
-        if self.stats.loop_count > 0 {
-            table.add_row(vec![
-                Cell::new("Βρόχοι (Loops)"),
-                Cell::new(self.stats.loop_count),
-            ]);
-        }
-
-        if self.stats.max_depth > 0 {
-            table.add_row(vec![
-                Cell::new("Βάθος (Max Depth)"),
-                Cell::new(self.stats.max_depth),
-            ]);
-        }
-
-        writeln!(f)?;
-        writeln!(f, "   {}", "Γ Λ Ω Σ Σ Α   R E P O R T".bold().cyan())?;
-        writeln!(f, "   {}", "Language Metrics Dashboard".italic().dim())?;
-        writeln!(f)?;
-        writeln!(f, "{}", table)?;
-
-        // If there are top-level functions, list them
-        let mut functions = self.program.scope.functions().peekable();
-        if functions.peek().is_some() {
-            writeln!(f, "\n{}", "ΣΥΝΑΡΤΗΣΕΙΣ (FUNCTIONS)".bold())?;
-            let mut func_table = Table::new();
-            func_table.load_preset(presets::UTF8_FULL).set_header(vec![
-                "Ὄνομα (Name)",
-                "Παράμετροι (Params)",
-                "Επιστροφή (Returns)",
-            ]);
-
-            for func in functions {
-                // ⚡ Bolt Optimization: Build the formatted string directly to avoid the O(n) heap allocation
-                // of the intermediate Vec<_> created by .collect::<Vec<_>>().join(", ").
-                let mut params = String::with_capacity(func.param_types.len() * 8);
-                for (i, t) in func.param_types.iter().enumerate() {
-                    if i > 0 {
-                        params.push_str(", ");
-                    }
-                    params.push_str(&t.to_string());
+        for func in functions {
+            // ⚡ Bolt Optimization: Build the formatted string directly to avoid the O(n) heap allocation
+            // of the intermediate Vec<_> created by .collect::<Vec<_>>().join(", ").
+            let mut params = String::with_capacity(func.param_types.len() * 8);
+            for (i, t) in func.param_types.iter().enumerate() {
+                if i > 0 {
+                    params.push_str(", ");
                 }
-
-                let ret = func
-                    .return_type
-                    .as_ref()
-                    .map(|t| t.to_string())
-                    .unwrap_or_else(|| "Οὐδέν".to_string());
-
-                func_table.add_row(vec![
-                    Cell::new(&func.name).fg(Color::Cyan),
-                    Cell::new(if params.is_empty() { "-" } else { &params }),
-                    Cell::new(ret).fg(Color::Yellow),
-                ]);
+                params.push_str(&t.to_string());
             }
-            writeln!(f, "{}", func_table)?;
-        }
 
-        Ok(())
+            let ret = func
+                .return_type
+                .as_ref()
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "Οὐδέν".to_string());
+
+            func_table.add_row(vec![
+                Cell::new(&func.name).fg(Color::Cyan),
+                Cell::new(if params.is_empty() { "-" } else { &params }),
+                Cell::new(ret).fg(Color::Yellow),
+            ]);
+        }
+        writeln!(&mut f, "{}", func_table).unwrap();
     }
+
+    f
 }
 
 /// A comprehensive report for the compilation process
@@ -762,8 +745,7 @@ mod tests {
             Some(GlossaType::Boolean),
         );
 
-        let report = GlossaReport::new(&program, "test.gl".to_string());
-        let output = format!("{}", report);
+        let output = generate_report(&program, "test.gl");
 
         assert!(output.contains("R E P O R T"));
         assert!(output.contains("test.gl"));

--- a/src/tools/runner.rs
+++ b/src/tools/runner.rs
@@ -27,7 +27,7 @@ use crate::semantic::{AnalyzedProgram, analyze_program};
 use crate::tools::cache::Cache;
 use crate::tools::highlight::highlight;
 use crate::tools::narrator::tell_tale;
-use crate::tools::report::{CompilationReport, GlossaReport, ProgramStats};
+use crate::tools::report::{CompilationReport, ProgramStats, generate_report};
 use crate::tools::ui::Status;
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
@@ -449,7 +449,7 @@ pub fn report_file(input: &Path) -> Result<()> {
         .unwrap_or(input.as_os_str())
         .to_string_lossy()
         .to_string();
-    let report = GlossaReport::new(&analyzed, filename);
+    let report = generate_report(&analyzed, &filename);
 
     status.success();
     println!("{}", report);


### PR DESCRIPTION
## [Reduction]
**Bloat:** Unnecessary object-oriented `Sanitizer` and `GlossaReport` structs implementing `Display` for simple string building.
**Cut:** Flattened both into standard procedural functions (`format_sanitized` and `generate_report`).
**Saved:** Replaced localized object-oriented abstractions with direct formatting.

---
*PR created automatically by Jules for task [11096253299706338197](https://jules.google.com/task/11096253299706338197) started by @madmax983*