### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -20,3 +20,6 @@
 **Tangle:** Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`, breaking encapsulation by exposing internal implementation details to the public API.
 **Blueprint:** Modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these modules with `pub(crate) mod`.
 **Stability:** Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains.
+## [Module Visibility Encapsulation]
+**Tangle:** Several modules under `src/semantic` were marked as `pub mod`, leaking the internal implementation details of the Semantic AST and analysis phases to users.
+**Blueprint:** Modified `src/semantic/mod.rs` to restrict these modules with `pub(crate) mod` while retaining specific `pub use` statements for the public API surface.

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -160,7 +160,7 @@ pub use model::*;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::semantic::assembly::Assembler;
+/// use glossa::semantic::Assembler;
 /// let mut asm = Assembler::new();
 /// // Then feed analysis and finalise statement
 /// ```

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -34,7 +34,7 @@
 pub(crate) mod analyzer;
 #[cfg(test)]
 mod assembler_tests;
-pub mod assembly;
+pub(crate) mod assembly;
 #[cfg(test)]
 mod classification_tests;
 pub(crate) mod control_flow;
@@ -49,11 +49,11 @@ pub(crate) mod patterns;
 mod property_access_tests;
 #[cfg(test)]
 mod recursion_safety_tests;
-mod resolver;
+pub(crate) mod resolver;
 #[cfg(test)]
 mod sentry_conversion_tests;
 
-mod types;
+pub(crate) mod types;
 pub(crate) mod validation;
 
 pub use crate::morphology::{DisambiguationContext, analyze_article, disambiguate, resolve_best};


### PR DESCRIPTION
🕸️ Tangle: Several internal modules under `src/semantic` were marked as `pub mod`, leaking the internal implementation details of the Semantic AST and analysis phases to users.
📐 Blueprint: Modified `src/semantic/mod.rs` to restrict these internal modules with `pub(crate) mod` while retaining specific `pub use` statements for the public API surface (e.g., `Assembler`, `AnalyzedProgram`).
🧱 Stability: Improves architectural boundaries by preventing external users from directly relying on deep internal module paths, reducing coupling.
🔬 Verification: Builds successfully and all tests pass.

---
*PR created automatically by Jules for task [3196945436786494911](https://jules.google.com/task/3196945436786494911) started by @madmax983*