### PR TITLE
🗣️ Echo: Fix unused variable warning in CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🤦 **The Confusion:** "Tried to run any basic command in the terminal. The compiler always shouted a warning about `unused variable: input` for the Gnomon command, even when I wasn't using it. It's very noisy."
🕵️ **The Reality:** "Turns out the Gnomon command takes an `input` argument, but in the default build (without the `nova` feature), it bails with an error message without actually consuming the `input` variable."
💡 **The Fix:** "Add `let _ = input;` inside the disabled `cfg` block for the Gnomon command so the compiler knows it was intentionally ignored."

---
*PR created automatically by Jules for task [9863690171585211592](https://jules.google.com/task/9863690171585211592) started by @madmax983*