### PR TITLE
Fix unused_variable warning in Commands::Gnomon

### DIFF
--- a/.jules/razor.md
+++ b/.jules/razor.md
@@ -7,3 +7,8 @@
 **Bloat:** `DotGenerator` in `src/tools/haruspex.rs` used an object-oriented builder pattern for graph generation.
 **Cut:** Flattened the object into pure procedural functions passing mutable references to `next_id` and `output` state.
 **Saved:** Replaced a localized object-oriented abstraction with standard procedural Rust functions.
+
+## [Reduction]
+**Bloat:** `unused_variable` warning in `Commands::Gnomon` branch due to lack of `let _ = input;` when the `nova` feature is not enabled.
+**Cut:** Added `let _ = input;` to the `#[cfg(not(feature = "nova"))]` conditional branch, similarly to other commands (like `Scholar` or `Haruspex`).
+**Saved:** Suppressed a localized compiler warning with an explicit empty assignment.

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {


### PR DESCRIPTION
Fixes an unused_variable warning in the Commands::Gnomon match arm when the nova feature is not enabled by adding let _ = input; to the cfg(not(feature = "nova")) branch.

---
*PR created automatically by Jules for task [6502717280933620478](https://jules.google.com/task/6502717280933620478) started by @madmax983*