### PR TITLE
🗣️ Echo: Getting Started example fails with undocumented Greek error

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🤦 **The Confusion:**
I followed the README's instructions to run a file by literally copy-pasting `cargo run --release -- hero.γλ`. Instead of working or giving a helpful error, it crashed with a completely Greek error: `Error:   × Ἀρχεῖον οὐχ εὑρέθη: hero.γλ`. I checked the Troubleshooting table, but this error isn't listed there!

🕵️ **The Reality:**
It turns out this just means "File not found" because `hero.γλ` doesn't exist on my machine. 

💡 **The Fix:**
Either add `Ἀρχεῖον οὐχ εὑρέθη` to the Troubleshooting table so users know what it means, or better yet, just use English for basic I/O errors like "File not found"!

---
*PR created automatically by Jules for task [16372270706230124206](https://jules.google.com/task/16372270706230124206) started by @madmax983*