### PR TITLE
🎨 Mosaic: UI Polish for Mosaic Table Errors

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/mosaic.rs
+++ b/src/tools/mosaic.rs
@@ -101,7 +101,10 @@ pub fn run_mosaic_inner<W: std::io::Write>(source: &str, writer: &mut W) -> Resu
                 Err(e) => {
                     table.add_row(vec![
                         Cell::new(i + 1),
-                        Cell::new(format!("Error: {}", e)).fg(Color::Red),
+                        Cell::new(format!(" ✕ Error: {} ", e))
+                            .bg(Color::DarkRed)
+                            .fg(Color::White)
+                            .add_attribute(Attribute::Bold),
                         Cell::new(""),
                         Cell::new(""),
                         Cell::new(""),


### PR DESCRIPTION
🖌️ **Before:**
If a statement failed semantic assembly, the Mosaic tool would output a row with the line number and the raw red error string (`Error: ...`) in the 'Subject' column, leaving the remaining columns empty and looking unpolished.

✨ **After:**
The error is now enclosed in a highly visible error cell spanning its column with a dark red background, bold white text, and a `✕` icon, giving it a proper "dashboard" feel and conforming to visual hierarchy rules.

🖼️ **Visuals:**
The error cell now matches the bold styling seen in `tester.rs` for failures, replacing plain red text with a proper stylized alert block.

---
*PR created automatically by Jules for task [14241680665828280583](https://jules.google.com/task/14241680665828280583) started by @madmax983*