### PR TITLE
⚡ Bolt: Optimize push_str with format! to avoid intermediate heap allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 **[Optimizing recursive type formatting]**
 **Learning:** Using `format!` recursively (e.g., in `to_rust_type` for nested types like `Result<Option<Vec<String>>, i64>`) creates multiple intermediate heap-allocated `String`s that are immediately concatenated and dropped.
 **Action:** Replace recursive `format!` calls with a `write!` macro approach using `std::fmt::Write`. Pre-allocate a single `String` buffer (e.g., `String::with_capacity`) and pass a mutable reference to it down the recursive tree to drastically reduce allocations.
+**Avoid `push_str(&format!(...))`**
+**Learning:** `format!(...)` inside `push_str` causes an unnecessary intermediate heap allocation.
+**Action:** Replace `var.push_str(&format!(...))` with `write!(var, ...)` or `writeln!(var, ...)`, remembering to `use std::fmt::Write;` and ignore the return value (`let _ = write!(...);`). Also note that `writeln!` should be used instead of `write!` if the format string ends in a newline `\n` to avoid a clippy warning `clippy::write_with_newline`.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -502,14 +502,14 @@ fn classify_assignment(
 
     let var_name = subject.normalized.clone();
 
-    match scope.lookup_binding(&var_name) {
+    match scope.lookup_binding(var_name.as_str()) {
         None => Err(GlossaError::semantic(format!(
             "Τὸ «{}» οὐχ ὡρίσθη — πρῶτον ὅρισον αὐτό",
             var_name
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name.as_str()
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()
@@ -528,7 +528,7 @@ fn classify_assignment(
             }
 
             let (value_expr, _) = extract_value(asm_stmt, scope)?;
-            scope.mark_used(&var_name);
+            scope.mark_used(var_name.as_str());
             Ok(Some(AnalyzedStatement::Assignment {
                 name: var_name.clone(),
                 value: value_expr,

--- a/src/tools/alchemist.rs
+++ b/src/tools/alchemist.rs
@@ -131,7 +131,7 @@ fn transpile_statement(stmt: &AnalyzedStatement, indent: usize) -> String {
         AnalyzedStatement::Expression(exprs) => {
             let mut out = String::new();
             for expr in exprs {
-                out.push_str(&format!("{}{}\n", ind, transpile_expr(expr)));
+                let _ = writeln!(out, "{}{}", ind, transpile_expr(expr));
             }
             out.trim_end().to_string()
         }
@@ -167,7 +167,7 @@ fn transpile_if(
     let ind = "    ".repeat(indent);
     let mut out = format!("{}if {}:\n", ind, transpile_expr(condition));
     if then_body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in then_body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -175,9 +175,9 @@ fn transpile_if(
         }
     }
     if let Some(ebody) = else_body {
-        out.push_str(&format!("{}else:\n", ind));
+        let _ = writeln!(out, "{}else:", ind);
         if ebody.is_empty() {
-            out.push_str(&format!("{}    pass\n", ind));
+            let _ = writeln!(out, "{}    pass", ind);
         } else {
             for b_stmt in ebody {
                 out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -192,7 +192,7 @@ fn transpile_while(condition: &AnalyzedExpr, body: &[AnalyzedStatement], indent:
     let ind = "    ".repeat(indent);
     let mut out = format!("{}while {}:\n", ind, transpile_expr(condition));
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -216,7 +216,7 @@ fn transpile_for(
         transpile_expr(iterator)
     );
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -243,7 +243,7 @@ fn transpile_function_def(
     out.push_str("):\n");
 
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for (i, b_stmt) in body.iter().enumerate() {
             let mut is_last_expr = false;
@@ -255,9 +255,9 @@ fn transpile_function_def(
                 if let AnalyzedStatement::Expression(exprs) = b_stmt {
                     for (j, expr) in exprs.iter().enumerate() {
                         if j == exprs.len() - 1 {
-                            out.push_str(&format!("{}    return {}\n", ind, transpile_expr(expr)));
+                            let _ = writeln!(out, "{}    return {}", ind, transpile_expr(expr));
                         } else {
-                            out.push_str(&format!("{}    {}\n", ind, transpile_expr(expr)));
+                            let _ = writeln!(out, "{}    {}", ind, transpile_expr(expr));
                         }
                     }
                 }
@@ -283,10 +283,10 @@ fn transpile_type_def(
         sanitize_ident(name)
     );
     if fields.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for (f_name, _) in fields {
-            out.push_str(&format!("{}    {}: Any\n", ind, sanitize_ident(f_name)));
+            let _ = writeln!(out, "{}    {}: Any", ind, sanitize_ident(f_name));
         }
     }
     out.trim_end().to_string()
@@ -298,7 +298,7 @@ fn transpile_test_declaration(name: &str, body: &[AnalyzedStatement], indent: us
     let safe_name = name.replace(" ", "_").replace("-", "_").replace("\"", "");
     let mut out = format!("{}def test_{}():\n", ind, safe_name);
     if body.is_empty() {
-        out.push_str(&format!("{}    pass\n", ind));
+        let _ = writeln!(out, "{}    pass", ind);
     } else {
         for b_stmt in body {
             out.push_str(&transpile_statement(b_stmt, indent + 1));
@@ -317,13 +317,9 @@ fn transpile_match(
     // Python 3.10+ match statement
     let mut out = format!("{}match {}:\n", ind, transpile_expr(scrutinee));
     for (pattern_expr, arm_body) in arms {
-        out.push_str(&format!(
-            "{}    case {}:\n",
-            ind,
-            transpile_expr(pattern_expr)
-        ));
+        let _ = writeln!(out, "{}    case {}:", ind, transpile_expr(pattern_expr));
         if arm_body.is_empty() {
-            out.push_str(&format!("{}        pass\n", ind));
+            let _ = writeln!(out, "{}        pass", ind);
         } else {
             for b_stmt in arm_body {
                 out.push_str(&transpile_statement(b_stmt, indent + 2));

--- a/src/tools/labyrinth.rs
+++ b/src/tools/labyrinth.rs
@@ -19,6 +19,7 @@ use crate::semantic::{AnalyzedProgram, AnalyzedStatement};
 use crate::tools::ui::Status;
 use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
+use std::fmt::Write;
 use std::path::Path;
 
 /// Run the Labyrinth tool on a file
@@ -146,10 +147,10 @@ pub fn generate_cfg(program: &AnalyzedProgram) -> String {
 
     let mut out = String::from("graph TD\n");
     for node in nodes {
-        out.push_str(&format!("    {}\n", node));
+        let _ = writeln!(out, "    {}", node);
     }
     for edge in edges {
-        out.push_str(&format!("    {}\n", edge));
+        let _ = writeln!(out, "    {}", edge);
     }
     out
 }

--- a/src/tools/weave.rs
+++ b/src/tools/weave.rs
@@ -16,6 +16,7 @@ use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
 use crossterm::style::Stylize;
 use miette::{IntoDiagnostic, Result};
+use std::fmt::Write;
 use std::fs;
 use std::path::Path;
 
@@ -62,7 +63,7 @@ pub fn run_weave(input: &Path) -> Result<()> {
 
     let filename = input.file_name().unwrap_or_default().to_string_lossy();
 
-    md.push_str(&format!("# Rosetta Stone: `{}`\n\n", filename));
+    let _ = writeln!(md, "# Rosetta Stone: `{}`\n", filename);
 
     md.push_str("## 📜 ΓΛΩΣΣΑ Source\n\n");
     md.push_str("```glossa\n");


### PR DESCRIPTION
💡 What: Replaced occurrences of `out.push_str(&format!(...))` with `write!(out, ...)` or `writeln!(out, ...)` in `src/tools/alchemist.rs`, `src/tools/weave.rs`, and `src/tools/labyrinth.rs`.
🎯 Why: `format!(...)` inside `push_str` causes an unnecessary intermediate heap allocation. The formatted string is created on the heap, appended to the target string, and then immediately dropped. Using `write!` or `writeln!` avoids this by writing directly into the target string's buffer.
📊 Impact: Removes dozens of intermediate heap allocations per run when using the transpiler, mosaic, or labyrinth tools, improving performance and memory usage.
🔬 Measurement: Run `cargo test` and observe that tools output remains identical, while executing `cargo build --release` and profiling will show reduced allocation count.

---
*PR created automatically by Jules for task [12163955090390546893](https://jules.google.com/task/12163955090390546893) started by @madmax983*