### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-05-18 - Missing documentation for `to_rust_type`
+**Confusion:** The `to_rust_type` function in `src/codegen.rs` was missing rustdoc comments, leading to warnings when compiling with `-W missing_docs`. The documentation was placed before the `use std::fmt::Write;` statement, making it module-level documentation instead of function-level documentation.
+**Clarification:** I moved the documentation block immediately above the `to_rust_type` function definition and ensured it correctly documents the function's purpose, usage, and examples. I also suppressed missing documentation warnings in test files that were not meant to be public APIs.

--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -79,3 +79,6 @@
 ## 2026-05-18 - Missing documentation for `to_rust_type`
 **Confusion:** The `to_rust_type` function in `src/codegen.rs` was missing rustdoc comments, leading to warnings when compiling with `-W missing_docs`. The documentation was placed before the `use std::fmt::Write;` statement, making it module-level documentation instead of function-level documentation.
 **Clarification:** I moved the documentation block immediately above the `to_rust_type` function definition and ensured it correctly documents the function's purpose, usage, and examples. I also suppressed missing documentation warnings in test files that were not meant to be public APIs.
+## 2026-05-18 - `clippy::useless_borrows_in_formatting` in conversion
+**Confusion:** The CI failed with a `clippy::useless_borrows_in_formatting` lint in `src/semantic/conversion.rs` at line 512, where a reference (`&var_name`) was passed to the `format!` macro.
+**Clarification:** Passing a reference to a variable that is already borrowed or owned directly inside a `format!` macro (e.g., `format!("{}", &var_name)`) triggers the lint. The fix is to pass the variable directly without the redundant borrow (`format!("{}", var_name)`).

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,8 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +275,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/tests/havoc_clone_drop.rs
+++ b/tests/havoc_clone_drop.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use glossa::ast::{Expr, Word};
 use std::thread;
 

--- a/tests/havoc_proptest_unicode_fuzz.rs
+++ b/tests/havoc_proptest_unicode_fuzz.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use glossa::parser::parse;
 use glossa::semantic::analyze_program;
 use proptest::prelude::*;

--- a/tests/havoc_repl_empty.rs
+++ b/tests/havoc_repl_empty.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use glossa::tools::repl::run_repl;
 
 // test wrapper for REPL crash

--- a/tests/sentry_codegen_perf.rs
+++ b/tests/sentry_codegen_perf.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use glossa::codegen::generate_rust_file;
 use glossa::semantic::{
     AnalyzedExpr, AnalyzedExprKind, AnalyzedProgram, AnalyzedStatement, GlossaType, Scope,

--- a/tests/warden_unsafe_deny.rs
+++ b/tests/warden_unsafe_deny.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use glossa::codegen::generate_rust_file;
 use glossa::semantic::{AnalyzedProgram, Scope};
 


### PR DESCRIPTION
* 📖 Chapter: The `codegen` module's `to_rust_type` function.
* 🔦 Insight: Added missing rustdoc documentation to `to_rust_type`, preventing warnings when running `cargo clippy` with `-W missing_docs`. Suppressed `missing_docs` lints in test files as they do not constitute public API.
* 🧪 Example: Code examples were already present, but the documentation block was misplaced.
* 🖼️ Preview: Documentation is now correctly associated with the `to_rust_type` function.

---
*PR created automatically by Jules for task [7259009321819298063](https://jules.google.com/task/7259009321819298063) started by @madmax983*