### PR TITLE
⚒️ Forge: [refactor classify_expression]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+
+**Refactored classify_expression in semantic conversion**
+**Learning:** Found a "God Function" `classify_expression` (~78 lines) handling literal building, expression fallback building, and propagation application.
+**Action:** Extracted logic into `build_initial_expressions`, `build_fallback_binary_expression`, `build_subject_object_fallback`, and `apply_propagation`. Used `#[allow(clippy::collapsible_if)]` on outer loops to prevent Clippy from suggesting unstable `let_chains` syntax.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -2905,7 +2905,7 @@ mod conversion_tests {
     use super::*;
     use crate::semantic::Scope;
     use crate::semantic::assembly::model::{AssembledStatement, Constituent, VerbConstituent};
-    use crate::semantic::model::{AnalyzedStatement, AnalyzedExprKind};
+    use crate::semantic::model::{AnalyzedExprKind, AnalyzedStatement};
 
     #[test]
     fn test_subject_object_fallback() {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            var_name
+            &var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -2905,7 +2905,7 @@ mod conversion_tests {
     use super::*;
     use crate::semantic::Scope;
     use crate::semantic::assembly::model::{AssembledStatement, Constituent, VerbConstituent};
-    use crate::semantic::model::{AnalyzedExprKind, AnalyzedStatement};
+    use crate::semantic::model::{AnalyzedStatement, AnalyzedExprKind};
 
     #[test]
     fn test_subject_object_fallback() {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -2899,3 +2899,116 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod conversion_tests {
+    use super::*;
+    use crate::semantic::Scope;
+    use crate::semantic::assembly::model::{AssembledStatement, Constituent, VerbConstituent};
+    use crate::semantic::model::{AnalyzedStatement, AnalyzedExprKind};
+
+    #[test]
+    fn test_subject_object_fallback() {
+        let mut scope = Scope::new();
+
+        let asm_stmt = AssembledStatement {
+            subject: Some(Constituent {
+                lemma: "x".into(),
+                original: "".into(),
+                normalized: "x".into(),
+                case: crate::morphology::models::Case::Nominative,
+                number: Some(crate::morphology::models::Number::Singular),
+                gender: Some(crate::morphology::models::Gender::Masculine),
+                person: None,
+            }),
+            nominatives: vec![],
+            verb: Some(VerbConstituent {
+                lemma: "is".into(),
+                original: "".into(),
+                normalized: "is".into(),
+                person: Some(crate::morphology::models::Person::Third),
+                number: Some(crate::morphology::models::Number::Singular),
+                tense: Some(crate::morphology::models::Tense::Present),
+                mood: Some(crate::morphology::models::Mood::Indicative),
+                voice: Some(crate::morphology::models::Voice::Active),
+            }),
+            object: None,
+            indirect: None,
+            genitives: vec![],
+            adjectives: vec![],
+            literals: vec![],
+            arrays: vec![],
+            index_accesses: vec![],
+            property_accesses: vec![],
+            operators: vec![],
+            blocks: vec![],
+            nested_phrases: vec![],
+            participles: vec![],
+            unwraps: vec![],
+            is_query: false,
+            is_propagate: false,
+            has_mutable_marker: false,
+            has_containment_preposition: false,
+            has_delimiter_preposition: false,
+            string_method: None,
+        };
+
+        let result = classify_assembled_statement(&asm_stmt, &mut scope).unwrap();
+        if let AnalyzedStatement::Expression(exprs) = result {
+            assert_eq!(exprs.len(), 1);
+            assert!(matches!(exprs[0].expr, AnalyzedExprKind::Variable(_)));
+        } else {
+            panic!("Expected expression");
+        }
+
+        let asm_stmt_obj = AssembledStatement {
+            subject: None,
+            nominatives: vec![],
+            verb: Some(VerbConstituent {
+                lemma: "is".into(),
+                original: "".into(),
+                normalized: "is".into(),
+                person: Some(crate::morphology::models::Person::Third),
+                number: Some(crate::morphology::models::Number::Singular),
+                tense: Some(crate::morphology::models::Tense::Present),
+                mood: Some(crate::morphology::models::Mood::Indicative),
+                voice: Some(crate::morphology::models::Voice::Active),
+            }),
+            object: Some(Constituent {
+                lemma: "y".into(),
+                original: "".into(),
+                normalized: "y".into(),
+                case: crate::morphology::models::Case::Accusative,
+                number: Some(crate::morphology::models::Number::Singular),
+                gender: Some(crate::morphology::models::Gender::Masculine),
+                person: None,
+            }),
+            indirect: None,
+            genitives: vec![],
+            adjectives: vec![],
+            literals: vec![],
+            arrays: vec![],
+            index_accesses: vec![],
+            property_accesses: vec![],
+            operators: vec![],
+            blocks: vec![],
+            nested_phrases: vec![],
+            participles: vec![],
+            unwraps: vec![],
+            is_query: false,
+            is_propagate: false,
+            has_mutable_marker: false,
+            has_containment_preposition: false,
+            has_delimiter_preposition: false,
+            string_method: None,
+        };
+
+        let result2 = classify_assembled_statement(&asm_stmt_obj, &mut scope).unwrap();
+        if let AnalyzedStatement::Expression(exprs) = result2 {
+            assert_eq!(exprs.len(), 1);
+            assert!(matches!(exprs[0].expr, AnalyzedExprKind::Variable(_)));
+        } else {
+            panic!("Expected expression");
+        }
+    }
+}

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -1107,11 +1107,33 @@ fn classify_expression(
     asm_stmt: &AssembledStatement,
     scope: &Scope,
 ) -> Result<AnalyzedStatement, GlossaError> {
-    // Determine if we should attempt to build expressions from literals+operators
-    // or if we are in a fallback scenario (using Subject/Object with operators).
-    // If literals < operators + 1, build_expressions_from_literals_and_ops will fail.
-    // In that case, we only build literals and let the fallback logic handle operators.
+    let mut exprs = build_initial_expressions(asm_stmt)?;
 
+    // If we have operators but couldn't build a full expression from literals alone (usually implies literals < 2),
+    // we should look for Subject/Object to complete the binary expression.
+    #[allow(clippy::collapsible_if)]
+    if !asm_stmt.operators.is_empty() && asm_stmt.literals.len() < 2 {
+        if let Some(bin_expr) = build_fallback_binary_expression(asm_stmt, &exprs) {
+            exprs = vec![bin_expr];
+        }
+    }
+
+    // Fallback: If no literals/ops, check Subject/Object
+    #[allow(clippy::collapsible_if)]
+    if exprs.is_empty() {
+        if let Some(fallback_expr) = build_subject_object_fallback(asm_stmt) {
+            exprs.push(fallback_expr);
+        }
+    }
+
+    apply_propagation(asm_stmt, &mut exprs);
+
+    Ok(AnalyzedStatement::Expression(exprs))
+}
+
+fn build_initial_expressions(
+    asm_stmt: &AssembledStatement,
+) -> Result<Vec<AnalyzedExpr>, GlossaError> {
     let (literals_to_build, operators_to_build) = if !asm_stmt.operators.is_empty()
         && asm_stmt.literals.len() < asm_stmt.operators.len() + 1
     {
@@ -1121,56 +1143,54 @@ fn classify_expression(
         (asm_stmt.literals.as_slice(), asm_stmt.operators.as_slice())
     };
 
-    let mut exprs = build_expressions_from_literals_and_ops(literals_to_build, operators_to_build)?;
+    build_expressions_from_literals_and_ops(literals_to_build, operators_to_build)
+}
 
-    // If we have operators but couldn't build a full expression from literals alone (usually implies literals < 2),
-    // we should look for Subject/Object to complete the binary expression.
-    if !asm_stmt.operators.is_empty() && asm_stmt.literals.len() < 2 {
-        let op = asm_stmt.operators[0];
+fn build_fallback_binary_expression(
+    asm_stmt: &AssembledStatement,
+    exprs: &[AnalyzedExpr],
+) -> Option<AnalyzedExpr> {
+    let op = asm_stmt.operators[0];
 
-        let left = asm_stmt.subject.as_ref().map(|subj| AnalyzedExpr {
+    let left = asm_stmt.subject.as_ref().map(|subj| AnalyzedExpr {
+        expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
+        glossa_type: GlossaType::Unknown,
+    })?;
+
+    let right = if let Some(lit_expr) = exprs.first() {
+        Some(lit_expr.clone())
+    } else if let Some(ref obj) = asm_stmt.object {
+        Some(AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+            glossa_type: GlossaType::Unknown,
+        })
+    } else {
+        asm_stmt.nominatives.first().map(|nom| AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(nom.lemma.clone()),
+            glossa_type: GlossaType::Unknown,
+        })
+    }?;
+
+    Some(build_binary_expr(left, op, right))
+}
+
+fn build_subject_object_fallback(asm_stmt: &AssembledStatement) -> Option<AnalyzedExpr> {
+    if let Some(ref subj) = asm_stmt.subject {
+        Some(AnalyzedExpr {
             expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
             glossa_type: GlossaType::Unknown,
-        });
-
-        // Try to get right operand from exprs (literal) or object or nominatives
-        let right = if let Some(lit_expr) = exprs.first() {
-            Some(lit_expr.clone())
-        } else if let Some(ref obj) = asm_stmt.object {
-            Some(AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                glossa_type: GlossaType::Unknown,
-            })
-        } else {
-            asm_stmt.nominatives.first().map(|nom| AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(nom.lemma.clone()),
-                glossa_type: GlossaType::Unknown,
-            })
-        };
-
-        if let (Some(l), Some(r)) = (left, right) {
-            let bin_expr = build_binary_expr(l, op, r);
-            exprs = vec![bin_expr];
-        }
+        })
+    } else {
+        asm_stmt.object.as_ref().map(|obj| AnalyzedExpr {
+            expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
+            glossa_type: GlossaType::Unknown,
+        })
     }
+}
 
-    // Fallback: If no literals/ops, check Subject/Object
-    if exprs.is_empty() {
-        if let Some(ref subj) = asm_stmt.subject {
-            exprs.push(AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(subj.lemma.clone()),
-                glossa_type: GlossaType::Unknown,
-            });
-        } else if let Some(ref obj) = asm_stmt.object {
-            exprs.push(AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(obj.lemma.clone()),
-                glossa_type: GlossaType::Unknown,
-            });
-        }
-    }
-
+fn apply_propagation(asm_stmt: &AssembledStatement, exprs: &mut Vec<AnalyzedExpr>) {
+    #[allow(clippy::collapsible_if)]
     if asm_stmt.is_propagate && !exprs.is_empty() {
-        #[allow(clippy::collapsible_if)]
         if let Some(last_expr) = exprs.pop() {
             let try_expr = AnalyzedExpr {
                 glossa_type: last_expr.glossa_type.clone(),
@@ -1179,8 +1199,6 @@ fn classify_expression(
             exprs.push(try_expr);
         }
     }
-
-    Ok(AnalyzedStatement::Expression(exprs))
 }
 
 /// Helper: Common logic for genitive method call parsing


### PR DESCRIPTION
🚮 Smell: The `classify_expression` function in `src/semantic/conversion.rs` was a "God Function" (~78 lines) handling multiple responsibilities including literal building, fallback binary expressions, and fallback expressions. It had deep nesting and high cognitive complexity.
✨ Solution: Extracted the logic into four smaller, named helper functions: `build_initial_expressions`, `build_fallback_binary_expression`, `build_subject_object_fallback`, and `apply_propagation`. Used early returns (`?`) where possible to flatten structure. Added `#[allow(clippy::collapsible_if)]` to prevent Clippy from suggesting unstable `let_chains` syntax.
🧼 Benefit: Significantly reduces cognitive load, clarifies the fallback cascade, and flattens nested `if` statements.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [7975632062593427823](https://jules.google.com/task/7975632062593427823) started by @madmax983*