### PR TITLE
🔒 Warden: anyhow security fix

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -134,3 +134,6 @@ Signed,
 **YYYY-MM-DD - [DoS Mitigation]
 **Threat:** Memory Exhaustion / Unbounded Allocations via standard IO.
 **Defense:** Wrapped mutable readers using `.by_ref().take(LIMIT)` inside `repl.rs` and `mentor.rs`.
+**2026-06-25 - [anyhow Unsoundness Vulnerability]
+**Threat:** Unsoundness in `Error::downcast_mut()` in `anyhow` version 1.0.102 (RUSTSEC-2026-0190).
+**Defense:** Upgraded `anyhow` to version 1.0.104.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🦠 Threat: Unsoundness in `Error::downcast_mut()` in `anyhow` version 1.0.102 (RUSTSEC-2026-0190).
🛡️ Defense: Upgraded `anyhow` to version 1.0.104.
💥 Severity: Critical - could allow memory unsafety or Undefined Behavior.
🧪 Verification: `cargo audit` passes clean and test suite passes.

---
*PR created automatically by Jules for task [416380595743918259](https://jules.google.com/task/416380595743918259) started by @madmax983*