### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2024-11-20 - [Fixing Misplaced Doc Comments]
+**Confusion:** The documentation for `to_rust_type` in `src/codegen.rs` was not appearing in the generated `cargo doc` output, causing `-D missing_docs` to fail, even though the doc block was present.
+**Clarification:** A `use std::fmt::Write;` statement was placed between the doc comment (`///`) and the function declaration. In Rust, doc comments attach to the *immediately following* item. The comment was incorrectly attaching to the `use` statement. Fixed by moving the `use` statement above the doc comment.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 📖 Chapter: The `codegen` module.
* 🔦 Insight: Fixed an issue where the documentation for `to_rust_type` was failing to attach to the function because a `use` statement was placed between the doc comment and the function declaration.
* 🧪 Example: Verified via `RUSTDOCFLAGS="-D warnings -D missing_docs" cargo doc --no-deps`.
* 🖼️ Preview: N/A

---
*PR created automatically by Jules for task [14533481890741395598](https://jules.google.com/task/14533481890741395598) started by @madmax983*