### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/022-decouple-storage.md
+++ b/docs/adr/022-decouple-storage.md
@@ -1,0 +1,19 @@
+# 022. Decouple Storage from Core
+
+Date: 2026-07-16
+
+## Status
+
+Proposed
+
+## Context
+
+Circular dependencies were causing build failures.
+
+## Decision
+
+Move persistence logic to a dedicated crate.
+
+## Consequences
+
+Build times improve, but FFI complexity increases.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,7 @@ C4Container
     }
 
     Container(codegen, "Code Generator", "src/codegen.rs", "Generates Rust source code")
+    Container(storage, "Storage", "src/storage", "Decoupled Persistence Logic")
 
     Rel(lexer, parser, "Stream<Token>")
     Rel(parser, morphology, "AST (Unresolved)")
@@ -74,11 +75,22 @@ C4Container
     Rel(semantic, weave, "Analyzed Program")
     Rel(semantic, papyrus, "Analyzed Program")
     Rel(semantic, codegen, "Analyzed Program")
+    Rel(semantic, storage, "Uses (Trait Bound)")
 
     Rel(morphology, dictionary, "Lexicon Data")
     Rel(morphology, catalog, "Lexicon Data")
     Rel(parser, tester, "AST")
     Rel(codegen, tester, "Rust Source")
+```
+
+## Storage Architecture (Class Diagram)
+
+```mermaid
+classDiagram
+  class Core
+  class Storage
+  Core --> Storage : Uses (Trait Bound)
+  %% Removed the circular dependency arrow
 ```
 
 ## Semantic Analysis (C4 Component Level)


### PR DESCRIPTION
🧠 **Decision:** Recorded the move to `storage` crate.
🗺️ **Visuals:** Updated C4 Component diagram to show new boundaries.
🔗 **Link:** See `docs/adr/022-decouple-storage.md`.

---
*PR created automatically by Jules for task [1887867074868438287](https://jules.google.com/task/1887867074868438287) started by @madmax983*