### PR TITLE
⚒️ Forge: [Refactor: Extract haruspex visitors]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,3 +1,7 @@
 **Refactored Cartographer's generate_map**
 **Learning:** Found a god object function > 100 lines handling struct rendering, trait rendering, dependencies, and implementations.
 **Action:** Created clear, small helpers (`format_structs`, `format_traits`, `format_dependencies`, `format_trait_impls`) and passed mutable states down.
+
+**[Refactoring God Functions in AST Visitors]**
+**Learning:** AST Visitors like `haruspex.rs` tend to become "God Functions" containing massive `match` blocks over every AST node variant, violating readability principles.
+**Action:** Extract grouped branches (like literals, or basic statements) into focused helper functions to keep the main match statements clean and under 50 lines.

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,0 @@
-1. **Analyze CI Failure:** The check run failed on "Format Check" running `cargo fmt --all -- --check`. The diff shows missing trailing commas in the array initializing the `Table` rows.
-2. **Fix `src/tools/tester.rs`:** Run `cargo fmt --all` to automatically apply the formatting changes required to fix the trailing comma issues.
-3. **Verify:** Ensure `cargo fmt --all -- --check` passes.
-4. **Submit PR.**

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()

--- a/src/tools/haruspex.rs
+++ b/src/tools/haruspex.rs
@@ -253,36 +253,22 @@ fn visit_expr(next_id: &mut usize, output: &mut String, expr: &AnalyzedExpr) -> 
 
     match &expr.expr {
         AnalyzedExprKind::StringLiteral(s) => {
-            emit_node(
+            visit_literal_or_variable_expr(
                 output,
                 id,
-                &format!("String\\n\\\"{}\\\"{}", s, type_info),
-                "lightyellow",
+                "String",
+                &format!("\\\"{}\\\"", s),
+                &type_info,
             );
         }
         AnalyzedExprKind::NumberLiteral(n) => {
-            emit_node(
-                output,
-                id,
-                &format!("Number\\n{}{}", n, type_info),
-                "lightyellow",
-            );
+            visit_literal_or_variable_expr(output, id, "Number", &n.to_string(), &type_info);
         }
         AnalyzedExprKind::BooleanLiteral(b) => {
-            emit_node(
-                output,
-                id,
-                &format!("Boolean\\n{}{}", b, type_info),
-                "lightyellow",
-            );
+            visit_literal_or_variable_expr(output, id, "Boolean", &b.to_string(), &type_info);
         }
         AnalyzedExprKind::Variable(v) => {
-            emit_node(
-                output,
-                id,
-                &format!("Variable\\n{}{}", v, type_info),
-                "lightyellow",
-            );
+            visit_literal_or_variable_expr(output, id, "Variable", v, &type_info);
         }
         AnalyzedExprKind::PropertyAccess { owner, property } => {
             emit_node(
@@ -649,6 +635,21 @@ fn visit_test_decl_statement(
         let s_id = visit_statement(next_id, output, s);
         emit_edge(output, body_id, s_id, "");
     }
+}
+
+fn visit_literal_or_variable_expr(
+    output: &mut String,
+    id: usize,
+    kind: &str,
+    value: &str,
+    type_info: &str,
+) {
+    emit_node(
+        output,
+        id,
+        &format!("{}\\n{}{}", kind, value, type_info),
+        "lightyellow",
+    );
 }
 
 fn visit_verb_call_expr(


### PR DESCRIPTION
* 🚮 Smell: "God Functions" `visit_expr` was extremely long and matched many variants inline with repeated emit logic.
* ✨ Solution: Extracted logic for literals and variables into `visit_literal_or_variable_expr`.
* 🧼 Benefit: Reduces cognitive load and flattens the structure, avoiding repetition of emit_node logic.
* 🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [5664329005480770049](https://jules.google.com/task/5664329005480770049) started by @madmax983*