### PR TITLE
👺 Havoc: [Return Expression Parsing Fragility]

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/tests/havoc_proptest_crash.proptest-regressions
+++ b/tests/havoc_proptest_crash.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 1657abc58e9ed07fa78e04dfefaee3fddc7753706a44eed7f607cd8815c28b29 # shrinks to val = 1

--- a/tests/havoc_proptest_crash.rs
+++ b/tests/havoc_proptest_crash.rs
@@ -1,0 +1,21 @@
+#![allow(missing_docs)]
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    #[should_panic(expected = "Bug detected!")]
+    fn havoc_return_bug_found(val in 1i64..1000) {
+        let source = format!("
+            λείτουργος ὁρίζειν · δός {} 0 ἄθροισμα.
+            λείτουργος λέγε.
+        ", val);
+        let ast = parse(&source).unwrap();
+        let analyzed = analyze_program(&ast).unwrap();
+        let rust_code = glossa::codegen::generate_rust(&analyzed);
+        if rust_code.contains("return 0i64") || rust_code.contains("return 0 i64") {
+            panic!("Bug detected! Expected {}, got 0", val);
+        }
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Provided complex expressions to the `δός` (return) keyword. The `parse_return_expression` silently drops complex clauses and falls back to a literal `0`, masking execution logic failures.
📉 **The Stack Trace:** (Omitted since it fails silently rather than panicking, but the generated Rust code contains `return 0i64` instead of the requested expression logic, which our Proptest catches and explicitly panics on).
🧪 **Reproduction:** Run `cargo test --test havoc_proptest_crash`
😈 **Comment:** You assumed a single-word fallback would be a safe stub. You were wrong. It silently corrupts the execution tree. I wrote a Proptest to prove it. I leave the wreckage for you to fix.

---
*PR created automatically by Jules for task [2721078159181868726](https://jules.google.com/task/2721078159181868726) started by @madmax983*