### PR TITLE
📜 Codex: ADR Updates & Maintenance

### DIFF
--- a/docs/adr/016-alchemist-and-weave.md
+++ b/docs/adr/016-alchemist-and-weave.md
@@ -1,7 +1,7 @@
 # 16. Add Alchemist and Weave to Developer Experience Tools
 
 Date: 2024-11-15
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/017-labyrinth-control-flow-graph.md
+++ b/docs/adr/017-labyrinth-control-flow-graph.md
@@ -1,7 +1,7 @@
 # 17. Add Labyrinth to Developer Experience Tools
 
 Date: 2024-11-15
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/020-catalog-api-generator.md
+++ b/docs/adr/020-catalog-api-generator.md
@@ -4,7 +4,7 @@ Date: 2026-04-19
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/021-split-assembly-module.md
+++ b/docs/adr/021-split-assembly-module.md
@@ -4,7 +4,7 @@ Date: 2026-04-21
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/022-encapsulate-internal-modules.md
+++ b/docs/adr/022-encapsulate-internal-modules.md
@@ -1,0 +1,21 @@
+# 022. Encapsulate Internal Modules
+
+Date: 2026-07-21
+
+## Status
+
+Proposed
+
+## Context
+
+Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`. This broke encapsulation by exposing internal implementation details to the public API and creating a sprawling API surface.
+
+## Decision
+
+We have updated the visibility of these internal modules to `pub(crate) mod` in `src/tools/mod.rs` and `src/semantic/assembly/mod.rs`. This restricts their usage to within the crate while ensuring that they are not accessible to external consumers.
+
+## Consequences
+
+*   **Positive:** The internal structure of the `tools` and `assembly` modules is better encapsulated.
+*   **Positive:** The public API of the `glossa` crate is smaller and more intentional.
+*   **Negative:** Developers must be conscious of module boundaries and cannot rely on everything being publicly available across the workspace.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🧠 **Decision:** Transitioned outdated Proposed ADRs (016, 017, 020, 021) to Accepted status. Recorded the decision to encapsulate internal tools (`cache`, `report`, `ui`) and assembly `model` by changing their visibility to `pub(crate)`.
🗺️ **Visuals:** Architectural diagrams are up-to-date and reflect the current state. No new visuals were strictly required for these specific maintenance updates.
🔗 **Link:** See `docs/adr/022-encapsulate-internal-modules.md`.

---
*PR created automatically by Jules for task [9039672951741429754](https://jules.google.com/task/9039672951741429754) started by @madmax983*