### PR TITLE
⚒️ Forge: Extract CLI command router in main.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -5,3 +5,7 @@
 **[Extracted CLI command router]**
 **Learning:** `src/main.rs` had a God Function (`main`) of ~200 lines matching on every CLI command with feature gates.
 **Action:** Extracted it into `execute_command` and `execute_nova_command` to flatten the structure and keep main tiny.
+
+**[Removed redundant borrow in format!]**
+**Learning:** Passing a reference `&var_name` inside `format!()` when `var_name` is already a string slice/owned string triggers the `clippy::useless_borrows_in_formatting` lint.
+**Action:** Removed the redundant `&` to satisfy Clippy's strict warnings (`-D warnings`).

--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
-**Refactored Cartographer's generate_map**
-**Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
-**Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+**[Extracted CLI command router]
+**Learning:** `src/main.rs` had a God Function (`main`) of ~200 lines matching on every CLI command with feature gates.
+**Action:** Extracted it into `execute_command` and `execute_nova_command` to flatten the structure and keep main tiny.
+
+**[Extracted CLI command router]**
+**Learning:** `src/main.rs` had a God Function (`main`) of ~200 lines matching on every CLI command with feature gates.
+**Action:** Extracted it into `execute_command` and `execute_nova_command` to flatten the structure and keep main tiny.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,8 @@ use clap::Parser;
 use miette::Result;
 
 use glossa::tools::cli::{Cli, Commands};
-use glossa::tools::dictionary::lookup_word;
 use glossa::tools::repl::run_repl;
-use glossa::tools::runner::{
-    bard_file, build_file, check_file, highlight_file, report_file, run_file,
-};
+use glossa::tools::runner::run_file;
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -21,190 +18,75 @@ fn main() -> Result<()> {
         return run_file(&file);
     }
 
-    match cli.command {
-        Some(Commands::Run { input }) => {
-            run_file(&input)?;
-        }
+    execute_command(cli.command)
+}
 
-        Some(Commands::Mentor) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::mentor::run_mentor()?;
-
-            #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'mentor' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
-        }
-
+fn execute_command(command: Option<Commands>) -> Result<()> {
+    match command {
+        Some(Commands::Run { input }) => glossa::tools::runner::run_file(&input),
         Some(Commands::Build { input, output }) => {
-            build_file(&input, output.as_deref())?;
+            glossa::tools::runner::build_file(&input, output.as_deref())
         }
+        Some(Commands::Check { input }) => glossa::tools::runner::check_file(&input),
+        Some(Commands::Report { input }) => glossa::tools::runner::report_file(&input),
+        Some(Commands::Highlight { input }) => glossa::tools::runner::highlight_file(&input),
+        Some(Commands::Bard { input }) => glossa::tools::runner::bard_file(&input),
+        Some(Commands::Lookup { word }) => glossa::tools::dictionary::lookup_word(&word),
+        Some(Commands::Test { input }) => glossa::tools::tester::run_tests(&input),
+        Some(Commands::Repl) | None => run_repl(),
+        Some(cmd @ Commands::Mentor)
+        | Some(cmd @ Commands::Mosaic { .. })
+        | Some(cmd @ Commands::Map { .. })
+        | Some(cmd @ Commands::Labyrinth { .. })
+        | Some(cmd @ Commands::Weave { .. })
+        | Some(cmd @ Commands::Alchemist { .. })
+        | Some(cmd @ Commands::Papyrus { .. })
+        | Some(cmd @ Commands::Haruspex { .. })
+        | Some(cmd @ Commands::Audit { .. })
+        | Some(cmd @ Commands::Catalog)
+        | Some(cmd @ Commands::Gnomon { .. })
+        | Some(cmd @ Commands::Scholar { .. }) => execute_nova_command(cmd),
+    }
+}
 
-        Some(Commands::Check { input }) => {
-            check_file(&input)?;
-        }
-
-        Some(Commands::Report { input }) => {
-            report_file(&input)?;
-        }
-
-        Some(Commands::Highlight { input }) => {
-            highlight_file(&input)?;
-        }
-
-        Some(Commands::Bard { input }) => {
-            bard_file(&input)?;
-        }
-
-        Some(Commands::Lookup { word }) => {
-            lookup_word(&word)?;
-        }
-
-        Some(Commands::Test { input }) => {
-            glossa::tools::tester::run_tests(&input)?;
-        }
-
-        Some(Commands::Mosaic { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::mosaic::run_mosaic(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'mosaic' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Map { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::cartographer::run_map(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'map' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Labyrinth { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::labyrinth::run_labyrinth(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'labyrinth' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Weave { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::weave::run_weave(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'weave' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Alchemist { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::alchemist::run_alchemist(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'alchemist' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Papyrus { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::papyrus::run_papyrus(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'papyrus' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Haruspex { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::haruspex::run_haruspex(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'haruspex' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Audit { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::auditor::run_auditor(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'audit' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Catalog) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::catalog::run_catalog()?;
-
-            #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'catalog' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
-        }
-
-        Some(Commands::Gnomon { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::gnomon::run_gnomon(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
-        }
-
-        Some(Commands::Scholar { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::scholar::run_scholar(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'scholar' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Repl) | None => {
-            run_repl()?;
-        }
+fn execute_nova_command(command: Commands) -> Result<()> {
+    #[cfg(feature = "nova")]
+    match command {
+        Commands::Mentor => glossa::tools::mentor::run_mentor(),
+        Commands::Mosaic { input } => glossa::tools::mosaic::run_mosaic(&input),
+        Commands::Map { input } => glossa::tools::cartographer::run_map(&input),
+        Commands::Labyrinth { input } => glossa::tools::labyrinth::run_labyrinth(&input),
+        Commands::Weave { input } => glossa::tools::weave::run_weave(&input),
+        Commands::Alchemist { input } => glossa::tools::alchemist::run_alchemist(&input),
+        Commands::Papyrus { input } => glossa::tools::papyrus::run_papyrus(&input),
+        Commands::Haruspex { input } => glossa::tools::haruspex::run_haruspex(&input),
+        Commands::Audit { input } => glossa::tools::auditor::run_auditor(&input),
+        Commands::Catalog => glossa::tools::catalog::run_catalog(),
+        Commands::Gnomon { input } => glossa::tools::gnomon::run_gnomon(&input),
+        Commands::Scholar { input } => glossa::tools::scholar::run_scholar(&input),
+        _ => unreachable!(), // The outer match guarantees we only pass Nova commands here.
     }
 
-    Ok(())
+    #[cfg(not(feature = "nova"))]
+    {
+        let cmd_name = match command {
+            Commands::Mentor => "mentor",
+            Commands::Mosaic { .. } => "mosaic",
+            Commands::Map { .. } => "map",
+            Commands::Labyrinth { .. } => "labyrinth",
+            Commands::Weave { .. } => "weave",
+            Commands::Alchemist { .. } => "alchemist",
+            Commands::Papyrus { .. } => "papyrus",
+            Commands::Haruspex { .. } => "haruspex",
+            Commands::Audit { .. } => "audit",
+            Commands::Catalog => "catalog",
+            Commands::Gnomon { .. } => "gnomon",
+            Commands::Scholar { .. } => "scholar",
+            _ => unreachable!(), // The outer match guarantees we only pass Nova commands here.
+        };
+        miette::bail!(
+            "The '{}' command is experimental. Recompile glossa with '--features nova' to enable it.",
+            cmd_name
+        );
+    }
 }

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🚮 Smell: `src/main.rs` had a God Function (`main`) of ~200 lines matching on every CLI command with deep nesting and feature gates.
✨ Solution: Extracted the match logic into `execute_command` and `execute_nova_command`, using explicit match arms to maintain exhaustive pattern safety.
🧼 Benefit: Flattens the structure, reduces cognitive load, keeps the main function tiny, and respects exhaustive compile-time safety checks.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [14352360271157267797](https://jules.google.com/task/14352360271157267797) started by @madmax983*