### PR TITLE
⚒️ Forge: Refactored CLI Command Routing

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+
+**Refactored CLI Command Matcher**
+**Learning:** The `main` function was becoming a God Function due to a massive `match` statement handling dozens of CLI commands, exacerbated by duplicated `#[cfg(feature = "nova")]` compiler directives in every experimental command arm.
+**Action:** Extracted the routing logic into `execute_command` and `execute_nova_command` helper functions, and grouped feature-gated logic into single conditionally compiled helpers to reduce repetition and maintain high diff coverage.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,108 @@ use glossa::tools::runner::{
     bard_file, build_file, check_file, highlight_file, report_file, run_file,
 };
 
+#[cfg(feature = "nova")]
+fn execute_nova_command(command: Commands) -> Result<()> {
+    match command {
+        Commands::Mentor => glossa::tools::mentor::run_mentor(),
+        Commands::Mosaic { input } => glossa::tools::mosaic::run_mosaic(&input),
+        Commands::Map { input } => glossa::tools::cartographer::run_map(&input),
+        Commands::Labyrinth { input } => glossa::tools::labyrinth::run_labyrinth(&input),
+        Commands::Weave { input } => glossa::tools::weave::run_weave(&input),
+        Commands::Alchemist { input } => glossa::tools::alchemist::run_alchemist(&input),
+        Commands::Papyrus { input } => glossa::tools::papyrus::run_papyrus(&input),
+        Commands::Haruspex { input } => glossa::tools::haruspex::run_haruspex(&input),
+        Commands::Audit { input } => glossa::tools::auditor::run_auditor(&input),
+        Commands::Catalog => glossa::tools::catalog::run_catalog(),
+        Commands::Gnomon { input } => glossa::tools::gnomon::run_gnomon(&input),
+        Commands::Scholar { input } => glossa::tools::scholar::run_scholar(&input),
+        _ => unreachable!("Only nova commands should be passed to execute_nova_command"),
+    }
+}
+
+#[cfg(not(feature = "nova"))]
+fn execute_nova_command(command: Commands) -> Result<()> {
+    // Unpack inputs conditionally if they exist in the command enum variants
+    // To avoid unused variable warnings when compiling without "nova" feature
+    let command_name = match command {
+        Commands::Mentor => "mentor",
+        Commands::Mosaic { input } => {
+            let _ = input;
+            "mosaic"
+        }
+        Commands::Map { input } => {
+            let _ = input;
+            "map"
+        }
+        Commands::Labyrinth { input } => {
+            let _ = input;
+            "labyrinth"
+        }
+        Commands::Weave { input } => {
+            let _ = input;
+            "weave"
+        }
+        Commands::Alchemist { input } => {
+            let _ = input;
+            "alchemist"
+        }
+        Commands::Papyrus { input } => {
+            let _ = input;
+            "papyrus"
+        }
+        Commands::Haruspex { input } => {
+            let _ = input;
+            "haruspex"
+        }
+        Commands::Audit { input } => {
+            let _ = input;
+            "audit"
+        }
+        Commands::Catalog => "catalog",
+        Commands::Gnomon { input } => {
+            let _ = input;
+            "gnomon"
+        }
+        Commands::Scholar { input } => {
+            let _ = input;
+            "scholar"
+        }
+        _ => unreachable!("Only nova commands should be passed to execute_nova_command"),
+    };
+
+    miette::bail!(
+        "The '{}' command is experimental. Recompile glossa with '--features nova' to enable it.",
+        command_name
+    )
+}
+
+fn execute_command(command: Commands) -> Result<()> {
+    match command {
+        Commands::Run { input } => run_file(&input),
+        Commands::Build { input, output } => build_file(&input, output.as_deref()),
+        Commands::Check { input } => check_file(&input),
+        Commands::Report { input } => report_file(&input),
+        Commands::Highlight { input } => highlight_file(&input),
+        Commands::Bard { input } => bard_file(&input),
+        Commands::Lookup { word } => lookup_word(&word),
+        Commands::Test { input } => glossa::tools::tester::run_tests(&input),
+        Commands::Repl => run_repl(),
+        // All Nova commands
+        cmd @ (Commands::Mentor
+        | Commands::Mosaic { .. }
+        | Commands::Map { .. }
+        | Commands::Labyrinth { .. }
+        | Commands::Weave { .. }
+        | Commands::Alchemist { .. }
+        | Commands::Papyrus { .. }
+        | Commands::Haruspex { .. }
+        | Commands::Audit { .. }
+        | Commands::Catalog
+        | Commands::Gnomon { .. }
+        | Commands::Scholar { .. }) => execute_nova_command(cmd),
+    }
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -21,189 +123,10 @@ fn main() -> Result<()> {
         return run_file(&file);
     }
 
-    match cli.command {
-        Some(Commands::Run { input }) => {
-            run_file(&input)?;
-        }
-
-        Some(Commands::Mentor) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::mentor::run_mentor()?;
-
-            #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'mentor' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
-        }
-
-        Some(Commands::Build { input, output }) => {
-            build_file(&input, output.as_deref())?;
-        }
-
-        Some(Commands::Check { input }) => {
-            check_file(&input)?;
-        }
-
-        Some(Commands::Report { input }) => {
-            report_file(&input)?;
-        }
-
-        Some(Commands::Highlight { input }) => {
-            highlight_file(&input)?;
-        }
-
-        Some(Commands::Bard { input }) => {
-            bard_file(&input)?;
-        }
-
-        Some(Commands::Lookup { word }) => {
-            lookup_word(&word)?;
-        }
-
-        Some(Commands::Test { input }) => {
-            glossa::tools::tester::run_tests(&input)?;
-        }
-
-        Some(Commands::Mosaic { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::mosaic::run_mosaic(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'mosaic' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Map { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::cartographer::run_map(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'map' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Labyrinth { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::labyrinth::run_labyrinth(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'labyrinth' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Weave { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::weave::run_weave(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'weave' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Alchemist { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::alchemist::run_alchemist(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'alchemist' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Papyrus { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::papyrus::run_papyrus(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'papyrus' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Haruspex { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::haruspex::run_haruspex(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'haruspex' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Audit { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::auditor::run_auditor(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'audit' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Catalog) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::catalog::run_catalog()?;
-
-            #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'catalog' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
-        }
-
-        Some(Commands::Gnomon { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::gnomon::run_gnomon(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            miette::bail!(
-                "The 'gnomon' command is experimental. Recompile glossa with '--features nova' to enable it."
-            );
-        }
-
-        Some(Commands::Scholar { input }) => {
-            #[cfg(feature = "nova")]
-            glossa::tools::scholar::run_scholar(&input)?;
-
-            #[cfg(not(feature = "nova"))]
-            {
-                let _ = input;
-                miette::bail!(
-                    "The 'scholar' command is experimental. Recompile glossa with '--features nova' to enable it."
-                );
-            }
-        }
-
-        Some(Commands::Repl) | None => {
-            run_repl()?;
-        }
+    if let Some(command) = cli.command {
+        execute_command(command)?;
+    } else {
+        run_repl()?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,4 +161,14 @@ mod tests {
             assert!(err_msg.contains("Recompile glossa with '--features nova'"));
         }
     }
+
+    #[test]
+    #[cfg(not(feature = "nova"))]
+    fn test_execute_command_routes_nova_commands() {
+        let cmd = Commands::Mentor;
+        let result = execute_command(cmd);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("is experimental"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,3 +131,34 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(feature = "nova"))]
+    use super::*;
+    #[cfg(not(feature = "nova"))]
+    use std::path::PathBuf;
+
+    #[test]
+    #[cfg(not(feature = "nova"))]
+    fn test_execute_nova_command_without_nova_feature() {
+        let commands = vec![
+            Commands::Mentor,
+            Commands::Mosaic {
+                input: PathBuf::from("test.γλ"),
+            },
+            Commands::Map {
+                input: PathBuf::from("test.γλ"),
+            },
+            Commands::Catalog,
+        ];
+
+        for cmd in commands {
+            let result = execute_nova_command(cmd);
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().to_string();
+            assert!(err_msg.contains("is experimental"));
+            assert!(err_msg.contains("Recompile glossa with '--features nova'"));
+        }
+    }
+}

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
🚮 Smell: `main` was a God Function (>150 lines) dominated by a massive `match` statement and repeated `#[cfg]` feature flag boilerplate.
✨ Solution: Extracted CLI routing into `execute_command` and grouped all experimental tools into a single `execute_nova_command` helper, utilizing whole-function conditional compilation.
🧼 Benefit: Reduces cognitive load, flattens nesting, removes redundant boilerplate, and keeps `main` clean.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [8054470890915195022](https://jules.google.com/task/8054470890915195022) started by @madmax983*