### PR TITLE
⚒️ Forge: Refactor God function in haruspex.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,7 +1,9 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
-**Refactored Haruspex visit_expr**\n**Learning:** Found a god function  > 160 lines, handling too many match arms directly inline.\n**Action:** Extracted the match arms for , , , , , and  into small, named helper functions to flatten the structure and improve readability.
 **Refactored Haruspex visit_expr**
 **Learning:** Found a god function visit_expr > 160 lines, handling too many match arms directly inline.
 **Action:** Extracted the match arms for Some, None, Ok, Err, Unwrap, and Try into small, named helper functions to flatten the structure and improve readability.
+**Fixed Useless Borrow**
+**Learning:** Clippy reported useless borrow in format macro.
+**Action:** Removed redundant ampersand from var_name in src/semantic/conversion.rs.

--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+**Refactored Haruspex visit_expr**\n**Learning:** Found a god function  > 160 lines, handling too many match arms directly inline.\n**Action:** Extracted the match arms for , , , , , and  into small, named helper functions to flatten the structure and improve readability.
+**Refactored Haruspex visit_expr**
+**Learning:** Found a god function visit_expr > 160 lines, handling too many match arms directly inline.
+**Action:** Extracted the match arms for Some, None, Ok, Err, Unwrap, and Try into small, named helper functions to flatten the structure and improve readability.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -321,32 +321,22 @@ fn visit_expr(next_id: &mut usize, output: &mut String, expr: &AnalyzedExpr) -> 
             visit_array_literal_expr(next_id, output, id, exprs, &type_info);
         }
         AnalyzedExprKind::Some(e) => {
-            emit_node(output, id, &format!("Some{}", type_info), "lightyellow");
-            let e_id = visit_expr(next_id, output, e);
-            emit_edge(output, id, e_id, "value");
+            visit_some_expr(next_id, output, id, e, &type_info);
         }
         AnalyzedExprKind::None => {
-            emit_node(output, id, &format!("None{}", type_info), "lightyellow");
+            visit_none_expr(output, id, &type_info);
         }
         AnalyzedExprKind::Ok(e) => {
-            emit_node(output, id, &format!("Ok{}", type_info), "lightyellow");
-            let e_id = visit_expr(next_id, output, e);
-            emit_edge(output, id, e_id, "value");
+            visit_ok_expr(next_id, output, id, e, &type_info);
         }
         AnalyzedExprKind::Err(e) => {
-            emit_node(output, id, &format!("Err{}", type_info), "lightyellow");
-            let e_id = visit_expr(next_id, output, e);
-            emit_edge(output, id, e_id, "error");
+            visit_err_expr(next_id, output, id, e, &type_info);
         }
         AnalyzedExprKind::Unwrap(e) => {
-            emit_node(output, id, &format!("Unwrap{}", type_info), "lightyellow");
-            let e_id = visit_expr(next_id, output, e);
-            emit_edge(output, id, e_id, "target");
+            visit_unwrap_expr(next_id, output, id, e, &type_info);
         }
         AnalyzedExprKind::Try(e) => {
-            emit_node(output, id, &format!("Try{}", type_info), "lightyellow");
-            let e_id = visit_expr(next_id, output, e);
-            emit_edge(output, id, e_id, "target");
+            visit_try_expr(next_id, output, id, e, &type_info);
         }
         AnalyzedExprKind::IndexAccess { array, index } => {
             emit_node(
@@ -820,6 +810,70 @@ fn visit_lambda_expr(
     );
     let body_id = visit_expr(next_id, output, body);
     emit_edge(output, id, body_id, "body");
+}
+
+fn visit_some_expr(
+    next_id: &mut usize,
+    output: &mut String,
+    id: usize,
+    e: &AnalyzedExpr,
+    type_info: &str,
+) {
+    emit_node(output, id, &format!("Some{}", type_info), "lightyellow");
+    let e_id = visit_expr(next_id, output, e);
+    emit_edge(output, id, e_id, "value");
+}
+
+fn visit_none_expr(output: &mut String, id: usize, type_info: &str) {
+    emit_node(output, id, &format!("None{}", type_info), "lightyellow");
+}
+
+fn visit_ok_expr(
+    next_id: &mut usize,
+    output: &mut String,
+    id: usize,
+    e: &AnalyzedExpr,
+    type_info: &str,
+) {
+    emit_node(output, id, &format!("Ok{}", type_info), "lightyellow");
+    let e_id = visit_expr(next_id, output, e);
+    emit_edge(output, id, e_id, "value");
+}
+
+fn visit_err_expr(
+    next_id: &mut usize,
+    output: &mut String,
+    id: usize,
+    e: &AnalyzedExpr,
+    type_info: &str,
+) {
+    emit_node(output, id, &format!("Err{}", type_info), "lightyellow");
+    let e_id = visit_expr(next_id, output, e);
+    emit_edge(output, id, e_id, "error");
+}
+
+fn visit_unwrap_expr(
+    next_id: &mut usize,
+    output: &mut String,
+    id: usize,
+    e: &AnalyzedExpr,
+    type_info: &str,
+) {
+    emit_node(output, id, &format!("Unwrap{}", type_info), "lightyellow");
+    let e_id = visit_expr(next_id, output, e);
+    emit_edge(output, id, e_id, "target");
+}
+
+fn visit_try_expr(
+    next_id: &mut usize,
+    output: &mut String,
+    id: usize,
+    e: &AnalyzedExpr,
+    type_info: &str,
+) {
+    emit_node(output, id, &format!("Try{}", type_info), "lightyellow");
+    let e_id = visit_expr(next_id, output, e);
+    emit_edge(output, id, e_id, "target");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🚮 Smell: Large god function `visit_expr` over 160 lines in `haruspex.rs`.
✨ Solution: Extracted Some, None, Ok, Err, Unwrap, Try match arms into helper functions.
🧼 Benefit: Reduces cognitive load and flattens the structure of `visit_expr`.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [15918053133961872986](https://jules.google.com/task/15918053133961872986) started by @madmax983*