### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-03-22 - Code Generation Documentation Fixed
+**Confusion:** The documentation for `to_rust_type` in `src/codegen.rs` was generating missing documentation warnings during `cargo doc` despite having a docstring, because the `pub fn to_rust_type` item was not properly attached to the rustdoc block due to an intervening `use std::fmt::Write;` statement.
+**Clarification:** I moved the `use std::fmt::Write;` statement either above the rustdoc comment or inside the function body so that the `///` comment directly precedes the function declaration, ensuring it is properly linked and recognized by rustdoc.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -244,6 +244,9 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 }
 
 // ==================================================================================
+use std::fmt::Write;
+
+// ==================================================================================
 // TYPES
 // ==================================================================================
 
@@ -273,8 +276,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 📖 Chapter: The `codegen` module.
* 🔦 Insight: Fixed `missing_docs` warning for `to_rust_type` by moving the `use` statement away from between the docstring and function definition.
* 🧪 Example: Maintained the existing 4 executable doctests.
* 🖼️ Preview: Documentation for `to_rust_type` is now generated properly.

---
*PR created automatically by Jules for task [10368508786440240354](https://jules.google.com/task/10368508786440240354) started by @madmax983*