### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -275,6 +275,19 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// ```
 use std::fmt::Write;
 
+/// Converts a `GlossaType` into a valid Rust type string.
+///
+/// This function wraps `write_rust_type` and allocates a new `String`
+/// containing the Rust representation of the provided ΓΛΩΣΣΑ type.
+///
+/// # Examples
+///
+/// ```rust
+/// use glossa::codegen::to_rust_type;
+/// use glossa::semantic::GlossaType;
+///
+/// assert_eq!(to_rust_type(&GlossaType::Number), "i64");
+/// ```
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 📖 Chapter: The `codegen` module.
* 🔦 Insight: Clarified the `to_rust_type` function.
* 🧪 Example: Added an executable doctest for converting types.
* 🖼️ Preview: (None)

---
*PR created automatically by Jules for task [2357845735858296838](https://jules.google.com/task/2357845735858296838) started by @madmax983*