### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -247,6 +247,7 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 // TYPES
 // ==================================================================================
 
+use std::fmt::Write;
 /// Convert a Glossa type to its Rust equivalent string
 ///
 /// This function recursively traverses complex types (like `Vec<Option<i64>>`)
@@ -273,8 +274,6 @@ fn transliterate_fmt<W: std::fmt::Write>(text: &str, result: &mut W) -> std::fmt
 /// );
 /// assert_eq!(to_rust_type(&result_type), "Result<i64, String>");
 /// ```
-use std::fmt::Write;
-
 pub fn to_rust_type(ty: &GlossaType) -> String {
     let mut result = String::with_capacity(32);
     write_rust_type(ty, &mut result).unwrap();

--- a/src/semantic/conversion.rs
+++ b/src/semantic/conversion.rs
@@ -509,7 +509,7 @@ fn classify_assignment(
         ))),
         Some(b) if !b.mutable => Err(GlossaError::semantic(format!(
             "Τὸ «{}» ἀμετάβλητόν ἐστιν — χρῆσον μετά πρὸ τοῦ ὁρισμοῦ",
-            &var_name
+            var_name
         ))),
         Some(_) => {
             let has_value = !asm_stmt.literals.is_empty()


### PR DESCRIPTION
* 📖 Chapter: `codegen`
* 🔦 Insight: Reattached the documentation to the `to_rust_type` function. An intervening `use std::fmt::Write;` was detaching the rich doc block and causing missing_docs warnings.
* 🧪 Example: Preserved the existing executable doctests showing `to_rust_type` usage.
* 🖼️ Preview: Documentation for `to_rust_type` is now visible again.

---
*PR created automatically by Jules for task [1858804863721880660](https://jules.google.com/task/1858804863721880660) started by @madmax983*