### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/.jules/sentry.md
+++ b/.jules/sentry.md
@@ -92,3 +92,7 @@
 **[Parser Unexpected Rule Defensive Checks]
 **Learning:** In the PEG parsing stage, using `match pair.as_rule()` with a generic `_ => Err(ParseError::UnexpectedRule(...))` fallback is good defensive practice, but these branches remain permanently uncovered because the `pest` grammar guarantees input validity before it reaches the AST builder.
 **Action:** Craft manual `pest` `Pairs` (often by parsing mismatched rules intentionally) and feed them to the specific AST builder functions inside an embedded `#[cfg(test)] mod tests` block to cover these critical safety guards.
+
+**[Semantic Validation Depth Limits]
+**Learning:** Discovered uncovered error paths inside `src/semantic/validation.rs` where AST bounds checking returns errors for expressions and clauses when `MAX_AST_DEPTH` is exceeded. Also empty statement branches were not verified explicitly.
+**Action:** Explicitly instantiate AST bounds edge cases at `MAX_AST_DEPTH + 1` in tests, checking specific error variants to guarantee safety bounds are strictly enforced.

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/semantic/validation.rs
+++ b/src/semantic/validation.rs
@@ -292,4 +292,85 @@ mod tests {
         let result = check_statement_depth(&stmt, 0);
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_ast_statement_depth_limit_exceeded() {
+        use crate::ast::Statement;
+        let stmt = Statement::Regular {
+            clauses: vec![],
+            is_query: false,
+            is_propagate: false,
+        };
+        let result = check_ast_statement_depth(&stmt, MAX_AST_DEPTH + 1);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            GlossaError::SemanticError { message, .. } => {
+                assert_eq!(message, "Recursion limit exceeded in statement analysis");
+            }
+            _ => panic!("Expected Semantic error"),
+        }
+    }
+
+    #[test]
+    fn test_ast_expr_depth_limit_exceeded() {
+        use crate::ast::Expr;
+        let expr = Expr::Phrase(vec![]);
+        let result = check_ast_expr_depth(&expr, MAX_AST_DEPTH + 1);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            GlossaError::SemanticError { message, .. } => {
+                assert_eq!(message, "Recursion limit exceeded in expression analysis");
+            }
+            _ => panic!("Expected Semantic error"),
+        }
+    }
+
+    #[test]
+    fn test_ast_clause_depth_limit_exceeded() {
+        use crate::ast::Clause;
+        let clause = Clause {
+            expressions: vec![],
+        };
+        let result = check_ast_clause_depth(&clause, MAX_AST_DEPTH + 1);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            GlossaError::SemanticError { message, .. } => {
+                assert_eq!(message, "Recursion limit exceeded in clause analysis");
+            }
+            _ => panic!("Expected Semantic error"),
+        }
+    }
+
+    #[test]
+    fn test_analyzed_statement_empty_branches() {
+        let stmt1 = AnalyzedStatement::Break;
+        let result1 = check_statement_depth(&stmt1, 0);
+        assert!(result1.is_ok());
+
+        let stmt2 = AnalyzedStatement::Continue;
+        let result2 = check_statement_depth(&stmt2, 0);
+        assert!(result2.is_ok());
+
+        let stmt3 = AnalyzedStatement::TypeDefinition {
+            name: "TestType".into(),
+            fields: vec![],
+        };
+        let result3 = check_statement_depth(&stmt3, 0);
+        assert!(result3.is_ok());
+
+        let stmt4 = AnalyzedStatement::TraitDefinition {
+            name: "TestTrait".into(),
+            methods: vec![],
+        };
+        let result4 = check_statement_depth(&stmt4, 0);
+        assert!(result4.is_ok());
+
+        let stmt5 = AnalyzedStatement::TraitImplementation {
+            trait_name: "TestTrait".into(),
+            type_name: "TestType".into(),
+            methods: vec![],
+        };
+        let result5 = check_statement_depth(&stmt5, 0);
+        assert!(result5.is_ok());
+    }
 }


### PR DESCRIPTION
🎯 Target: src/semantic/validation.rs - `check_ast_expr_depth`, `check_ast_clause_depth`, `check_ast_statement_depth`, `check_statement_depth` (Break, Continue, TypeDefinition, TraitDefinition, TraitImplementation)
💣 Risk: Prevents untested paths in semantic validation's depth limits, reducing the risk of hidden stack overflows or incorrect error propagation during extremely deep AST processing.
🧪 Strategy: Added specific unit tests driving recursive checks past `MAX_AST_DEPTH` limit to cover the `LimitExceeded` error cases for AST structures, and covered empty branches.
🔬 Verification: cargo test --lib semantic::validation::tests

---
*PR created automatically by Jules for task [17575227149310544162](https://jules.google.com/task/17575227149310544162) started by @madmax983*