### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,10 +247,14 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
+
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
-/// and produces a string that is valid Rust syntax.
+/// and produces a string that is valid Rust syntax. It exists to abstract the
+/// complex logic of unrolling nested variants in the syntax tree (such as lists
+/// of options of numbers) into a concrete Rust type path during source-to-source transpilation.
 ///
 /// # Examples
 ///
@@ -273,8 +277,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 📖 Chapter: The `codegen` module.
* 🔦 Insight: Added missing documentation to the `to_rust_type` function, clarifying that it transforms a `GlossaType` into a valid Rust type signature string. Repositioned a `use std::fmt::Write;` statement to prevent the rich doc tests from improperly binding to the import.
* 🧪 Example: Maintained the existing 4 executable doctests.
* 🖼️ Preview: N/A.

---
*PR created automatically by Jules for task [10069975775122199446](https://jules.google.com/task/10069975775122199446) started by @madmax983*