### PR TITLE
🪒 Razor: [Remove TraitMethodParts abstraction]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** `TraitMethodParts` struct in `src/codegen.rs` used solely to group return values.
+**Cut:** Flattened the object into standard Rust tuple `(Ident, Vec<TokenStream>, Option<TokenStream>)`.
+**Saved:** Eliminated a single-use struct abstraction and simplified destructuring at caller sites.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -795,13 +795,9 @@ fn generate_struct_def(name: &str, fields: &[(smol_str::SmolStr, GlossaType)]) -
     }
 }
 
-struct TraitMethodParts {
-    name: Ident,
-    params: Vec<TokenStream>,
-    return_type: Option<TokenStream>,
-}
-
-fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
+fn generate_trait_method_parts(
+    method: &AnalyzedMethod,
+) -> (Ident, Vec<TokenStream>, Option<TokenStream>) {
     let method_name = sanitize_ident(&method.name);
 
     let param_tokens = method
@@ -820,11 +816,7 @@ fn generate_trait_method_parts(method: &AnalyzedMethod) -> TraitMethodParts {
 
     let ret_tokens = method.return_type.as_ref().map(generate_type_tokens);
 
-    TraitMethodParts {
-        name: method_name,
-        params: param_tokens.collect(),
-        return_type: ret_tokens,
-    }
+    (method_name, param_tokens.collect(), ret_tokens)
 }
 
 fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
@@ -840,11 +832,9 @@ fn generate_trait_def(name: &str, methods: &[AnalyzedMethod]) -> TokenStream {
 
     // Generate method signatures
     let method_tokens = methods.iter().map(|method| {
-        let parts = generate_trait_method_parts(method);
-        let method_name = parts.name;
-        let param_tokens = parts.params;
+        let (method_name, param_tokens, return_type) = generate_trait_method_parts(method);
 
-        if let Some(ret_ty) = parts.return_type {
+        if let Some(ret_ty) = return_type {
             if let Some(body) = &method.body {
                 let body_stmts = generate_statements(body);
                 quote! {
@@ -903,9 +893,7 @@ fn generate_trait_impl(
 
     // Generate method implementations
     let method_tokens = methods.iter().map(|method| {
-        let parts = generate_trait_method_parts(method);
-        let method_name = parts.name;
-        let param_tokens = parts.params;
+        let (method_name, param_tokens, return_type) = generate_trait_method_parts(method);
 
         // Generate method body
         let body_stmts: Vec<TokenStream> = if let Some(body) = &method.body {
@@ -914,7 +902,7 @@ fn generate_trait_impl(
             Vec::new()
         };
 
-        if let Some(ret_ty) = parts.return_type {
+        if let Some(ret_ty) = return_type {
             quote! {
                 fn #method_name(#(#param_tokens),*) -> #ret_ty {
                     #(#body_stmts)*
@@ -1679,20 +1667,20 @@ mod tests {
                 return_type: Some(GlossaType::Boolean),
             };
 
-            let parts = generate_trait_method_parts(&method);
+            let (name, params, return_type) = generate_trait_method_parts(&method);
 
-            assert_eq!(parts.name.to_string(), "g_test_method");
+            assert_eq!(name.to_string(), "g_test_method");
 
             // Check params
-            let params_str: Vec<String> = parts.params.iter().map(|t| t.to_string()).collect();
+            let params_str: Vec<String> = params.iter().map(|t| t.to_string()).collect();
             assert_eq!(params_str.len(), 2);
             assert_eq!(params_str[0], "& self");
             assert!(params_str[1].contains("g_arg1"));
             assert!(params_str[1].contains("i64"));
 
             // Check return type
-            assert!(parts.return_type.is_some());
-            assert_eq!(parts.return_type.unwrap().to_string(), "bool");
+            assert!(return_type.is_some());
+            assert_eq!(return_type.unwrap().to_string(), "bool");
         }
 
         #[test]


### PR DESCRIPTION
## [Reduction]
**Bloat:** `TraitMethodParts` struct in `src/codegen.rs` used solely to group return values.
**Cut:** Flattened the object into standard Rust tuple `(Ident, Vec<TokenStream>, Option<TokenStream>)`.
**Saved:** Eliminated a single-use struct abstraction and simplified destructuring at caller sites.

---
*PR created automatically by Jules for task [170709482466004903](https://jules.google.com/task/170709482466004903) started by @madmax983*