### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/.jules/bard.md
+++ b/.jules/bard.md
@@ -76,3 +76,7 @@
 ## 2026-05-03 - The Scholar Tool's Missing Link
 **Confusion:** The `src/tools/scholar.rs` module lacked module-level documentation and an executable doc-test for its public `run_scholar` function. It was not telling a story of *why* it existed, only what it was called, making it a "Black Box".
 **Clarification:** Added a comprehensive module-level `//!` documentation block that explicitly outlines the "Missing Link" and explains the philosophy behind automatically generating Markdown API docs from AST definitions. Added an executable `## Examples` block to `run_scholar`.
+## 2024-05-24 - Documenting code generation conversion function
+
+**Confusion:** The `to_rust_type` function in `src/codegen.rs` was missing documentation, which caused the build to fail with `cargo rustdoc -- -D missing_docs`. The function converts complex Glossa types into Rust types and is heavily used.
+**Clarification:** I added comprehensive documentation for `to_rust_type`, including an `## Examples` section showing how to convert simple types, lists, and Result types. This makes it clear how the internal representation of types maps to generated Rust code.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -275,6 +275,32 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// ```
 use std::fmt::Write;
 
+/// Convert a Glossa type to its Rust equivalent string
+///
+/// This function recursively traverses complex types (like `Vec<Option<i64>>`)
+/// and produces a string that is valid Rust syntax.
+///
+/// # Examples
+///
+/// ```
+/// use glossa::codegen::to_rust_type;
+/// use glossa::semantic::GlossaType;
+///
+/// // Simple types
+/// assert_eq!(to_rust_type(&GlossaType::Number), "i64");
+/// assert_eq!(to_rust_type(&GlossaType::String), "String");
+///
+/// // Complex nested types
+/// let list_of_numbers = GlossaType::List(Box::new(GlossaType::Number));
+/// assert_eq!(to_rust_type(&list_of_numbers), "Vec<i64>");
+///
+/// // Result types
+/// let result_type = GlossaType::Result(
+///     Box::new(GlossaType::Number),
+///     Box::new(GlossaType::String)
+/// );
+/// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
+/// ```
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 📖 Chapter: The `codegen` module's `to_rust_type` function
* 🔦 Insight: Clarified how internal representation of complex Glossa types map to generated Rust code.
* 🧪 Example: Added 3 executable doctests covering simple, List, and Result types.
* 🖼️ Preview: (Docs successfully rendered using cargo doc)

---
*PR created automatically by Jules for task [9334530479292993963](https://jules.google.com/task/9334530479292993963) started by @madmax983*