### PR TITLE
⚡ Bolt: [performance improvement] Zero-cost abstraction for `tell_type`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 **[Optimizing recursive tree formatting]**
 **Learning:** When formatting a recursive enum representing a tree structure (like `GlossaType`), returning a new `String` at each level of recursion and combining them with `format!` causes many intermediate string allocations. A zero-cost abstraction passes a mutable reference `&mut String` buffer down the recursive stack and appends directly to it.
 **Action:** Replaced recursive `format!` calls in `tell_type` with a `write_tell_type(ty, buf: &mut String)` helper, and pre-allocated the top-level buffer with `String::with_capacity`.
+
+**[Clippy useless borrows in formatting]**
+**Learning:** Passing an explicit reference to `format!` (e.g. `format!("{}", &var)`) when the variable is already a reference or owned value triggers the `clippy::useless_borrows_in_formatting` lint.
+**Action:** Removed redundant `&` from `format!` macro arguments in `src/semantic/conversion.rs`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+
+**[Optimizing recursive tree formatting]**
+**Learning:** When formatting a recursive enum representing a tree structure (like `GlossaType`), returning a new `String` at each level of recursion and combining them with `format!` causes many intermediate string allocations. A zero-cost abstraction passes a mutable reference `&mut String` buffer down the recursive stack and appends directly to it.
+**Action:** Replaced recursive `format!` calls in `tell_type` with a `write_tell_type(ty, buf: &mut String)` helper, and pre-allocated the top-level buffer with `String::with_capacity`.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -194,17 +194,6 @@ fn format_exprs(exprs: &[AnalyzedExpr]) -> String {
     buf
 }
 
-fn format_types(types: &[GlossaType]) -> String {
-    let mut buf = String::with_capacity(types.len() * 16);
-    for (i, ty) in types.iter().enumerate() {
-        if i > 0 {
-            buf.push_str(", ");
-        }
-        buf.push_str(&tell_type(ty));
-    }
-    buf
-}
-
 fn add_print(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
     let script = format!("Proclaim: {}", format_exprs(exprs));
     table.add_row(vec![
@@ -564,21 +553,59 @@ fn tell_lambda(
 /// (e.g., `Number`, `[Type]`) to help developers map the Greek concepts to
 /// concepts they already understand.
 fn tell_type(ty: &GlossaType) -> String {
+    let mut buf = String::with_capacity(32);
+    write_tell_type(ty, &mut buf);
+    buf
+}
+
+fn write_tell_type(ty: &GlossaType, buf: &mut String) {
     match ty {
-        GlossaType::Number => "Number".to_string(),
-        GlossaType::String => "String".to_string(),
-        GlossaType::Boolean => "Bool".to_string(),
-        GlossaType::List(inner) => format!("[{}]", tell_type(inner)),
-        GlossaType::Set(inner) => format!("Set<{}>", tell_type(inner)),
-        GlossaType::Map(k, v) => format!("Map<{}, {}>", tell_type(k), tell_type(v)),
-        GlossaType::Option(inner) => format!("Option<{}>", tell_type(inner)),
-        GlossaType::Result(ok, err) => format!("Result<{}, {}>", tell_type(ok), tell_type(err)),
-        GlossaType::Struct { name, .. } => name.to_string(),
-        GlossaType::Function { params, returns } => {
-            format!("Fn({}) -> {}", format_types(params), tell_type(returns))
+        GlossaType::Number => buf.push_str("Number"),
+        GlossaType::String => buf.push_str("String"),
+        GlossaType::Boolean => buf.push_str("Bool"),
+        GlossaType::List(inner) => {
+            buf.push('[');
+            write_tell_type(inner, buf);
+            buf.push(']');
         }
-        GlossaType::Unit => "()".to_string(),
-        GlossaType::Unknown => "?".to_string(),
+        GlossaType::Set(inner) => {
+            buf.push_str("Set<");
+            write_tell_type(inner, buf);
+            buf.push('>');
+        }
+        GlossaType::Map(k, v) => {
+            buf.push_str("Map<");
+            write_tell_type(k, buf);
+            buf.push_str(", ");
+            write_tell_type(v, buf);
+            buf.push('>');
+        }
+        GlossaType::Option(inner) => {
+            buf.push_str("Option<");
+            write_tell_type(inner, buf);
+            buf.push('>');
+        }
+        GlossaType::Result(ok, err) => {
+            buf.push_str("Result<");
+            write_tell_type(ok, buf);
+            buf.push_str(", ");
+            write_tell_type(err, buf);
+            buf.push('>');
+        }
+        GlossaType::Struct { name, .. } => buf.push_str(name),
+        GlossaType::Function { params, returns } => {
+            buf.push_str("Fn(");
+            for (i, param) in params.iter().enumerate() {
+                if i > 0 {
+                    buf.push_str(", ");
+                }
+                write_tell_type(param, buf);
+            }
+            buf.push_str(") -> ");
+            write_tell_type(returns, buf);
+        }
+        GlossaType::Unit => buf.push_str("()"),
+        GlossaType::Unknown => buf.push('?'),
     }
 }
 


### PR DESCRIPTION
💡 What: Refactored `tell_type` in `src/tools/narrator.rs` to use a `write_tell_type(ty: &GlossaType, buf: &mut String)` helper instead of recursively calling `format!`. Also removed the unused `format_types` helper function and passed the mutable buffer directly inside `tell_type`.
🎯 Why: `tell_type` previously generated multiple intermediate `String` heap allocations on the recursive path for composite types (`List`, `Set`, `Map`, `Option`, `Result`, `Function`), which were immediately concatenated and dropped.
📊 Impact: Zero heap allocations during recursive type formatting once the top-level string buffer is allocated via `String::with_capacity`.
🔬 Measurement: Run `cargo bench` (if available) or `cargo test` to ensure performance and correctness of type formatting. No compile-time warnings (`cargo clippy`) remain.

---
*PR created automatically by Jules for task [15646860756007657846](https://jules.google.com/task/15646860756007657846) started by @madmax983*