### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-07-22 - The Floating Doc Comment
+**Confusion:** The documentation for the public `to_rust_type` function in `src/codegen.rs` was missing from the generated rustdoc, and running `cargo doc` with `-W missing_docs` issued a warning. This happened because a `use std::fmt::Write;` statement was placed exactly between the `///` doc block and the function signature.
+**Clarification:** In Rust, a `///` doc comment attaches strictly to the very next syntax item. If an import or unrelated statement interrupts it, the documentation binds to that intermediate item, leaving the intended function undocumented. I fixed this by moving the `use` statement above the doc block.

--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -79,3 +79,6 @@
 ## 2026-07-22 - The Floating Doc Comment
 **Confusion:** The documentation for the public `to_rust_type` function in `src/codegen.rs` was missing from the generated rustdoc, and running `cargo doc` with `-W missing_docs` issued a warning. This happened because a `use std::fmt::Write;` statement was placed exactly between the `///` doc block and the function signature.
 **Clarification:** In Rust, a `///` doc comment attaches strictly to the very next syntax item. If an import or unrelated statement interrupts it, the documentation binds to that intermediate item, leaving the intended function undocumented. I fixed this by moving the `use` statement above the doc block.
+## 2026-07-22 - Useless Borrows in Formatting
+**Confusion:** The CI pipeline failed on a `clippy::useless_borrows_in_formatting` lint because a format string used `&var_name` as an argument (e.g., `format!("...", &var_name)`).
+**Clarification:** The `format!` macro implicitly takes a reference to its arguments, so passing an explicit reference to a variable that might already be a reference (like `&String` or `&str`) is redundant and triggers a clippy warning when run with `-D warnings`. The fix is simply to remove the explicit `&`.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 📖 Chapter: The `codegen` module
* 🔦 Insight: Fixed missing documentation warning by moving `use std::fmt::Write;` above the doc block for `to_rust_type`.
* 🧪 Example: N/A (Formatting fix)
* 🖼️ Preview: N/A

---
*PR created automatically by Jules for task [5421653766383066414](https://jules.google.com/task/5421653766383066414) started by @madmax983*