### PR TITLE
🗣️ Echo: Getting Started example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ Translate your code into an English narrative (available without `nova`).
 cargo run --release -- bard examples/quickstart.γλ
 ```
 
+### 5. The Gnomon
+Estimate the Big-O time complexity of a program.
+
+```bash
+cargo run --release --features nova -- gnomon examples/quickstart.γλ
+```
+
 ## Features
 
 - **Greek Syntax**: Write code using authentic Ancient Greek grammatical constructs

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ fn main() -> Result<()> {
             glossa::tools::gnomon::run_gnomon(&input)?;
 
             #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
+            {
+                let _ = input;
+                miette::bail!(
+                    "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
+                );
+            }
         }
 
         Some(Commands::Scholar { input }) => {

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 🤦 **The Confusion:** "Tried to run the `gnomon` command. Compiler said the command was experimental but it was not documented in the README."
* 🕵️ **The Reality:** "Turns out I needed to enable feature `nova` to run `gnomon` but it was missing from the Nova Toolset section in the README."
* 💡 **The Fix:** "Add a new section for `gnomon` in the README under 'The Nova Toolset (Experimental)'."

---
*PR created automatically by Jules for task [91346294529287964](https://jules.google.com/task/91346294529287964) started by @madmax983*