### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**[Title: Avoid Unnecessary `.clone()` on Map Values]
+**Learning:** Calling `.get(&key).unwrap().clone()` on a `HashMap` just to consume or iterate over a value creates an unnecessary, expensive deep clone of the object (like a `Vec` or `String`) when the original entry in the map is no longer needed.
+**Action:** Use `.remove(&key).unwrap()` to transfer ownership directly out of the map without allocating new memory, achieving a zero-cost extraction.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -42,7 +42,7 @@ pub fn run_catalog() -> Result<()> {
             Cell::new("Rust Equivalent").fg(Color::Cyan),
         ]);
 
-        let mut pos_entries = entries_by_pos.get(&pos).unwrap().clone();
+        let mut pos_entries = entries_by_pos.remove(&pos).unwrap();
         pos_entries.sort_by_key(|(word, _)| *word);
 
         for (word, entry) in pos_entries {


### PR DESCRIPTION
💡 What: Switched `entries_by_pos.get(&pos).unwrap().clone()` to `entries_by_pos.remove(&pos).unwrap()` in `src/tools/catalog.rs`.
🎯 Why: The original code fetched a reference from the `HashMap` and cloned the entire `Vec` of lexicon entries just to sort and iterate over them. The original map entry is no longer needed after this loop iteration.
📊 Impact: Eliminates an O(N) heap allocation (where N is the number of lexicon entries for a given part of speech) for every part of speech processed during the catalog command. This is a zero-cost abstraction win.
🔬 Measurement: Run `cargo run --bin glossa catalog` and observe identical output with fewer internal allocations. Verified via `cargo test`.

---
*PR created automatically by Jules for task [1120705813057392622](https://jules.google.com/task/1120705813057392622) started by @madmax983*