### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -134,3 +134,7 @@ Signed,
 **YYYY-MM-DD - [DoS Mitigation]
 **Threat:** Memory Exhaustion / Unbounded Allocations via standard IO.
 **Defense:** Wrapped mutable readers using `.by_ref().take(LIMIT)` inside `repl.rs` and `mentor.rs`.
+
+**2026-06-25 - Unsoundness in `Error::downcast_mut()`**
+**Threat:** The `anyhow` crate version 1.0.102 has a known vulnerability (RUSTSEC-2026-0190) involving unsoundness in `Error::downcast_mut()` which could lead to memory safety issues.
+**Defense:** Updated the `anyhow` dependency in `Cargo.lock` to version `1.0.104` via `cargo update -p anyhow` which resolves the vulnerability.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🦠 Threat: The `anyhow` crate version 1.0.102 has a known vulnerability (RUSTSEC-2026-0190) involving unsoundness in `Error::downcast_mut()` which could lead to memory safety issues.
🛡️ Defense: Updated the `anyhow` dependency in `Cargo.lock` to version `1.0.104` via `cargo update -p anyhow` which resolves the vulnerability.
💥 Severity: High - potential memory safety issues.
🔭 Verification: `cargo audit` now passes cleanly. Code compiles and tests pass.

---
*PR created automatically by Jules for task [11402131945525216345](https://jules.google.com/task/11402131945525216345) started by @madmax983*