### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-05-04 - The Intervening Use Statement
+**Confusion:** The function `to_rust_type` in `src/codegen.rs` triggered a `missing_docs` warning despite having a well-written documentation block directly above it.
+**Clarification:** A `use std::fmt::Write;` statement was placed between the doc comment (`///`) and the function signature. In Rust, documentation comments attach to the very next syntactical item. Thus, `cargo doc` attached the documentation to the `use` statement instead of the function. I moved the `use` statement above the documentation block.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -243,6 +243,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
     Ok(())
 }
 
+use std::fmt::Write;
+
 // ==================================================================================
 // TYPES
 // ==================================================================================
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 📖 Chapter: The `codegen` module's `to_rust_type` function.
* 🔦 Insight: A `use` statement placed between a doc block and a function hijacked the documentation, leading to a `missing_docs` warning. I moved the `use` statement above the doc block so `cargo doc` correctly attaches the documentation to the function itself.
* 🧪 Example: Fixed the docs for `to_rust_type`.
* 🖼️ Preview: Resolves the `RUSTDOCFLAGS="-W missing_docs" cargo doc` warning.

---
*PR created automatically by Jules for task [11861558288942567565](https://jules.google.com/task/11861558288942567565) started by @madmax983*