### PR TITLE
⚒️ Forge: DRY parse_match_pattern

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+
+**Refactoring parse_match_pattern in control_flow.rs**
+**Learning:** `parse_match_pattern` duplicated the same word parsing logic twice (once for Phrase(Word), once for Word).
+**Action:** Extract the Word first with match, then apply the parsing logic once to DRY it up.

--- a/src/semantic/control_flow.rs
+++ b/src/semantic/control_flow.rs
@@ -534,78 +534,51 @@ fn parse_return_expression(clause: &Clause, scope: &Scope) -> Result<AnalyzedExp
 /// Parse a match pattern expression
 fn parse_match_pattern(expr: &Expr, scope: &mut Scope) -> Result<AnalyzedExpr, GlossaError> {
     // Pattern is typically: value ᾖ
-    if let Expr::Phrase(terms) = expr {
-        if terms.is_empty() {
-            return Err(GlossaError::semantic("Empty match pattern"));
-        }
-
-        // Get first word (the pattern value)
-        if let Expr::Word(w) = &terms[0] {
-            let normalized = &w.normalized;
-
-            // Check if it's ἄλλο (wildcard)
-            if normalized == "αλλο" {
-                return Ok(AnalyzedExpr {
-                    expr: AnalyzedExprKind::BooleanLiteral(true),
-                    glossa_type: GlossaType::Boolean,
-                });
+    let word = match expr {
+        Expr::Phrase(terms) => {
+            if terms.is_empty() {
+                return Err(GlossaError::semantic("Empty match pattern"));
             }
-
-            // Check if it's a numeral
-            if let Some(val) = lexicon::numeral_value(normalized) {
-                return Ok(AnalyzedExpr {
-                    expr: AnalyzedExprKind::NumberLiteral(val),
-                    glossa_type: GlossaType::Number,
-                });
-            }
-
-            // Otherwise, treat as variable reference
-            let var_type = scope
-                .lookup(normalized)
-                .cloned()
-                .unwrap_or(GlossaType::Unknown);
-            if var_type == GlossaType::Unknown && !scope.is_function(normalized) {
-                return Err(GlossaError::undefined(normalized.clone()));
-            }
-            return Ok(AnalyzedExpr {
-                expr: AnalyzedExprKind::Variable(normalized.clone()),
-                glossa_type: var_type,
-            });
+            let Expr::Word(w) = &terms[0] else {
+                return Err(GlossaError::semantic("Invalid match pattern"));
+            };
+            w
         }
-    } else if let Expr::Word(w) = expr {
-        let normalized = &w.normalized;
+        Expr::Word(w) => w,
+        _ => return Err(GlossaError::semantic("Invalid match pattern")),
+    };
 
-        // Check for wildcard
-        if normalized == "αλλο" {
-            return Ok(AnalyzedExpr {
-                expr: AnalyzedExprKind::BooleanLiteral(true),
-                glossa_type: GlossaType::Boolean,
-            });
-        }
+    let normalized = &word.normalized;
 
-        // Check for numeral
-        if let Some(val) = lexicon::numeral_value(normalized) {
-            return Ok(AnalyzedExpr {
-                expr: AnalyzedExprKind::NumberLiteral(val),
-                glossa_type: GlossaType::Number,
-            });
-        }
-
-        let var_type = scope
-            .lookup(normalized)
-            .cloned()
-            .unwrap_or(GlossaType::Unknown);
-        if var_type == GlossaType::Unknown && !scope.is_function(normalized) {
-            return Err(GlossaError::undefined(normalized.clone()));
-        }
-
+    // Check if it's ἄλλο (wildcard)
+    if normalized == "αλλο" {
         return Ok(AnalyzedExpr {
-            expr: AnalyzedExprKind::Variable(normalized.clone()),
-            glossa_type: var_type,
+            expr: AnalyzedExprKind::BooleanLiteral(true),
+            glossa_type: GlossaType::Boolean,
         });
     }
 
-    Err(GlossaError::semantic("Invalid match pattern"))
+    // Check if it's a numeral
+    if let Some(val) = lexicon::numeral_value(normalized) {
+        return Ok(AnalyzedExpr {
+            expr: AnalyzedExprKind::NumberLiteral(val),
+            glossa_type: GlossaType::Number,
+        });
+    }
+
+    // Otherwise, treat as variable reference
+    let var_type = scope
+        .lookup(normalized)
+        .cloned()
+        .unwrap_or(GlossaType::Unknown);
+    if var_type == GlossaType::Unknown && !scope.is_function(normalized) {
+        return Err(GlossaError::undefined(normalized.clone()));
+    }
+
+    Ok(AnalyzedExpr {
+        expr: AnalyzedExprKind::Variable(normalized.clone()),
+        glossa_type: var_type,
+    })
 }
 
 /// Parse a conditional statement (εἰ/ἐάν)

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🚮 Smell: `parse_match_pattern` had duplicated logic for parsing a word as a wildcard, numeral, or variable. It used `if let` chaining which caused deep nesting and duplication.
✨ Solution: Extracted the `Word` first using a `match` expression and guard clauses, then applied the parsing logic once.
🧼 Benefit: Flattens the function, removes duplicate code, and improves readability (DRY principle).
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [8321529131837601815](https://jules.google.com/task/8321529131837601815) started by @madmax983*