### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -134,3 +134,6 @@ Signed,
 **YYYY-MM-DD - [DoS Mitigation]
 **Threat:** Memory Exhaustion / Unbounded Allocations via standard IO.
 **Defense:** Wrapped mutable readers using `.by_ref().take(LIMIT)` inside `repl.rs` and `mentor.rs`.
+**2024-08-01 - Update anyhow to fix unsoundness**
+**Threat:** Unsoundness in `Error::downcast_mut()` (RUSTSEC-2026-0190) in `anyhow` v1.0.102
+**Defense:** Updated `anyhow` to v1.0.104

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🦠 **Threat:** The `anyhow` crate version `1.0.102` has a known soundness vulnerability (RUSTSEC-2026-0190) in `Error::downcast_mut()`.
🛡️ **Defense:** Updated `anyhow` to version `1.0.104` via `cargo update -p anyhow` which contains the patch for this vulnerability.
💥 **Severity:** High - Could lead to undefined behavior (UB).
🔭 **Verification:** Ran `cargo audit` to confirm the vulnerability was mitigated. Verified with `cargo test --all-features` to ensure no regressions.

---
*PR created automatically by Jules for task [7721613016962019137](https://jules.google.com/task/7721613016962019137) started by @madmax983*