### PR TITLE
⚒️ Forge: Extract print_test_results in tester.rs

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+
+**Refactored Tester's print_test_results**
+**Learning:** Found a god function `print_test_results` doing too much: formatting the header, success summary, failure summary, results table, and error extraction.
+**Action:** Extracted logic into `print_header`, `print_summary_status`, `print_results_table`, and `print_failures`.

--- a/src/tools/tester.rs
+++ b/src/tools/tester.rs
@@ -281,13 +281,22 @@ fn execute_test_binary(exe_path: &Path, status: &mut Status) -> Result<std::proc
 }
 
 fn print_test_results(results: &[TestResult], test_output: &std::process::Output, stdout: &str) {
+    print_header();
+    print_summary_status(results.is_empty(), test_output.status.success());
+    print_results_table(results);
+    print_failures(test_output, stdout);
+}
+
+fn print_header() {
     println!();
     println!("   {}", "Γ Λ Ω Σ Σ Α   T E S T E R".bold().cyan());
     println!("   {}", "Unit Test Results".italic().dim());
     println!();
+}
 
-    if test_output.status.success() {
-        if !results.is_empty() {
+fn print_summary_status(is_empty: bool, is_success: bool) {
+    if is_success {
+        if !is_empty {
             let mut success_table = Table::new();
             success_table.load_preset(presets::UTF8_FULL);
             success_table.add_row(vec![
@@ -311,35 +320,10 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
         println!("{failure_table}");
         println!();
     }
+}
 
-    if !results.is_empty() {
-        let mut table = Table::new();
-        table.load_preset(presets::UTF8_FULL);
-
-        table.set_header(vec![
-            Cell::new("Test Case")
-                .add_attribute(Attribute::Bold)
-                .fg(Color::Cyan),
-            Cell::new("Status").add_attribute(Attribute::Bold),
-        ]);
-
-        for result in results {
-            let status_cell = match result.status {
-                TestStatus::Ok => Cell::new("PASSED").fg(Color::Green),
-                TestStatus::Failed => Cell::new("FAILED")
-                    .fg(Color::Red)
-                    .add_attribute(Attribute::Bold),
-                TestStatus::Ignored => Cell::new("IGNORED").fg(Color::Yellow),
-            };
-
-            // Clean up test name (remove module prefix if any)
-            // e.g., "tests::test_name" -> "test_name"
-            let display_name = result.name.split("::").last().unwrap_or(&result.name);
-
-            table.add_row(vec![Cell::new(display_name), status_cell]);
-        }
-        println!("{table}");
-    } else {
+fn print_results_table(results: &[TestResult]) {
+    if results.is_empty() {
         let mut empty_table = Table::new();
         empty_table.load_preset(presets::UTF8_FULL);
         empty_table.set_header(vec![
@@ -354,41 +338,73 @@ fn print_test_results(results: &[TestResult], test_output: &std::process::Output
                 .set_alignment(CellAlignment::Center),
         ]);
         println!("{empty_table}");
+        return;
     }
 
-    // If there were failures, try to extract and print them nicely
-    if !test_output.status.success() {
-        println!();
-        println!("{}", "--- 📜 Λεπτoμέρειες (Details) ---".dim());
+    let mut table = Table::new();
+    table.load_preset(presets::UTF8_FULL);
 
-        let failures = extract_failures(stdout);
+    table.set_header(vec![
+        Cell::new("Test Case")
+            .add_attribute(Attribute::Bold)
+            .fg(Color::Cyan),
+        Cell::new("Status").add_attribute(Attribute::Bold),
+    ]);
 
-        if !failures.is_empty() {
-            for (name, msg) in failures {
-                let mut header_table = Table::new();
-                header_table.load_preset(presets::UTF8_FULL);
-                header_table.add_row(vec![
-                    Cell::new(format!(" FAILED: {} ", name))
-                        .bg(Color::DarkRed)
-                        .fg(Color::White)
-                        .add_attribute(Attribute::Bold),
-                ]);
-                println!("{header_table}");
+    for result in results {
+        let status_cell = match result.status {
+            TestStatus::Ok => Cell::new("PASSED").fg(Color::Green),
+            TestStatus::Failed => Cell::new("FAILED")
+                .fg(Color::Red)
+                .add_attribute(Attribute::Bold),
+            TestStatus::Ignored => Cell::new("IGNORED").fg(Color::Yellow),
+        };
 
-                // Create a box for the error message using comfy_table
-                let mut error_table = Table::new();
-                error_table.load_preset(presets::UTF8_FULL);
-                error_table.add_row(vec![Cell::new(format!("\n{}\n", msg)).fg(Color::Red)]);
-                println!("{error_table}");
-                println!();
-            }
-        } else {
-            // Fallback to raw output if extraction failed but tests failed
-            println!("{}", stdout);
-            if !test_output.stderr.is_empty() {
-                println!("{}", String::from_utf8_lossy(&test_output.stderr).red());
-            }
+        // Clean up test name (remove module prefix if any)
+        // e.g., "tests::test_name" -> "test_name"
+        let display_name = result.name.split("::").last().unwrap_or(&result.name);
+
+        table.add_row(vec![Cell::new(display_name), status_cell]);
+    }
+    println!("{table}");
+}
+
+fn print_failures(test_output: &std::process::Output, stdout: &str) {
+    if test_output.status.success() {
+        return;
+    }
+
+    println!();
+    println!("{}", "--- 📜 Λεπτoμέρειες (Details) ---".dim());
+
+    let failures = extract_failures(stdout);
+
+    if failures.is_empty() {
+        // Fallback to raw output if extraction failed but tests failed
+        println!("{}", stdout);
+        if !test_output.stderr.is_empty() {
+            println!("{}", String::from_utf8_lossy(&test_output.stderr).red());
         }
+        return;
+    }
+
+    for (name, msg) in failures {
+        let mut header_table = Table::new();
+        header_table.load_preset(presets::UTF8_FULL);
+        header_table.add_row(vec![
+            Cell::new(format!(" FAILED: {} ", name))
+                .bg(Color::DarkRed)
+                .fg(Color::White)
+                .add_attribute(Attribute::Bold),
+        ]);
+        println!("{header_table}");
+
+        // Create a box for the error message using comfy_table
+        let mut error_table = Table::new();
+        error_table.load_preset(presets::UTF8_FULL);
+        error_table.add_row(vec![Cell::new(format!("\n{}\n", msg)).fg(Color::Red)]);
+        println!("{error_table}");
+        println!();
     }
 }
 


### PR DESCRIPTION
🚮 Smell: `print_test_results` was a God Function over 100 lines long, handling header printing, summary generation, table rendering, and error extraction.
✨ Solution: Extracted logic into clear, private helpers: `print_header`, `print_summary_status`, `print_results_table`, and `print_failures`.
🧼 Benefit: Reduces cognitive load. Each function now handles a single responsibility, making the UI logic much easier to follow and maintain.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [14844170990493898993](https://jules.google.com/task/14844170990493898993) started by @madmax983*