### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🤦 **The Confusion:** Tried to run the 'Troubleshooting' examples from the README to learn how the compiler talks to me. The README says 'Διπλοῦν ὑποκείμενον' means 'Two Nominatives', 'Οὐκ οἶδα τὸ ὄνομα' means 'Undefined variable'. But when I actually make these mistakes in the code, I don't get the error message I was promised. For example, `ὁ ἄνθρωπος ὁ θεὸς λέγει.` just compiles and does nothing (no error), and `ψ λέγει.` just compiles and prints empty string (no error).

🕵️ **The Reality:** Turns out the parser/compiler doesn't actually produce these errors when I write bad code! The documentation claims there are helpful errors for troubleshooting, but the compiler silently accepts these invalid inputs.

💡 **The Fix:** Actually emit the promised errors in the compiler, or remove the Troubleshooting guide from the README so users aren't misled.

---
*PR created automatically by Jules for task [12396062431679699481](https://jules.google.com/task/12396062431679699481) started by @madmax983*