### PR TITLE
👺 Havoc: Stack Overflow vulnerabilities exposed via deeply nested structures

### DIFF
--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/tests/havoc_tests.rs
+++ b/tests/havoc_tests.rs
@@ -1,0 +1,50 @@
+use glossa::parser::parse;
+use glossa::semantic::analyze_program;
+
+#[test]
+#[should_panic]
+fn test_havoc_deep_nesting_panic() {
+    let mut s = String::new();
+    for _ in 0..10000 {
+        s.push_str("εἰ ἀληθὲς ᾖ, {\n");
+    }
+    s.push_str("«τέλος» λέγε.\n");
+    for _ in 0..10000 {
+        s.push_str("}\n");
+    }
+    let ast = parse(&s).unwrap();
+    let _ = analyze_program(&ast);
+}
+
+#[test]
+#[should_panic]
+fn test_havoc_codegen_stack_overflow() {
+    let mut s = String::new();
+    for _ in 0..10000 {
+        s.push_str("εἰ ἀληθὲς ᾖ, {\n");
+    }
+    s.push_str("«τέλος» λέγε.\n");
+    for _ in 0..10000 {
+        s.push_str("}\n");
+    }
+    let ast = parse(&s).unwrap();
+    if let Ok(program) = analyze_program(&ast) {
+        let _ = glossa::codegen::generate_rust(&program);
+    } else {
+        panic!("analysis failed");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_havoc_lexer_stack_overflow() {
+    let mut s = String::new();
+    for _ in 0..100000 {
+        s.push('(');
+    }
+    for _ in 0..100000 {
+        s.push(')');
+    }
+    let ast = parse(&s).unwrap();
+    let _ = analyze_program(&ast);
+}


### PR DESCRIPTION
* 🧨 **The Trigger:** Input strings with massive nesting of expressions (e.g. 10,000 deep `if` statements or parentheses) cause compiler stack overflows during parsing and code generation.
* 📉 **The Stack Trace:** Fatal runtime error: stack overflow (aborted).
* 🧪 **Reproduction:** Run `cargo test --test havoc_tests`.
* 😈 **Comment:** You assumed the AST would never be deeper than the compiler's call stack limit. You were wrong.

---
*PR created automatically by Jules for task [539904275146411277](https://jules.google.com/task/539904275146411277) started by @madmax983*