### PR TITLE
⚡ Bolt: Use .remove() instead of .get().unwrap().clone() in catalog tool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**HashMap entry removal optimization**
+**Learning:** When retrieving a value from a `HashMap` where the original map entry is no longer needed (especially heap-allocated types like `Vec` or `String`), using `.get(&key).unwrap().clone()` incurs unnecessary heap allocations.
+**Action:** Use `.remove(&key).unwrap()` to safely transfer ownership out of the map without cloning.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,6 @@
 **HashMap entry removal optimization**
 **Learning:** When retrieving a value from a `HashMap` where the original map entry is no longer needed (especially heap-allocated types like `Vec` or `String`), using `.get(&key).unwrap().clone()` incurs unnecessary heap allocations.
 **Action:** Use `.remove(&key).unwrap()` to safely transfer ownership out of the map without cloning.
+**Formatting strings memory optimization**
+**Learning:** When using `format!`, passing a string explicitly by reference (e.g., `&var_name`) causes clippy to issue a `useless_borrows_in_formatting` warning.
+**Action:** Always pass variables directly to `format!` (e.g., `var_name`) to avoid the redundant borrow and satisfy clippy lints.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -42,7 +42,9 @@ pub fn run_catalog() -> Result<()> {
             Cell::new("Rust Equivalent").fg(Color::Cyan),
         ]);
 
-        let mut pos_entries = entries_by_pos.get(&pos).unwrap().clone();
+        // ⚡ Bolt Optimization: Use `.remove()` instead of `.get().unwrap().clone()` to avoid
+        // unnecessary heap allocation of the Vec since the HashMap entry is no longer needed.
+        let mut pos_entries = entries_by_pos.remove(&pos).unwrap();
         pos_entries.sort_by_key(|(word, _)| *word);
 
         for (word, entry) in pos_entries {


### PR DESCRIPTION
💡 What: Swapped `.get(&pos).unwrap().clone()` with `.remove(&pos).unwrap()` in `src/tools/catalog.rs`.
🎯 Why: The `Vec` from the `HashMap` was being cloned unnecessarily, when ownership could simply be transferred out of the map since the entry is no longer needed.
📊 Impact: Eliminates heap allocations and data copies for vectors of entries during catalog printing.
🔬 Measurement: Run `cargo run -- catalog` to verify it behaves correctly.

---
*PR created automatically by Jules for task [12863588100543899024](https://jules.google.com/task/12863588100543899024) started by @madmax983*