### PR TITLE
🛡️ Sentry: [prevent stack overflow in codegen]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,11 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+
+**2025-03-05 - [Prevent Stack Overflow in Codegen]**
+**Learning:** Programmatically constructed, deeply nested `AnalyzedStatement` types that bypass standard parsing limits can crash the thread with a stack overflow during recursive token stream generation in `generate_rust()`.
+**Action:** Enforced existing depth limits globally by calling `validate_program` *before* initiating any recursion in code generators. Also discovered that ensuring panic safeguards correctly abort integration tests avoids crashing the entire test runner.
+
+**2025-03-05 - [Prevent Stack Overflow in Codegen]**
+**Learning:** Programmatically constructed, deeply nested `AnalyzedStatement` types that bypass standard parsing limits can crash the thread with a stack overflow during recursive token stream generation in `generate_rust()`. When a subprocess crash test is refactored into a `#[should_panic]` test, cloning or using standard variables for the large memory block can cause a stack overflow *before* the intended function call.
+**Action:** Enforced existing depth limits globally by calling `validate_program` *before* initiating any recursion in code generators. When running high-depth `#[should_panic]` tests, construct the objects as `Box::leak(Box::new(...))` to avoid overflowing the stack during test setup.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -403,6 +403,11 @@ pub fn generate_type_tokens(ty: &GlossaType) -> TokenStream {
 /// assert!(rust_code.contains("println"));
 /// ```
 pub fn generate_rust(program: &AnalyzedProgram) -> String {
+    // 🛡️ Sentry Validation: Enforce depth limits before recursive code generation starts
+    // to prevent programmatically constructed ASTs from overflowing the thread stack.
+    crate::semantic::validation::validate_program(program)
+        .expect("Recursion limit exceeded in code generation");
+
     // Separate trait defs, struct defs, trait impls, function defs, tests, and main body statements
     // ⚡ Bolt Optimization: Pre-allocate vectors based on statement length.
     // This reduces internal reallocation overhead during partitioning.

--- a/tests/havoc_codegen_stack_overflow.rs
+++ b/tests/havoc_codegen_stack_overflow.rs
@@ -4,65 +4,39 @@ use glossa::morphology::BinaryOp;
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,
 };
-use std::env;
-use std::process::Command;
 
 /// 👺 Havoc: Stack Overflow in Codegen
 ///
-/// If a deeply nested expression manages to bypass the parser limits or is
-/// constructed programmatically, generating Rust code for it will immediately crash
-/// the thread with a stack overflow.
+/// Sentry validation step prevents deep nesting.
 #[test]
+#[should_panic(expected = "Recursion limit exceeded in code generation")]
 fn havoc_codegen_stack_overflow() {
-    if env::var("HAVOC_DETONATE_CODEGEN_OVERFLOW").is_ok() {
-        let depth = 50_000;
-        let mut expr = AnalyzedExpr {
-            expr: AnalyzedExprKind::NumberLiteral(1),
+    let depth = 50_000;
+    let mut expr = AnalyzedExpr {
+        expr: AnalyzedExprKind::NumberLiteral(1),
+        glossa_type: GlossaType::Number,
+    };
+    for _ in 0..depth {
+        expr = AnalyzedExpr {
+            expr: AnalyzedExprKind::BinOp {
+                left: Box::new(expr),
+                op: BinaryOp::Add,
+                right: Box::new(AnalyzedExpr {
+                    expr: AnalyzedExprKind::NumberLiteral(1),
+                    glossa_type: GlossaType::Number,
+                }),
+            },
             glossa_type: GlossaType::Number,
         };
-        for _ in 0..depth {
-            expr = AnalyzedExpr {
-                expr: AnalyzedExprKind::BinOp {
-                    left: Box::new(expr),
-                    op: BinaryOp::Add,
-                    right: Box::new(AnalyzedExpr {
-                        expr: AnalyzedExprKind::NumberLiteral(1),
-                        glossa_type: GlossaType::Number,
-                    }),
-                },
-                glossa_type: GlossaType::Number,
-            };
-        }
-
-        let stmt = AnalyzedStatement::Expression(vec![expr]);
-        let scope = Scope::new();
-        let program = AnalyzedProgram {
-            statements: vec![stmt],
-            scope,
-        };
-
-        // 💥 DETONATE
-        println!(
-            "Generating rust code for deep expression (depth {})...",
-            depth
-        );
-        let _ = generate_rust(&program);
-
-        println!("Survived and mitigated!");
-        std::process::exit(0);
     }
 
-    let exe = env::current_exe().expect("Failed to get current executable");
+    let stmt = AnalyzedStatement::Expression(vec![expr]);
+    let scope = Scope::new();
+    let program = Box::leak(Box::new(AnalyzedProgram {
+        statements: vec![stmt],
+        scope,
+    }));
 
-    let status = Command::new(exe)
-        .env("HAVOC_DETONATE_CODEGEN_OVERFLOW", "1")
-        .arg("--nocapture")
-        .arg("havoc_codegen_stack_overflow")
-        .status()
-        .expect("Failed to spawn subprocess");
-
-    assert!(
-        !status.success(),
-        "Subprocess should have crashed due to stack overflow!"
-    );
+    // 💥 DETONATE
+    let _ = generate_rust(program);
 }


### PR DESCRIPTION
🎯 Target: `generate_rust` in `src/codegen.rs`
💣 Risk: Deeply nested ASTs (bypassing normal parser limits) could crash the code generation thread with an unrecoverable stack overflow.
🧪 Strategy: Validated the program depth using `validate_program` before starting the recursive token stream generation, failing gracefully with a panic when limits are exceeded. Refactored the chaotic Havoc test to a standard `#[should_panic]` test.
🔬 Verification: `cargo test havoc_codegen_stack_overflow`

---
*PR created automatically by Jules for task [12202820071707233462](https://jules.google.com/task/12202820071707233462) started by @madmax983*