### PR TITLE
🗣️ Echo: Fix confusing unused variable warning on every run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🤦 **The Confusion:** When trying to use standard commands or running Glossa scripts without the `nova` feature, the compiler outputs an `unused_variables` warning related to the `Gnomon` command.
🕵️ **The Reality:** The `Gnomon` match arm captures `input` but only uses it if the `nova` feature is enabled. When disabled, the warning is emitted, confusing users.
💡 **The Fix:** Bound and consume the variable explicitly using `let _ = input;` in the disabled feature branch.

---
*PR created automatically by Jules for task [13414169625530664857](https://jules.google.com/task/13414169625530664857) started by @madmax983*