### PR TITLE
🎨 Mosaic: UI Polish for Status UI

### DIFF
--- a/src/tools/ui.rs
+++ b/src/tools/ui.rs
@@ -150,9 +150,12 @@ impl Status {
             return;
         }
 
-        let msg = self.message.as_str().bold().to_string();
+        let msg = format!(
+            "{} [{}]",
+            self.message.as_str().bold(),
+            err.to_string().red()
+        );
         self.print_done("✕".red(), &msg);
-        eprintln!("{}", err);
         self.active = false;
     }
 


### PR DESCRIPTION
* 🖌️ **Before:** Errors rendered using `Status::error` displayed a status indicator ("✕ Module (Action)") on one line and the error description on a new line, often causing redundant texts or confusing spacing when bubbling up `miette::Report` panics (e.g., printing `Σφάλμα (Error)` on one line, and `Error: x Σφάλμα συντάξεως...` on the next).
* ✨ **After:** The error description is appended inline next to the status message within brackets, maintaining the visual hierarchy.
* 🖼️ **Visuals:** The terminal output now neatly reads `✕ Ἀφήγησις (Narrating) [Σφάλμα (Error)]` on a single line before falling back natively to `miette`'s rich formatting.

---
*PR created automatically by Jules for task [3827686676477910753](https://jules.google.com/task/3827686676477910753) started by @madmax983*