### PR TITLE
⚒️ Forge: Refactor loop variable extraction in control flow

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,6 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+**Refactored Semantic loop variable extraction**
+**Learning:** `parse_for_range_loop` and `parse_for_iteration_loop` both contained a duplicated nested `if let` block to extract the loop variable name.
+**Action:** Extracted this into a private helper function `extract_loop_variable(body_clauses: &[Clause], default_name: &str) -> smol_str::SmolStr`.

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -179,6 +179,27 @@ fn parse_range_bound(
 
 /// Parse a for loop with range (ἀπὸ ... μέχρι/ἕως ...)
 /// Structure: ἀπὸ start μέχρι/ἕως end, body
+fn extract_loop_variable(
+    body_clauses: &[Clause],
+    default_name: &str,
+) -> smol_str::SmolStr {
+    if let Some(first_expr) = body_clauses[0].expressions.first() {
+        if let Expr::Phrase(terms) = first_expr {
+            if let Some(Expr::Word(w)) = terms.first() {
+                w.normalized.clone()
+            } else {
+                default_name.into()
+            }
+        } else if let Expr::Word(w) = first_expr {
+            w.normalized.clone()
+        } else {
+            default_name.into()
+        }
+    } else {
+        default_name.into()
+    }
+}
+
 fn parse_for_range_loop(
     stmt: &Statement,
     scope: &mut Scope,
@@ -241,21 +262,7 @@ fn parse_for_range_loop(
     }
 
     // Extract variable name from first word of first body clause
-    let variable = if let Some(first_expr) = body_clauses[0].expressions.first() {
-        if let Expr::Phrase(terms) = first_expr {
-            if let Some(Expr::Word(w)) = terms.first() {
-                w.normalized.clone()
-            } else {
-                "i".into()
-            }
-        } else if let Expr::Word(w) = first_expr {
-            w.normalized.clone()
-        } else {
-            "i".into()
-        }
-    } else {
-        "i".into()
-    };
+    let variable = extract_loop_variable(body_clauses, "i");
 
     let body_stmt = Statement::Regular {
         clauses: body_clauses.to_vec(),
@@ -327,21 +334,7 @@ fn parse_for_iteration_loop(
     let body_clauses = &stmt.clauses()[1..];
 
     // Extract variable name from first word of body
-    let variable = if let Some(first_expr) = body_clauses[0].expressions.first() {
-        if let Expr::Phrase(terms) = first_expr {
-            if let Some(Expr::Word(w)) = terms.first() {
-                w.normalized.clone()
-            } else {
-                "x".into()
-            }
-        } else if let Expr::Word(w) = first_expr {
-            w.normalized.clone()
-        } else {
-            "x".into()
-        }
-    } else {
-        "x".into()
-    };
+    let variable = extract_loop_variable(body_clauses, "x");
 
     let body_stmt = Statement::Regular {
         clauses: body_clauses.to_vec(),

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -179,10 +179,7 @@ fn parse_range_bound(
 
 /// Parse a for loop with range (ἀπὸ ... μέχρι/ἕως ...)
 /// Structure: ἀπὸ start μέχρι/ἕως end, body
-fn extract_loop_variable(
-    body_clauses: &[Clause],
-    default_name: &str,
-) -> smol_str::SmolStr {
+fn extract_loop_variable(body_clauses: &[Clause], default_name: &str) -> smol_str::SmolStr {
     if let Some(first_expr) = body_clauses[0].expressions.first() {
         if let Expr::Phrase(terms) = first_expr {
             if let Some(Expr::Word(w)) = terms.first() {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🚬 Smell: Duplicated nested `if let` blocks in `parse_for_range_loop` and `parse_for_iteration_loop` for extracting the loop variable name.
✨ Solution: Extracted the logic into a private helper function `extract_loop_variable`.
🧼 Benefit: Reduces cognitive load, DRYs up the code, and makes the loop parsing functions shorter and easier to read.
🛡️ Verification: Ran `cargo test` and `cargo clippy`. No logic changed.

---
*PR created automatically by Jules for task [6824839811372223128](https://jules.google.com/task/6824839811372223128) started by @madmax983*