### PR TITLE
🎨 Mosaic: UI Polish for Haruspex

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -13,6 +13,7 @@
 use crate::semantic::{AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement};
 use crate::tools::runner::load_source;
 use crate::tools::ui::Status;
+use comfy_table::{Attribute, Cell, Color, Table, presets};
 use crossterm::style::Stylize;
 use miette::Result;
 use std::fmt::Write;
@@ -61,15 +62,33 @@ fn print_dashboard(dot: &str, is_tty: bool) {
         );
         println!();
 
-        let actual_nodes = dot.lines().filter(|l| l.contains("[label=")).count();
-        let edges = dot.matches("->").count();
+        let mut table = Table::new();
+        table.load_preset(presets::UTF8_FULL);
 
-        println!("   {} {}", "Nodes:".bold(), actual_nodes.to_string().cyan());
-        println!("   {} {}", "Edges:".bold(), edges.to_string().cyan());
+        table.set_header(vec![
+            Cell::new("Graphviz DOT Diagram")
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Cyan),
+        ]);
+
+        let formatted_dot = format!("```dot\n{}\n```", dot.trim());
+        table.add_row(vec![Cell::new(formatted_dot)]);
+
+        println!("{table}");
         println!();
         println!(
             "   {}",
-            "To view the graph, pipe this command to a file or tool:".dim()
+            "📋 Usage Instructions:".bold().underlined()
+        );
+        println!("   1. Copy the code block above.");
+        println!(
+            "   2. Paste it into {}",
+            "a Graphviz viewer (e.g. GraphvizOnline)".cyan().underlined()
+        );
+        println!();
+        println!(
+            "   {}",
+            "Or pipe this command to a file/tool:".dim()
         );
         println!(
             "   {}",

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -76,20 +76,16 @@ fn print_dashboard(dot: &str, is_tty: bool) {
 
         println!("{table}");
         println!();
-        println!(
-            "   {}",
-            "📋 Usage Instructions:".bold().underlined()
-        );
+        println!("   {}", "📋 Usage Instructions:".bold().underlined());
         println!("   1. Copy the code block above.");
         println!(
             "   2. Paste it into {}",
-            "a Graphviz viewer (e.g. GraphvizOnline)".cyan().underlined()
+            "a Graphviz viewer (e.g. GraphvizOnline)"
+                .cyan()
+                .underlined()
         );
         println!();
-        println!(
-            "   {}",
-            "Or pipe this command to a file/tool:".dim()
-        );
+        println!("   {}", "Or pipe this command to a file/tool:".dim());
         println!(
             "   {}",
             "cargo run --features nova --bin glossa -- haruspex <file> > ast.dot".dim()


### PR DESCRIPTION
🖌️ **Before:** The AST Graphviz generation dumped raw DOT configuration as plain text mixed with its CLI header and printed separate "Nodes" and "Edges" values above the instructions. This lacked visual hierarchy and looked inconsistent with other modern CLI tools in the repository.

✨ **After:** The generated DOT format is now elegantly wrapped inside a `comfy-table` labeled "Graphviz DOT Diagram," which preserves formatting but sets it apart from textual instructions. The user-friendly usage instructions now also match the visual structure and consistency established by the `labyrinth` module, guiding the user on how to pipe the text correctly or paste it online.

🖼️ **Visuals:** A clear blue box outlining the "Graphviz DOT Diagram" containing the raw node/edge text, immediately followed by underscored `📋 Usage Instructions:`.

---
*PR created automatically by Jules for task [7121457953343088600](https://jules.google.com/task/7121457953343088600) started by @madmax983*