### PR TITLE
⚒️ Forge: Refactor print_test_results

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,6 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+**Refactoring God Functions**
+**Learning:** Extracting parts of a massive formatting function into cleanly named helper functions (e.g. `print_summary_table`, `print_results_table`, `print_failure_details`) radically improves readability while preserving original functionality and safely decoupling distinct logical blocks.
+**Action:** When a method primarily coordinates multiple sub-tasks (like different parts of an output string/table), break it down into specialized helpers. This flattens the pyramid of doom and makes testing or modifying individual format sections much simpler later.

--- a/find_long_fns.py
+++ b/find_long_fns.py
@@ -1,12 +1,43 @@
-import ast
-import re
+import os
 import sys
+import re
 
-def find_long_functions(filepath):
-    with open(filepath, 'r') as f:
-        content = f.read()
+def main():
+    root = "src"
+    results = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        for filename in filenames:
+            if not filename.endswith(".rs"):
+                continue
+            path = os.path.join(dirpath, filename)
+            with open(path, "r", encoding="utf-8") as f:
+                lines = f.readlines()
 
-    # Simple regex to find fn ... {
-    # Not perfect but gives an idea
-    # Let's use a rust parser or a simpler script to find long functions
-    pass
+            in_fn = False
+            fn_name = ""
+            fn_start = 0
+            brace_count = 0
+
+            for i, line in enumerate(lines):
+                # Basic heuristic
+                if not in_fn:
+                    m = re.match(r'^\s*(?:pub(?:\([^)]+\))?\s+)?(?:async\s+)?fn\s+([a-zA-Z0-9_]+)\s*\(', line)
+                    if m:
+                        in_fn = True
+                        fn_name = m.group(1)
+                        fn_start = i
+                        brace_count = line.count("{") - line.count("}")
+                else:
+                    brace_count += line.count("{") - line.count("}")
+                    if brace_count <= 0:
+                        fn_len = i - fn_start + 1
+                        if fn_len > 50:
+                            results.append((fn_len, fn_name, path, fn_start + 1))
+                        in_fn = False
+
+    results.sort(key=lambda x: x[0], reverse=True)
+    for res in results[:20]:
+        print(f"{res[0]} lines: {res[1]} in {res[2]}:{res[3]}")
+
+if __name__ == "__main__":
+    main()

--- a/plan.md
+++ b/plan.md
@@ -1,16 +1,80 @@
-1. **Refactor `print_test_results` in `src/tools/tester.rs`**:
-    - `print_test_results` is a "God Function" (over 100 lines, currently 111 lines, starting from line 283).
-    - It handles formatting success/failure summary tables, formatting individual test result tables, and extracting/formatting detailed error messages.
-    - We will extract this into smaller helper functions:
-        - `print_summary_table(success: bool)`
-        - `print_results_table(results: &[TestResult])`
-        - `print_failure_details(stdout: &str, test_output: &std::process::Output)`
-    - We will keep the original logic and ensure there are no behavior changes, just separating concerns for readability.
-2. **Execute tests**:
-    - Run `cargo test` to verify everything works and no functionality is broken.
+1. **Add test for newly extracted functions in `src/tools/tester.rs`**:
+   - Use `replace_with_git_merge_diff` to add tests for `print_summary_table`, `print_results_table`, `print_failure_details`, and `print_test_results` in `src/tools/tester.rs` by inserting:
+```
+<<<<<<< SEARCH
+    #[test]
+    fn test_run_tests_semantic_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("semantic_error.gl");
+        std::fs::write(&input_path, "ψ 10 γίγνεται.").unwrap();
+
+        let result = run_tests(&input_path);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        // The underlying error bubbles up.
+        assert!(err_msg.contains("Semantic error") || err_msg.contains("Σφάλμα"));
+    }
+}
+=======
+    #[test]
+    fn test_run_tests_semantic_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("semantic_error.gl");
+        std::fs::write(&input_path, "ψ 10 γίγνεται.").unwrap();
+
+        let result = run_tests(&input_path);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        // The underlying error bubbles up.
+        assert!(err_msg.contains("Semantic error") || err_msg.contains("Σφάλμα"));
+    }
+
+    #[test]
+    fn test_print_test_results_coverage() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let success_output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: vec![],
+            stderr: vec![],
+        };
+        let fail_output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(256),
+            stdout: b"failures:\n\n---- test stdout ----\nerr\n\nfailures:\n    test\n".to_vec(),
+            stderr: b"stderr output".to_vec(),
+        };
+
+        let empty_results = vec![];
+        let some_results = vec![
+            TestResult { name: "test_ok".to_string(), status: TestStatus::Ok },
+            TestResult { name: "test_failed".to_string(), status: TestStatus::Failed },
+            TestResult { name: "tests::test_ignored".to_string(), status: TestStatus::Ignored },
+        ];
+
+        // We capture output implicitly by just running these, since they write to stdout.
+        // It's mostly to trigger the code paths for coverage.
+        print_summary_table(true, true);
+        print_summary_table(false, true);
+
+        print_results_table(&empty_results);
+        print_results_table(&some_results);
+
+        print_failure_details("", &success_output);
+        print_failure_details("failures:\n\n---- t stdout ----\nmsg\n\nfailures:\n    t\n", &fail_output);
+        print_failure_details("raw failure", &fail_output);
+
+        print_test_results(&some_results, &fail_output, "failures:\n\n---- t stdout ----\nmsg\n\nfailures:\n    t\n");
+    }
+}
+>>>>>>> REPLACE
+```
+2. **Verify test added**:
+   - Use `read_file` to verify the modified contents of `src/tools/tester.rs`.
 3. **Run Clippy & Fmt**:
-    - Run `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all`.
-4. **Pre-commit**:
-    - Complete pre-commit steps to ensure proper testing, verifications, reviews and reflections are done.
-5. **Submit PR**:
-    - Use the submit tool to create a PR: "⚒️ Forge: [refactor name]".
+   - Use `run_in_bash_session` to execute `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all`.
+4. **Execute tests**:
+   - Use `run_in_bash_session` to execute `cargo test` across the workspace to verify everything works.
+5. **Pre-commit**:
+   - Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
+6. **Submit PR**:
+   - Use the `submit` tool to update the PR.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,16 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+1. **Refactor `print_test_results` in `src/tools/tester.rs`**:
+    - `print_test_results` is a "God Function" (over 100 lines, currently 111 lines, starting from line 283).
+    - It handles formatting success/failure summary tables, formatting individual test result tables, and extracting/formatting detailed error messages.
+    - We will extract this into smaller helper functions:
+        - `print_summary_table(success: bool)`
+        - `print_results_table(results: &[TestResult])`
+        - `print_failure_details(stdout: &str, test_output: &std::process::Output)`
+    - We will keep the original logic and ensure there are no behavior changes, just separating concerns for readability.
+2. **Execute tests**:
+    - Run `cargo test` to verify everything works and no functionality is broken.
+3. **Run Clippy & Fmt**:
+    - Run `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all`.
+4. **Pre-commit**:
+    - Complete pre-commit steps to ensure proper testing, verifications, reviews and reflections are done.
+5. **Submit PR**:
+    - Use the submit tool to create a PR: "⚒️ Forge: [refactor name]".

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -280,14 +280,9 @@ fn execute_test_binary(exe_path: &Path, status: &mut Status) -> Result<std::proc
     Ok(test_output)
 }
 
-fn print_test_results(results: &[TestResult], test_output: &std::process::Output, stdout: &str) {
-    println!();
-    println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
-    println!("   {}", "Unit Test Results".italic().dim());
-    println!();
-
-    if test_output.status.success() {
-        if !results.is_empty() {
+fn print_summary_table(success: bool, has_results: bool) {
+    if success {
+        if has_results {
             let mut success_table = Table::new();
             success_table.load_preset(presets::UTF8_FULL);
             success_table.add_row(vec![
@@ -311,7 +306,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         println!("{failure_table}");
         println!();
     }
+}
 
+fn print_results_table(results: &[TestResult]) {
     if !results.is_empty() {
         let mut table = Table::new();
         table.load_preset(presets::UTF8_FULL);
@@ -355,41 +352,55 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         ]);
         println!("{empty_table}");
     }
+}
 
-    // If there were failures, try to extract and print them nicely
-    if !test_output.status.success() {
-        println!();
-        println!("{}", "--- 📜 Λεπτoμέρειες (Details) ---".dim());
+fn print_failure_details(stdout: &str, test_output: &std::process::Output) {
+    if test_output.status.success() {
+        return;
+    }
 
-        let failures = extract_failures(stdout);
+    println!();
+    println!("{}", "--- 📜 Λεπτoμέρειες (Details) ---".dim());
 
-        if !failures.is_empty() {
-            for (name, msg) in failures {
-                let mut header_table = Table::new();
-                header_table.load_preset(presets::UTF8_FULL);
-                header_table.add_row(vec![
-                    Cell::new(format!(" FAILED: {} ", name))
-                        .bg(Color::DarkRed)
-                        .fg(Color::White)
-                        .add_attribute(Attribute::Bold),
-                ]);
-                println!("{header_table}");
+    let failures = extract_failures(stdout);
 
-                // Create a box for the error message using comfy_table
-                let mut error_table = Table::new();
-                error_table.load_preset(presets::UTF8_FULL);
-                error_table.add_row(vec![Cell::new(format!("\n{}\n", msg)).fg(Color::Red)]);
-                println!("{error_table}");
-                println!();
-            }
-        } else {
-            // Fallback to raw output if extraction failed but tests failed
-            println!("{}", stdout);
-            if !test_output.stderr.is_empty() {
-                println!("{}", String::from_utf8_lossy(&test_output.stderr).red());
-            }
+    if !failures.is_empty() {
+        for (name, msg) in failures {
+            let mut header_table = Table::new();
+            header_table.load_preset(presets::UTF8_FULL);
+            header_table.add_row(vec![
+                Cell::new(format!(" FAILED: {} ", name))
+                    .bg(Color::DarkRed)
+                    .fg(Color::White)
+                    .add_attribute(Attribute::Bold),
+            ]);
+            println!("{header_table}");
+
+            // Create a box for the error message using comfy_table
+            let mut error_table = Table::new();
+            error_table.load_preset(presets::UTF8_FULL);
+            error_table.add_row(vec![Cell::new(format!("\n{}\n", msg)).fg(Color::Red)]);
+            println!("{error_table}");
+            println!();
+        }
+    } else {
+        // Fallback to raw output if extraction failed but tests failed
+        println!("{}", stdout);
+        if !test_output.stderr.is_empty() {
+            println!("{}", String::from_utf8_lossy(&test_output.stderr).red());
         }
     }
+}
+
+fn print_test_results(results: &[TestResult], test_output: &std::process::Output, stdout: &str) {
+    println!();
+    println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
+    println!("   {}", "Unit Test Results".italic().dim());
+    println!();
+
+    print_summary_table(test_output.status.success(), !results.is_empty());
+    print_results_table(results);
+    print_failure_details(stdout, test_output);
 }
 
 /// Run unit tests defined within a ΓΛΩΣΣΑ file.

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -872,4 +872,66 @@ test name with spaces ... ok
         // The underlying error bubbles up.
         assert!(err_msg.contains("Semantic error") || err_msg.contains("Σφάλμα"));
     }
+
+    #[test]
+    fn test_print_test_results_coverage() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let success_output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: vec![],
+            stderr: vec![],
+        };
+        let fail_output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(256),
+            stdout: b"failures:\n\n---- test stdout ----\nerr\n\nfailures:\n    test\n".to_vec(),
+            stderr: b"stderr output".to_vec(),
+        };
+
+        let empty_results = vec![];
+        let some_results = vec![
+            TestResult {
+                name: "test_ok".to_string(),
+                status: TestStatus::Ok,
+            },
+            TestResult {
+                name: "test_failed".to_string(),
+                status: TestStatus::Failed,
+            },
+            TestResult {
+                name: "tests::test_ignored".to_string(),
+                status: TestStatus::Ignored,
+            },
+        ];
+
+        let fail_output_no_stderr = std::process::Output {
+            status: std::process::ExitStatus::from_raw(256),
+            stdout: vec![],
+            stderr: vec![],
+        };
+
+        // We capture output implicitly by just running these, since they write to stdout.
+        // It's mostly to trigger the code paths for coverage.
+        print_summary_table(true, true);
+        print_summary_table(true, false);
+        print_summary_table(false, true);
+        print_summary_table(false, false);
+
+        print_results_table(&empty_results);
+        print_results_table(&some_results);
+
+        print_failure_details("", &success_output);
+        print_failure_details(
+            "failures:\n\n---- t stdout ----\nmsg\n\nfailures:\n    t\n",
+            &fail_output,
+        );
+        print_failure_details("raw failure", &fail_output);
+        print_failure_details("raw failure", &fail_output_no_stderr);
+
+        print_test_results(
+            &some_results,
+            &fail_output,
+            "failures:\n\n---- t stdout ----\nmsg\n\nfailures:\n    t\n",
+        );
+    }
 }

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -875,7 +875,10 @@ test name with spaces ... ok
 
     #[test]
     fn test_print_test_results_coverage() {
+        #[cfg(unix)]
         use std::os::unix::process::ExitStatusExt;
+        #[cfg(windows)]
+        use std::os::windows::process::ExitStatusExt;
 
         let success_output = std::process::Output {
             status: std::process::ExitStatus::from_raw(0),


### PR DESCRIPTION
🚮 Smell: `print_test_results` in `src/tools/tester.rs` was a "God Function" (over 110 lines) handling three distinct tasks: printing the success/failure summary table, printing the individual test case results table, and printing detailed error output for failures.
✨ Solution: Extracted the logical sections into clearly named helper functions: `print_summary_table`, `print_results_table`, and `print_failure_details`. Used a guard clause (early return) in `print_failure_details` to reduce nesting.
🧼 Benefit: Significantly reduces cognitive load when reading the code, separates concerns, and flattens the pyramid of doom.
🛡️ Verification: Tests passed. No logic changed. All output formatting remains identical.

---
*PR created automatically by Jules for task [11919880639093028555](https://jules.google.com/task/11919880639093028555) started by @madmax983*