### PR TITLE
🪒 Razor: [flatten GnomonVisitor]

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,7 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+## [Reduction]
+**Bloat:** `GnomonVisitor` in `src/tools/gnomon.rs` used an object-oriented visitor pattern to track max depth.
+**Cut:** Flattened the object into a pure recursive function `calculate_max_depth` without state parameters.
+**Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,3 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
+2. Submit the change.
+   - Once all tests pass, I will submit the change with a descriptive commit message.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -17,84 +17,69 @@ use crossterm::style::Stylize;
 use miette::Result;
 use std::path::Path;
 
-/// A visitor that traverses the Abstract Syntax Tree to calculate loop depth.
+/// Analyzes a statement to calculate its maximum loop depth.
 ///
-/// Just as a gnomon casts a shadow to indicate time, this visitor casts a shadow
+/// Just as a gnomon casts a shadow to indicate time, this function casts a shadow
 /// over the structure of a program to estimate its execution time complexity.
 /// It tracks the maximum nesting depth of `while` and `for` loops.
-#[derive(Default)]
-pub struct GnomonVisitor {
-    /// The current nesting depth of loops during traversal.
-    pub current_depth: usize,
-    /// The maximum nesting depth encountered so far.
-    pub max_depth: usize,
-}
-
-impl GnomonVisitor {
-    /// Creates a new `GnomonVisitor` starting at depth 0.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Recursively visits a statement and updates loop depth metrics.
-    ///
-    /// Increases depth when entering `While` or `For` loops, and explores
-    /// inner statements in branches (`If`, `Match`, functions).
-    pub fn visit_statement(&mut self, stmt: &AnalyzedStatement) {
-        match stmt {
-            AnalyzedStatement::While { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
-            }
-            AnalyzedStatement::For { body, .. } => {
-                self.current_depth += 1;
-                if self.current_depth > self.max_depth {
-                    self.max_depth = self.current_depth;
-                }
-                for s in body {
-                    self.visit_statement(s);
-                }
-                self.current_depth -= 1;
-            }
-            AnalyzedStatement::If {
-                then_body,
-                else_body,
-                ..
-            } => {
-                for s in then_body {
-                    self.visit_statement(s);
-                }
-                if let Some(else_stmts) = else_body {
-                    for s in else_stmts {
-                        self.visit_statement(s);
-                    }
+pub fn calculate_max_depth(stmt: &AnalyzedStatement) -> usize {
+    match stmt {
+        AnalyzedStatement::While { body, .. } | AnalyzedStatement::For { body, .. } => {
+            let mut max_child = 0;
+            for s in body {
+                let d = calculate_max_depth(s);
+                if d > max_child {
+                    max_child = d;
                 }
             }
-            AnalyzedStatement::Match { arms, .. } => {
-                for (_, stmts) in arms {
-                    for s in stmts {
-                        self.visit_statement(s);
-                    }
-                }
-            }
-            AnalyzedStatement::FunctionDef { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            AnalyzedStatement::TestDeclaration { body, .. } => {
-                for s in body {
-                    self.visit_statement(s);
-                }
-            }
-            _ => {}
+            1 + max_child
         }
+        AnalyzedStatement::If {
+            then_body,
+            else_body,
+            ..
+        } => {
+            let mut max_child = 0;
+            for s in then_body {
+                let d = calculate_max_depth(s);
+                if d > max_child {
+                    max_child = d;
+                }
+            }
+            if let Some(else_stmts) = else_body {
+                for s in else_stmts {
+                    let d = calculate_max_depth(s);
+                    if d > max_child {
+                        max_child = d;
+                    }
+                }
+            }
+            max_child
+        }
+        AnalyzedStatement::Match { arms, .. } => {
+            let mut max_child = 0;
+            for (_, stmts) in arms {
+                for s in stmts {
+                    let d = calculate_max_depth(s);
+                    if d > max_child {
+                        max_child = d;
+                    }
+                }
+            }
+            max_child
+        }
+        AnalyzedStatement::FunctionDef { body, .. }
+        | AnalyzedStatement::TestDeclaration { body, .. } => {
+            let mut max_child = 0;
+            for s in body {
+                let d = calculate_max_depth(s);
+                if d > max_child {
+                    max_child = d;
+                }
+            }
+            max_child
+        }
+        _ => 0,
     }
 }
 
@@ -146,9 +131,12 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
 
     status.success();
 
-    let mut visitor = GnomonVisitor::new();
+    let mut max_depth = 0;
     for stmt in &program.statements {
-        visitor.visit_statement(stmt);
+        let d = calculate_max_depth(stmt);
+        if d > max_depth {
+            max_depth = d;
+        }
     }
 
     println!();
@@ -170,23 +158,23 @@ pub fn run_gnomon(input: &Path) -> Result<()> {
         Cell::new("Value").add_attribute(Attribute::Bold),
     ]);
 
-    let complexity = if visitor.max_depth == 0 {
+    let complexity = if max_depth == 0 {
         "O(1)".to_string()
-    } else if visitor.max_depth == 1 {
+    } else if max_depth == 1 {
         "O(N)".to_string()
     } else {
-        format!("O(N^{})", visitor.max_depth)
+        format!("O(N^{})", max_depth)
     };
 
     table.add_row(vec![
         Cell::new("Max Loop Depth"),
-        Cell::new(visitor.max_depth.to_string()),
+        Cell::new(max_depth.to_string()),
     ]);
     table.add_row(vec![
         Cell::new("Estimated Big-O"),
-        Cell::new(complexity).fg(if visitor.max_depth > 2 {
+        Cell::new(complexity).fg(if max_depth > 2 {
             Color::Red
-        } else if visitor.max_depth == 2 {
+        } else if max_depth == 2 {
             Color::Yellow
         } else {
             Color::Green
@@ -214,30 +202,25 @@ mod tests {
 
     #[test]
     fn test_gnomon_while_loop() {
-        let mut visitor = GnomonVisitor::new();
         let stmt = AnalyzedStatement::While {
             condition: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        assert_eq!(calculate_max_depth(&stmt), 1);
     }
 
     #[test]
     fn test_gnomon_for_loop() {
-        let mut visitor = GnomonVisitor::new();
         let stmt = AnalyzedStatement::For {
             variable: SmolStr::new("x"),
             iterator: dummy_expr(),
             body: vec![],
         };
-        visitor.visit_statement(&stmt);
-        assert_eq!(visitor.max_depth, 1);
+        assert_eq!(calculate_max_depth(&stmt), 1);
     }
 
     #[test]
     fn test_gnomon_nested_loops() {
-        let mut visitor = GnomonVisitor::new();
         let inner_loop = AnalyzedStatement::For {
             variable: SmolStr::new("y"),
             iterator: dummy_expr(),
@@ -247,7 +230,6 @@ mod tests {
             condition: dummy_expr(),
             body: vec![inner_loop],
         };
-        visitor.visit_statement(&outer_loop);
-        assert_eq!(visitor.max_depth, 2);
+        assert_eq!(calculate_max_depth(&outer_loop), 2);
     }
 }

--- a/src/tools/gnomon.rs
+++ b/src/tools/gnomon.rs
@@ -232,4 +232,67 @@ mod tests {
         };
         assert_eq!(calculate_max_depth(&outer_loop), 2);
     }
+
+    #[test]
+    fn test_gnomon_if_statement() {
+        let inner_loop = AnalyzedStatement::While {
+            condition: dummy_expr(),
+            body: vec![],
+        };
+        let stmt = AnalyzedStatement::If {
+            condition: dummy_expr(),
+            then_body: vec![inner_loop],
+            else_body: Some(vec![]),
+        };
+        assert_eq!(calculate_max_depth(&stmt), 1);
+    }
+
+    #[test]
+    fn test_gnomon_match_statement() {
+        let inner_loop = AnalyzedStatement::For {
+            variable: SmolStr::new("x"),
+            iterator: dummy_expr(),
+            body: vec![],
+        };
+        let stmt = AnalyzedStatement::Match {
+            expression: dummy_expr(),
+            arms: vec![(dummy_expr(), vec![inner_loop])],
+        };
+        assert_eq!(calculate_max_depth(&stmt), 1);
+    }
+
+    #[test]
+    fn test_gnomon_function_def() {
+        let inner_loop = AnalyzedStatement::While {
+            condition: dummy_expr(),
+            body: vec![],
+        };
+        let stmt = AnalyzedStatement::FunctionDef {
+            name: SmolStr::new("test"),
+            params: vec![],
+            return_type: GlossaType::Void,
+            body: vec![inner_loop],
+            is_public: false,
+        };
+        assert_eq!(calculate_max_depth(&stmt), 1);
+    }
+
+    #[test]
+    fn test_gnomon_test_declaration() {
+        let inner_loop = AnalyzedStatement::While {
+            condition: dummy_expr(),
+            body: vec![],
+        };
+        let stmt = AnalyzedStatement::TestDeclaration {
+            name: SmolStr::new("test"),
+            body: vec![inner_loop],
+        };
+        assert_eq!(calculate_max_depth(&stmt), 1);
+    }
+
+    #[test]
+    fn test_gnomon_other_statement() {
+        let stmt = AnalyzedStatement::Expression(dummy_expr());
+        assert_eq!(calculate_max_depth(&stmt), 0);
+    }
 }


### PR DESCRIPTION
🪒 Razor: Flatten GnomonVisitor

**Bloat:** `GnomonVisitor` in `src/tools/gnomon.rs` used an object-oriented visitor pattern to simply track maximum loop depth.
**Cut:** Flattened the object into a pure recursive function `calculate_max_depth` without state parameters.
**Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.

---
*PR created automatically by Jules for task [16658937113659417769](https://jules.google.com/task/16658937113659417769) started by @madmax983*