### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/016-alchemist-and-weave.md
+++ b/docs/adr/016-alchemist-and-weave.md
@@ -1,7 +1,7 @@
 # 16. Add Alchemist and Weave to Developer Experience Tools
 
 Date: 2024-11-15
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/017-labyrinth-control-flow-graph.md
+++ b/docs/adr/017-labyrinth-control-flow-graph.md
@@ -1,7 +1,7 @@
 # 17. Add Labyrinth to Developer Experience Tools
 
 Date: 2024-11-15
-Status: Proposed
+Status: Accepted
 
 ## Context
 

--- a/docs/adr/020-catalog-api-generator.md
+++ b/docs/adr/020-catalog-api-generator.md
@@ -4,7 +4,7 @@ Date: 2026-04-19
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/021-split-assembly-module.md
+++ b/docs/adr/021-split-assembly-module.md
@@ -4,7 +4,7 @@ Date: 2026-04-21
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/adr/022-encapsulate-internal-modules.md
+++ b/docs/adr/022-encapsulate-internal-modules.md
@@ -1,0 +1,24 @@
+# 022. Encapsulate Internal Modules
+
+Date: 2026-07-25
+
+## Status
+
+Accepted
+
+## Context
+
+As the ΓΛΩΣΣΑ compiler grew, several internal helper modules under the `src/tools/` directory (specifically `cache`, `report`, and `ui`) and the `src/semantic/assembly/` directory (`model`) were exposed as `pub mod`. This broke encapsulation by unintentionally exposing internal implementation details and DTOs to the public API of the compiler crate. A sprawling public API makes it difficult for consumers to discern which tools are intended for external use and which are strictly internal helpers.
+
+## Decision
+
+We restricted the visibility of these internal modules to `pub(crate) mod`.
+Specifically, `src/tools/mod.rs` was updated to encapsulate `cache`, `report`, and `ui`.
+`src/semantic/assembly/mod.rs` was updated to encapsulate `model`.
+Public structures that are still needed externally (like `Cache`) are explicitly re-exported using `pub use`.
+
+## Consequences
+
+*   **Positive:** The public API surface is now minimal and intentional, achieving higher cohesion.
+*   **Positive:** Internal structures and DTOs no longer leak out of their intended domains, preventing external dependencies on implementation details.
+*   **Negative:** Internal modules can no longer be directly accessed by external integration tests, requiring tests to go through public facades.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ C4Container
     Container_Boundary(tools, "Developer Experience (Nova)") {
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
         Container(auditor, "The Auditor", "src/tools/auditor.rs", "Static analysis to find unused variables and mutability smells")
-        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
+        Container(cache, "Cache (Internal)", "src/tools/cache.rs", "Incremental compilation cache")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(catalog, "The Catalog", "src/tools/catalog.rs", "Lexicon Explorer (CLI)")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -48,10 +48,10 @@ C4Container
         Container(narrator, "The Bard", "src/tools/narrator.rs", "Generates English narrative ('Scroll of Logic') from AST")
         Container(papyrus, "Papyrus", "src/tools/papyrus.rs", "Generates SQL CREATE TABLE schemas")
         Container(repl, "REPL", "src/tools/repl.rs", "Interactive Read-Eval-Print Loop")
-        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+        Container(report, "Reporter (Internal)", "src/tools/report.rs", "Generates statistics and structured reports")
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
-        Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(ui, "The Stage (Internal)", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
         Container(weave, "Weave", "src/tools/weave.rs", "Rosetta Stone Markdown Exporter")
     }
 
@@ -96,7 +96,7 @@ C4Component
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
         Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
-        Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
+        Component(assembly_model, "Assembly Model (Internal)", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🧠 **Decision:** Recorded the encapsulation of internal tool modules (`cache`, `report`, `ui`, `model`) to `pub(crate)` visibility to ensure a clean public API surface. Also audited and promoted all stale 'Proposed' ADRs older than 7 days (016, 017, 020, 021) to 'Accepted'.
🗺️ **Visuals:** Updated the Mermaid.js C4 Container and Component diagrams in `docs/architecture.md` to tag the restricted modules as "(Internal)".
🔗 **Link:** See `docs/adr/022-encapsulate-internal-modules.md`.

---
*PR created automatically by Jules for task [1940225909997056323](https://jules.google.com/task/1940225909997056323) started by @madmax983*