### PR TITLE
⚡ Bolt: Eliminate intermediate allocations in tester and cartographer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+**[Optimizing `format!` in `clean_panic_message`]**
+**Learning:** `format!` inside `clean_panic_message` in `src/tools/tester.rs` was reallocating unnecessarily and invoking the formatting machinery on a hot path during test parsing. Replacing it with an exact-sized `String::with_capacity` and manual `push_str` calls reduces allocations overhead during failed test parsing.
+**Action:** Always check if a simple concatenation using `push_str` and `String::with_capacity` can replace a `format!` macro for basic string prepends/appends, as it completely skips the `fmt::Display` machinery overhead.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/cartographer.rs
+++ b/src/tools/cartographer.rs
@@ -166,15 +166,16 @@ fn format_traits(map: &mut String, program: &AnalyzedProgram) {
         let _ = writeln!(map, "    class {} {{", name);
         map.push_str("        <<interface>>\n");
         for method in &trait_def.methods {
-            let mut params_str = String::new();
+            // ⚡ Bolt Optimization: Eliminated intermediate `String` allocation for parameters by writing directly to `map`
+            let _ = write!(map, "        +{}(", method.name);
             for (i, (n, t)) in method.params.iter().enumerate() {
                 if i > 0 {
-                    params_str.push_str(", ");
+                    map.push_str(", ");
                 }
-                write!(&mut params_str, "{}: {}", n, t).unwrap();
+                let _ = write!(map, "{}: {}", n, t);
             }
+            map.push(')');
 
-            let _ = write!(map, "        +{}({})", method.name, params_str);
             if let Some(t) = &method.return_type {
                 let _ = write!(map, ": {}", t);
             }

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -193,7 +193,13 @@ fn clean_panic_message(current: &str) -> Option<String> {
     }
 
     let panicked_idx = current.find("panicked at")?;
-    let mut clean_panic = format!("{}panicked", &current[..panicked_idx]);
+
+    // ⚡ Bolt Optimization: Replace `format!` with `String::with_capacity` and `push_str`
+    // to avoid unnecessary `format!` machinery overhead.
+    let prefix = &current[..panicked_idx];
+    let mut clean_panic = String::with_capacity(prefix.len() + 8);
+    clean_panic.push_str(prefix);
+    clean_panic.push_str("panicked");
 
     // Remove the "(pid)" thread id
     #[allow(clippy::collapsible_if)]


### PR DESCRIPTION
💡 What: Replaced a `format!` allocation with `String::with_capacity()` and `.push_str()` in `clean_panic_message` (`src/tools/tester.rs`), and removed an intermediate string allocation for method parameters in `src/tools/cartographer.rs` by writing directly to the parent buffer.
🎯 Why: `format!` inside `clean_panic_message` invoked the formatting machinery unnecessarily on a hot path during failed test parsing. In `cartographer.rs`, creating a `String::new()` inside a loop caused multiple heap re-allocations.
📊 Impact: Eliminates several unnecessary string re-allocations during test parsing and AST processing, slightly reducing memory overhead.
🔬 Measurement: Run `cargo test` and verify that the tests complete correctly and fast without any regressions in compilation or runtime checks.

---
*PR created automatically by Jules for task [6671174756209855151](https://jules.google.com/task/6671174756209855151) started by @madmax983*