### PR TITLE
⚡ Bolt: Remove unnecessary Vec clone in catalog explorer

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -42,7 +42,10 @@ pub fn run_catalog() -> Result<()> {
             Cell::new("Rust Equivalent").fg(Color::Cyan),
         ]);
 
-        let mut pos_entries = entries_by_pos.get(&pos).unwrap().clone();
+        // ⚡ Bolt Optimization: Using `.remove()` instead of `.get().unwrap().clone()`
+        // to take ownership of the vector and avoid an expensive heap allocation and copy,
+        // since the original map entry is no longer needed.
+        let mut pos_entries = entries_by_pos.remove(&pos).unwrap();
         pos_entries.sort_by_key(|(word, _)| *word);
 
         for (word, entry) in pos_entries {


### PR DESCRIPTION
💡 **What:** Switched from `entries_by_pos.get(&pos).unwrap().clone()` to `entries_by_pos.remove(&pos).unwrap()`.
🎯 **Why:** The original `entries_by_pos` map is no longer needed after extracting each vector of words. Cloning the vector was causing unnecessary heap allocations.
📊 **Impact:** Removes a heap allocation and deep copy for every part of speech category when running the catalog tool.
🔬 **Measurement:** Run `cargo test` to verify no regressions in functionality, or run `cargo bench` if available.

---
*PR created automatically by Jules for task [18243136106336942281](https://jules.google.com/task/18243136106336942281) started by @madmax983*