### PR TITLE
🗺️ Atlas: Encapsulating Assembly Inner Workings

### DIFF
--- a/.jules/atlas.md
+++ b/.jules/atlas.md
@@ -20,3 +20,9 @@
 **Tangle:** Several modules under `src/tools/` (specifically `cache`, `report`, and `ui`) and `src/semantic/assembly/` (`model`) were exposed as `pub mod`, breaking encapsulation by exposing internal implementation details to the public API.
 **Blueprint:** Modified `src/tools/mod.rs` and `src/semantic/assembly/mod.rs` to restrict these modules with `pub(crate) mod`.
 **Stability:** Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures don't leak out of their intended domains.
+## [Encapsulating Assembly Inner Workings]
+**Tangle:** The `src/semantic/assembly/mod.rs` module was exposed publicly (`pub mod assembly;`) in `src/semantic/mod.rs`, breaking the module boundaries. Moreover, `Assembler` was exported out of `assembly` by `pub use assembly::Assembler`. Then `assembly` module leaked more internal structure.
+**Blueprint:**
+1. Modified `src/semantic/mod.rs` to restrict the `assembly` module with `pub(crate) mod assembly;`.
+2. Changed `use glossa::semantic::assembly::Assembler;` to `use glossa::semantic::Assembler;` inside `src/semantic/assembly/mod.rs` doc tests to adapt to the new visibility restrictions since `Assembler` is exported in `semantic`.
+**Stability:** Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures like `assembly` sub-components don't leak out of their intended domains.

--- a/src/semantic/assembly/mod.rs
+++ b/src/semantic/assembly/mod.rs
@@ -160,7 +160,7 @@ pub use model::*;
 /// # Examples
 ///
 /// ```rust
-/// use glossa::semantic::assembly::Assembler;
+/// use glossa::semantic::Assembler;
 /// let mut asm = Assembler::new();
 /// // Then feed analysis and finalise statement
 /// ```

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name.clone()
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -34,7 +34,7 @@
 pub(crate) mod analyzer;
 #[cfg(test)]
 mod assembler_tests;
-pub mod assembly;
+pub(crate) mod assembly;
 #[cfg(test)]
 mod classification_tests;
 pub(crate) mod control_flow;


### PR DESCRIPTION
🕸️ Tangle: The `src/semantic/assembly/mod.rs` module was exposed publicly (`pub mod assembly;`) in `src/semantic/mod.rs`, breaking the module boundaries. Moreover, `Assembler` was exported out of `assembly` by `pub use assembly::Assembler`. Then `assembly` module leaked more internal structure.
   
📐 Blueprint: 
1. Modified `src/semantic/mod.rs` to restrict the `assembly` module with `pub(crate) mod assembly;`.
2. Changed `use glossa::semantic::assembly::Assembler;` to `use glossa::semantic::Assembler;` inside `src/semantic/assembly/mod.rs` doc tests to adapt to the new visibility restrictions since `Assembler` is exported in `semantic`.
   
🧱 Stability: Achieved higher cohesion by keeping the public API surface minimal and ensuring internal structures like `assembly` sub-components don't leak out of their intended domains.
   
🔬 Verification: Builds successfully, strict separation enforced. Tested with `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [6673020942847238685](https://jules.google.com/task/6673020942847238685) started by @madmax983*