### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,7 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+
+## 2024-08-07 - Test Documentation Requirements
+**Confusion:** `cargo doc` flags `missing_docs` in integration test files, and docs for functions are lost if a `use` statement separates the doc block from the function.
+**Clarification:** Added `//!` module-level documentation to integration test files. Moved `use` statements above the documentation blocks so they correctly attach to the function definitions.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/tests/havoc_clone_drop.rs
+++ b/tests/havoc_clone_drop.rs
@@ -1,3 +1,5 @@
+//! Tests for stack overflow protection during clone and drop.
+
 use glossa::ast::{Expr, Word};
 use std::thread;
 

--- a/tests/havoc_proptest_unicode_fuzz.rs
+++ b/tests/havoc_proptest_unicode_fuzz.rs
@@ -1,3 +1,5 @@
+//! Fuzz testing for parser using random unicode strings.
+
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
 use proptest::prelude::*;

--- a/tests/havoc_repl_empty.rs
+++ b/tests/havoc_repl_empty.rs
@@ -1,3 +1,5 @@
+//! Tests for the empty REPL crash.
+
 use glossa::tools::repl::run_repl;
 
 // test wrapper for REPL crash

--- a/tests/sentry_codegen_perf.rs
+++ b/tests/sentry_codegen_perf.rs
@@ -1,3 +1,5 @@
+//! Performance and execution tests for the codegen module.
+
 use glossa::codegen::generate_rust_file;
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,

--- a/tests/warden_unsafe_deny.rs
+++ b/tests/warden_unsafe_deny.rs
@@ -1,3 +1,5 @@
+//! Tests that generated Rust files deny unsafe code.
+
 use glossa::codegen::generate_rust_file;
 use glossa::semantic::{AnalyzedProgram, Scope};
 


### PR DESCRIPTION
* 📖 Chapter: "The `codegen` module and Integration Tests"
* 🔦 Insight: "Clarified how documentation blocks bind to functions instead of intermediate `use` statements, and added module-level documentation to integration tests."
* 🧪 Example: "Fixed `to_rust_type` documentation."
* 🖼️ Preview: ""

---
*PR created automatically by Jules for task [6613388618577292450](https://jules.google.com/task/6613388618577292450) started by @madmax983*