### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,6 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2026-05-03 - Intervening use statements break documentation
+**Confusion:** The `cargo clippy --all-targets --all-features -- -D warnings -D missing_docs` build step was failing because `missing_docs` was triggered on `pub fn to_rust_type`. However, the function clearly had a detailed rustdoc comment right above it.
+**Clarification:** In Rust, if a `use` statement (like `use std::fmt::Write;`) is placed directly between a `///` doc comment and the function or struct it is meant for, the documentation is attached to the `use` statement instead of the function! Moving the `use` statement out of the way correctly re-attaches the documentation to the function and resolves the `missing_docs` error.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -273,13 +273,13 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();
     result
 }
+
+use std::fmt::Write;
 
 fn write_rust_type(ty: &GlossaType, out: &mut String) -> std::fmt::Result {
     match ty {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 📖 Chapter: The `codegen` module
* 🔦 Insight: Fixed an issue where an intervening `use std::fmt::Write;` statement detached documentation from the `to_rust_type` function, causing a `missing_docs` lint error.
* 🧪 Example: Preserved the existing executable doctests for `to_rust_type` demonstrating type generation.
* 🖼️ Preview: Documentation for `to_rust_type` now renders correctly in HTML.

---
*PR created automatically by Jules for task [11118020651681847222](https://jules.google.com/task/11118020651681847222) started by @madmax983*