### PR TITLE
🪒 Razor: [Refactor GnomonVisitor to pure procedural functions]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,7 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+## [Reduction]
+**Bloat:** `GnomonVisitor` in `src/tools/gnomon.rs` used an object-oriented visitor pattern to estimate the loop depth by accumulating internal state (`current_depth`, `max_depth`).
+**Cut:** Flattened the object into pure procedural functions `get_max_loop_depth` and `get_statement_depth` that operate directly on the AST slice to calculate loop depth recursively.
+**Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -22,79 +22,35 @@ use std::path::Path;
 /// Just as a gnomon casts a shadow to indicate time, this visitor casts a shadow
 /// over the structure of a program to estimate its execution time complexity.
 /// It tracks the maximum nesting depth of `while` and `for` loops.
-#[derive(Default)]
-pub struct GnomonVisitor {
-    /// The current nesting depth of loops during traversal.
-    pub current_depth: usize,
-    /// The maximum nesting depth encountered so far.
-    pub max_depth: usize,
+fn get_max_loop_depth(stmts: &[AnalyzedStatement]) -> usize {
+    stmts.iter().map(get_statement_depth).max().unwrap_or(0)
 }
 
-impl GnomonVisitor {
-    /// Creates a new `GnomonVisitor` starting at depth 0.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Recursively visits a statement and updates loop depth metrics.
-    ///
-    /// Increases depth when entering `While` or `For` loops, and explores
-    /// inner statements in branches (`If`, `Match`, functions).
-    pub fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
-        match stmt {
-            AnalyzedStatement::While { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
-            }
-            AnalyzedStatement::For { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
-            }
-            AnalyzedStatement::If {
-                then_body,
-                else_body,
-                ..
-            } => {
-                for s in then_body {
-                    self.visit_statement(s);
-                }
-                if let Some(else_stmts) = else_body {
-                    for s in else_stmts {
-                        self.visit_statement(s);
-                    }
-                }
-            }
-            AnalyzedStatement::Match { arms, .. } => {
-                for (_, stmts) in arms {
-                    for s in stmts {
-                        self.visit_statement(s);
-                    }
-                }
-            }
-            AnalyzedStatement::FunctionDef { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            _ => {}
+fn get_statement_depth(stmt: &AnalyzedStatement) -> usize {
+    match stmt {
+        AnalyzedStatement::While { body, .. } | AnalyzedStatement::For { body, .. } => {
+            1 + get_max_loop_depth(body)
         }
+        AnalyzedStatement::If {
+            then_body,
+            else_body,
+            ..
+        } => {
+            let then_depth = get_max_loop_depth(then_body);
+            let else_depth = else_body
+                .as_ref()
+                .map(|b| get_max_loop_depth(b))
+                .unwrap_or(0);
+            then_depth.max(else_depth)
+        }
+        AnalyzedStatement::Match { arms, .. } => arms
+            .iter()
+            .map(|(_, stmts)| get_max_loop_depth(stmts))
+            .max()
+            .unwrap_or(0),
+        AnalyzedStatement::FunctionDef { body, .. }
+        | AnalyzedStatement::TestDeclaration { body, .. } => get_max_loop_depth(body),
+        _ => 0,
     }
 }
 
@@ -146,10 +102,7 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
 
     status.success();
 
-    let mut visitor = GnomonVisitor::new();
-    for stmt in &program.statements {
-        visitor.visit_statement(stmt);
-    }
+    let max_depth = get_max_loop_depth(&program.statements);
 
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   G N O M O N".cyan().bold());
@@ -170,23 +123,23 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
         Cell::new("Value").add_attribute(Attribute::Bold),
     ]);
 
-    let complexity = if visitor.max_depth == 0 {
+    let complexity = if max_depth == 0 {
         "O(1)".to_string()
-    } else if visitor.max_depth == 1 {
+    } else if max_depth == 1 {
         "O(N)".to_string()
     } else {
-        format!("O(N^{})", visitor.max_depth)
+        format!("O(N^{})", max_depth)
     };
 
     table.add_row(vec![
         Cell::new("Max Loop Depth"),
-        Cell::new(visitor.max_depth.to_string()),
+        Cell::new(max_depth.to_string()),
     ]);
     table.add_row(vec![
         Cell::new("Estimated Big-O"),
-        Cell::new(complexity).fg(if visitor.max_depth > 2 {
+        Cell::new(complexity).fg(if max_depth > 2 {
             Color::Red
-        } else if visitor.max_depth == 2 {
+        } else if max_depth == 2 {
             Color::Yellow
         } else {
             Color::Green
@@ -214,30 +167,25 @@ mod tests {
 
     #[test]
     fn test_gnomon_while_loop() {
-        let mut visitor = GnomonVisitor::new();
         let stmt = AnalyzedStatement::While {
             condition: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        assert_eq!(get_statement_depth(&stmt), 1);
     }
 
     #[test]
     fn test_gnomon_for_loop() {
-        let mut visitor = GnomonVisitor::new();
         let stmt = AnalyzedStatement::For {
             variable: SmolStr::new("x"),
             iterator: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        assert_eq!(get_statement_depth(&stmt), 1);
     }
 
     #[test]
     fn test_gnomon_nested_loops() {
-        let mut visitor = GnomonVisitor::new();
         let inner_loop = AnalyzedStatement::For {
             variable: SmolStr::new("y"),
             iterator: dummy_expr(),
@@ -247,7 +195,6 @@ mod tests {
             condition: dummy_expr(),
             body: vec![inner_loop],
         };
-        visitor.visit_statement(&outer_loop);
-        assert_eq!(visitor.max_depth, 2);
+        assert_eq!(get_statement_depth(&outer_loop), 2);
     }
 }

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn test_gnomon_function_def() {
         let stmt = AnalyzedStatement::FunctionDef {
-            name: SmolStr::new("func").into(),
+            name: SmolStr::new("func"),
             params: vec![],
             return_type: None,
             body: vec![AnalyzedStatement::While {
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn test_gnomon_test_decl() {
         let stmt = AnalyzedStatement::TestDeclaration {
-            name: SmolStr::new("test").into(),
+            name: String::from("test"),
             body: vec![AnalyzedStatement::While {
                 condition: dummy_expr(),
                 body: vec![],

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -261,4 +261,32 @@ mod tests {
         let stmt = AnalyzedStatement::Break;
         assert_eq!(get_statement_depth(&stmt), 0);
     }
+
+    #[test]
+    fn test_get_max_loop_depth_empty() {
+        let stmts: Vec<AnalyzedStatement> = vec![];
+        assert_eq!(get_max_loop_depth(&stmts), 0);
+    }
+
+    #[test]
+    fn test_get_statement_depth_if_missing_else() {
+        let stmt = AnalyzedStatement::If {
+            condition: dummy_expr(),
+            then_body: vec![AnalyzedStatement::While {
+                condition: dummy_expr(),
+                body: vec![],
+            }],
+            else_body: None,
+        };
+        assert_eq!(get_statement_depth(&stmt), 1);
+    }
+
+    #[test]
+    fn test_get_statement_depth_match_empty() {
+        let stmt = AnalyzedStatement::Match {
+            scrutinee: dummy_expr(),
+            arms: vec![],
+        };
+        assert_eq!(get_statement_depth(&stmt), 0);
+    }
 }

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn test_gnomon_function_def() {
         let stmt = AnalyzedStatement::FunctionDef {
-            name: SmolStr::new("func"),
+            name: SmolStr::new("func").into(),
             params: vec![],
             return_type: None,
             body: vec![AnalyzedStatement::While {
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn test_gnomon_test_decl() {
         let stmt = AnalyzedStatement::TestDeclaration {
-            name: SmolStr::new("test"),
+            name: SmolStr::new("test").into(),
             body: vec![AnalyzedStatement::While {
                 condition: dummy_expr(),
                 body: vec![],

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -197,4 +197,68 @@ mod tests {
         };
         assert_eq!(get_statement_depth(&outer_loop), 2);
     }
+
+    #[test]
+    fn test_gnomon_if_statement() {
+        let stmt = AnalyzedStatement::If {
+            condition: dummy_expr(),
+            then_body: vec![AnalyzedStatement::While {
+                condition: dummy_expr(),
+                body: vec![],
+            }],
+            else_body: Some(vec![AnalyzedStatement::For {
+                variable: SmolStr::new("z"),
+                iterator: dummy_expr(),
+                body: vec![],
+            }]),
+        };
+        assert_eq!(get_statement_depth(&stmt), 1);
+    }
+
+    #[test]
+    fn test_gnomon_match_statement() {
+        let stmt = AnalyzedStatement::Match {
+            scrutinee: dummy_expr(),
+            arms: vec![(
+                *dummy_expr(),
+                vec![AnalyzedStatement::While {
+                    condition: dummy_expr(),
+                    body: vec![],
+                }],
+            )],
+        };
+        assert_eq!(get_statement_depth(&stmt), 1);
+    }
+
+    #[test]
+    fn test_gnomon_function_def() {
+        let stmt = AnalyzedStatement::FunctionDef {
+            name: SmolStr::new("func"),
+            params: vec![],
+            return_type: None,
+            body: vec![AnalyzedStatement::While {
+                condition: dummy_expr(),
+                body: vec![],
+            }],
+        };
+        assert_eq!(get_statement_depth(&stmt), 1);
+    }
+
+    #[test]
+    fn test_gnomon_test_decl() {
+        let stmt = AnalyzedStatement::TestDeclaration {
+            name: SmolStr::new("test"),
+            body: vec![AnalyzedStatement::While {
+                condition: dummy_expr(),
+                body: vec![],
+            }],
+        };
+        assert_eq!(get_statement_depth(&stmt), 1);
+    }
+
+    #[test]
+    fn test_gnomon_other_statement() {
+        let stmt = AnalyzedStatement::Break;
+        assert_eq!(get_statement_depth(&stmt), 0);
+    }
 }

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -289,4 +289,19 @@ mod tests {
         };
         assert_eq!(get_statement_depth(&stmt), 0);
     }
+
+    #[test]
+    fn test_get_statement_depth_other_unhandled() {
+        let stmt = AnalyzedStatement::Continue;
+        assert_eq!(get_statement_depth(&stmt), 0);
+
+        let stmt2 = AnalyzedStatement::Return { value: None };
+        assert_eq!(get_statement_depth(&stmt2), 0);
+
+        let stmt3 = AnalyzedStatement::Print(vec![]);
+        assert_eq!(get_statement_depth(&stmt3), 0);
+
+        let stmt4 = AnalyzedStatement::Expression(vec![]);
+        assert_eq!(get_statement_depth(&stmt4), 0);
+    }
 }


### PR DESCRIPTION
## [Reduction]
**Bloat:** `GnomonVisitor` in `src/tools/gnomon.rs` used an object-oriented visitor pattern to estimate the loop depth by accumulating internal state (`current_depth`, `max_depth`).
**Cut:** Flattened the object into pure procedural functions `get_max_loop_depth` and `get_statement_depth` that operate directly on the AST slice to calculate loop depth recursively.
**Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.

---
*PR created automatically by Jules for task [11975678734954233107](https://jules.google.com/task/11975678734954233107) started by @madmax983*