### PR TITLE
⚒️ Forge: [Refactor test results formatter]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+
+**Extracted print_test_results**
+**Learning:** The print_test_results function in tester.rs became a God Function managing display of test outcomes.
+**Action:** Extracted display sections into named helpers (print_header, print_summary_status, print_results_table, print_failure_details).

--- a/find_long_fns.py
+++ b/find_long_fns.py
@@ -1,12 +1,32 @@
-import ast
-import re
 import sys
+import re
 
-def find_long_functions(filepath):
-    with open(filepath, 'r') as f:
-        content = f.read()
+def main():
+    for filepath in sys.argv[1:]:
+        with open(filepath, 'r') as f:
+            lines = f.readlines()
 
-    # Simple regex to find fn ... {
-    # Not perfect but gives an idea
-    # Let's use a rust parser or a simpler script to find long functions
-    pass
+        current_fn = None
+        start_line = 0
+        brace_count = 0
+        in_fn = False
+
+        # very naive parsing
+        for i, line in enumerate(lines):
+            # check for function start
+            match = re.match(r'^\s*(?:pub\s+|pub\(crate\)\s+)?(?:async\s+)?fn\s+([a-zA-Z0-9_]+)\s*\(', line)
+            if match and not in_fn:
+                in_fn = True
+                current_fn = match.group(1)
+                start_line = i + 1
+                brace_count = line.count('{') - line.count('}')
+            elif in_fn:
+                brace_count += line.count('{') - line.count('}')
+                if brace_count <= 0:
+                    in_fn = False
+                    length = i + 1 - start_line + 1
+                    if length > 50:
+                        print(f"{filepath}:{start_line} fn {current_fn} - {length} lines")
+
+if __name__ == "__main__":
+    main()

--- a/plan.md
+++ b/plan.md
@@ -1,24 +1,36 @@
-Let's fix the clippy warnings about unused variable `input` in `src/main.rs`. We can do `let _ = input;` inside the disabled cfg block for Gnomon to be consistent with others (like Scholar, Papyrus, etc.) or just rename it to `_input`. Looking at others:
-
+1. **Fix `clippy::useless_borrows_in_formatting` in `src/semantic/conversion.rs`**
+   - The CI failed with:
+     ```
+     error: redundant reference in `format!` argument
+     --> src/semantic/conversion.rs:512:13
+      |
+     512 |             &var_name
+      |             ^^^^^^^^^ help: remove the redundant `&`: `var_name`
+     ```
+   - I will use `replace_with_git_merge_diff` to remove the redundant `&` before `var_name` on line 512 in `src/semantic/conversion.rs`.
+   - The exact replacement will be:
 ```rust
-        Some(Commands::Scholar { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::scholar::run_scholar(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'scholar' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
+<<<<<<< SEARCH
+        Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
+            "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
+            &var_name
+        ))),
+=======
+        Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
+            "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
+            var_name
+        ))),
+>>>>>>> REPLACE
 ```
-I'll fix Gnomon the same way to resolve the warning, which is part of Forge's responsibilities to leave code better ("Apply `clippy` suggestions..."). Wait, the memory says: "When destructuring variables in a conditionally compiled `match` arm in Rust (e.g., `Some(Commands::MyCommand { input })`), explicitly consume the destructured variables inside the disabled configuration block (e.g., using `let _ = input;`) to prevent `unused_variables` compiler warnings when the feature flag is disabled."
 
-So I will definitely do that for Gnomon.
+2. **Verify changes in `src/semantic/conversion.rs`**
+   - Use `run_in_bash_session` to run `cat src/semantic/conversion.rs | sed -n '505,515p'` to visually inspect the fix.
 
-The main refactor for Forge:
-In `src/tools/tester.rs`, `print_test_results` is 111 lines and violates the "God Function" smell. I'll extract logic out into smaller functions as planned.
+3. **Verify tests and clippy pass**
+   - Use `run_in_bash_session` to run `cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings && cargo test` to ensure all checks pass.
 
-Let's do a plan review.
+4. **Complete pre-commit steps**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+5. **Submit PR**
+   - Use the `submit` tool to update the PR with the new fix.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,24 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**
+Let's fix the clippy warnings about unused variable `input` in `src/main.rs`. We can do `let _ = input;` inside the disabled cfg block for Gnomon to be consistent with others (like Scholar, Papyrus, etc.) or just rename it to `_input`. Looking at others:
+
+```rust
+        Some(Commands::Scholar { input }) => {
+            #[cfg(feature = "nova")]
+            glossa::tools::scholar::run_scholar(&input)?;
+
+            #[cfg(not(feature = "nova"))]
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'scholar' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
+        }
+```
+I'll fix Gnomon the same way to resolve the warning, which is part of Forge's responsibilities to leave code better ("Apply `clippy` suggestions..."). Wait, the memory says: "When destructuring variables in a conditionally compiled `match` arm in Rust (e.g., `Some(Commands::MyCommand { input })`), explicitly consume the destructured variables inside the disabled configuration block (e.g., using `let _ = input;`) to prevent `unused_variables` compiler warnings when the feature flag is disabled."
+
+So I will definitely do that for Gnomon.
+
+The main refactor for Forge:
+In `src/tools/tester.rs`, `print_test_results` is 111 lines and violates the "God Function" smell. I'll extract logic out into smaller functions as planned.
+
+Let's do a plan review.

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -281,11 +281,20 @@ fn execute_test_binary(exe_path: &Path, status: &mut Status) -> Result<std::proc
 }
 
 fn print_test_results(results: &[TestResult], test_output: &std::process::Output, stdout: &str) {
+    print_header();
+    print_summary_status(test_output, results);
+    print_results_table(results);
+    print_failure_details(test_output, stdout);
+}
+
+fn print_header() {
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
     println!("   {}", "Unit Test Results".italic().dim());
     println!();
+}
 
+fn print_summary_status(test_output: &std::process::Output, results: &[TestResult]) {
     if test_output.status.success() {
         if !results.is_empty() {
             let mut success_table = Table::new();
@@ -311,7 +320,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         println!("{failure_table}");
         println!();
     }
+}
 
+fn print_results_table(results: &[TestResult]) {
     if !results.is_empty() {
         let mut table = Table::new();
         table.load_preset(presets::UTF8_FULL);
@@ -355,8 +366,9 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         ]);
         println!("{empty_table}");
     }
+}
 
-    // If there were failures, try to extract and print them nicely
+fn print_failure_details(test_output: &std::process::Output, stdout: &str) {
     if !test_output.status.success() {
         println!();
         println!("{}", "--- 📜 Λεπτoμέρειες (Details) ---".dim());


### PR DESCRIPTION
🚮 Smell: The `print_test_results` function in `src/tools/tester.rs` grew to over 100 lines, violating the "God Function" smell and managing multiple responsibilities for displaying test output. Also, `src/main.rs` had an unused variable warning (`clippy::unused_variables`) for `input` in the `Commands::Gnomon` branch when `nova` features were disabled.
✨ Solution: Extracted the display logic in `print_test_results` into four smaller, named helpers (`print_header`, `print_summary_status`, `print_results_table`, `print_failure_details`). Modified the `Commands::Gnomon` block in `src/main.rs` to ignore the variable using `let _ = input;`.
🧼 Benefit: Reduces cognitive load and flattens nesting levels in the tester tool. Keeps the CI green by applying clippy suggestions without modifying runtime behavior.
🛡️ Verification: `cargo test` passes. `cargo clippy --all-targets --all-features -- -D warnings` passes clean.

---
*PR created automatically by Jules for task [3593154109154864350](https://jules.google.com/task/3593154109154864350) started by @madmax983*