### PR TITLE
📜 Codex: ADR 022 & Architecture Diagram Update

### DIFF
--- a/docs/adr/022-encapsulate-internal-modules.md
+++ b/docs/adr/022-encapsulate-internal-modules.md
@@ -1,0 +1,21 @@
+# 022. Encapsulate Internal Modules
+
+Date: 2026-08-07
+
+## Status
+
+Proposed
+
+## Context
+
+Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`. This broke encapsulation by exposing internal implementation details to the public API, leading to a sprawling API surface and potential misuse of internal structures.
+
+## Decision
+
+The visibility of `src/tools/cache.rs`, `src/tools/report.rs`, `src/tools/ui.rs`, and `src/semantic/assembly/model.rs` was modified to use `pub(crate) mod` instead of `pub mod`.
+
+## Consequences
+
+*   The public API surface is reduced and kept minimal.
+*   Higher cohesion is achieved by ensuring internal structures do not leak out of their intended domains.
+*   Internal tools and structural components are better encapsulated.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ C4Container
     Container_Boundary(tools, "Developer Experience (Nova)") {
         Container(alchemist, "The Alchemist", "src/tools/alchemist.rs", "Python Exporter")
         Container(auditor, "The Auditor", "src/tools/auditor.rs", "Static analysis to find unused variables and mutability smells")
-        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache")
+        Container(cache, "Cache", "src/tools/cache.rs", "Incremental compilation cache [Internal]")
         Container(cartographer, "Cartographer", "src/tools/cartographer.rs", "Generates Mermaid Class Diagrams")
         Container(catalog, "The Catalog", "src/tools/catalog.rs", "Lexicon Explorer (CLI)")
         Container(cli, "CLI", "src/tools/cli.rs", "Command-line interface definition")
@@ -48,10 +48,10 @@ C4Container
         Container(narrator, "The Bard", "src/tools/narrator.rs", "Generates English narrative ('Scroll of Logic') from AST")
         Container(papyrus, "Papyrus", "src/tools/papyrus.rs", "Generates SQL CREATE TABLE schemas")
         Container(repl, "REPL", "src/tools/repl.rs", "Interactive Read-Eval-Print Loop")
-        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports")
+        Container(report, "Reporter", "src/tools/report.rs", "Generates statistics and structured reports [Internal]")
         Container(runner, "Runner", "src/tools/runner.rs", "Orchestrates the compilation pipeline")
         Container(tester, "The Judge", "src/tools/tester.rs", "Verifies Correctness (Test Runner)")
-        Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers")
+        Container(ui, "The Stage", "src/tools/ui.rs", "Presentation Layer & UI Helpers [Internal]")
         Container(weave, "Weave", "src/tools/weave.rs", "Rosetta Stone Markdown Exporter")
     }
 
@@ -96,7 +96,7 @@ C4Component
         Component(expressions, "Expressions", "src/semantic/expressions.rs", "Recursively analyzes nested expressions")
         Component(resolver, "Resolver", "src/semantic/resolver.rs", "Manages Scope and Bindings")
         Component(assembly, "Assembly", "src/semantic/assembly/mod.rs", "Routes words to grammatical slots")
-        Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs)")
+        Component(assembly_model, "Assembly Model", "src/semantic/assembly/model.rs", "Data Transfer Objects (DTOs) [Internal]")
         Component(conversion, "Conversion", "src/semantic/conversion.rs", "Interprets assembled slots into statements")
         Component(patterns, "Pattern Matcher", "src/semantic/patterns.rs", "Identifies high-level constructs")
         Component(model, "Semantic Model", "src/semantic/model.rs", "Type-checked HIR (AnalyzedStatement)")

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🧠 **Decision:** Recorded the change to `pub(crate) mod` for internal tool and assembly model modules to strictly enforce API boundaries.
🗺️ **Visuals:** Updated the Container and Component Mermaid C4 diagrams to mark `cache`, `report`, `ui`, and `assembly_model` as `[Internal]`.
🔗 **Link:** See `docs/adr/022-encapsulate-internal-modules.md`.

---
*PR created automatically by Jules for task [5300261891791387079](https://jules.google.com/task/5300261891791387079) started by @madmax983*