### PR TITLE
⚡ Bolt: [performance improvement] Optimize string format allocation in tell_type

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,10 +1,3 @@
-**[Optimizing Collections in iterators]**
-**Learning:** Checking for `.is_empty()` after `.collect::<Vec<_>>()` forces an unnecessary heap allocation. We can check if an iterator is empty dynamically using `.peekable()`. Additionally, if strings from `&'a str` need to be converted to `Cow<'static, str>`, we must use `.to_string()` as `.into()` or `Cow::Borrowed` will result in static lifetime compilation errors.
-**Action:** Replace `Vec<_> = iter.collect()` with `.peekable()` for emptiness checking whenever possible, and be mindful of `Cow` lifetimes.
-
-**[Optimizing AST Node Cloning with `std::mem::replace`]**
-**Learning:** During iterative AST tree building (e.g., when wrapping an expression in successive `MethodCall`s like `.iter().map().filter().collect()`), the previous expression `current_expr` had to be passed into the new node. Because it's stored in a `Box`, using `Box::new(current_expr.clone())` causes an expensive deep clone of the entire recursive AST structure for each method in the chain. However, since the old node is entirely moved into the new node (and we overwrite `current_expr` immediately after), we can use `std::mem::replace(&mut current_expr, AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unknown })` to safely extract the old tree without a single allocation, effectively a zero-cost transfer of ownership.
-**Action:** Use `std::mem::replace` to avoid deep cloning of AST nodes when building recursive or iterative tree structures in place.
-**[Optimizing recursive type formatting]**
-**Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
-**Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**Avoid Recursive format! Macro Allocations**
+**Learning:** When recursively formatting composite structures or trees into strings, using recursive `format!` calls creates unnecessary intermediate heap allocations at each level.
+**Action:** Use a helper function that takes a `&mut String` buffer to append directly into a single pre-allocated string instead of using `format!`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,13 @@
+**[Optimizing Collections in iterators]**
+**Learning:** Checking for `.is_empty()` after `.collect::<Vec<_>>()` forces an unnecessary heap allocation. We can check if an iterator is empty dynamically using `.peekable()`. Additionally, if strings from `&'a str` need to be converted to `Cow<'static, str>`, we must use `.to_string()` as `.into()` or `Cow::Borrowed` will result in static lifetime compilation errors.
+**Action:** Replace `Vec<_> = iter.collect()` with `.peekable()` for emptiness checking whenever possible, and be mindful of `Cow` lifetimes.
+
+**[Optimizing AST Node Cloning with `std::mem::replace`]**
+**Learning:** During iterative AST tree building (e.g., when wrapping an expression in successive `MethodCall`s like `.iter().map().filter().collect()`), the previous expression `current_expr` had to be passed into the new node. Because it's stored in a `Box`, using `Box::new(current_expr.clone())` causes an expensive deep clone of the entire recursive AST structure for each method in the chain. However, since the old node is entirely moved into the new node (and we overwrite `current_expr` immediately after), we can use `std::mem::replace(&mut current_expr, AnalyzedExpr { expr: AnalyzedExprKind::None, glossa_type: GlossaType::Unknown })` to safely extract the old tree without a single allocation, effectively a zero-cost transfer of ownership.
+**Action:** Use `std::mem::replace` to avoid deep cloning of AST nodes when building recursive or iterative tree structures in place.
+**[Optimizing recursive type formatting]**
+**Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
+**Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
 **Avoid Recursive format! Macro Allocations**
 **Learning:** When recursively formatting composite structures or trees into strings, using recursive `format!` calls creates unnecessary intermediate heap allocations at each level.
 **Action:** Use a helper function that takes a `&mut String` buffer to append directly into a single pre-allocated string instead of using `format!`.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/narrator.rs
+++ b/src/tools/narrator.rs
@@ -194,17 +194,6 @@ fn format_exprs(exprs: &[AnalyzedExpr]) -> String {
     buf
 }
 
-fn format_types(types: &[GlossaType]) -> String {
-    let mut buf = String::with_capacity(types.len() * 16);
-    for (i, ty) in types.iter().enumerate() {
-        if i > 0 {
-            buf.push_str(", ");
-        }
-        buf.push_str(&tell_type(ty));
-    }
-    buf
-}
-
 fn add_print(table: &mut Table, prefix: &str, exprs: &[AnalyzedExpr]) {
     let script = format!("Proclaim: {}", format_exprs(exprs));
     table.add_row(vec![
@@ -564,21 +553,61 @@ fn tell_lambda(
 /// (e.g., `Number`, `[Type]`) to help developers map the Greek concepts to
 /// concepts they already understand.
 fn tell_type(ty: &GlossaType) -> String {
+    let mut buf = String::with_capacity(32);
+    write_tell_type(ty, &mut buf);
+    buf
+}
+
+/// ⚡ Bolt Optimization: Recursive formatting helper that appends directly to a `&mut String`
+/// buffer to avoid allocating intermediate strings for composite types.
+fn write_tell_type(ty: &GlossaType, buf: &mut String) {
     match ty {
-        GlossaType::Number => "Number".to_string(),
-        GlossaType::String => "String".to_string(),
-        GlossaType::Boolean => "Bool".to_string(),
-        GlossaType::List(inner) => format!("[{}]", tell_type(inner)),
-        GlossaType::Set(inner) => format!("Set<{}>", tell_type(inner)),
-        GlossaType::Map(k, v) => format!("Map<{}, {}>", tell_type(k), tell_type(v)),
-        GlossaType::Option(inner) => format!("Option<{}>", tell_type(inner)),
-        GlossaType::Result(ok, err) => format!("Result<{}, {}>", tell_type(ok), tell_type(err)),
-        GlossaType::Struct { name, .. } => name.to_string(),
-        GlossaType::Function { params, returns } => {
-            format!("Fn({}) -> {}", format_types(params), tell_type(returns))
+        GlossaType::Number => buf.push_str("Number"),
+        GlossaType::String => buf.push_str("String"),
+        GlossaType::Boolean => buf.push_str("Bool"),
+        GlossaType::List(inner) => {
+            buf.push('[');
+            write_tell_type(inner, buf);
+            buf.push(']');
         }
-        GlossaType::Unit => "()".to_string(),
-        GlossaType::Unknown => "?".to_string(),
+        GlossaType::Set(inner) => {
+            buf.push_str("Set<");
+            write_tell_type(inner, buf);
+            buf.push('>');
+        }
+        GlossaType::Map(k, v) => {
+            buf.push_str("Map<");
+            write_tell_type(k, buf);
+            buf.push_str(", ");
+            write_tell_type(v, buf);
+            buf.push('>');
+        }
+        GlossaType::Option(inner) => {
+            buf.push_str("Option<");
+            write_tell_type(inner, buf);
+            buf.push('>');
+        }
+        GlossaType::Result(ok, err) => {
+            buf.push_str("Result<");
+            write_tell_type(ok, buf);
+            buf.push_str(", ");
+            write_tell_type(err, buf);
+            buf.push('>');
+        }
+        GlossaType::Struct { name, .. } => buf.push_str(name),
+        GlossaType::Function { params, returns } => {
+            buf.push_str("Fn(");
+            for (i, p) in params.iter().enumerate() {
+                if i > 0 {
+                    buf.push_str(", ");
+                }
+                write_tell_type(p, buf);
+            }
+            buf.push_str(") -> ");
+            write_tell_type(returns, buf);
+        }
+        GlossaType::Unit => buf.push_str("()"),
+        GlossaType::Unknown => buf.push('?'),
     }
 }
 


### PR DESCRIPTION
💡 What: Replaced recursive `format!` calls in `tell_type` with a `write_tell_type` helper that appends directly to a `&mut String`. Also removed the unnecessary `format_types` helper function.
🎯 Why: Formatting recursive tree-like enums with `format!` causes an intermediate heap allocation for every depth level.
📊 Impact: Reduces heap allocations by passing a single mutable buffer down the recursion tree.
🔬 Measurement: Run tests using `cargo test` and verify that the formatting logic functions identically to before without the overhead.

---
*PR created automatically by Jules for task [4899742566680221074](https://jules.google.com/task/4899742566680221074) started by @madmax983*